### PR TITLE
fix: notify user when message dropped after max consecutive API errors

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -651,6 +651,18 @@ async function processGroupMessages(chatJid: string): Promise<boolean> {
         { errorCount },
         'Max consecutive errors reached, advancing cursor past failing messages',
       );
+
+      // Notify the user so the message isn't silently dropped (fixes #94)
+      if (channel) {
+        const errorMsg = "Sorry, I hit a server error a few times and couldn't process your message. Please try again.";
+        const formatted = formatOutbound(channel, errorMsg, getAgentName(group));
+        if (formatted) {
+          channel.sendMessage(chatJid, formatted, triggeringMessageId || undefined).catch((err) => {
+            log.warn({ err }, 'Failed to send error notification to user');
+          });
+        }
+      }
+
       consecutiveErrors[chatJid] = 0;
       return false;
     }


### PR DESCRIPTION
## Summary

When the Anthropic API returns 500 errors 3+ times consecutively (`MAX_CONSECUTIVE_ERRORS`), the message cursor is advanced past the failing batch to prevent a permanently stuck queue. Previously, this happened **silently** — the user received no response and no indication anything went wrong.

Now sends a brief error message to the chat before advancing:
> "Sorry, I hit a server error a few times and couldn't process your message. Please try again."

## Changes
- `src/index.ts`: Add user notification in the `errorCount >= MAX_CONSECUTIVE_ERRORS` branch
- Uses existing `formatOutbound` + `channel.sendMessage` pattern
- Fire-and-forget (`.catch`) to avoid blocking cursor advancement
- Reply-threads to the triggering message for context

## Test plan
- [x] `tsc --noEmit` — clean
- [x] `bun test` — 544 tests pass, 0 failures

Fixes #94

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Users now receive error notifications when repeated server errors occur for group messages, providing better visibility into system recovery and error resolution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->