### PR TITLE
fix: prevent SQLite FK crash when task deleted during execution

### DIFF
--- a/src/db.ts
+++ b/src/db.ts
@@ -560,10 +560,12 @@ export function updateTaskAfterRun(
 }
 
 export function logTaskRun(log: TaskRunLog): void {
+  // Use SELECT ... WHERE EXISTS to skip gracefully if the task was deleted while running.
   db.query(
     `
     INSERT INTO task_run_logs (task_id, run_at, duration_ms, status, result, error)
-    VALUES (?, ?, ?, ?, ?, ?)
+    SELECT ?, ?, ?, ?, ?, ?
+    WHERE EXISTS (SELECT 1 FROM scheduled_tasks WHERE id = ?)
   `,
   ).run(
     log.task_id,
@@ -572,6 +574,7 @@ export function logTaskRun(log: TaskRunLog): void {
     log.status,
     log.result,
     log.error,
+    log.task_id,
   );
 }
 

--- a/src/task-scheduler.test.ts
+++ b/src/task-scheduler.test.ts
@@ -366,9 +366,23 @@ describe('DB task lifecycle', () => {
     it('silently no-ops when task was deleted while running', () => {
       // Simulate: task existed when run started, but was deleted before logTaskRun
       // Should NOT throw SQLITE_CONSTRAINT_FOREIGNKEY
+      createTask({
+        id: 'deleted-task',
+        group_folder: 'main',
+        chat_jid: 'g@g.us',
+        prompt: 'run me',
+        schedule_type: 'once',
+        schedule_value: '2024-06-01T00:00:00.000Z',
+        context_mode: 'isolated',
+        next_run: null,
+        status: 'active',
+        created_at: '2024-01-01T00:00:00.000Z',
+      });
+      deleteTask('deleted-task');
+
       expect(() => {
         logTaskRun({
-          task_id: 'nonexistent-deleted-task',
+          task_id: 'deleted-task',
           run_at: '2024-06-01T00:00:01.000Z',
           duration_ms: 3000,
           status: 'success',

--- a/src/task-scheduler.test.ts
+++ b/src/task-scheduler.test.ts
@@ -363,6 +363,21 @@ describe('DB task lifecycle', () => {
       });
     });
 
+    it('silently no-ops when task was deleted while running', () => {
+      // Simulate: task existed when run started, but was deleted before logTaskRun
+      // Should NOT throw SQLITE_CONSTRAINT_FOREIGNKEY
+      expect(() => {
+        logTaskRun({
+          task_id: 'nonexistent-deleted-task',
+          run_at: '2024-06-01T00:00:01.000Z',
+          duration_ms: 3000,
+          status: 'success',
+          result: 'completed but task gone',
+          error: null,
+        });
+      }).not.toThrow();
+    });
+
     it('deleteTask cleans up associated run logs', () => {
       createTask({
         id: 'cleanup-task',


### PR DESCRIPTION
## Summary
- [Upstream PR #433] `logTaskRun` now uses `INSERT...SELECT...WHERE EXISTS` so inserting a run log for a task that was deleted while running silently no-ops instead of throwing `SQLITE_CONSTRAINT_FOREIGNKEY`
- Root cause: if a scheduled task is cancelled/deleted while its execution is in-flight, `logTaskRun` tries to insert a foreign-key reference to a now-deleted task, crashing the scheduler
- Adds test verifying the no-op behavior for nonexistent tasks

## Changes
- `src/db.ts`: Changed `INSERT INTO ... VALUES` to `INSERT ... SELECT ... WHERE EXISTS` pattern (+3/-1 LOC)
- `src/task-scheduler.test.ts`: Added test case for deleted-task scenario (+15 LOC)

## Test plan
- [x] All 423 tests pass (51 in task-scheduler, up from 50)
- [x] `tsc --noEmit` clean
- [x] New test verifies `logTaskRun` doesn't throw for nonexistent task IDs

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Log operations for running tasks now gracefully no-op if the task was removed, preventing constraint errors and orphaned log entries.

* **Tests**
  * Added a test ensuring logging does not throw when a task is deleted while running.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->