### PR TITLE
ci: add tsc --noEmit type checking to CI workflow

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -5,6 +5,14 @@ on:
     branches: [main]
 
 jobs:
+  check:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: oven-sh/setup-bun@v2
+      - run: bun install
+      - run: npx tsc --noEmit
+
   test:
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
## Summary
- Adds a separate `check` job to the CI workflow that runs `npx tsc --noEmit`
- Catches TypeScript errors before merge (bun build only transpiles, doesn't type-check)
- Prevents regressions like #25 (22 TS errors merged undetected, fixed by PR #27)

## Test plan
- [ ] CI passes on this PR (meta: the new `check` job validates itself)
- [ ] Existing `test` job still runs independently

Closes #47

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced CI/CD pipeline to include TypeScript type checking in automated build workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->