### PR TITLE
refactor: extract task lifecycle handler + use shared splitMessage

### DIFF
--- a/src/channels/telegram.ts
+++ b/src/channels/telegram.ts
@@ -197,8 +197,9 @@ export class TelegramChannel implements Channel {
         ? { reply_parameters: { message_id: parseInt(replyToMessageId, 10) } }
         : {};
 
-      // Telegram has a 4096 character limit per message — split if needed
-      const chunks = splitMessage(text, 4096);
+      // Telegram has a 4096 character limit per message — split if needed.
+      // Preserve leading whitespace so code blocks / indented content aren't mangled.
+      const chunks = splitMessage(text, 4096, { preserveLeadingWhitespace: true });
       for (let i = 0; i < chunks.length; i++) {
         const opts = i === 0 ? replyParams : {};
         await this.bot.api.sendMessage(numericId, chunks[i], opts);

--- a/src/channels/telegram.ts
+++ b/src/channels/telegram.ts
@@ -6,6 +6,7 @@ import {
 } from '../config.js';
 import { logger } from '../logger.js';
 import { Channel, OnInboundMessage, OnChatMetadata, RegisteredGroup } from '../types.js';
+import { splitMessage } from './utils.js';
 
 export interface TelegramChannelOpts {
   onMessage: OnInboundMessage;
@@ -197,14 +198,10 @@ export class TelegramChannel implements Channel {
         : {};
 
       // Telegram has a 4096 character limit per message — split if needed
-      const MAX_LENGTH = 4096;
-      if (text.length <= MAX_LENGTH) {
-        await this.bot.api.sendMessage(numericId, text, replyParams);
-      } else {
-        for (let i = 0; i < text.length; i += MAX_LENGTH) {
-          const opts = i === 0 ? replyParams : {};
-          await this.bot.api.sendMessage(numericId, text.slice(i, i + MAX_LENGTH), opts);
-        }
+      const chunks = splitMessage(text, 4096);
+      for (let i = 0; i < chunks.length; i++) {
+        const opts = i === 0 ? replyParams : {};
+        await this.bot.api.sendMessage(numericId, chunks[i], opts);
       }
       logger.info({ jid, length: text.length }, 'Telegram message sent');
     } catch (err) {

--- a/src/channels/utils.ts
+++ b/src/channels/utils.ts
@@ -2,15 +2,37 @@
  * Shared utilities for channel implementations.
  */
 
+export interface SplitMessageOptions {
+  /** If true, prefer splitting at newlines/spaces rather than mid-word (default: true). */
+  preferBreaks?: boolean;
+  /**
+   * If true, only strip the delimiter character (newline/space) at the split point,
+   * preserving any leading whitespace on subsequent chunks. Useful for platforms
+   * where messages may contain code blocks or indented content (e.g. Telegram).
+   * Default: false (strips one leading newline or space).
+   */
+  preserveLeadingWhitespace?: boolean;
+}
+
 /**
  * Split a long message into chunks that fit within a platform's message limit.
  *
  * @param text - The text to split
  * @param maxLength - Maximum characters per chunk (e.g. 2000 for Discord, 4000 for Slack)
- * @param preferBreaks - If true, prefer splitting at newlines/spaces rather than mid-word.
- *                       If false, splits at exact maxLength boundaries.
+ * @param optsOrPreferBreaks - Options object or legacy boolean for preferBreaks
  */
-export function splitMessage(text: string, maxLength: number, preferBreaks = true): string[] {
+export function splitMessage(
+  text: string,
+  maxLength: number,
+  optsOrPreferBreaks: SplitMessageOptions | boolean = true,
+): string[] {
+  const opts: SplitMessageOptions =
+    typeof optsOrPreferBreaks === 'boolean'
+      ? { preferBreaks: optsOrPreferBreaks }
+      : optsOrPreferBreaks;
+  const preferBreaks = opts.preferBreaks ?? true;
+  const preserveLeadingWhitespace = opts.preserveLeadingWhitespace ?? false;
+
   if (text.length <= maxLength) return [text];
 
   if (!preferBreaks) {
@@ -22,17 +44,32 @@ export function splitMessage(text: string, maxLength: number, preferBreaks = tru
     return chunks;
   }
 
-  // Prefer splitting at newlines/spaces (used by Discord)
+  // Prefer splitting at newlines/spaces (used by Discord, Telegram)
   const chunks: string[] = [];
   let remaining = text;
 
   while (remaining.length > maxLength) {
     let splitIdx = remaining.lastIndexOf('\n', maxLength);
-    if (splitIdx <= 0) splitIdx = remaining.lastIndexOf(' ', maxLength);
+    const splitAtNewline = splitIdx > 0;
+    if (!splitAtNewline) splitIdx = remaining.lastIndexOf(' ', maxLength);
     if (splitIdx <= 0) splitIdx = maxLength;
 
     chunks.push(remaining.slice(0, splitIdx));
-    remaining = remaining.slice(splitIdx).replace(/^[\n ]/, '');
+    remaining = remaining.slice(splitIdx);
+
+    if (preserveLeadingWhitespace) {
+      // Only strip the delimiter character at the split point:
+      // - newline split: strip the leading '\n', preserve any indentation on the next line
+      // - space split: strip the leading ' '
+      if (splitAtNewline) {
+        remaining = remaining.replace(/^\n/, '');
+      } else {
+        remaining = remaining.replace(/^ /, '');
+      }
+    } else {
+      // Legacy behavior: strip one leading newline or space
+      remaining = remaining.replace(/^[\n ]/, '');
+    }
   }
 
   if (remaining) chunks.push(remaining);

--- a/src/ipc.ts
+++ b/src/ipc.ts
@@ -243,13 +243,11 @@ export function startIpcWatcher(deps: IpcDeps): void {
                     if (user) {
                       switch (user.platform) {
                         case 'discord':
+                        case 'slack':
                           formattedMention = `<@${user.id}>`;
                           break;
                         case 'whatsapp':
                           formattedMention = `@${user.id}`;
-                          break;
-                        case 'slack':
-                          formattedMention = `<@${user.id}>`;
                           break;
                         default:
                           formattedMention = `@${user.name}`;
@@ -473,6 +471,29 @@ export async function processTaskIpc(
     deps.writeTasksSnapshot?.(sourceGroup, isMain);
   };
 
+  /** Shared handler for pause/resume/cancel — identical auth + dispatch pattern */
+  const TASK_ACTION_LABELS: Record<string, string> = {
+    pause_task: 'paused',
+    resume_task: 'resumed',
+    cancel_task: 'cancelled',
+  };
+  const handleTaskLifecycle = (action: string, taskId: string | undefined, srcGroup: string, isMainGroup: boolean) => {
+    if (!taskId) return;
+    const task = getTaskById(taskId);
+    const label = TASK_ACTION_LABELS[action] ?? action;
+    if (task && (isMainGroup || task.group_folder === srcGroup)) {
+      if (action === 'cancel_task') {
+        deleteTask(taskId);
+      } else {
+        updateTask(taskId, { status: action === 'pause_task' ? 'paused' : 'active' });
+      }
+      logger.info({ taskId, sourceGroup: srcGroup }, `Task ${label} via IPC`);
+      refreshTasksSnapshot();
+    } else {
+      logger.warn({ taskId, sourceGroup: srcGroup }, `Unauthorized task ${label.replace('d', '')} attempt`);
+    }
+  };
+
   switch (data.type) {
     case 'schedule_task':
       if (
@@ -541,60 +562,9 @@ export async function processTaskIpc(
       break;
 
     case 'pause_task':
-      if (data.taskId) {
-        const task = getTaskById(data.taskId);
-        if (task && (isMain || task.group_folder === sourceGroup)) {
-          updateTask(data.taskId, { status: 'paused' });
-          logger.info(
-            { taskId: data.taskId, sourceGroup },
-            'Task paused via IPC',
-          );
-          refreshTasksSnapshot();
-        } else {
-          logger.warn(
-            { taskId: data.taskId, sourceGroup },
-            'Unauthorized task pause attempt',
-          );
-        }
-      }
-      break;
-
     case 'resume_task':
-      if (data.taskId) {
-        const task = getTaskById(data.taskId);
-        if (task && (isMain || task.group_folder === sourceGroup)) {
-          updateTask(data.taskId, { status: 'active' });
-          logger.info(
-            { taskId: data.taskId, sourceGroup },
-            'Task resumed via IPC',
-          );
-          refreshTasksSnapshot();
-        } else {
-          logger.warn(
-            { taskId: data.taskId, sourceGroup },
-            'Unauthorized task resume attempt',
-          );
-        }
-      }
-      break;
-
     case 'cancel_task':
-      if (data.taskId) {
-        const task = getTaskById(data.taskId);
-        if (task && (isMain || task.group_folder === sourceGroup)) {
-          deleteTask(data.taskId);
-          logger.info(
-            { taskId: data.taskId, sourceGroup },
-            'Task cancelled via IPC',
-          );
-          refreshTasksSnapshot();
-        } else {
-          logger.warn(
-            { taskId: data.taskId, sourceGroup },
-            'Unauthorized task cancel attempt',
-          );
-        }
-      }
+      handleTaskLifecycle(data.type, data.taskId, sourceGroup, isMain);
       break;
 
     case 'refresh_groups':


### PR DESCRIPTION
## Summary

• Extract `handleTaskLifecycle` helper in ipc.ts — consolidates near-identical pause/resume/cancel switch cases (-33 net lines)
• Merge discord/slack cases in `format_mention` switch — both use identical `<@${user.id}>` format
• Use shared `splitMessage()` utility in Telegram channel — replaces naive character-boundary splitting that could break mid-word

## Changes

| File | Before | After | Net |
|------|--------|-------|-----|
| `src/ipc.ts` | 3 duplicate switch cases (55 lines) | 1 shared handler (22 lines) | -33 |
| `src/ipc.ts` | Separate discord/slack format_mention | Combined with fallthrough | -2 |
| `src/channels/telegram.ts` | Inline character-boundary split | Shared `splitMessage()` from utils.ts | +1/-8 |

## Test plan

- [x] `npx tsc --noEmit` passes (zero type errors)
- [x] `bun test` — 432 pass, 0 fail, 802 expect() calls

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Consolidated task lifecycle actions (pause, resume, cancel) into a single unified handler for streamlined processing and logging.
* **Improvements**
  * Messaging now uses an updated chunking utility that preserves leading whitespace to avoid mangling code blocks and indented content.
  * Slack user-mention formatting now aligns with Discord for consistent behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->