### PR TITLE
fix: prevent reactions leaking into task lane via shared IPC directory

### DIFF
--- a/container/agent-runner/src/__tests__/ipc-lane.test.ts
+++ b/container/agent-runner/src/__tests__/ipc-lane.test.ts
@@ -1,0 +1,16 @@
+import { describe, it, expect } from 'bun:test';
+import { resolveIpcInputDir } from '../index.ts';
+
+describe('IPC lane selection', () => {
+  it('returns message lane when isScheduledTask is false', () => {
+    expect(resolveIpcInputDir(false)).toBe('/workspace/ipc/input');
+  });
+
+  it('returns message lane when isScheduledTask is undefined', () => {
+    expect(resolveIpcInputDir(undefined)).toBe('/workspace/ipc/input');
+  });
+
+  it('returns task lane when isScheduledTask is true', () => {
+    expect(resolveIpcInputDir(true)).toBe('/workspace/ipc/input-task');
+  });
+});

--- a/src/backends/local-backend.ts
+++ b/src/backends/local-backend.ts
@@ -170,22 +170,14 @@ function buildVolumeMounts(
   fs.mkdirSync(path.join(groupIpcDir, 'input'), { recursive: true });
   fs.mkdirSync(path.join(groupIpcDir, 'input-task'), { recursive: true });
 
-  // Mount the full IPC directory. For scheduled tasks, override the input/
-  // subdirectory with input-task/ so follow-up messages don't cross lanes.
-  // Note: Apple Container doesn't support file-level bind mounts, so we
-  // mount the whole directory and override only the input subdirectory.
+  // Mount the full IPC directory. The agent-runner inside the container
+  // selects the correct input subdirectory (input/ vs input-task/) based
+  // on containerInput.isScheduledTask, so no mount overlay trick is needed.
   mounts.push({
     hostPath: groupIpcDir,
     containerPath: '/workspace/ipc',
     readonly: false,
   });
-  if (isScheduledTask) {
-    mounts.push({
-      hostPath: path.join(groupIpcDir, 'input-task'),
-      containerPath: '/workspace/ipc/input',
-      readonly: false,
-    });
-  }
 
   // Environment file
   const envDir = path.join(DATA_DIR, 'env');


### PR DESCRIPTION
## Summary

- Agent-runner now derives its IPC input directory (`input/` vs `input-task/`) from `containerInput.isScheduledTask` instead of relying on Apple Container mount overlay shadowing
- Removed the fragile mount overlay hack from `local-backend.ts` that mounted `input-task/` over `input/` for scheduled tasks
- Added 5 IPC lane isolation tests to `group-queue.test.ts` and 3 agent-runner lane selection tests

## Test plan

- [x] `bun test ./src/group-queue.test.ts` — 16 tests pass (5 new)
- [x] `bun test ./container/agent-runner/src/__tests__/` — 20 tests pass (3 new)
- [x] `bunx tsc --noEmit` — no new type errors
- [ ] Rebuild container and verify agent-runner picks up the change
- [ ] Run a scheduled task alongside an active message container and confirm no reaction leakage

Closes #2

🤖 Generated with [Claude Code](https://claude.com/claude-code)