### PR TITLE
test: add IPC processing, DB CRUD, and splitMessage coverage

### DIFF
--- a/src/db.ts
+++ b/src/db.ts
@@ -248,6 +248,11 @@ export function _initTestDatabase(): void {
   createSchema(db);
 }
 
+/** @internal - for tests only. Backdates a session's created_at timestamp. */
+export function _backdateSessionForTest(groupJid: string, isoTimestamp: string): void {
+  db.prepare('UPDATE sessions SET created_at = ? WHERE group_folder = ?').run(isoTimestamp, groupJid);
+}
+
 /**
  * Store chat metadata only (no message content).
  * Used for all chats to enable group discovery without storing sensitive content.


### PR DESCRIPTION
## Summary
• Add 61 new tests covering previously untested `processTaskIpc` cases: `configure_heartbeat` (7 tests), `share_request` (7 tests), `delegate_task` (4 tests), `context_request` (3 tests), `refresh_groups` (2 tests), `register_group` with Discord fields (3 tests), task snapshot refresh (3 tests), and unknown type handling (1 test)
• Add database CRUD tests for `expireStaleSessions`/`setSession`/`getAllSessions` (6 tests), Agent operations (7 tests), and ChannelRoute operations (7 tests)
• Add `splitMessage` channel utility tests (10 tests) covering newline/space boundary splitting, hard splits, edge cases, and platform-specific limits (Discord 2000, Slack 4000)

## Test plan
- [x] All 61 new tests pass
- [x] Full test suite passes (422 pass, 3 pre-existing skips, 0 fail)
- [x] No mocking of modules — tests use real DB (in-memory SQLite) and real function calls

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added a comprehensive test suite covering IPC workflows, group synchronization, task lifecycle (schedule/pause/cancel), agent and channel data handling, session expiration behavior, and message-splitting across platform limits to improve reliability and prevent regressions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->