### PR TITLE
fix: repair CI workflows (upstream sync + token count)

### DIFF
--- a/.github/workflows/update-tokens.yml
+++ b/.github/workflows/update-tokens.yml
@@ -9,6 +9,8 @@ on:
 jobs:
   update-tokens:
     runs-on: ubuntu-latest
+    # Skip if GitHub App secrets aren't configured (fork without app setup)
+    if: ${{ secrets.APP_ID != '' }}
     steps:
       - uses: actions/create-github-app-token@v1
         id: app-token

--- a/.github/workflows/upstream-sync.yml
+++ b/.github/workflows/upstream-sync.yml
@@ -23,9 +23,9 @@ jobs:
       - name: Add upstream remotes
         run: |
           git remote add upstream https://github.com/qwibitai/nanoclaw.git || true
-          git remote add microclaw https://github.com/cosmin/microclaw.git || true
+          git remote add microclaw https://github.com/microclaw/microclaw.git || true
           git fetch upstream
-          git fetch microclaw
+          git fetch microclaw || echo "Warning: microclaw fetch failed, continuing..."
 
       - name: Check for new upstream PRs
         id: check_prs
@@ -38,8 +38,8 @@ jobs:
       - name: Check for upstream issues in microclaw
         id: check_issues
         run: |
-          echo "Checking cosmin/microclaw for upstream tracking issues..."
-          gh api repos/cosmin/microclaw/issues --jq '.[] | select(.state=="open" and (.title | contains("Upstream"))) | "#\(.number) - \(.title)"'
+          echo "Checking microclaw/microclaw for upstream tracking issues..."
+          gh api repos/microclaw/microclaw/issues --jq '.[] | select(.state=="open" and (.title | contains("Upstream"))) | "#\(.number) - \(.title)"' || echo "No microclaw issues found"
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
@@ -50,7 +50,7 @@ jobs:
           echo "### qwibitai/nanoclaw PRs" >> $GITHUB_STEP_SUMMARY
           gh api repos/qwibitai/nanoclaw/pulls --jq '.[] | select(.state=="open") | "- [#\(.number)](\(.html_url)) - \(.title)"' | head -10 >> $GITHUB_STEP_SUMMARY
           echo "" >> $GITHUB_STEP_SUMMARY
-          echo "### cosmin/microclaw Issues" >> $GITHUB_STEP_SUMMARY
-          gh api repos/cosmin/microclaw/issues --jq '.[] | select(.state=="open" and (.title | contains("Upstream"))) | "- [#\(.number)](\(.html_url)) - \(.title)"' | head -10 >> $GITHUB_STEP_SUMMARY
+          echo "### microclaw/microclaw Issues" >> $GITHUB_STEP_SUMMARY
+          gh api repos/microclaw/microclaw/issues --jq '.[] | select(.state=="open" and (.title | contains("Upstream"))) | "- [#\(.number)](\(.html_url)) - \(.title)"' | head -10 >> $GITHUB_STEP_SUMMARY || echo "- No upstream issues" >> $GITHUB_STEP_SUMMARY
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary
- Update microclaw remote URL from `cosmin/microclaw` → `microclaw/microclaw` (repo moved to org account). Fixes daily upstream sync failure.
- Add fallback handling for microclaw fetch failures to prevent blocking the entire workflow
- Skip token count workflow when GitHub App secrets (`APP_ID`/`APP_PRIVATE_KEY`) aren't configured — prevents repeated CI failures on fork

## Test plan
- [ ] Upstream sync workflow should pass after merge (next daily run or manual trigger)
- [ ] Token count workflow should skip gracefully instead of failing
- [ ] Verify microclaw/microclaw API calls return valid results

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved CI/CD workflow reliability with conditional guards to prevent token generation failures.
  * Enhanced upstream synchronization robustness with fallback mechanisms and better error handling for network failures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->