### PR TITLE
security: harden IPC file intake against symlinks, oversized payloads, and TOCTOU races

### DIFF
--- a/src/ipc-file-security.test.ts
+++ b/src/ipc-file-security.test.ts
@@ -1,0 +1,185 @@
+import { describe, it, expect, beforeEach, afterEach } from 'bun:test';
+import { mkdtempSync, rmSync, symlinkSync, writeFileSync, mkdirSync, existsSync } from 'node:fs';
+import path from 'path';
+import os from 'os';
+
+import {
+  readIpcJsonFile,
+  listIpcJsonFiles,
+  quarantineIpcFile,
+} from './ipc-file-security.js';
+
+let tmpDir: string;
+
+beforeEach(() => {
+  tmpDir = mkdtempSync(path.join(os.tmpdir(), 'ipc-security-test-'));
+});
+
+afterEach(() => {
+  rmSync(tmpDir, { recursive: true, force: true });
+});
+
+describe('readIpcJsonFile', () => {
+  it('reads a valid JSON file', () => {
+    const filePath = path.join(tmpDir, 'valid.json');
+    writeFileSync(filePath, JSON.stringify({ type: 'message', text: 'hello' }));
+
+    const result = readIpcJsonFile(filePath);
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect((result.data as { type: string }).type).toBe('message');
+      expect((result.data as { text: string }).text).toBe('hello');
+    }
+  });
+
+  it('rejects symlinks', () => {
+    const realFile = path.join(tmpDir, 'real.json');
+    const link = path.join(tmpDir, 'link.json');
+    writeFileSync(realFile, JSON.stringify({ type: 'test' }));
+    symlinkSync(realFile, link);
+
+    const result = readIpcJsonFile(link);
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.reason).toBe('symlink rejected');
+    }
+  });
+
+  it('rejects non-existent files', () => {
+    const result = readIpcJsonFile(path.join(tmpDir, 'missing.json'));
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.reason).toContain('lstat failed');
+    }
+  });
+
+  it('rejects directories', () => {
+    const dirPath = path.join(tmpDir, 'subdir');
+    mkdirSync(dirPath);
+
+    const result = readIpcJsonFile(dirPath);
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.reason).toContain('not a regular file');
+    }
+  });
+
+  it('rejects oversized files', () => {
+    const filePath = path.join(tmpDir, 'big.json');
+    // Create a file just over 1 MiB
+    const bigContent = '{"data":"' + 'x'.repeat(1024 * 1024 + 100) + '"}';
+    writeFileSync(filePath, bigContent);
+
+    const result = readIpcJsonFile(filePath);
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.reason).toContain('too large');
+    }
+  });
+
+  it('rejects invalid JSON', () => {
+    const filePath = path.join(tmpDir, 'bad.json');
+    writeFileSync(filePath, '{ invalid json !!!');
+
+    const result = readIpcJsonFile(filePath);
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.reason).toContain('invalid JSON');
+    }
+  });
+
+  it('reads files with unicode content', () => {
+    const filePath = path.join(tmpDir, 'unicode.json');
+    writeFileSync(filePath, JSON.stringify({ text: '🎉 こんにちは 안녕하세요' }));
+
+    const result = readIpcJsonFile(filePath);
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect((result.data as { text: string }).text).toBe('🎉 こんにちは 안녕하세요');
+    }
+  });
+
+  it('reads empty JSON object', () => {
+    const filePath = path.join(tmpDir, 'empty.json');
+    writeFileSync(filePath, '{}');
+
+    const result = readIpcJsonFile(filePath);
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.data).toEqual({});
+    }
+  });
+
+  it('accepts file just under size limit', () => {
+    const filePath = path.join(tmpDir, 'justunder.json');
+    // Create a file just under 1 MiB (leave room for JSON wrapper)
+    const content = JSON.stringify({ data: 'a'.repeat(1024 * 1024 - 50) });
+    writeFileSync(filePath, content);
+
+    const result = readIpcJsonFile(filePath);
+    expect(result.ok).toBe(true);
+  });
+});
+
+describe('listIpcJsonFiles', () => {
+  it('lists only .json regular files', () => {
+    writeFileSync(path.join(tmpDir, 'a.json'), '{}');
+    writeFileSync(path.join(tmpDir, 'b.json'), '{}');
+    writeFileSync(path.join(tmpDir, 'readme.txt'), 'hello');
+    mkdirSync(path.join(tmpDir, 'subdir'));
+
+    const files = listIpcJsonFiles(tmpDir);
+    expect(files.sort()).toEqual(['a.json', 'b.json']);
+  });
+
+  it('excludes symlinks to .json files', () => {
+    const realFile = path.join(tmpDir, 'real.json');
+    writeFileSync(realFile, '{}');
+    symlinkSync(realFile, path.join(tmpDir, 'link.json'));
+
+    const files = listIpcJsonFiles(tmpDir);
+    expect(files).toEqual(['real.json']);
+  });
+
+  it('returns empty array for non-existent directory', () => {
+    const files = listIpcJsonFiles(path.join(tmpDir, 'nonexistent'));
+    expect(files).toEqual([]);
+  });
+
+  it('returns empty array for empty directory', () => {
+    const emptyDir = path.join(tmpDir, 'empty');
+    mkdirSync(emptyDir);
+
+    const files = listIpcJsonFiles(emptyDir);
+    expect(files).toEqual([]);
+  });
+});
+
+describe('quarantineIpcFile', () => {
+  it('moves file to errors directory', () => {
+    const filePath = path.join(tmpDir, 'bad.json');
+    writeFileSync(filePath, 'corrupt');
+
+    quarantineIpcFile(filePath, tmpDir, 'invalid JSON', 'test-group');
+
+    expect(existsSync(filePath)).toBe(false);
+    expect(existsSync(path.join(tmpDir, 'errors', 'test-group-bad.json'))).toBe(true);
+  });
+
+  it('creates errors directory if it does not exist', () => {
+    const filePath = path.join(tmpDir, 'bad2.json');
+    writeFileSync(filePath, 'corrupt');
+
+    expect(existsSync(path.join(tmpDir, 'errors'))).toBe(false);
+    quarantineIpcFile(filePath, tmpDir, 'test', 'mygroup');
+    expect(existsSync(path.join(tmpDir, 'errors'))).toBe(true);
+  });
+
+  it('handles already-deleted files gracefully', () => {
+    const filePath = path.join(tmpDir, 'gone.json');
+    // File doesn't exist - should not throw
+    expect(() => {
+      quarantineIpcFile(filePath, tmpDir, 'missing', 'test-group');
+    }).not.toThrow();
+  });
+});

