### PR TITLE
refactor: add typed IPC payloads, remove `any` from processing pipeline

### DIFF
--- a/src/backends/daytona-ipc-poller.ts
+++ b/src/backends/daytona-ipc-poller.ts
@@ -10,14 +10,14 @@ import { type Sandbox } from '@daytonaio/sdk';
 
 import { IPC_POLL_INTERVAL } from '../config.js';
 import { logger } from '../logger.js';
-import { RegisteredGroup } from '../types.js';
+import { IpcMessagePayload, IpcTaskPayload, RegisteredGroup } from '../types.js';
 import { DaytonaBackend } from './daytona-backend.js';
 
 interface DaytonaIpcPollerDeps {
   daytonaBackend: DaytonaBackend;
   registeredGroups: () => Record<string, RegisteredGroup>;
-  processMessage: (sourceGroup: string, data: any) => Promise<void>;
-  processTask: (sourceGroup: string, isMain: boolean, data: any) => Promise<void>;
+  processMessage: (sourceGroup: string, data: IpcMessagePayload) => Promise<void>;
+  processTask: (sourceGroup: string, isMain: boolean, data: IpcTaskPayload) => Promise<void>;
 }
 
 let pollerRunning = false;
@@ -93,7 +93,7 @@ async function pollDirectory(
     return; // Directory doesn't exist yet
   }
 
-  const jsonFiles = entries.filter((e: any) => !e.isDir && e.name.endsWith('.json'));
+  const jsonFiles = entries.filter((e) => !e.isDir && e.name.endsWith('.json'));
 
   for (const entry of jsonFiles) {
     const filePath = `${dirPath}/${entry.name}`;

--- a/src/backends/sprites-ipc-poller.ts
+++ b/src/backends/sprites-ipc-poller.ts
@@ -6,7 +6,7 @@
 
 import { IPC_POLL_INTERVAL } from '../config.js';
 import { logger } from '../logger.js';
-import { RegisteredGroup } from '../types.js';
+import { IpcMessagePayload, IpcTaskPayload, RegisteredGroup } from '../types.js';
 import { SpritesBackend } from './sprites-backend.js';
 
 const API_BASE = 'https://api.sprites.dev/v1';
@@ -15,9 +15,9 @@ interface SpritesIpcPollerDeps {
   spritesBackend: SpritesBackend;
   registeredGroups: () => Record<string, RegisteredGroup>;
   /** Process an IPC message file's contents */
-  processMessage: (sourceGroup: string, data: any) => Promise<void>;
+  processMessage: (sourceGroup: string, data: IpcMessagePayload) => Promise<void>;
   /** Process an IPC task file's contents */
-  processTask: (sourceGroup: string, isMain: boolean, data: any) => Promise<void>;
+  processTask: (sourceGroup: string, isMain: boolean, data: IpcTaskPayload) => Promise<void>;
 }
 
 let pollerRunning = false;

--- a/src/backends/types.ts
+++ b/src/backends/types.ts
@@ -3,9 +3,9 @@
  * Defines the AgentBackend interface that all backends implement.
  */
 
-import { Agent, ContainerProcess, RegisteredGroup } from '../types.js';
+import { Agent, type BackendType, ContainerProcess, RegisteredGroup } from '../types.js';
 
-export type BackendType = 'apple-container' | 'docker' | 'sprites' | 'daytona' | 'railway' | 'hetzner';
+export type { BackendType };
 
 /**
  * Unified group-or-agent type for backwards compatibility.

--- a/src/s3/ipc-poller.ts
+++ b/src/s3/ipc-poller.ts
@@ -9,6 +9,7 @@
 
 import { IPC_POLL_INTERVAL } from '../config.js';
 import { logger } from '../logger.js';
+import type { IpcMessagePayload, IpcTaskPayload } from '../types.js';
 import type { OmniClawS3 } from './client.js';
 import type { S3Output } from './types.js';
 
@@ -19,9 +20,9 @@ export interface S3IpcPollerDeps {
   /** Process an outbox result (deliver to channel). */
   processOutput: (agentId: string, output: S3Output) => Promise<void>;
   /** Process an IPC message file's contents (from agent's IPC messages dir). */
-  processMessage: (sourceAgentId: string, data: any) => Promise<void>;
+  processMessage: (sourceAgentId: string, data: IpcMessagePayload) => Promise<void>;
   /** Process an IPC task file's contents. */
-  processTask: (sourceAgentId: string, isAdmin: boolean, data: any) => Promise<void>;
+  processTask: (sourceAgentId: string, isAdmin: boolean, data: IpcTaskPayload) => Promise<void>;
   /** Check if an agent is admin. */
   isAdmin: (agentId: string) => boolean;
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -206,3 +206,61 @@ export function registeredGroupToRoute(jid: string, group: RegisteredGroup): Cha
     createdAt: group.added_at,
   };
 }
