### PR TITLE
fix: prevent duplicate message delivery (issue #12)

### DIFF
--- a/src/db.test.ts
+++ b/src/db.test.ts
@@ -287,15 +287,14 @@ describe('getNewMessages', () => {
     expect(newTimestamp).toBe('2024-01-01T00:00:04.000Z');
   });
 
-  it('filters by timestamp', () => {
+  it('filters by timestamp (strictly after)', () => {
     const { messages } = getNewMessages(
       ['group1@g.us', 'group2@g.us'],
       '2024-01-01T00:00:02.000Z',
     );
-    // Messages at or after timestamp (g2 msg1 at 00:00:02, g1 msg2 at 00:00:04)
-    expect(messages).toHaveLength(2);
-    expect(messages[0].content).toBe('g2 msg1');
-    expect(messages[1].content).toBe('g1 msg2');
+    // Only messages strictly after the cursor (g1 msg2 at 00:00:04)
+    expect(messages).toHaveLength(1);
+    expect(messages[0].content).toBe('g1 msg2');
   });
 
   it('returns empty for no registered groups', () => {

--- a/src/db.ts
+++ b/src/db.ts
@@ -351,7 +351,7 @@ export function getNewMessages(
   const sql = `
     SELECT id, chat_jid, sender, sender_name, content, timestamp, sender_user_id, mentions
     FROM messages
-    WHERE timestamp >= ? AND chat_jid IN (${placeholders}) AND (is_from_me IS NULL OR is_from_me = 0)
+    WHERE timestamp > ? AND chat_jid IN (${placeholders}) AND (is_from_me IS NULL OR is_from_me = 0)
     ORDER BY timestamp
   `;
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -121,7 +121,6 @@ let agents: Record<string, Agent> = {};
 let channelRoutes: Record<string, ChannelRoute> = {};
 let lastAgentTimestamp: Record<string, string> = {};
 let messageLoopRunning = false;
-let processedIds = new Set<string>(); // Deduplication for timestamp boundary messages
 
 // Track consecutive errors per group to prevent infinite error loops.
 // After MAX_CONSECUTIVE_ERRORS, the cursor advances past the failing batch
@@ -790,20 +789,8 @@ async function startMessageLoop(): Promise<void> {
         lastTimestamp,
       );
 
-      // Clear processedIds when timestamp advances (prevents memory growth)
-      if (newTimestamp > lastTimestamp) {
-        processedIds.clear();
-      }
-
-      // Filter out already-processed messages (deduplication at timestamp boundaries)
-      const uniqueMessages = messages.filter((msg) => {
-        if (processedIds.has(msg.id)) return false;
-        processedIds.add(msg.id);
-        return true;
-      });
-
-      if (uniqueMessages.length > 0) {
-        logger.info({ count: uniqueMessages.length }, 'New messages');
+      if (messages.length > 0) {
+        logger.info({ count: messages.length }, 'New messages');
 
         // Advance the "seen" cursor for all messages immediately
         lastTimestamp = newTimestamp;
@@ -811,7 +798,7 @@ async function startMessageLoop(): Promise<void> {
 
         // Deduplicate by group
         const messagesByGroup = new Map<string, NewMessage[]>();
-        for (const msg of uniqueMessages) {
+        for (const msg of messages) {
           const existing = messagesByGroup.get(msg.chat_jid);
           if (existing) {
             existing.push(msg);


### PR DESCRIPTION
## Summary

• Changed `getNewMessages` SQL query from `>=` to `>` (strict greater-than), matching how `getMessagesSince` already works
• Removed the fragile in-memory `processedIds` Set that was supposed to deduplicate boundary messages but was cleared prematurely and bypassed by recovery/queue paths
• Updated test to reflect strict-after semantics

## Root Cause

The message loop polled with `timestamp >= lastTimestamp`, re-fetching messages at the cursor boundary every cycle. `processedIds` was meant to handle this but:
1. Cleared when timestamp advanced — before all consumers finished
2. Only checked in the main message loop — `recoverPendingMessages()` and queue fallback bypassed it entirely
3. Non-persistent — lost on process restart

This caused the same message to be delivered 2-3x to agents.

## Fix

Use `>` instead of `>=` in `getNewMessages`, eliminating boundary re-fetches at the source. Since `lastTimestamp` is set to the max timestamp of each batch, `>` ensures only truly new messages are returned. This makes `processedIds` unnecessary — removed entirely.

## Test plan

- [x] `bun test src/db.test.ts` — all 20 tests pass
- [x] `bun test` — all relevant tests pass (2 unrelated failures in container/agent-runner due to missing SDK dep)

Closes #12