### PR TITLE
Remove duplicate storeMessageDirect function

### DIFF
--- a/src/channels/discord.ts
+++ b/src/channels/discord.ts
@@ -28,7 +28,7 @@ import {
 import {
   getAllRegisteredGroups,
   storeChatMetadata,
-  storeMessageDirect,
+  storeMessage,
 } from '../db.js';
 import { logger } from '../logger.js';
 import { Channel, RegisteredGroup } from '../types.js';
@@ -675,7 +675,7 @@ export class DiscordChannel implements Channel {
     this.cleanupOldMedia(group.folder);
 
     // Store message — startMessageLoop() will pick it up
-    storeMessageDirect({
+    storeMessage({
       id: msgId,
       chat_jid: chatJid,
       sender,

--- a/src/db.test.ts
+++ b/src/db.test.ts
@@ -10,7 +10,6 @@ import {
   getTaskById,
   storeChatMetadata,
   storeMessage,
-  storeMessageDirect,
   updateTask,
 } from './db.js';
 
@@ -137,13 +136,13 @@ describe('storeMessage', () => {
   });
 });
 
-// --- storeMessageDirect (sender_user_id + mentions) ---
+// --- storeMessage (sender_user_id + mentions) ---
 
-describe('storeMessageDirect', () => {
+describe('storeMessage with sender_user_id and mentions', () => {
   it('persists sender_user_id and mentions', () => {
     storeChatMetadata('group@g.us', '2024-01-01T00:00:00.000Z');
 
-    storeMessageDirect({
+    storeMessage({
       id: 'dc-msg-1',
       chat_jid: 'group@g.us',
       sender: 'discord:user123',
@@ -161,10 +160,10 @@ describe('storeMessageDirect', () => {
     expect(messages[0].mentions).toEqual([{ id: 'user456', name: 'Bob', platform: 'discord' }]);
   });
 
-  it('stores null sender_user_id and mentions when not provided', () => {
+  it('stores undefined sender_user_id and mentions when not provided', () => {
     storeChatMetadata('group@g.us', '2024-01-01T00:00:00.000Z');
 
-    storeMessageDirect({
+    storeMessage({
       id: 'dc-msg-2',
       chat_jid: 'group@g.us',
       sender: 'discord:user789',
@@ -179,12 +178,8 @@ describe('storeMessageDirect', () => {
     expect(messages[0].sender_user_id).toBeUndefined();
     expect(messages[0].mentions).toBeUndefined();
   });
-});
 
-// --- storeMessage (sender_user_id + mentions via NewMessage) ---
-
-describe('storeMessage with sender_user_id and mentions', () => {
-  it('persists sender_user_id and mentions from NewMessage', () => {
+  it('persists sender_user_id and mentions from NewMessage format', () => {
     storeChatMetadata('group@g.us', '2024-01-01T00:00:00.000Z');
 
     storeMessage({

--- a/src/db.ts
+++ b/src/db.ts
@@ -311,34 +311,6 @@ export function storeMessage(msg: NewMessage): void {
   );
 }
 
-/**
- * Store a message directly (for non-WhatsApp channels that don't use Baileys proto).
- */
-export function storeMessageDirect(msg: {
-  id: string;
-  chat_jid: string;
-  sender: string;
-  sender_name: string;
-  content: string;
-  timestamp: string;
-  is_from_me: boolean;
-  sender_user_id?: string; // Platform-specific user ID (Issue #66)
-  mentions?: Array<{ id: string; name: string; platform: string }>; // User mentions (Issue #66)
-}): void {
-  db.query(
-    `INSERT OR REPLACE INTO messages (id, chat_jid, sender, sender_name, content, timestamp, is_from_me, sender_user_id, mentions) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)`,
-  ).run(
-    msg.id,
-    msg.chat_jid,
-    msg.sender,
-    msg.sender_name,
-    msg.content,
-    msg.timestamp,
-    msg.is_from_me ? 1 : 0,
-    msg.sender_user_id ?? null,
-    msg.mentions ? JSON.stringify(msg.mentions) : null,
-  );
-}
 
 export function getNewMessages(
   jids: string[],

--- a/src/index.ts
+++ b/src/index.ts
@@ -71,9 +71,6 @@ import { findMainGroupJid } from './group-helpers.js';
 import { logger } from './logger.js';
 import { Effect } from 'effect';
 
-// Re-export for backwards compatibility during refactor
-export { escapeXml, formatMessages } from './router.js';
-
 // Global error handlers to prevent crashes from unhandled rejections/exceptions
 // See: https://github.com/omniaura/omniclaw/issues/221
 // Adopted from [Upstream PR #243] - Critical stability fix

--- a/src/telegram.ts
+++ b/src/telegram.ts
@@ -6,7 +6,7 @@ import {
 import {
   getAllRegisteredGroups,
   storeChatMetadata,
-  storeMessageDirect,
+  storeMessage,
 } from './db.js';
 import { logger } from './logger.js';
 
@@ -34,7 +34,7 @@ function storeNonTextMessage(ctx: any, placeholder: string): void {
   const caption = ctx.message.caption ? ` ${ctx.message.caption}` : '';
 
   storeChatMetadata(chatId, timestamp);
-  storeMessageDirect({
+  storeMessage({
     id: ctx.message.message_id.toString(),
     chat_jid: chatId,
     sender: ctx.from?.id?.toString() || '',
@@ -125,7 +125,7 @@ export async function connectTelegram(botToken: string): Promise<void> {
     }
 
     // Store message — startMessageLoop() will pick it up
-    storeMessageDirect({
+    storeMessage({
       id: msgId,
       chat_jid: chatId,
       sender,


### PR DESCRIPTION
## Summary
• Removes `storeMessageDirect` from `db.ts` — it was identical to `storeMessage` (same SQL, same 9 fields, same logic). The only difference was the type annotation (inline object vs `NewMessage`), and all callers already pass objects conforming to `NewMessage`.
• Updates 3 callers (Discord channel, Telegram module, tests) to use `storeMessage` instead.
• Removes unused backwards-compat re-export of `escapeXml` and `formatMessages` from `index.ts` — nothing in the codebase imports these from index.

*Net: -36 lines, one less exported function to maintain.*

## Test plan
- [x] `bunx tsc --noEmit` passes (0 errors)
- [x] `bun test` passes (276 pass, 0 fail)
- [x] Tests for sender_user_id + mentions consolidated under `storeMessage` describe block

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Consolidated message storage API into a single unified function across messaging integrations
  * Simplified database layer by removing duplicate message storage implementations
  * Removed unused internal API re-exports from main module exports

<!-- end of auto-generated comment: release notes by coderabbit.ai -->