--- a/src/ipc-file-security.ts
+++ b/src/ipc-file-security.ts
@@ -1,0 +1,198 @@
+/**
+ * IPC File Security Hardening
+ *
+ * Provides secure file reading for IPC JSON files with defense-in-depth:
+ * - Symlink rejection (lstat + O_NOFOLLOW)
+ * - File size limits (1 MiB hard cap)
+ * - TOCTOU protection (post-open fstat validation)
+ * - Quarantine for malformed/unsafe files
+ * - Directory listing filtered to regular files only
+ *
+ * Inspired by upstream qwibitai/nanoclaw PR #364 (lawyered0).
+ * Adapted for omniaura/omniclaw fork's multi-backend architecture.
+ *
+ * NOTE: Uses node:fs for low-level operations (lstatSync, openSync, fstatSync,
+ * readSync, closeSync, readdirSync with withFileTypes) because bun's polyfilled
+ * 'fs' module does not expose these functions. Higher-level operations (mkdirSync,
+ * renameSync, unlinkSync) use the standard 'fs' import for consistency with the
+ * rest of the codebase.
+ */
+
+import {
+  closeSync,
+  constants as fsConstants,
+  fstatSync,
+  lstatSync,
+  mkdirSync,
+  openSync,
+  readSync,
+  readdirSync,
+  renameSync,
+  unlinkSync,
+} from 'node:fs';
+import type { Dirent, Stats } from 'node:fs';
+import path from 'path';
+import { logger } from './logger.js';
+
+/** Maximum IPC file size: 1 MiB */
+const MAX_IPC_FILE_SIZE = 1024 * 1024;
+
+/** Chunk size for reading: 64 KiB */
+const READ_CHUNK_SIZE = 64 * 1024;
+
+/**
+ * Result of attempting to read an IPC JSON file securely.
+ */
+export type IpcReadResult<T = unknown> =
+  | { ok: true; data: T }
+  | { ok: false; reason: string };
+
+/**
+ * Securely read and parse a JSON file from the IPC directory.
+ *
+ * Defense layers:
+ * 1. lstatSync() - reject symlinks before opening
+ * 2. O_NOFOLLOW open flag - OS-level symlink prevention (platform-dependent)
+ * 3. fstatSync(fd) - post-open validation that fd is a regular file (TOCTOU defense)
+ * 4. Size check - reject files exceeding MAX_IPC_FILE_SIZE
+ * 5. Chunked reads with running byte total - catches growth-during-read attacks
+ */
+export function readIpcJsonFile<T = unknown>(filePath: string): IpcReadResult<T> {
+  // Layer 1: Pre-open symlink check via lstat
+  let lstat: Stats;
+  try {
+    lstat = lstatSync(filePath);
+  } catch (err) {
+    return { ok: false, reason: `lstat failed: ${(err as Error).message}` };
+  }
+
+  if (lstat.isSymbolicLink()) {
+    return { ok: false, reason: 'symlink rejected' };
+  }
+
+  if (!lstat.isFile()) {
+    return { ok: false, reason: `not a regular file (mode: ${lstat.mode})` };
+  }
+
+  // Layer 2 & 3: Open with O_NOFOLLOW (where supported) + post-open fstat
+  let fd: number;
+  try {
+    // O_NOFOLLOW (0x20000 on Linux, 0x0100 on macOS) prevents symlink following
+    // Fall back to O_RDONLY if O_NOFOLLOW is not available
+    const O_NOFOLLOW = 0x20000; // Linux value; macOS uses 0x0100
+    try {
+      fd = openSync(filePath, fsConstants.O_RDONLY | O_NOFOLLOW);
+    } catch {
+      // Platform may not support O_NOFOLLOW or constants differ; fall back
+      fd = openSync(filePath, fsConstants.O_RDONLY);
+    }
+  } catch (err) {
+    return { ok: false, reason: `open failed: ${(err as Error).message}` };
+  }
+
+  try {
+    // Layer 3: Post-open fstat to guard against TOCTOU race
+    const fstat = fstatSync(fd);
+    if (!fstat.isFile()) {
+      return { ok: false, reason: 'fd is not a regular file after open (TOCTOU)' };
+    }
+
+    // Layer 4: Size check
+    if (fstat.size > MAX_IPC_FILE_SIZE) {
+      return {
+        ok: false,
+        reason: `file too large: ${fstat.size} bytes (limit: ${MAX_IPC_FILE_SIZE})`,
+      };
+    }
+
+    // Layer 5: Chunked read with running byte total
+    const chunks: Buffer[] = [];
+    let totalBytes = 0;
+    const buf = Buffer.alloc(READ_CHUNK_SIZE);
+
+    // eslint-disable-next-line no-constant-condition
+    while (true) {
+      const bytesRead = readSync(fd, buf, 0, READ_CHUNK_SIZE, null);
+      if (bytesRead === 0) break;
+
+      totalBytes += bytesRead;
+      if (totalBytes > MAX_IPC_FILE_SIZE) {
+        return {
+          ok: false,
+          reason: `file grew during read: ${totalBytes} bytes exceeds limit`,
+        };
+      }
+
+      chunks.push(Buffer.from(buf.subarray(0, bytesRead)));
+    }
+
+    const content = Buffer.concat(chunks).toString('utf-8');
+
+    // Layer 6: JSON parse
+    let data: T;
+    try {
+      data = JSON.parse(content) as T;
+    } catch (err) {
+      return { ok: false, reason: `invalid JSON: ${(err as Error).message}` };
+    }
+
+    return { ok: true, data };
+  } finally {
+    closeSync(fd);
+  }
+}
+
+/**
+ * List JSON files in a directory, filtering to regular files only.
+ * Rejects symlinks and non-regular entries at the directory listing level.
+ */
+export function listIpcJsonFiles(dirPath: string): string[] {
+  let entries: Dirent[];
+  try {
+    entries = readdirSync(dirPath, { withFileTypes: true });
+  } catch {
+    return [];
+  }
+
+  return entries
+    .filter((e) => e.isFile() && e.name.endsWith('.json'))
+    .map((e) => e.name);
+}
+
+/**
+ * Move a problematic IPC file to a quarantine directory.
+ * Falls back to unlinkSync if rename fails (cross-device, permissions).
+ */
+export function quarantineIpcFile(
+  filePath: string,
+  ipcBaseDir: string,
+  reason: string,
+  sourceGroup: string,
+): void {
+  const quarantineDir = path.join(ipcBaseDir, 'errors');
+  const fileName = path.basename(filePath);
+
+  try {
+    mkdirSync(quarantineDir, { recursive: true });
+    const destPath = path.join(quarantineDir, `${sourceGroup}-${fileName}`);
+    renameSync(filePath, destPath);
+    logger.warn(
+      { file: fileName, sourceGroup, reason, quarantined: destPath },
+      'IPC file quarantined',
+    );
+  } catch (renameErr) {
+    // Fallback: delete the file if quarantine fails
+    try {
+      unlinkSync(filePath);
+      logger.warn(
+        { file: fileName, sourceGroup, reason, error: renameErr },
+        'IPC file deleted (quarantine rename failed)',
+      );
+    } catch (unlinkErr) {
+      logger.error(
+        { file: fileName, sourceGroup, reason, renameErr, unlinkErr },
+        'Failed to quarantine or delete IPC file',
+      );
+    }
+  }
+}


