### PR TITLE
fix: resolve all 22 TypeScript errors in tsc --noEmit

### DIFF
--- a/src/db.test.ts
+++ b/src/db.test.ts
@@ -155,7 +155,7 @@ describe('storeMessageDirect', () => {
       mentions: [{ id: 'user456', name: 'Bob', platform: 'discord' }],
     });
 
-    const messages = getMessagesSince('group@g.us', '2024-01-01T00:00:00.000Z', 'BotName');
+    const messages = getMessagesSince('group@g.us', '2024-01-01T00:00:00.000Z');
     expect(messages).toHaveLength(1);
     expect(messages[0].sender_user_id).toBe('user123');
     expect(messages[0].mentions).toEqual([{ id: 'user456', name: 'Bob', platform: 'discord' }]);
@@ -174,7 +174,7 @@ describe('storeMessageDirect', () => {
       is_from_me: false,
     });
 
-    const messages = getMessagesSince('group@g.us', '2024-01-01T00:00:00.000Z', 'BotName');
+    const messages = getMessagesSince('group@g.us', '2024-01-01T00:00:00.000Z');
     expect(messages).toHaveLength(1);
     expect(messages[0].sender_user_id).toBeUndefined();
     expect(messages[0].mentions).toBeUndefined();
@@ -199,7 +199,7 @@ describe('storeMessage with sender_user_id and mentions', () => {
       mentions: [{ id: 'user222', name: 'Eve', platform: 'discord' }],
     });
 
-    const messages = getMessagesSince('group@g.us', '2024-01-01T00:00:00.000Z', 'BotName');
+    const messages = getMessagesSince('group@g.us', '2024-01-01T00:00:00.000Z');
     expect(messages).toHaveLength(1);
     expect(messages[0].sender_user_id).toBe('user111');
     expect(messages[0].mentions).toEqual([{ id: 'user222', name: 'Eve', platform: 'discord' }]);

