### PR TITLE
feat: expose ANTHROPIC_MODEL from .env to containers

### DIFF
--- a/src/backends/local-backend.ts
+++ b/src/backends/local-backend.ts
@@ -190,7 +190,7 @@ function buildVolumeMounts(
   const envFile = path.join(projectRoot, '.env');
   if (fs.existsSync(envFile)) {
     const envContent = fs.readFileSync(envFile, 'utf-8');
-    const allowedVars = ['CLAUDE_CODE_OAUTH_TOKEN', 'ANTHROPIC_API_KEY', 'GITHUB_TOKEN', 'GIT_AUTHOR_NAME', 'GIT_AUTHOR_EMAIL', 'CLAUDE_MODEL'];
+    const allowedVars = ['CLAUDE_CODE_OAUTH_TOKEN', 'ANTHROPIC_API_KEY', 'ANTHROPIC_MODEL', 'GITHUB_TOKEN', 'GIT_AUTHOR_NAME', 'GIT_AUTHOR_EMAIL', 'CLAUDE_MODEL'];
     const filteredLines = envContent.split('\n').filter((line) => {
       const trimmed = line.trim();
       if (!trimmed || trimmed.startsWith('#')) return false;

--- a/src/config.ts
+++ b/src/config.ts
@@ -79,6 +79,9 @@ export function buildTriggerPattern(trigger?: string): RegExp {
   return new RegExp(`^@${escapeRegex(name)}\\b`, 'i');
 }
 
+// Allow overriding the Anthropic model (e.g. switch to cheaper model)
+export const ANTHROPIC_MODEL = process.env.ANTHROPIC_MODEL || undefined;
+
 // Timezone for scheduled tasks (cron expressions, etc.)
 // Uses system timezone by default
 export const TIMEZONE =


### PR DESCRIPTION
## Summary
- Add `ANTHROPIC_MODEL` to config exports for container environment passthrough
- Add `ANTHROPIC_MODEL` to the env allowlist in `local-backend.ts`
- Allows switching Claude model (e.g. to cheaper model) via `.env` without code changes

[Upstream PR #468](https://github.com/qwibitai/nanoclaw/pull/468)

## Changes
- `src/config.ts`: Export `ANTHROPIC_MODEL` from `process.env`
- `src/backends/local-backend.ts`: Add to `allowedVars` array for env filtering

## Test plan
- [x] Verify `ANTHROPIC_MODEL` is exported from config
- [x] Verify env allowlist includes `ANTHROPIC_MODEL`
- [ ] Set `ANTHROPIC_MODEL=claude-sonnet-4-20250514` in `.env`, confirm container picks it up

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for the ANTHROPIC_MODEL environment variable, which can now be read from project .env files and made available to the application.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->