### PR TITLE
fix: prevent fs module mock leak between test files

### DIFF
--- a/src/group-queue.test.ts
+++ b/src/group-queue.test.ts
@@ -8,8 +8,11 @@ mockModule.module('./config.js', () => ({
   MAX_TASK_CONTAINERS: 2,
 }));
 
+import realFs from 'fs';
+
 mockModule.module('fs', () => ({
   default: {
+    ...realFs,
     mkdirSync: mock(),
     writeFileSync: mock(),
     renameSync: mock(),


### PR DESCRIPTION
## Summary

- Fixes `group-queue.test.ts` fs module mock that leaked into `task-scheduler.test.ts`, causing `fs.mkdtempSync is not a function` error
- Spreads the real `fs` module into the mock so all methods remain available while still overriding the 3 needed for group-queue tests

## Test Results

Before: 422 pass, 1 fail
After: 423 pass, 0 fail

Closes #70

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved test infrastructure for filesystem mocking to better support testing scenarios while maintaining mock coverage of critical filesystem operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->