### PR TITLE
fix(security): block .env access from project root mount

### DIFF
--- a/container/agent-runner/src/__tests__/security-hooks.test.ts
+++ b/container/agent-runner/src/__tests__/security-hooks.test.ts
@@ -66,6 +66,15 @@ describe('Security Hooks - Issue #79', () => {
       await expect(hook(input as any, 'id', {} as any)).rejects.toThrow(/restricted file/i);
     });
 
+    it('should block redirected access to /workspace/project/.env', async () => {
+      const hook = createSanitizeBashHook();
+      const input = {
+        tool_name: 'Bash',
+        tool_input: { command: 'cat /workspace/project/.env>/tmp/out' },
+      };
+      await expect(hook(input as any, 'id', {} as any)).rejects.toThrow(/restricted file/i);
+    });
+
     it('should block access to /proc/self/mountinfo', async () => {
       const hook = createSanitizeBashHook();
       const input = {

--- a/container/agent-runner/src/index.ts
+++ b/container/agent-runner/src/index.ts
@@ -397,7 +397,7 @@ export function createSanitizeBashHook(): HookCallback {
     const blockedPaths = [
       /\/tmp\/input\.json/,              // Stdin buffer
       /\/workspace\/env-dir(?:\/|$)/,   // Mounted env directory (with or without trailing slash)
-      /\/workspace\/project\/\.env(?:\s|$|[;|&])/,  // Project root .env (masked by /dev/null mount, defense-in-depth)
+      /\/workspace\/project\/\.env(?:\s|$|[;|&><)\n]|\$\()/,  // Project root .env (masked by /dev/null mount, defense-in-depth)
       /\/proc\/.*\/mountinfo/,       // Mount enumeration
       /\/proc\/.*\/mounts/,          // Mount list
       /\/etc\/mtab/,                 // Mount table

--- a/docs/SECURITY.md
+++ b/docs/SECURITY.md
@@ -99,7 +99,7 @@ const allowedVars = [
 **Project Root `.env` Protection (Defense-in-Depth):**
 
 The project root is bind-mounted read-only at `/workspace/project`. The `.env` file
-contains ALL secrets (not just `allowedVars`). Three layers prevent agent access:
+contains ALL secrets (not just `allowedVars`). Four layers prevent agent access:
 
 1. **Mount overlay** - `/dev/null` is mounted over `/workspace/project/.env`,
    making the file appear empty at the kernel level (upstream PR #419)

--- a/src/backends/local-backend.ts
+++ b/src/backends/local-backend.ts
@@ -77,8 +77,8 @@ function buildVolumeMounts(
     // Secrets should only flow through the filtered env-dir mount (allowedVars).
     // Overlay /dev/null so `cat /workspace/project/.env` returns empty content.
     // (Upstream PR #419, Issue #40)
-    const envFile = path.join(projectRoot, '.env');
-    if (fs.existsSync(envFile)) {
+    const projectEnvFile = path.join(projectRoot, '.env');
+    if (fs.existsSync(projectEnvFile)) {
       mounts.push({
         hostPath: '/dev/null',
         containerPath: '/workspace/project/.env',


### PR DESCRIPTION
## Summary

The project root is bind-mounted at `/workspace/project` (read-only per PR #30). However, the `.env` file containing **ALL secrets** (not just the filtered `allowedVars` subset) was still readable via `cat /workspace/project/.env`.

Existing protections were insufficient:
- `.claude/settings.json` deny rule (PR #127) — only blocks Claude Code's Read tool, bypassed by Bash
- CLAUDE.md instruction — prompt-level only, not enforceable
- env-dir hooks — block `/workspace/env-dir/`, not `/workspace/project/.env`

### Defense-in-Depth Fix (3 layers)

| Layer | Mechanism | Bypass Resistance |
|-------|-----------|------------------|
| **Mount overlay** | `/dev/null` → `/workspace/project/.env` | Kernel-level, cannot be bypassed by any tool |
| **Bash hook** | Blocks commands accessing the path | Catches attempts before execution |
| **Read hook** | Blocks Read tool access with symlink resolution | Catches Read tool + path traversal |

### Changes

- `src/backends/local-backend.ts` — Add `/dev/null` mount overlay after project root mount (+14 LOC)
- `container/agent-runner/src/index.ts` — Add `/workspace/project/.env` to both Bash and Read hook blocked patterns (+3 LOC)
- `container/agent-runner/src/__tests__/security-hooks.test.ts` — 4 new test cases (+36 LOC)
- `docs/SECURITY.md` — Document the protection layers (+13 LOC)

Adopts approach from [Upstream PR #419](https://github.com/qwibitai/nanoclaw/pull/419) with fork-specific adaptations (local-backend.ts instead of container-runner.ts).

Fixes #44

## Test plan

- [x] All 361 tests pass (`bun test`)
- [x] TypeScript clean (`npx tsc --noEmit`)
- [x] New tests cover: `cat .env`, `grep .env`, piped `.env` access (Bash hook), and Read tool `.env` access
- [ ] Verify mount overlay in Apple Container (file-level bind mount compatibility)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Security**
  * Enhanced protection of project .env and sensitive config files with additional runtime safeguards and masking to prevent leakage.
  * Strengthened multi-layered defenses and credential isolation inside containers.

* **Tests**
  * Added test coverage validating blocked access to project .env via file reads and shell operations.

* **Documentation**
  * Expanded security guidance and credential-handling notes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->