### PR TITLE
fix: fetch latest WA web version and add reconnect backoff

### DIFF
--- a/src/whatsapp-auth.ts
+++ b/src/whatsapp-auth.ts
@@ -14,6 +14,7 @@ import readline from 'readline';
 import makeWASocket, {
   Browsers,
   DisconnectReason,
+  fetchLatestWaWebVersion,
   makeCacheableSignalKeyStore,
   useMultiFileAuthState,
 } from '@whiskeysockets/baileys';
@@ -53,7 +54,9 @@ async function connectSocket(phoneNumber?: string, isReconnect = false): Promise
     process.exit(0);
   }
 
+  const { version } = await fetchLatestWaWebVersion({});
   const sock = makeWASocket({
+    version,
     auth: {
       creds: state.creds,
       keys: makeCacheableSignalKeyStore(state.keys, logger),


### PR DESCRIPTION
## Summary
- Port `fetchLatestWaWebVersion` fix from upstream [qwibitai/nanoclaw#443](https://github.com/qwibitai/nanoclaw/pull/443) — Baileys ships a hardcoded WA Web version that falls behind WhatsApp's protocol, causing 405 \"Method Not Allowed\" errors on connect. Fetching the latest version at startup fixes this.
- Add exponential backoff to the internal reconnect loop in `WhatsAppChannel` (3s → 6s → 12s → ... → 5min cap). Previously it retried immediately on every disconnect, which hammered WA servers and caused rate limiting that blocked re-authentication entirely.
- The backoff counter resets to 0 on successful open, so normal reconnects after brief blips stay fast.

## Files changed
- `src/channels/whatsapp.ts` — `fetchLatestWaWebVersion` + backoff reconnect
- `src/whatsapp-auth.ts` — `fetchLatestWaWebVersion`

## Test plan
- [ ] Auth succeeds via `bun src/whatsapp-auth.ts` (was failing with "Connection failed" before this fix)
- [ ] Service reconnects with increasing delay after WA disconnects instead of hammering immediately

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Implemented exponential backoff strategy for reconnection attempts after disconnections, with configurable retry limits
  * Added automatic WhatsApp Web version detection at startup for improved compatibility

<!-- end of auto-generated comment: release notes by coderabbit.ai -->