### PR TITLE
[Upstream PR #378] Improve type safety and add error logging

### DIFF
--- a/src/backends/daytona-backend.ts
+++ b/src/backends/daytona-backend.ts
@@ -116,7 +116,9 @@ class DaytonaProcessWrapper implements ContainerProcess {
   kill(): void {
     if (this._killed) return;
     this._killed = true;
-    this.sandbox.process.deleteSession(this.sessionId).catch(() => {});
+    this.sandbox.process.deleteSession(this.sessionId).catch((err) => {
+      logger.warn({ err, sessionId: this.sessionId }, 'Failed to delete Daytona session');
+    });
   }
 
   get pid(): number {

--- a/src/index.ts
+++ b/src/index.ts
@@ -636,7 +636,9 @@ async function processGroupMessages(chatJid: string): Promise<boolean> {
     // Stop the typing keep-alive loop — must be in finally to prevent stuck
     // typing indicators when runAgent throws or the process is interrupted.
     if (typingInterval) clearInterval(typingInterval);
-    if (channel?.setTyping) await channel.setTyping(chatJid, false).catch(() => {});
+    if (channel?.setTyping) await channel.setTyping(chatJid, false).catch((err) => {
+      logger.debug({ err, chatJid }, 'Failed to clear typing indicator');
+    });
     if (idleTimer) clearTimeout(idleTimer);
   }
 

--- a/src/whatsapp-auth.ts
+++ b/src/whatsapp-auth.ts
@@ -96,7 +96,7 @@ async function connectSocket(phoneNumber?: string, isReconnect = false): Promise
     }
 
     if (connection === 'close') {
-      const reason = (lastDisconnect?.error as any)?.output?.statusCode;
+      const reason = (lastDisconnect?.error as { output?: { statusCode?: number } })?.output?.statusCode;
 
       if (reason === DisconnectReason.loggedOut) {
         fs.writeFileSync(STATUS_FILE, 'failed:logged_out');


### PR DESCRIPTION
## Summary
- Replace `as any` with proper type assertions for WhatsApp disconnect reason parsing in `whatsapp.ts` and `whatsapp-auth.ts`
- Add error logging to previously-silent `.catch(() => {})` handlers:
  - WhatsApp `sendPresenceUpdate('available')` → warns on failure
  - WhatsApp stale typing indicator cleanup → warns with JID
  - `setTyping(false)` cleanup in index.ts → debug log
  - Daytona session deletion → warns with session ID

Inspired by [upstream PR #378](https://github.com/qwibitai/nanoclaw/pull/378) (merged Feb 22). Fork adaptation extends beyond upstream's 2-file change to cover all silent catches in the codebase (+14/-6 LOC, 4 files).

## Test plan
- [x] `tsc --noEmit` passes (0 errors)
- [x] All 276 tests pass
- [ ] Verify presence update failures now appear in logs during reconnection events

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error logging and visibility for message delivery and connection management operations, enabling better diagnostics and troubleshooting.
  * Background operations now properly surface errors instead of silently suppressing them.

* **Refactor**
  * Strengthened type safety in error detection and handling logic.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->