### PR TITLE
security: add --pids-limit and --no-new-privileges to containers

### DIFF
--- a/src/backends/hetzner-backend.ts
+++ b/src/backends/hetzner-backend.ts
@@ -252,6 +252,8 @@ runcmd:
   - ssh-keyscan github.com >> /root/.ssh/known_hosts 2>/dev/null
   - docker pull ${CONTAINER_IMAGE}
   - docker run -d --name ${appName}-agent \\
+      --pids-limit 256 \\
+      --security-opt no-new-privileges:true \\
       -v /root/.ssh:/home/bun/.ssh:ro \\
       -e OMNICLAW_S3_ENDPOINT=${B2_ENDPOINT} \\
       -e OMNICLAW_S3_REGION=${B2_REGION} \\

--- a/src/backends/local-backend.ts
+++ b/src/backends/local-backend.ts
@@ -238,7 +238,13 @@ function buildVolumeMounts(
 }
 
 function buildContainerArgs(mounts: VolumeMount[], containerName: string): string[] {
-  const args: string[] = ['run', '-i', '--rm', '--memory', CONTAINER_MEMORY, '--name', containerName];
+  const args: string[] = [
+    'run', '-i', '--rm',
+    '--memory', CONTAINER_MEMORY,
+    '--pids-limit', '256',
+    '--security-opt', 'no-new-privileges:true',
+    '--name', containerName,
+  ];
 
   // Pass host timezone so container's local time matches the user's
   args.push('-e', `TZ=${TIMEZONE}`);


### PR DESCRIPTION
## Summary
- Adds `--pids-limit 256` to prevent fork bomb / runaway process attacks inside containers
- Adds `--security-opt no-new-privileges:true` to prevent privilege escalation (setuid binaries, capabilities)
- Applied to both local (Apple Container) and Hetzner (Docker) backends
- Inspired by [upstream PR #395](https://github.com/qwibitai/nanoclaw/pull/395)

## Changes
- `src/backends/local-backend.ts`: Added flags to `buildContainerArgs()`
- `src/backends/hetzner-backend.ts`: Added flags to cloud-init `docker run` command

## Test plan
- [ ] Verify local containers start with the new flags
- [ ] Verify Hetzner cloud-init script includes the flags
- [ ] All 422 existing tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)