### PR TITLE
refactor: add debug logging to remaining silent .catch handlers

### DIFF
--- a/src/backends/local-backend.ts
+++ b/src/backends/local-backend.ts
@@ -366,7 +366,8 @@ export class LocalBackend implements AgentBackend {
           clearTimeout(killTimer);
           container.kill(9);
         }
-      }).catch(() => {
+      }).catch((err) => {
+        log.debug({ err }, 'Graceful container stop failed, force killing');
         clearTimeout(killTimer);
         container.kill(9);
       });

--- a/src/index.ts
+++ b/src/index.ts
@@ -464,8 +464,8 @@ async function processGroupMessages(chatJid: string): Promise<boolean> {
     try {
       await channel.setTyping(chatJid, true);
       typingInterval = setInterval(() => {
-        channel.setTyping!(chatJid, true).catch(() => {
-          // Non-fatal — typing indicator is best-effort
+        channel.setTyping!(chatJid, true).catch((err) => {
+          log.debug({ err, chatJid }, 'Typing indicator refresh failed (non-fatal)');
         });
       }, 8_000);
     } catch (err) {


### PR DESCRIPTION
## Summary
- Replace the last 2 silent `.catch(() => {})` handlers with debug-level logging
- `local-backend.ts`: graceful container stop failure (last-resort cleanup path)
- `index.ts`: typing indicator refresh failure (best-effort, non-fatal)

Closes #87

## Test plan
- [x] `tsc --noEmit` clean
- [x] All 606 tests pass
- [x] No behavioral change — only adds debug-level log output

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved error logging and diagnostics for enhanced visibility into system operation failures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->