### PR TITLE
test: add file-transfer and router test coverage

### DIFF
--- a/src/file-transfer.test.ts
+++ b/src/file-transfer.test.ts
@@ -1,0 +1,382 @@
+/**
+ * Tests for cross-backend file transfer (file-transfer.ts).
+ *
+ * Validates path-traversal rejection, push/pull direction logic,
+ * error handling, and correct backend routing.
+ */
+import { describe, it, expect, beforeEach, mock } from 'bun:test';
+
+import type { AgentBackend } from './backends/types.js';
+import type { RegisteredGroup } from './types.js';
+
+// ---- Mocks ----
+
+// Mock the logger to prevent noise
+mock.module('./logger.js', () => ({
+  logger: {
+    info: () => {},
+    warn: () => {},
+    error: () => {},
+    debug: () => {},
+  },
+}));
+
+// Create mock backends
+function createMockBackend(name: string): AgentBackend & {
+  _files: Map<string, Buffer>;
+  _written: Array<{ folder: string; path: string; content: Buffer | string }>;
+} {
+  const files = new Map<string, Buffer>();
+  const written: Array<{ folder: string; path: string; content: Buffer | string }> = [];
+
+  return {
+    name,
+    _files: files,
+    _written: written,
+    readFile: async (_folder: string, relativePath: string) => {
+      return files.get(relativePath) ?? null;
+    },
+    writeFile: async (folder: string, relativePath: string, content: Buffer | string) => {
+      written.push({ folder, path: relativePath, content });
+    },
+    initialize: async () => {},
+    shutdown: async () => {},
+    runAgent: async () => ({ output: '', exitCode: 0 }),
+    closeStdin: async () => {},
+  } as unknown as AgentBackend & {
+    _files: Map<string, Buffer>;
+    _written: Array<{ folder: string; path: string; content: Buffer | string }>;
+  };
+}
+
+let mockSourceBackend: ReturnType<typeof createMockBackend>;
+let mockTargetBackend: ReturnType<typeof createMockBackend>;
+
+// Mock the backends/index module to return our mocks
+mock.module('./backends/index.js', () => ({
+  resolveBackend: (group: RegisteredGroup) => {
+    if (group.folder === 'source-group') return mockSourceBackend;
+    if (group.folder === 'target-group') return mockTargetBackend;
+    throw new Error(`Unknown group folder: ${group.folder}`);
+  },
+}));
+
+// Import after mocks
+import { transferFiles } from './file-transfer.js';
+
+// ---- Test data ----
+
+const sourceGroup: RegisteredGroup = {
+  name: 'Source Group',
+  folder: 'source-group',
+  trigger: '@Omni',
+  added_at: '2026-01-01T00:00:00Z',
+};
+
+const targetGroup: RegisteredGroup = {
+  name: 'Target Group',
+  folder: 'target-group',
+  trigger: '@Omni',
+  added_at: '2026-01-01T00:00:00Z',
+};
+
+// ---- Tests ----
+
+describe('transferFiles', () => {
+  beforeEach(() => {
+    mockSourceBackend = createMockBackend('mock-source');
+    mockTargetBackend = createMockBackend('mock-target');
+  });
+
+  // --- Push direction ---
+
+  describe('push direction (source → target)', () => {
+    it('transfers a single file from source to target', async () => {
+      mockSourceBackend._files.set('data.json', Buffer.from('{"key":"value"}'));
+
+      const result = await transferFiles({
+        sourceGroup,
+        targetGroup,
+        files: ['data.json'],
+        direction: 'push',
+      });
+
+      expect(result.transferred).toBe(1);
+      expect(result.errors).toHaveLength(0);
+      expect(mockTargetBackend._written).toHaveLength(1);
+      expect(mockTargetBackend._written[0].folder).toBe('target-group');
+      expect(mockTargetBackend._written[0].path).toBe('shared/source-group/data.json');
+    });
+
+    it('transfers multiple files', async () => {
+      mockSourceBackend._files.set('a.txt', Buffer.from('aaa'));
+      mockSourceBackend._files.set('b.txt', Buffer.from('bbb'));
+      mockSourceBackend._files.set('dir/c.txt', Buffer.from('ccc'));
+
+      const result = await transferFiles({
+        sourceGroup,
+        targetGroup,
+        files: ['a.txt', 'b.txt', 'dir/c.txt'],
+        direction: 'push',
+      });
+
+      expect(result.transferred).toBe(3);
+      expect(result.errors).toHaveLength(0);
+      expect(mockTargetBackend._written).toHaveLength(3);
+      // Note: path.basename strips directory, so dir/c.txt → c.txt
+      expect(mockTargetBackend._written[2].path).toBe('shared/source-group/c.txt');
+    });
+
+    it('uses basename for destination path (strips directories)', async () => {
+      mockSourceBackend._files.set('deeply/nested/dir/report.md', Buffer.from('# Report'));
+
+      const result = await transferFiles({
+        sourceGroup,
+        targetGroup,
+        files: ['deeply/nested/dir/report.md'],
+        direction: 'push',
+      });
+
+      expect(result.transferred).toBe(1);
+      expect(mockTargetBackend._written[0].path).toBe('shared/source-group/report.md');
+    });
+  });
+
+  // --- Pull direction ---
+
+  describe('pull direction (target → source)', () => {
+    it('pulls file from target to source', async () => {
+      mockTargetBackend._files.set('context.md', Buffer.from('# Context'));
+
+      const result = await transferFiles({
+        sourceGroup,
+        targetGroup,
+        files: ['context.md'],
+        direction: 'pull',
+      });
+
+      expect(result.transferred).toBe(1);
+      expect(result.errors).toHaveLength(0);
+      // In pull mode, target is source of data, source is destination
+      expect(mockSourceBackend._written).toHaveLength(1);
+      expect(mockSourceBackend._written[0].folder).toBe('source-group');
+      expect(mockSourceBackend._written[0].path).toBe('shared/target-group/context.md');
+    });
+  });
+
+  // --- File not found ---
+
+  describe('file not found handling', () => {
+    it('reports error when source file does not exist', async () => {
+      const result = await transferFiles({
+        sourceGroup,
+        targetGroup,
+        files: ['missing.txt'],
+        direction: 'push',
+      });
+
+      expect(result.transferred).toBe(0);
+      expect(result.errors).toHaveLength(1);
+      expect(result.errors[0]).toContain('File not found');
+      expect(result.errors[0]).toContain('missing.txt');
+    });
+
+    it('continues transferring remaining files after a missing file', async () => {
+      mockSourceBackend._files.set('exists.txt', Buffer.from('data'));
+
+      const result = await transferFiles({
+        sourceGroup,
+        targetGroup,
+        files: ['missing.txt', 'exists.txt'],
+        direction: 'push',
+      });
+
+      expect(result.transferred).toBe(1);
+      expect(result.errors).toHaveLength(1);
+      expect(result.errors[0]).toContain('missing.txt');
+    });
+  });
+
+  // --- Empty file list ---
+
+  describe('empty inputs', () => {
+    it('handles empty file list', async () => {
+      const result = await transferFiles({
+        sourceGroup,
+        targetGroup,
+        files: [],
+        direction: 'push',
+      });
+
+      expect(result.transferred).toBe(0);
+      expect(result.errors).toHaveLength(0);
+    });
+  });
+
+  // --- Path traversal rejection (security) ---
+
+  describe('path traversal rejection', () => {
+    it('rejects paths with ../ traversal', async () => {
+      const result = await transferFiles({
+        sourceGroup,
+        targetGroup,
+        files: ['../../../etc/passwd'],
+        direction: 'push',
+      });
+
+      expect(result.transferred).toBe(0);
+      expect(result.errors).toHaveLength(1);
+      expect(result.errors[0]).toContain('traversal');
+    });
+
+    it('rejects paths with encoded traversal', async () => {
+      const result = await transferFiles({
+        sourceGroup,
+        targetGroup,
+        files: ['..%2F..%2Fetc/passwd'],
+        direction: 'push',
+      });
+
+      // rejectTraversalSegments checks for literal '..' segments
+      // The encoded version may or may not be caught depending on implementation
+      // Either way, the transfer should not succeed for malicious paths
+      expect(result.transferred).toBe(0);
+    });
+
+    it('rejects paths with bare .. component', async () => {
+      const result = await transferFiles({
+        sourceGroup,
+        targetGroup,
+        files: ['foo/../../../secret'],
+        direction: 'push',
+      });
+
+      expect(result.transferred).toBe(0);
+      expect(result.errors).toHaveLength(1);
+    });
+
+    it('continues processing valid files after rejecting traversal', async () => {
+      mockSourceBackend._files.set('good.txt', Buffer.from('safe'));
+
+      const result = await transferFiles({
+        sourceGroup,
+        targetGroup,
+        files: ['../evil.txt', 'good.txt'],
+        direction: 'push',
+      });
+
+      expect(result.transferred).toBe(1);
+      expect(result.errors).toHaveLength(1);
+      expect(result.errors[0]).toContain('traversal');
+      expect(mockTargetBackend._written[0].path).toBe('shared/source-group/good.txt');
+    });
+
+    it('rejects absolute paths', async () => {
+      const result = await transferFiles({
+        sourceGroup,
+        targetGroup,
+        files: ['/etc/passwd'],
+        direction: 'push',
+      });
+
+      expect(result.transferred).toBe(0);
+      expect(result.errors).toHaveLength(1);
+    });
+  });
+
+  // --- Backend error handling ---
+
+  describe('backend errors', () => {
+    it('reports error when readFile throws', async () => {
+      mockSourceBackend.readFile = async () => {
+        throw new Error('Backend read error');
+      };
+
+      const result = await transferFiles({
+        sourceGroup,
+        targetGroup,
+        files: ['data.json'],
+        direction: 'push',
+      });
+
+      expect(result.transferred).toBe(0);
+      expect(result.errors).toHaveLength(1);
+      expect(result.errors[0]).toContain('Backend read error');
+    });
+
+    it('reports error when writeFile throws', async () => {
+      mockSourceBackend._files.set('data.json', Buffer.from('test'));
+      mockTargetBackend.writeFile = async () => {
+        throw new Error('Backend write error');
+      };
+
+      const result = await transferFiles({
+        sourceGroup,
+        targetGroup,
+        files: ['data.json'],
+        direction: 'push',
+      });
+
+      expect(result.transferred).toBe(0);
+      expect(result.errors).toHaveLength(1);
+      expect(result.errors[0]).toContain('Backend write error');
+    });
+
+    it('continues after backend error on one file', async () => {
+      mockSourceBackend._files.set('a.txt', Buffer.from('aaa'));
+      mockSourceBackend._files.set('b.txt', Buffer.from('bbb'));
+
+      let callCount = 0;
+      const originalReadFile = mockSourceBackend.readFile.bind(mockSourceBackend);
+      mockSourceBackend.readFile = async (folder: string, path: string) => {
+        callCount++;
+        if (callCount === 1) throw new Error('Transient error');
+        return originalReadFile(folder, path);
+      };
+
+      const result = await transferFiles({
+        sourceGroup,
+        targetGroup,
+        files: ['a.txt', 'b.txt'],
+        direction: 'push',
+      });
+
+      expect(result.transferred).toBe(1);
+      expect(result.errors).toHaveLength(1);
+    });
+  });
+
+  // --- Content preservation ---
+
+  describe('content preservation', () => {
+    it('preserves binary content through transfer', async () => {
+      const binaryData = Buffer.from([0x00, 0xff, 0x42, 0x89, 0xab]);
+      mockSourceBackend._files.set('binary.bin', binaryData);
+
+      const result = await transferFiles({
+        sourceGroup,
+        targetGroup,
+        files: ['binary.bin'],
+        direction: 'push',
+      });
+
+      expect(result.transferred).toBe(1);
+      expect(mockTargetBackend._written[0].content).toEqual(binaryData);
+    });
+
+    it('preserves text content through transfer', async () => {
+      const text = 'Hello, world! 🌍\nLine 2\n';
+      mockSourceBackend._files.set('text.txt', Buffer.from(text));
+
+      const result = await transferFiles({
+        sourceGroup,
+        targetGroup,
+        files: ['text.txt'],
+        direction: 'push',
+      });
+
+      expect(result.transferred).toBe(1);
+      expect(mockTargetBackend._written[0].content.toString()).toBe(text);
+    });
+  });
+});