### PR DESCRIPTION
## Summary

- [Upstream PR #364] Adopt IPC file security hardening from upstream (`lawyered0`)
- New `readIpcJsonFile()` utility with 6-layer defense-in-depth for reading IPC JSON files
- New `listIpcJsonFiles()` with `withFileTypes` filtering to reject symlinks at directory listing level
- New `quarantineIpcFile()` with rename-or-delete fallback for problematic files
- Integrated into `ipc.ts` — replaces raw `readFileSync` + `JSON.parse` for both message and task files
- 16 new tests covering symlinks, oversized files, invalid JSON, unicode, quarantine, and edge cases

## Defense Layers

| Layer | Protection | Implementation |
|-------|-----------|----------------|
| 1 | Symlink rejection | `lstatSync()` pre-open check |
| 2 | OS-level symlink block | `O_NOFOLLOW` open flag |
| 3 | TOCTOU race guard | `fstatSync(fd)` post-open validation |
| 4 | Size limit | Reject files > 1 MiB |
| 5 | Growth-during-read | Chunked reads with running byte total |
| 6 | Parse validation | JSON.parse with structured error reporting |

## Fork-Specific Adaptations

- Uses `node:fs` named imports for low-level operations (`lstatSync`, `openSync`, `fstatSync`, `readSync`, `closeSync`, `readdirSync`) because bun's polyfilled `fs` module doesn't expose these functions
- Upstream PR #364 also changes WhatsApp payload filtering — that change is deferred for separate evaluation since our fork has different filtering (PRs #99, #123, #126)

## Test Plan

- [ ] 16 new tests in `ipc-file-security.test.ts` all pass
- [ ] 134 total tests pass (0 fail, 3 pre-existing skips)
- [ ] Verify IPC message and task processing still works end-to-end
- [ ] Verify malformed IPC files are quarantined to `errors/` directory

Fixes security gaps identified in [upstream PR #364](https://github.com/qwibitai/nanoclaw/pull/364).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Secure IPC file handling: stricter file validation, size limits, safe read semantics, and automated quarantine for problematic files.

* **Integration**
  * IPC processing now uses the secure file helpers and will quarantine invalid or unsafe JSON files while continuing normal processing.

* **Tests**
  * Added comprehensive tests covering valid reads, symlink and directory rejection, oversized/invalid files, listings, and quarantine behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->