### PR TITLE
fix: prevent duplicate task runs when scheduler polls during execution

### DIFF
--- a/src/group-queue.ts
+++ b/src/group-queue.ts
@@ -165,7 +165,11 @@ export class GroupQueue {
 
     const state = this.getGroup(groupJid);
 
-    // Prevent double-queuing of the same task
+    // Prevent double-queuing of the same task (check both running and pending)
+    if (state.activeTaskInfo?.taskId === taskId) {
+      logger.debug({ groupJid, taskId }, 'Task already running, skipping');
+      return;
+    }
     if (state.pendingTasks.some((t) => t.id === taskId)) {
       logger.debug({ groupJid, taskId }, 'Task already queued, skipping');
       return;


### PR DESCRIPTION
## Summary
- [Upstream PR #358] Fixes race condition where cron tasks run twice if execution exceeds the 60s scheduler poll interval
- Checks `activeTaskInfo.taskId` before queuing to skip tasks that are already running
- Fork adaptation: reuses existing `activeTaskInfo` tracking (dual-lane architecture) instead of upstream's new `runningTaskId` field

## The bug
When a scheduled task takes longer than the poll interval:
1. Task enqueued and starts running (removed from `pendingTasks`, tracked in `activeTaskInfo`)
2. Scheduler polls again, task still "due" (`next_run` not updated until completion)
3. Task not in `pendingTasks` → `enqueueTask()` sees `taskActive=true` → pushes duplicate to `pendingTasks`
4. When first run finishes, the duplicate runs immediately from `drainTaskLane()`

## Test plan
- [x] `npm test` passes (141 tests, 0 failures)
- [x] Type check passes (no new errors)
- [ ] Manual test: schedule a task >60s, verify it only runs once

🤖 Generated with [Claude Code](https://claude.com/claude-code)