--- a/src/effect/message-queue.test.ts
+++ b/src/effect/message-queue.test.ts
@@ -13,7 +13,7 @@ import {
 import type { AgentBackend } from '../backends/types.js';
 
 // Mock backend
-class MockBackend implements Partial<AgentBackend> {
+class MockBackend {
   public sendMessageCalls: Array<{ groupFolder: string; text: string }> = [];
   public shouldSucceed = true;
   public name = 'mock-backend';
@@ -44,7 +44,7 @@ describe('Effect Message Queue', () => {
   });
 
   it('should send a message successfully', async () => {
-    await queue.registerBackend('group1', mockBackend as AgentBackend, 'folder1')
+    await queue.registerBackend('group1', mockBackend as unknown as AgentBackend, 'folder1')
       .pipe(Effect.runPromise);
 
     const result = await queue.sendMessage('group1', 'Hello world')
@@ -61,7 +61,7 @@ describe('Effect Message Queue', () => {
   });
 
   it('should retry on failure and eventually succeed', async () => {
-    await queue.registerBackend('group1', mockBackend as AgentBackend, 'folder1')
+    await queue.registerBackend('group1', mockBackend as unknown as AgentBackend, 'folder1')
       .pipe(Effect.runPromise);
 
     let callCount = 0;
@@ -83,7 +83,7 @@ describe('Effect Message Queue', () => {
   });
 
   it('should fail after max retries', async () => {
-    await queue.registerBackend('group1', mockBackend as AgentBackend, 'folder1')
+    await queue.registerBackend('group1', mockBackend as unknown as AgentBackend, 'folder1')
       .pipe(Effect.runPromise);
 
     mockBackend.shouldSucceed = false;
@@ -123,7 +123,7 @@ describe('Effect Message Queue', () => {
       return originalSend(groupFolder, text);
     };
 
-    await queue.registerBackend('group1', slowBackend as AgentBackend, 'folder1')
+    await queue.registerBackend('group1', slowBackend as unknown as AgentBackend, 'folder1')
       .pipe(Effect.runPromise);
 
     // Start 3 concurrent sends (limit is 2)
@@ -151,9 +151,9 @@ describe('Effect Message Queue', () => {
   });
 
   it('should track stats correctly', async () => {
-    await queue.registerBackend('group1', mockBackend as AgentBackend, 'folder1')
+    await queue.registerBackend('group1', mockBackend as unknown as AgentBackend, 'folder1')
       .pipe(Effect.runPromise);
-    await queue.registerBackend('group2', mockBackend as AgentBackend, 'folder2')
+    await queue.registerBackend('group2', mockBackend as unknown as AgentBackend, 'folder2')
       .pipe(Effect.runPromise);
 
     const stats = await queue.getStats()
@@ -167,11 +167,11 @@ describe('Effect Message Queue', () => {
     const backend1 = new MockBackend();
     const backend2 = new MockBackend();
 
-    await queue.registerBackend('group1', backend1 as AgentBackend, 'folder1')
+    await queue.registerBackend('group1', backend1 as unknown as AgentBackend, 'folder1')
       .pipe(Effect.runPromise);
 
     // Send with explicit backend (should override registered one)
-    await queue.sendMessage('group1', 'Override test', backend2 as AgentBackend, 'folder2')
+    await queue.sendMessage('group1', 'Override test', backend2 as unknown as AgentBackend, 'folder2')
       .pipe(Effect.runPromise);
 
     expect(backend1.sendMessageCalls).toHaveLength(0);

--- a/src/effect/message-queue.ts
+++ b/src/effect/message-queue.ts
@@ -241,8 +241,8 @@ export const makeMessageQueue = (
     ): Effect.Effect<void, MessageSendError | ConcurrencyLimitError> =>
       Effect.gen(function* (_) {
         // Atomic check-and-increment for concurrency limit
-        const incrementResult = yield* _(
-          Ref.modify(activeCount, (current) => {
+        const incrementResult: Effect.Effect<void, ConcurrencyLimitError> = yield* _(
+          Ref.modify<number, Effect.Effect<void, ConcurrencyLimitError>>(activeCount, (current) => {
             if (current >= config.maxConcurrent) {
               return [
                 Effect.fail(
@@ -254,7 +254,7 @@ export const makeMessageQueue = (
                 current,
               ] as const;
             }
-            return [Effect.succeed(undefined), current + 1] as const;
+            return [Effect.void, current + 1] as const;
           }),
         );
 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -3,7 +3,7 @@
     "target": "ES2022",
     "module": "ESNext",
     "moduleResolution": "bundler",
-    "lib": ["ES2022"],
+    "lib": ["ES2023"],
     "outDir": "./dist",
     "rootDir": "./src",
     "strict": true,


### PR DESCRIPTION
## Summary

Fixes all 22 TypeScript errors reported by `tsc --noEmit`, bringing the project to zero type errors while maintaining all 187 tests passing.

### Changes by file:
- **src/db.test.ts** (3 errors): Remove extra 3rd argument from `getMessagesSince` calls — function signature only accepts 2 params
- **src/effect/message-queue.test.ts** (8 errors): Cast `MockBackend` through `unknown` before `as AgentBackend` — partial mock doesn't implement all required interface properties
- **src/effect/message-queue.ts** (3 errors): Add explicit type annotations to `Ref.modify` and use `Effect.void` instead of `Effect.succeed(undefined)` to fix Effect type inference
- **src/ipc.ts** (7 errors): Add `as string` type assertions for `Record<string, unknown>` properties used as function arguments; cast `processTaskIpc` data with intersection type
- **tsconfig.json** (1 error): Bump `lib` from `ES2022` to `ES2023` for `Array.findLast()` support

### Verification
- `tsc --noEmit` → ✅ zero errors
- `bun test` → ✅ 187 pass, 3 skip, 0 fail

Fixes #25

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated test suites for improved type handling and behavior verification.

* **Refactor**
  * Enhanced type safety throughout codebase with explicit type annotations and variable declarations.

* **Chores**
  * Updated TypeScript configuration to ES2023 library target.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->