### PR TITLE
effect: migrate schedule-utils to Effect.ts

### DIFF
--- a/src/schedule-utils.test.ts
+++ b/src/schedule-utils.test.ts
@@ -1,9 +1,17 @@
-import { describe, it, expect, beforeEach, afterEach, mock } from 'bun:test';
+import { describe, it, expect } from 'bun:test';
+import { Effect, Either } from 'effect';
 
-import { calculateNextRun, validateSchedule, type ScheduleType } from './schedule-utils.js';
+import {
+  calculateNextRun,
+  calculateNextRunEffect,
+  validateSchedule,
+  validateScheduleEffect,
+  ScheduleValidationError,
+  type ScheduleType,
+} from './schedule-utils.js';
 
 describe('schedule-utils', () => {
-  describe('calculateNextRun', () => {
+  describe('calculateNextRun (bridge)', () => {
     describe('cron schedules', () => {
       it('returns a valid ISO timestamp for a valid cron expression', () => {
         const result = calculateNextRun('cron', '0 9 * * *');
@@ -108,7 +116,7 @@ describe('schedule-utils', () => {
     });
   });
 
-  describe('validateSchedule', () => {
+  describe('validateSchedule (bridge)', () => {
     it('returns true for valid cron', () => {
       expect(validateSchedule('cron', '0 9 * * *')).toBe(true);
     });
@@ -131,6 +139,135 @@ describe('schedule-utils', () => {
 
     it('returns false for invalid once timestamp', () => {
       expect(validateSchedule('once', 'garbage')).toBe(false);
+    });
+  });
+
+  describe('calculateNextRunEffect', () => {
+    it('succeeds with ISO timestamp for valid cron', () => {
+      const result = Effect.runSync(
+        calculateNextRunEffect('cron', '0 9 * * *').pipe(Effect.either),
+      );
+      expect(Either.isRight(result)).toBe(true);
+      if (Either.isRight(result)) {
+        expect(new Date(result.right).toISOString()).toBe(result.right);
+      }
+    });
+
+    it('fails with ScheduleValidationError for invalid cron', () => {
+      const result = Effect.runSync(
+        calculateNextRunEffect('cron', 'not-a-cron').pipe(Effect.either),
+      );
+      expect(Either.isLeft(result)).toBe(true);
+      if (Either.isLeft(result)) {
+        expect(result.left._tag).toBe('ScheduleValidationError');
+        expect(result.left.scheduleType).toBe('cron');
+        expect(result.left.scheduleValue).toBe('not-a-cron');
+        expect(result.left.reason).toContain('Invalid cron expression');
+      }
+    });
+
+    it('succeeds with baseTime + interval for valid interval', () => {
+      const base = new Date('2025-01-15T10:00:00.000Z');
+      const result = Effect.runSync(
+        calculateNextRunEffect('interval', '60000', base).pipe(Effect.either),
+      );
+      expect(Either.isRight(result)).toBe(true);
+      if (Either.isRight(result)) {
+        expect(result.right).toBe('2025-01-15T10:01:00.000Z');
+      }
+    });
+
+    it('fails with ScheduleValidationError for zero interval', () => {
+      const result = Effect.runSync(
+        calculateNextRunEffect('interval', '0').pipe(Effect.either),
+      );
+      expect(Either.isLeft(result)).toBe(true);
+      if (Either.isLeft(result)) {
+        expect(result.left._tag).toBe('ScheduleValidationError');
+        expect(result.left.reason).toContain('positive integer');
+      }
+    });
+
+    it('fails with ScheduleValidationError for negative interval', () => {
+      const result = Effect.runSync(
+        calculateNextRunEffect('interval', '-500').pipe(Effect.either),
+      );
+      expect(Either.isLeft(result)).toBe(true);
+      if (Either.isLeft(result)) {
+        expect(result.left._tag).toBe('ScheduleValidationError');
+      }
+    });
+
+    it('succeeds with ISO timestamp for valid once schedule', () => {
+      const result = Effect.runSync(
+        calculateNextRunEffect('once', '2025-06-01T12:00:00.000Z').pipe(Effect.either),
+      );
+      expect(Either.isRight(result)).toBe(true);
+      if (Either.isRight(result)) {
+        expect(result.right).toBe('2025-06-01T12:00:00.000Z');
+      }
+    });
+
+    it('fails with ScheduleValidationError for invalid once timestamp', () => {
+      const result = Effect.runSync(
+        calculateNextRunEffect('once', 'garbage').pipe(Effect.either),
+      );
+      expect(Either.isLeft(result)).toBe(true);
+      if (Either.isLeft(result)) {
+        expect(result.left._tag).toBe('ScheduleValidationError');
+        expect(result.left.reason).toContain('Invalid timestamp');
+      }
+    });
+
+    it('fails with ScheduleValidationError for unknown schedule type', () => {
+      const result = Effect.runSync(
+        calculateNextRunEffect('bogus' as ScheduleType, '123').pipe(Effect.either),
+      );
+      expect(Either.isLeft(result)).toBe(true);
+      if (Either.isLeft(result)) {
+        expect(result.left._tag).toBe('ScheduleValidationError');
+        expect(result.left.reason).toContain('Unknown schedule type');
+      }
+    });
+
+    it('error is an instance of ScheduleValidationError', () => {
+      const result = Effect.runSync(
+        calculateNextRunEffect('interval', 'bad').pipe(Effect.either),
+      );
+      expect(Either.isLeft(result)).toBe(true);
+      if (Either.isLeft(result)) {
+        expect(result.left).toBeInstanceOf(ScheduleValidationError);
+      }
+    });
+  });
+
+  describe('validateScheduleEffect', () => {
+    it('succeeds for valid cron', () => {
+      const result = Effect.runSync(
+        validateScheduleEffect('cron', '0 9 * * *').pipe(Effect.either),
+      );
+      expect(Either.isRight(result)).toBe(true);
+    });
+
+    it('fails for invalid cron', () => {
+      const result = Effect.runSync(
+        validateScheduleEffect('cron', 'bad').pipe(Effect.either),
+      );
+      expect(Either.isLeft(result)).toBe(true);
+    });
+
+    it('succeeds for valid interval', () => {
+      const result = Effect.runSync(
+        validateScheduleEffect('interval', '60000').pipe(Effect.either),
+      );
+      expect(Either.isRight(result)).toBe(true);
+    });
+
+    it('fails for invalid interval', () => {
+      const result = Effect.runSync(
+        validateScheduleEffect('interval', '-1').pipe(Effect.either),
+      );
+      expect(Either.isLeft(result)).toBe(true);
     });
   });
 });

--- a/src/schedule-utils.ts
+++ b/src/schedule-utils.ts
@@ -1,80 +1,146 @@
 /**
  * Utilities for schedule calculation shared across task scheduling.
  * Extracted to eliminate duplication in task-scheduler.ts, ipc.ts, and db.ts.
+ *
+ * Effect-migrated: core logic uses Effect.ts with typed errors.
+ * Bridge functions maintain the original API for non-Effect callers.
  */
 
+import { Effect } from 'effect';
+import * as S from '@effect/schema/Schema';
 import { CronExpressionParser } from 'cron-parser';
 import { TIMEZONE } from './config.js';
 import { logger } from './logger.js';
 
 export type ScheduleType = 'cron' | 'interval' | 'once';
 
+// ============================================================================
+// Error Types
+// ============================================================================
+
+export class ScheduleValidationError extends S.TaggedError<ScheduleValidationError>()(
+  'ScheduleValidationError',
+  {
+    scheduleType: S.String,
+    scheduleValue: S.String,
+    reason: S.String,
+  },
+) {}
+
+// ============================================================================
+// Effect API
+// ============================================================================
+
+/**
+ * Calculate the next run time for a scheduled task (Effect version).
+ * Returns the next ISO timestamp or fails with ScheduleValidationError.
+ */
+export const calculateNextRunEffect = (
+  scheduleType: ScheduleType,
+  scheduleValue: string,
+  baseTime: Date = new Date(),
+): Effect.Effect<string, ScheduleValidationError> => {
+  switch (scheduleType) {
+    case 'cron':
+      return Effect.try({
+        try: () => {
+          const interval = CronExpressionParser.parse(scheduleValue, { tz: TIMEZONE });
+          const iso = interval.next().toISOString();
+          if (iso === null) {
+            throw new Error('CronDate.toISOString() returned null');
+          }
+          return iso;
+        },
+        catch: (err) =>
+          new ScheduleValidationError({
+            scheduleType,
+            scheduleValue,
+            reason: `Invalid cron expression: ${err instanceof Error ? err.message : String(err)}`,
+          }),
+      });
+
+    case 'interval': {
+      const ms = parseInt(scheduleValue, 10);
+      if (isNaN(ms) || ms <= 0) {
+        return Effect.fail(
+          new ScheduleValidationError({
+            scheduleType,
+            scheduleValue,
+            reason: 'Invalid interval: must be a positive integer',
+          }),
+        );
+      }
+      return Effect.succeed(new Date(baseTime.getTime() + ms).toISOString());
+    }
+
+    case 'once': {
+      const scheduled = new Date(scheduleValue);
+      if (isNaN(scheduled.getTime())) {
+        return Effect.fail(
+          new ScheduleValidationError({
+            scheduleType,
+            scheduleValue,
+            reason: 'Invalid timestamp for once schedule',
+          }),
+        );
+      }
+      return Effect.succeed(scheduled.toISOString());
+    }
+
+    default:
+      return Effect.fail(
+        new ScheduleValidationError({
+          scheduleType: scheduleType as string,
+          scheduleValue,
+          reason: `Unknown schedule type: ${scheduleType}`,
+        }),
+      );
+  }
+};
+
+/**
+ * Validate a schedule configuration (Effect version).
+ * Succeeds if valid, fails with ScheduleValidationError otherwise.
+ */
+export const validateScheduleEffect = (
+  scheduleType: ScheduleType,
+  scheduleValue: string,
+): Effect.Effect<void, ScheduleValidationError> =>
+  calculateNextRunEffect(scheduleType, scheduleValue).pipe(Effect.asVoid);
+
+// ============================================================================
+// Bridge API (maintains original signatures for non-Effect callers)
+// ============================================================================
+
 /**
  * Calculate the next run time for a scheduled task.
  * Returns null if the schedule is invalid or one-shot (once) tasks.
- *
- * @param scheduleType - The type of schedule (cron, interval, once)
- * @param scheduleValue - The schedule value (cron expression, milliseconds, or ISO timestamp)
- * @param baseTime - Optional base time for calculation (defaults to now)
- * @returns ISO timestamp string or null
  */
 export function calculateNextRun(
   scheduleType: ScheduleType,
   scheduleValue: string,
   baseTime: Date = new Date(),
 ): string | null {
-  switch (scheduleType) {
-    case 'cron': {
-      try {
-        const interval = CronExpressionParser.parse(scheduleValue, { tz: TIMEZONE });
-        return interval.next().toISOString();
-      } catch (err) {
+  return Effect.runSync(
+    calculateNextRunEffect(scheduleType, scheduleValue, baseTime).pipe(
+      Effect.catchAll((err) => {
         logger.warn(
-          { scheduleValue, error: err instanceof Error ? err.message : String(err) },
-          'Invalid cron expression',
+          { scheduleType: err.scheduleType, scheduleValue: err.scheduleValue },
+          err.reason,
         );
-        return null;
-      }
-    }
-
-    case 'interval': {
-      const ms = parseInt(scheduleValue, 10);
-      if (isNaN(ms) || ms <= 0) {
-        logger.warn({ scheduleValue }, 'Invalid interval');
-        return null;
-      }
-      return new Date(baseTime.getTime() + ms).toISOString();
-    }
-
-    case 'once': {
-      const scheduled = new Date(scheduleValue);
-      if (isNaN(scheduled.getTime())) {
-        logger.warn({ scheduleValue }, 'Invalid timestamp for once schedule');
-        return null;
-      }
-      // One-shot tasks return the scheduled time on first call,
-      // then null on subsequent calls (handled by caller)
-      return scheduled.toISOString();
-    }
-
-    default:
-      logger.warn({ scheduleType }, 'Unknown schedule type');
-      return null;
-  }
+        return Effect.succeed(null as string | null);
+      }),
+    ),
+  );
 }
 
 /**
  * Validate a schedule configuration without calculating the next run.
  * Useful for validating user input before persisting.
- *
- * @param scheduleType - The type of schedule
- * @param scheduleValue - The schedule value
- * @returns true if valid, false otherwise
  */
 export function validateSchedule(
   scheduleType: ScheduleType,
   scheduleValue: string,
 ): boolean {
-  const nextRun = calculateNextRun(scheduleType, scheduleValue);
-  return nextRun !== null;
+  return calculateNextRun(scheduleType, scheduleValue) !== null;
 }


### PR DESCRIPTION
## Summary

Migrates `schedule-utils.ts` to use Effect.ts with typed error handling, following the existing patterns in `src/effect/`.

• Adds `ScheduleValidationError` as a `TaggedError` (via `@effect/schema`) carrying `scheduleType`, `scheduleValue`, and `reason` fields
• Adds `calculateNextRunEffect` — returns `Effect<string, ScheduleValidationError>` using `Effect.try` for cron parsing and `Effect.fail` for validation errors
• Adds `validateScheduleEffect` — returns `Effect<void, ScheduleValidationError>` wrapping `calculateNextRunEffect`
• Keeps original `calculateNextRun` and `validateSchedule` as bridge functions using `Effect.runSync` + `catchAll` for backward compatibility with non-Effect callers (`task-scheduler.ts`, `ipc.ts`)
• Adds 13 new tests for the Effect API (typed errors, success values, error tags, instanceof checks)

## Effect patterns used

• `S.TaggedError` for typed, schema-validated error classes
• `Effect.try({ try, catch })` for wrapping synchronous operations that may throw
• `Effect.fail` for explicit validation failures
• `Effect.catchAll` + `Effect.runSync` for the bridge layer
• `Effect.either` in tests for inspecting success/failure channels
• `Effect.asVoid` for discarding success values

## Test plan

- [x] All 35 schedule-utils tests pass (22 bridge + 13 Effect)
- [x] Full test suite: 619 tests pass, 0 failures
- [x] `bunx tsc --noEmit` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added Effect-based APIs for schedule utilities, enabling improved error handling and control flow when calculating next run times and validating schedules.

* **Improvements**
  * Enhanced schedule validation with structured error types for better error reporting. Existing functions remain backward compatible.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->