### PR TITLE
docs: fix stale container-runner.ts and telegram.ts references

### DIFF
--- a/.claude/skills/debug/SKILL.md
+++ b/.claude/skills/debug/SKILL.md
@@ -146,8 +146,8 @@ If sessions aren't being resumed (new session ID every time), or Claude Code exi
 
 **Check the mount path:**
 ```bash
-# In container-runner.ts, verify mount is to /home/node/.claude/, NOT /root/.claude/
-grep -A3 "Claude sessions" src/container-runner.ts
+# In local-backend.ts, verify mount is to /home/node/.claude/, NOT /root/.claude/
+grep -A3 "Claude sessions" src/backends/local-backend.ts
 ```
 
 **Verify sessions are accessible:**
@@ -160,7 +160,7 @@ ls -la $HOME/.claude/projects/ 2>&1 | head -5
 '
 ```
 
-**Fix:** Ensure `container-runner.ts` mounts to `/home/node/.claude/`:
+**Fix:** Ensure `local-backend.ts` mounts to `/home/node/.claude/`:
 ```typescript
 mounts.push({
   hostPath: claudeDir,
@@ -333,7 +333,7 @@ echo -e "\n4. Container image exists?"
 echo '{}' | container run -i --entrypoint /bin/echo omniclaw-agent:latest "OK" 2>/dev/null || echo "MISSING - run ./container/build.sh"
 
 echo -e "\n5. Session mount path correct?"
-grep -q "/home/node/.claude" src/container-runner.ts 2>/dev/null && echo "OK" || echo "WRONG - should mount to /home/node/.claude/, not /root/.claude/"
+grep -q "/home/node/.claude" src/backends/local-backend.ts 2>/dev/null && echo "OK" || echo "WRONG - should mount to /home/node/.claude/, not /root/.claude/"
 
 echo -e "\n6. Groups directory?"
 ls -la groups/ 2>/dev/null || echo "MISSING - run setup"

--- a/docs/SPEC.md
+++ b/docs/SPEC.md
@@ -145,7 +145,6 @@ omniclaw/
 │   ├── schedule-utils.ts          # Cron/interval/once schedule helpers
 │   ├── thread-streaming.ts        # Stream intermediate output to channel threads
 │   ├── whatsapp-auth.ts           # Standalone WhatsApp QR authentication
-│   ├── telegram.ts                # Telegram standalone entry point
 │   │
 │   ├── channels/
 │   │   ├── whatsapp.ts            # WhatsApp channel (baileys)


### PR DESCRIPTION
## Summary

Follow-up to PR #66 (legacy file removal). Fixes three stale documentation references caught by CodeRabbit:

• Remove deleted `telegram.ts` from `docs/SPEC.md` directory tree listing
• Update `container-runner.ts` → `local-backend.ts` in debug `SKILL.md` (session resumption section)
• Update `container-runner.ts` → `local-backend.ts` in debug `SKILL.md` (quick diagnostic script grep)

## Test plan

- [x] Docs-only change, no functional impact
- [x] Verify all container-runner.ts and telegram.ts references removed from docs

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated architecture documentation to reflect current file references and structure.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->