### PR TITLE
security: mount project root read-only to prevent container escape

### DIFF
--- a/docs/SECURITY.md
+++ b/docs/SECURITY.md
@@ -21,7 +21,19 @@ Agents execute in Apple Container (lightweight Linux VMs), providing:
 
 This is the primary security boundary. Rather than relying on application-level permission checks, the attack surface is limited by what's mounted.
 
-### 2. Mount Security
+### 2. Read-Only Project Root
+
+The main group's project root is mounted **read-only** at `/workspace/project`. This prevents
+a container escape attack where the agent modifies host application code (e.g., `src/`, `dist/`,
+`package.json`) that runs outside the container on next restart.
+
+Writable paths the agent legitimately needs are mounted separately:
+- `/workspace/group` — group folder (rw)
+- `/workspace/ipc` — IPC directory (rw)
+- `/home/bun/.claude` — per-group Claude sessions (rw)
+- `/app/src` — per-group agent-runner copy (rw)
+
+### 3. Mount Security
 
 **External Allowlist** - Mount permissions stored at `~/.config/omniclaw/mount-allowlist.json`, which is:
 - Outside project root
@@ -40,14 +52,14 @@ private_key, .secret
 - Container path validation (rejects `..` and absolute paths)
 - `nonMainReadOnly` option forces read-only for non-main groups
 
-### 3. Session Isolation
+### 4. Session Isolation
 
 Each group has isolated Claude sessions at `data/sessions/{group}/.claude/`:
 - Groups cannot see other groups' conversation history
 - Session data includes full message history and file contents read
 - Prevents cross-group information disclosure
 
-### 4. IPC Authorization
+### 5. IPC Authorization
 
 Messages and task operations are verified against group identity:
 
@@ -60,7 +72,7 @@ Messages and task operations are verified against group identity:
 | View all tasks | ✓ | Own only |
 | Manage other groups | ✓ | ✗ |
 
-### 5. Credential Handling
+### 6. Credential Handling
 
 **Mounted Credentials:**
 - Claude auth tokens (filtered from `.env`, read-only)
@@ -82,7 +94,7 @@ const allowedVars = ['CLAUDE_CODE_OAUTH_TOKEN', 'ANTHROPIC_API_KEY'];
 
 | Capability | Main Group | Non-Main Group |
 |------------|------------|----------------|
-| Project root access | `/workspace/project` (rw) | None |
+| Project root access | `/workspace/project` (ro) | None |
 | Group folder | `/workspace/group` (rw) | `/workspace/group` (rw) |
 | Global memory | Implicit via project | `/workspace/global` (ro) |
 | Additional mounts | Configurable | Read-only unless allowed |

--- a/docs/SECURITY.md
+++ b/docs/SECURITY.md
@@ -85,7 +85,15 @@ Messages and task operations are verified against group identity:
 **Credential Filtering:**
 Only these environment variables are exposed to containers:
 ```typescript
-const allowedVars = ['CLAUDE_CODE_OAUTH_TOKEN', 'ANTHROPIC_API_KEY'];
+// Authoritative source: allowedVars in src/backends/local-backend.ts
+const allowedVars = [
+  'CLAUDE_CODE_OAUTH_TOKEN',
+  'ANTHROPIC_API_KEY',
+  'GITHUB_TOKEN',
+  'GIT_AUTHOR_NAME',
+  'GIT_AUTHOR_EMAIL',
+  'CLAUDE_MODEL',
+];
 ```
 
 > **Note:** Anthropic credentials are mounted so that Claude Code can authenticate when the agent runs. However, this means the agent itself can discover these credentials via Bash or file operations. Ideally, Claude Code would authenticate without exposing credentials to the agent's execution environment, but I couldn't figure this out. **PRs welcome** if you have ideas for credential isolation.