+
+// --- IPC Data Types ---
+
+/** IPC message payloads sent by agents to the orchestrator. */
+export interface IpcMessagePayload {
+  type: string;
+  chatJid?: string;
+  text?: string;
+  messageId?: string;
+  emoji?: string;
+  remove?: boolean;
+  userName?: string;
+  platform?: string;
+  requestId?: string;
+  pubkey?: string;
+}
+
+/** IPC task payloads sent by agents to the orchestrator. */
+export interface IpcTaskPayload {
+  type: string;
+  taskId?: string;
+  prompt?: string;
+  schedule_type?: string;
+  schedule_value?: string;
+  context_mode?: string;
+  groupFolder?: string;
+  chatJid?: string;
+  targetJid?: string;
+  // For register_group
+  jid?: string;
+  name?: string;
+  folder?: string;
+  trigger?: string;
+  requiresTrigger?: boolean;
+  containerConfig?: ContainerConfig;
+  discord_guild_id?: string;
+  // For configure_heartbeat
+  enabled?: boolean;
+  interval?: string;
+  heartbeat_schedule_type?: string;
+  target_group_jid?: string;
+  // For share_request
+  description?: string;
+  sourceGroup?: string;
+  scope?: string;
+  serverFolder?: string;
+  discordGuildId?: string;
+  target_agent?: string;
+  files?: string[];
+  request_files?: string[];
+  // For register_group: backend config
+  backend?: BackendType;
+  group_description?: string;
+  // For delegate_task
+  callbackAgentId?: string;
+  // For context_request
+  requestedTopics?: string[];
+}

--- a/src/types.ts
+++ b/src/types.ts
@@ -46,7 +46,7 @@ export interface HeartbeatConfig {
   scheduleType: 'cron' | 'interval';
 }
 
-export type BackendType = 'apple-container' | 'docker' | 'sprites' | 'daytona' | 'railway';
+export type BackendType = 'apple-container' | 'docker' | 'sprites' | 'daytona' | 'railway' | 'hetzner';
 
 export interface RegisteredGroup {
   name: string;


### PR DESCRIPTION
## Summary
- Extract `IpcMessagePayload` and `IpcTaskPayload` interfaces into `src/types.ts`, replacing `any` across the IPC processing pipeline
- Eliminate 11 `any` usages in `ipc.ts`, `s3/ipc-poller.ts`, `sprites-ipc-poller.ts`, and `daytona-ipc-poller.ts`
- Remove redundant `as string` casts in `ipc.ts` that are no longer needed with proper typing
- Remove `(e: any)` annotation in `daytona-ipc-poller.ts` (Daytona SDK already provides `FileInfo` type)

## Test plan
- [x] `npx tsc --noEmit` passes with zero errors
- [x] `bun run build` succeeds
- [x] `bun test` passes (418 pass, 4 pre-existing failures unrelated to this change)
- [x] All 121 IPC-specific tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a new backend option: hetzner.

* **Refactor**
  * Tightened inter-process communication typings across IPC handlers and pollers for improved reliability and consistency.
  * Introduced formal IPC payload types for messages and tasks, aligning public interfaces.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->