### PR TITLE
fix: migrate remaining console.log/error calls to structured logger

### DIFF
--- a/src/backends/local-backend.ts
+++ b/src/backends/local-backend.ts
@@ -634,11 +634,7 @@ export class LocalBackend implements AgentBackend {
   }
 
   private printContainerSystemError(): void {
-    console.error(
-      '\nFATAL: Container system failed to start.',
-      '\nRun `container system start` and restart the application.',
-      '\nSee the project README for installation instructions.\n',
-    );
+    logger.error('FATAL: Container system failed to start. Run `container system start` and restart the application. See the project README for installation instructions.');
   }
 
   private async cleanupOrphanedContainers(): Promise<void> {

--- a/src/channels/discord.ts
+++ b/src/channels/discord.ts
@@ -118,7 +118,7 @@ export class DiscordChannel implements Channel {
           { username: readyClient.user.tag, id: readyClient.user.id },
           'Discord bot connected',
         );
-        console.log(`\n  Discord bot: ${readyClient.user.tag}`);
+        logger.info({ tag: readyClient.user.tag }, 'Discord bot ready');
         resolve();
       });
 

--- a/src/channels/slack.ts
+++ b/src/channels/slack.ts
@@ -130,7 +130,6 @@ export class SlackChannel implements Channel {
       this.botUserId = authResult.user_id as string;
       const botName = authResult.user || ASSISTANT_NAME;
       logger.info({ botUserId: this.botUserId, botName }, 'Slack bot connected');
-      console.log(`\n  Slack bot: @${botName}`);
     } catch (err) {
       logger.warn({ err }, 'Failed to fetch Slack bot user ID');
     }

--- a/src/channels/telegram.ts
+++ b/src/channels/telegram.ts
@@ -177,10 +177,7 @@ export class TelegramChannel implements Channel {
             { username: botInfo.username, id: botInfo.id },
             'Telegram bot connected',
           );
-          console.log(`\n  Telegram bot: @${botInfo.username}`);
-          console.log(
-            `  Send /chatid to the bot to get a chat's registration ID\n`,
-          );
+          logger.info({ username: botInfo.username }, 'Telegram bot ready — send /chatid to get a chat registration ID');
           resolve();
         },
       });

--- a/src/telegram.ts
+++ b/src/telegram.ts
@@ -169,10 +169,7 @@ export async function connectTelegram(botToken: string): Promise<void> {
         { username: botInfo.username, id: botInfo.id },
         'Telegram bot connected',
       );
-      console.log(`\n  Telegram bot: @${botInfo.username}`);
-      console.log(
-        `  Send /chatid to the bot to get a chat's registration ID\n`,
-      );
+      logger.info({ username: botInfo.username }, 'Telegram bot ready — send /chatid to get a chat registration ID');
     },
   });
 }

--- a/src/whatsapp-auth.ts
+++ b/src/whatsapp-auth.ts
@@ -109,7 +109,7 @@ async function connectSocket(phoneNumber?: string, isReconnect = false): Promise
       } else if (reason === 515) {
         // 515 = stream error, often happens after pairing succeeds but before
         // registration completes. Reconnect to finish the handshake.
-        console.log('\n⟳ Stream error (515) after pairing — reconnecting...');
+        logger.warn({ statusCode: 515 }, 'Stream error after pairing — reconnecting');
         connectSocket(phoneNumber, true);
       } else {
         fs.writeFileSync(STATUS_FILE, `failed:${reason || 'unknown'}`);


### PR DESCRIPTION
## Summary

Migrate remaining `console.log`/`console.error` calls to the structured logger from `src/logger.ts`.

This is a **preparatory step** toward the full Effect.log() migration tracked in #18. It ensures all logging goes through the structured logger (consistent JSON format) rather than raw console output.

### Changes (6 files, +5/-16 LOC)

- `src/channels/discord.ts` — `console.log` → `logger.info` for bot ready message
- `src/channels/slack.ts` — Remove duplicate `console.log` (logger.info already present)
- `src/channels/telegram.ts` — Consolidate 2 `console.log` startup messages into single `logger.info`
- `src/telegram.ts` — Consolidate 2 `console.log` calls into single `logger.info`
- `src/backends/local-backend.ts` — `console.error` FATAL → `logger.error`
- `src/whatsapp-auth.ts` — `console.log` for stream error 515 → `logger.warn`

### Related

- Part of #18 (does not close it — full Effect.log() migration is a separate, larger effort)

🤖 Generated with [Claude Code](https://claude.com/claude-code)