--- a/src/backends/local-backend.ts
+++ b/src/backends/local-backend.ts
@@ -73,10 +73,15 @@ function buildVolumeMounts(
   const srvFolder = getServerFolder(group);
 
   if (isMain) {
+    // Main gets the project root read-only. Writable paths the agent needs
+    // (group folder, IPC, .claude/) are mounted separately below.
+    // Read-only prevents the agent from modifying host application code
+    // (src/, dist/, package.json, etc.) which would bypass the sandbox
+    // entirely on next restart. (Upstream PR #392)
     mounts.push({
       hostPath: projectRoot,
       containerPath: '/workspace/project',
-      readonly: false,
+      readonly: true,
     });
 
     // Main also gets its group folder as the working directory
@@ -201,12 +206,17 @@ function buildVolumeMounts(
     }
   }
 
-  // Agent-runner source mount
+  // Agent-runner source: copy to per-group writable location so each group
+  // can customize tools without modifying host code or affecting other groups.
   const agentRunnerSrc = path.join(projectRoot, 'container', 'agent-runner', 'src');
+  const groupAgentRunnerDir = path.join(DATA_DIR, 'sessions', folder, 'agent-runner-src');
+  if (!fs.existsSync(groupAgentRunnerDir) && fs.existsSync(agentRunnerSrc)) {
+    fs.cpSync(agentRunnerSrc, groupAgentRunnerDir, { recursive: true });
+  }
   mounts.push({
-    hostPath: agentRunnerSrc,
+    hostPath: fs.existsSync(groupAgentRunnerDir) ? groupAgentRunnerDir : agentRunnerSrc,
     containerPath: '/app/src',
-    readonly: true,
+    readonly: !fs.existsSync(groupAgentRunnerDir),
   });
 
   // Additional mounts

--- a/src/backends/local-backend.ts
+++ b/src/backends/local-backend.ts
@@ -210,13 +210,15 @@ function buildVolumeMounts(
   // can customize tools without modifying host code or affecting other groups.
   const agentRunnerSrc = path.join(projectRoot, 'container', 'agent-runner', 'src');
   const groupAgentRunnerDir = path.join(DATA_DIR, 'sessions', folder, 'agent-runner-src');
-  if (!fs.existsSync(groupAgentRunnerDir) && fs.existsSync(agentRunnerSrc)) {
+  let hasGroupDir = fs.existsSync(groupAgentRunnerDir);
+  if (!hasGroupDir && fs.existsSync(agentRunnerSrc)) {
     fs.cpSync(agentRunnerSrc, groupAgentRunnerDir, { recursive: true });
+    hasGroupDir = true;
   }
   mounts.push({
-    hostPath: fs.existsSync(groupAgentRunnerDir) ? groupAgentRunnerDir : agentRunnerSrc,
+    hostPath: hasGroupDir ? groupAgentRunnerDir : agentRunnerSrc,
     containerPath: '/app/src',
-    readonly: !fs.existsSync(groupAgentRunnerDir),
+    readonly: !hasGroupDir,
   });
 
   // Additional mounts


### PR DESCRIPTION
## Summary

- Mount main group's project root **read-only** at `/workspace/project` to prevent container escape via host code tampering
- Copy agent-runner source to per-group writable location (`data/sessions/{group}/agent-runner-src/`) so groups can customize tools without affecting host code
- Update SECURITY.md with new "Read-Only Project Root" section and corrected capability matrix

## Vulnerability

A container agent with read-write access to the project root could modify host application code (`src/`, `dist/`, `package.json`, etc.). On the next NanoClaw restart, the tampered code would execute on the host with full privileges — a complete sandbox escape.

## Fix

The project root mount changes from `readonly: false` to `readonly: true`. All writable paths the agent needs are already mounted separately:
- `/workspace/group` — group folder (rw)
- `/workspace/ipc` — IPC directory (rw)  
- `/home/bun/.claude` — per-group sessions (rw)
- `/app/src` — per-group agent-runner copy (rw)

Only the local backend (Apple Container) is affected. Sprites and Daytona backends use file sync (not bind mounts) and are not vulnerable.

## Test plan

- [ ] Verify main group container can read `/workspace/project` files (CLAUDE.md, registered_groups.json)
- [ ] Verify main group container cannot write to `/workspace/project` (e.g., `touch /workspace/project/test` should fail)
- [ ] Verify agent-runner source is copied to `data/sessions/{group}/agent-runner-src/` on first run
- [ ] Verify non-main groups are unaffected (they never had project root access)
- [ ] TypeScript check: `tsc --noEmit` passes ✅

[Upstream PR #392](https://github.com/qwibitai/nanoclaw/pull/392)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Security docs updated: clarified read-only project root, revised mount/privilege comparisons, credential handling, and section ordering.
  * Added guidance on allowed/blocked mount patterns and credential disclosure.

* **New Features**
  * Project root now mounted read-only with explicit writable paths for needed operations.
  * External mount allowlist added and per-group writable locations for agent-runner sources to improve isolation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->