### PR TITLE
refactor: remove dead code and deduplicate IPC request handlers

### DIFF
--- a/src/agents.ts
+++ b/src/agents.ts
@@ -3,10 +3,8 @@
  * Thin wrapper around db.ts accessors with convenience helpers.
  */
 
-import { getAllAgents, getAgent, setAgent } from './db.js';
+import { getAllAgents } from './db.js';
 import type { Agent, RegisteredGroup } from './types.js';
-
-export { getAllAgents, getAgent, setAgent };
 
 /**
  * Convert an Agent back to a RegisteredGroup for backwards compatibility.

--- a/src/channel-routes.ts
+++ b/src/channel-routes.ts
@@ -3,10 +3,7 @@
  * Maps channel JIDs to agents. Multiple channels can route to the same agent.
  */
 
-import { getAllChannelRoutes, getChannelRoute, getRoutesForAgent, setChannelRoute } from './db.js';
-import type { Agent, ChannelRoute } from './types.js';
-
-export { getAllChannelRoutes, getChannelRoute, getRoutesForAgent, setChannelRoute };
+import type { ChannelRoute } from './types.js';
 
 /**
  * Resolve which agent should handle a message from a given channel JID.

--- a/src/router.ts
+++ b/src/router.ts
@@ -48,16 +48,6 @@ export function formatOutbound(channel: Channel, rawText: string, agentName?: st
   return `${prefix}${text}`;
 }
 
-export async function routeOutbound(
-  channels: Channel[],
-  jid: string,
-  text: string,
-): Promise<void> {
-  const channel = channels.find((c) => c.ownsJid(jid) && c.isConnected());
-  if (!channel) throw new Error(`No channel for JID: ${jid}`);
-  await channel.sendMessage(jid, text);
-}
-
 export function findChannel(
   channels: Channel[],
   jid: string,


### PR DESCRIPTION
## Summary

- Consolidate `delegate_task` and `context_request` IPC handlers into a single case block — they followed an identical pattern (resolve source group, find main JID, build message, send, track request, log)
- Remove dead re-exports from `agents.ts` (`getAllAgents`, `getAgent`, `setAgent` were re-exported but nobody imports them from this module — `index.ts` imports directly from `db.ts`)
- Remove dead re-exports from `channel-routes.ts` (same pattern — `getAllChannelRoutes`, `getChannelRoute`, `getRoutesForAgent`, `setChannelRoute`)
- Remove dead `routeOutbound()` function from `router.ts` — never called in production code, `findChannel` + direct `sendMessage` supersedes it
- Remove corresponding `routeOutbound` tests

*Net: -100 lines across 5 files. All 539 tests pass, zero type errors.*

## Test plan

- [x] `bun test` — 539 pass, 0 fail
- [x] `bunx tsc --noEmit` — zero errors
- [ ] Verify IPC delegate_task and context_request still work end-to-end (message format unchanged)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Context requests are now handled through the IPC system with dynamic labeling and tracking.

* **Refactor**
  * Streamlined agent and channel route management APIs for improved maintainability.
  * Removed outbound message routing functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->