### PR TITLE
refactor: extract shared CloudProcessWrapper from backends

### DIFF
--- a/src/backends/cloud-process-wrapper.ts
+++ b/src/backends/cloud-process-wrapper.ts
@@ -1,0 +1,14 @@
+/**
+ * Shared dummy ContainerProcess for cloud backends that don't have real PIDs.
+ * Used by Railway, Hetzner, and similar S3-based backends.
+ */
+
+import { ContainerProcess } from '../types.js';
+
+export class CloudProcessWrapper implements ContainerProcess {
+  private _killed = false;
+
+  get killed(): boolean { return this._killed; }
+  kill(): void { this._killed = true; }
+  get pid(): number { return 0; }
+}

--- a/src/backends/hetzner-backend.ts
+++ b/src/backends/hetzner-backend.ts
@@ -29,6 +29,7 @@ import { ContainerProcess } from '../types.js';
 import { OmniClawS3 } from '../s3/client.js';
 import { syncFilesToS3 } from '../s3/file-sync.js';
 import type { S3Message, S3Output } from '../s3/types.js';
+import { CloudProcessWrapper } from './cloud-process-wrapper.js';
 import {
   AgentBackend,
   AgentOrGroup,
@@ -40,15 +41,6 @@ import {
   getServerFolder,
 } from './types.js';
 import * as HetznerAPI from './hetzner-api.js';
-
-/** Dummy process wrapper for Hetzner (no real PID). */
-class HetznerProcessWrapper implements ContainerProcess {
-  private _killed = false;
-
-  get killed(): boolean { return this._killed; }
-  kill(): void { this._killed = true; }
-  get pid(): number { return 0; }
-}
 
 interface HetznerServerContext {
   serverId: number;
@@ -110,7 +102,7 @@ export class HetznerBackend implements AgentBackend {
     this.servers.set(folder, serverCtx);
 
     // 4. Register dummy process
-    const processWrapper = new HetznerProcessWrapper();
+    const processWrapper = new CloudProcessWrapper();
     onProcess(processWrapper, `hetzner-${folder}`);
 
     try {

--- a/src/backends/railway-backend.ts
+++ b/src/backends/railway-backend.ts
@@ -24,6 +24,7 @@ import { ContainerProcess } from '../types.js';
 import { OmniClawS3 } from '../s3/client.js';
 import { syncFilesToS3 } from '../s3/file-sync.js';
 import type { S3Message, S3Output } from '../s3/types.js';
+import { CloudProcessWrapper } from './cloud-process-wrapper.js';
 import {
   AgentBackend,
   AgentOrGroup,
@@ -34,15 +35,6 @@ import {
   getName,
   getServerFolder,
 } from './types.js';
-
-/** Dummy process wrapper for Railway (no real PID). */
-class RailwayProcessWrapper implements ContainerProcess {
-  private _killed = false;
-
-  get killed(): boolean { return this._killed; }
-  kill(): void { this._killed = true; }
-  get pid(): number { return 0; }
-}
 
 export class RailwayBackend implements AgentBackend {
   readonly name = 'railway';
@@ -91,7 +83,7 @@ export class RailwayBackend implements AgentBackend {
     await this.s3.writeInbox(folder, inboxMessage);
 
     // 3. Register dummy process
-    const processWrapper = new RailwayProcessWrapper();
+    const processWrapper = new CloudProcessWrapper();
     onProcess(processWrapper, `railway-${folder}`);
 
     // 4. Poll S3 outbox for results


### PR DESCRIPTION
## Summary

- Extracted identical `ProcessWrapper` classes from Railway and Hetzner backends into a shared `CloudProcessWrapper` in `src/backends/cloud-process-wrapper.ts`
- Railway and Hetzner backends now import and use the shared class
- Net reduction of 2 lines (removed 20 lines of duplication, added 18 lines including the shared module)

Partial fix for #85 — this covers the ProcessWrapper extraction. S3 message factory and error handler deduplication tracked separately.

## Test plan

- [x] `tsc --noEmit` passes (0 type errors)
- [x] `bun test` passes (548 tests, 0 failures)
- [ ] Verify Railway backend still works in production
- [ ] Verify Hetzner backend still works in production

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Consolidated cloud backend process handling by unifying process wrapper implementations across cloud providers into a shared utility component, improving code maintainability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->