### PR TITLE
ci: fix update-tokens workflow failing when secrets not configured

### DIFF
--- a/.github/workflows/update-tokens.yml
+++ b/.github/workflows/update-tokens.yml
@@ -9,24 +9,38 @@ on:
 jobs:
   update-tokens:
     runs-on: ubuntu-latest
-    # Skip if GitHub App secrets aren't configured (fork without app setup)
-    if: ${{ secrets.APP_ID != '' }}
     steps:
+      - name: Check for GitHub App secrets
+        id: check-secrets
+        run: |
+          if [ -z "$APP_ID" ]; then
+            echo "skip=true" >> "$GITHUB_OUTPUT"
+            echo "GitHub App secrets not configured, skipping token count update"
+          else
+            echo "skip=false" >> "$GITHUB_OUTPUT"
+          fi
+        env:
+          APP_ID: ${{ secrets.APP_ID }}
+
       - uses: actions/create-github-app-token@v1
+        if: steps.check-secrets.outputs.skip != 'true'
         id: app-token
         with:
           app-id: ${{ secrets.APP_ID }}
           private-key: ${{ secrets.APP_PRIVATE_KEY }}
 
       - uses: actions/checkout@v4
+        if: steps.check-secrets.outputs.skip != 'true'
         with:
           token: ${{ steps.app-token.outputs.token }}
 
       - uses: actions/setup-python@v5
+        if: steps.check-secrets.outputs.skip != 'true'
         with:
           python-version: '3.12'
 
       - uses: ./repo-tokens
+        if: steps.check-secrets.outputs.skip != 'true'
         id: tokens
         with:
           include: 'src/**/*.ts container/agent-runner/src/**/*.ts container/Dockerfile container/build.sh launchd/com.omniclaw.plist CLAUDE.md'
@@ -34,6 +48,7 @@ jobs:
           badge-path: 'repo-tokens/badge.svg'
 
       - name: Commit if changed
+        if: steps.check-secrets.outputs.skip != 'true'
         run: |
           git add README.md repo-tokens/badge.svg
           git diff --cached --quiet && exit 0


### PR DESCRIPTION
## Summary
- Move secret check from job-level `if` to step-level shell check
- Job-level `if: secrets.APP_ID != ''` was causing "workflow file issue" failures instead of clean skips when GitHub App secrets aren't configured
- Step-level approach runs the job successfully (green ✅) with all subsequent steps skipped via `GITHUB_OUTPUT`

## Context
The `update-tokens.yml` workflow has been failing on every push to main since the repo doesn't have `APP_ID` / `APP_PRIVATE_KEY` secrets configured. While the existing job-level `if` condition *should* skip the job, GitHub Actions reports it as a "workflow file issue" failure with 0s duration and no jobs.

The fix checks for secrets in the first step and propagates a `skip` output to all subsequent steps, ensuring the workflow completes successfully rather than showing a failure badge.

## Test plan
- [ ] Push to main branch with `src/**` changes → workflow should run and show green (all steps skipped)
- [ ] Verify Test and Skill PR Check workflows still pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved workflow configuration handling to ensure steps skip gracefully when required secrets are not configured.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->