### PR TITLE
fix: stop typing indicator when agent goes idle

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -603,6 +603,13 @@ async function processGroupMessages(chatJid: string): Promise<boolean> {
         // (status: success with null result = session-update marker = idle-waiting)
         if (result.status === 'success') {
           queue.notifyIdle(chatJid);
+          // Stop typing indicator when agent goes idle — otherwise the 8s
+          // refresh loop keeps the indicator alive until the container exits,
+          // which can be minutes later. Fixes #9.
+          if (typingInterval) {
+            clearInterval(typingInterval);
+            typingInterval = null;
+          }
         }
 
         if (result.status === 'error') {


### PR DESCRIPTION
## Summary
- Clears the 8-second typing refresh interval when the agent enters idle state
- Previously, the typing indicator persisted for minutes after the agent finished because the container stayed alive in idle-waiting mode
- 7-line targeted fix in the streaming output callback

## Root Cause
The typing refresh loop (every 8s) was only cleared in the `finally` block — which runs when `processGroupMessages` returns. But with idle container preemption (PR #11), containers stay alive after finishing work, waiting for IPC input. The typing interval kept refreshing throughout this idle period.

## Fix
Clear the typing interval when `notifyIdle()` fires (agent finished work, status: success). The typing indicator then naturally expires within 10 seconds (Discord's auto-expiry).

## Test plan
- [x] `npm test` passes (141 tests, 0 failures)
- [x] No new type errors
- [ ] Manual: send message on Discord, verify typing stops within ~10s of response

Fixes #9

🤖 Generated with [Claude Code](https://claude.com/claude-code)