### PR TITLE
refactor: extract duplicated reaction handlers (-90 lines)

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1016,24 +1016,19 @@ async function handleReactionNotification(
 
   const reactionContent = `@${ASSISTANT_NAME} [${userName} reacted with ${emoji}]`;
 
-  const piped = await queue.sendMessage(chatJid, formatMessages([{
+  const reactionMessage = {
     id: `react-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`,
     chat_jid: chatJid,
     sender: 'system',
     sender_name: 'System',
     content: reactionContent,
     timestamp: new Date().toISOString(),
-  }]));
+    is_from_me: false,
+  };
+
+  const piped = await queue.sendMessage(chatJid, formatMessages([reactionMessage]));
   if (!piped) {
-    storeMessage({
-      id: `react-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`,
-      chat_jid: chatJid,
-      sender: 'system',
-      sender_name: 'System',
-      content: reactionContent,
-      timestamp: new Date().toISOString(),
-      is_from_me: false,
-    });
+    storeMessage(reactionMessage);
     queue.enqueueMessageCheck(chatJid);
   }
 }


### PR DESCRIPTION
## Summary
- Extracted share-request approval logic (duplicated 3x across WhatsApp, Discord, Slack) into `handleShareRequestApproval()`
- Extracted reaction notification logic (duplicated 2x across Discord, Slack) into `handleReactionNotification()`
- Net reduction of 90 lines in `src/index.ts` with no behavior change

## Details
The `onReaction` callbacks for all three channel adapters contained nearly identical code for:
1. Checking if a reaction is a share-request approval, consuming the tracked request, building a synthetic message, and enqueuing it
2. Building a reaction notification message, attempting to pipe it to an active container, and falling back to DB storage

Each channel handler now calls the shared functions, keeping only the platform-specific emoji format checks inline.

## Test plan
- [x] `bun tsc --noEmit` passes
- [x] All 361 tests pass (`bun test`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Refactored internal reaction handling and share approval workflows across messaging channels to standardize processing and reduce code duplication.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->