--- a/src/router.test.ts
+++ b/src/router.test.ts
@@ -1,0 +1,144 @@
+/**
+ * Tests for router.ts functions not covered by formatting.test.ts.
+ *
+ * Covers: getAgentName, routeOutbound, findChannel.
+ * (escapeXml, formatMessages, stripInternalTags, formatOutbound
+ *  are already tested in formatting.test.ts)
+ */
+import { describe, it, expect } from 'bun:test';
+
+import { ASSISTANT_NAME } from './config.js';
+import { Channel, RegisteredGroup } from './types.js';
+import { getAgentName, routeOutbound, findChannel } from './router.js';
+
+// --- Mock Channel factory ---
+
+function makeChannel(opts: {
+  jids: string[];
+  connected?: boolean;
+  sentMessages?: Array<{ jid: string; text: string }>;
+}): Channel {
+  const sent = opts.sentMessages ?? [];
+  return {
+    ownsJid: (jid: string) => opts.jids.includes(jid),
+    isConnected: () => opts.connected ?? true,
+    sendMessage: async (jid: string, text: string) => {
+      sent.push({ jid, text });
+    },
+    prefixAssistantName: true,
+  } as unknown as Channel;
+}
+
+function makeGroup(overrides: Partial<RegisteredGroup> = {}): RegisteredGroup {
+  return {
+    name: 'Test Group',
+    folder: 'test-group',
+    trigger: '@TestBot',
+    added_at: '2026-01-01T00:00:00Z',
+    ...overrides,
+  };
+}
+
+// --- getAgentName ---
+
+describe('getAgentName', () => {
+  it('extracts name from trigger by stripping @ prefix', () => {
+    expect(getAgentName(makeGroup({ trigger: '@OmarOmni' }))).toBe('OmarOmni');
+  });
+
+  it('returns trigger as-is if no @ prefix', () => {
+    expect(getAgentName(makeGroup({ trigger: 'Omni' }))).toBe('Omni');
+  });
+
+  it('falls back to ASSISTANT_NAME when trigger is undefined', () => {
+    expect(getAgentName(makeGroup({ trigger: undefined }))).toBe(ASSISTANT_NAME);
+  });
+
+  it('falls back to ASSISTANT_NAME when trigger is empty', () => {
+    expect(getAgentName(makeGroup({ trigger: '' }))).toBe(ASSISTANT_NAME);
+  });
+
+  it('handles multi-word triggers', () => {
+    expect(getAgentName(makeGroup({ trigger: '@My Bot' }))).toBe('My Bot');
+  });
+});
+
+// --- findChannel ---
+
+describe('findChannel', () => {
+  it('finds channel that owns the JID', () => {
+    const ch1 = makeChannel({ jids: ['abc@g.us'] });
+    const ch2 = makeChannel({ jids: ['def@g.us'] });
+
+    const result = findChannel([ch1, ch2], 'def@g.us');
+    expect(result).toBe(ch2);
+  });
+
+  it('returns undefined when no channel owns the JID', () => {
+    const ch = makeChannel({ jids: ['abc@g.us'] });
+
+    const result = findChannel([ch], 'unknown@g.us');
+    expect(result).toBeUndefined();
+  });
+
+  it('returns first matching channel when multiple own same JID', () => {
+    const ch1 = makeChannel({ jids: ['abc@g.us'] });
+    const ch2 = makeChannel({ jids: ['abc@g.us'] });
+
+    const result = findChannel([ch1, ch2], 'abc@g.us');
+    expect(result).toBe(ch1);
+  });
+
+  it('handles empty channels array', () => {
+    expect(findChannel([], 'abc@g.us')).toBeUndefined();
+  });
+});
+
+// --- routeOutbound ---
+
+describe('routeOutbound', () => {
+  it('sends message via the channel that owns the JID', async () => {
+    const sent: Array<{ jid: string; text: string }> = [];
+    const ch = makeChannel({ jids: ['abc@g.us'], connected: true, sentMessages: sent });
+
+    await routeOutbound([ch], 'abc@g.us', 'Hello!');
+
+    expect(sent).toHaveLength(1);
+    expect(sent[0].jid).toBe('abc@g.us');
+    expect(sent[0].text).toBe('Hello!');
+  });
+
+  it('throws when no channel owns the JID', async () => {
+    const ch = makeChannel({ jids: ['other@g.us'] });
+
+    await expect(routeOutbound([ch], 'unknown@g.us', 'Hello!')).rejects.toThrow(
+      'No channel for JID: unknown@g.us',
+    );
+  });
+
+  it('throws when matching channel is not connected', async () => {
+    const ch = makeChannel({ jids: ['abc@g.us'], connected: false });
+
+    await expect(routeOutbound([ch], 'abc@g.us', 'Hello!')).rejects.toThrow(
+      'No channel for JID: abc@g.us',
+    );
+  });
+
+  it('sends to first connected channel when multiple match', async () => {
+    const sent1: Array<{ jid: string; text: string }> = [];
+    const sent2: Array<{ jid: string; text: string }> = [];
+    const ch1 = makeChannel({ jids: ['abc@g.us'], connected: false, sentMessages: sent1 });
+    const ch2 = makeChannel({ jids: ['abc@g.us'], connected: true, sentMessages: sent2 });
+
+    await routeOutbound([ch1, ch2], 'abc@g.us', 'Hello!');
+
+    expect(sent1).toHaveLength(0);
+    expect(sent2).toHaveLength(1);
+  });
+
+  it('handles empty channels array', async () => {
+    await expect(routeOutbound([], 'abc@g.us', 'Hello!')).rejects.toThrow(
+      'No channel for JID: abc@g.us',
+    );
+  });
+});


### PR DESCRIPTION
## Summary

- Add 17 tests for `file-transfer.ts` — validates push/pull direction logic, path traversal rejection (security-critical, exercises the defense-in-depth from PR #35), backend error handling, file-not-found, content preservation (binary + text), and empty inputs
- Add 14 tests for `router.ts` — covers `getAgentName` (trigger parsing, `@`-prefix stripping, ASSISTANT_NAME fallback), `findChannel` (JID matching, empty array, duplicates), and `routeOutbound` (connected channel routing, error on missing/disconnected channels)
- Complements existing `formatting.test.ts` which covers `escapeXml`, `formatMessages`, `stripInternalTags`, `formatOutbound`

## Test plan

- [x] All 344 tests pass (341 pass, 3 skip, 0 fail)
- [x] TypeScript type check clean (`tsc --noEmit`)
- [x] No mock pollution between test files (verified formatting.test.ts still passes)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added comprehensive test suite for file transfer operations including transfer validation, security checks, error handling, and data integrity verification.
  * Added test suite for router functionality including agent name parsing, channel discovery, and message routing behaviors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->