### PR TITLE
fix: deliver agent response when last action is a tool call

### DIFF
--- a/container/agent-runner/src/index.ts
+++ b/container/agent-runner/src/index.ts
@@ -720,6 +720,7 @@ async function runQuery(
 
   let newSessionId: string | undefined;
   let lastAssistantUuid: string | undefined;
+  let lastAssistantText: string | undefined;
   let messageCount = 0;
   let resultCount = 0;
 
@@ -892,6 +893,18 @@ async function runQuery(
 
     if (message.type === 'assistant' && 'uuid' in message) {
       lastAssistantUuid = (message as { uuid: string }).uuid;
+      // Track the last assistant text so we can use it as fallback when the
+      // result event has no text (e.g. agent wrote text then did a final tool call)
+      const content = (message as { message?: { content?: unknown } }).message?.content;
+      if (Array.isArray(content)) {
+        const textBlocks = content
+          .filter((b: { type: string }) => b.type === 'text')
+          .map((b: { text: string }) => b.text)
+          .join('');
+        if (textBlocks) lastAssistantText = textBlocks;
+      } else if (typeof content === 'string' && content) {
+        lastAssistantText = content;
+      }
     }
 
     if (message.type === 'system' && message.subtype === 'init') {
@@ -907,13 +920,18 @@ async function runQuery(
     if (message.type === 'result') {
       resultCount++;
       const textResult = 'result' in message ? (message as { result?: string }).result : null;
+      // When the agent writes text then does a final tool call (e.g. closing the
+      // browser), the result event has no text. Fall back to the last assistant
+      // text so the user still gets the response.
+      const effectiveResult = textResult || lastAssistantText || null;
       const rm = message as any;
-      log(`Result #${resultCount}: subtype=${message.subtype} turns=${rm.num_turns || '?'} duration=${rm.duration_ms || '?'}ms cost=$${rm.total_cost_usd?.toFixed(4) || '?'}${textResult ? ` text=${textResult.slice(0, 200)}` : ''}`);
+      log(`Result #${resultCount}: subtype=${message.subtype} turns=${rm.num_turns || '?'} duration=${rm.duration_ms || '?'}ms cost=$${rm.total_cost_usd?.toFixed(4) || '?'}${effectiveResult ? ` text=${effectiveResult.slice(0, 200)}` : ''}`);
       writeOutput({
         status: 'success',
-        result: textResult || null,
+        result: effectiveResult,
         newSessionId
       });
+      lastAssistantText = undefined;
     }
   }
 


### PR DESCRIPTION
## Summary

[Upstream PR #436] When the agent writes a text response then performs a final tool call (e.g. `agent-browser close`), the SDK `result` event contains no text. The response was silently dropped and never sent to the user.

• Track the last assistant text block during the message stream
• Use it as fallback when the result event has no text
• Reset after each result to avoid stale fallbacks

## Repro

1. Ask the agent to browse a website and summarize it
2. Agent navigates, writes summary text, then calls `agent-browser close` as its last action
3. **Before fix:** The summary is never delivered — `result` event has `null` text
4. **After fix:** The summary is delivered using the fallback text

## Test plan

- [x] `bun run build` — compiles cleanly
- [x] `bun test` — 423 pass, 3 skip, 0 fail, no regressions
- [ ] Manual: Send a message that triggers browser use ending with `agent-browser close`
- [ ] Verify the agent's text response is delivered to the chat
- [ ] Verify normal (non-tool-ending) responses still work as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced result handling to ensure users always receive visible text output. The system now uses assistant message text as a fallback when direct results lack text content, providing consistent and reliable feedback during interactions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->