### PR TITLE
feat(security): add network isolation for non-main containers

### DIFF
--- a/docs/SECURITY.md
+++ b/docs/SECURITY.md
@@ -16,10 +16,12 @@
 Agents execute in Apple Container (lightweight Linux VMs), providing:
 - **Process isolation** - Container processes cannot affect the host
 - **Filesystem isolation** - Only explicitly mounted directories are visible
+- **Network isolation** - Non-main containers run with `--network none` (Docker), preventing data exfiltration. Main containers retain full network access for WebFetch/WebSearch tools. Per-group override via `containerConfig.networkMode: 'full' | 'none'`
 - **Non-root execution** - Runs as unprivileged `bun` user (uid 1000)
 - **Ephemeral containers** - Fresh environment per invocation (`--rm`)
+- **Resource limits** - `--pids-limit 256` (fork bomb prevention), `--no-new-privileges` (privilege escalation prevention)
 
-This is the primary security boundary. Rather than relying on application-level permission checks, the attack surface is limited by what's mounted.
+This is the primary security boundary. Rather than relying on application-level permission checks, the attack surface is limited by what's mounted and what's accessible via network.
 
 ### 2. Read-Only Project Root
 

--- a/src/backends/network-isolation.test.ts
+++ b/src/backends/network-isolation.test.ts
@@ -1,0 +1,109 @@
+import { describe, it, expect, mock, beforeEach } from 'bun:test';
+
+/**
+ * Tests for network isolation in container args.
+ *
+ * [Upstream PR #460] Non-main containers run with --network none by default
+ * to prevent data exfiltration. Main containers keep full network for
+ * WebFetch/WebSearch. Per-group override via containerConfig.networkMode.
+ */
+
+// Mock config module with all required exports
+const mockConfig = {
+  CONTAINER_IMAGE: 'test-image:latest',
+  CONTAINER_MEMORY: '4096m',
+  CONTAINER_TIMEOUT: 300_000,
+  IDLE_TIMEOUT: 30_000,
+  LOCAL_RUNTIME: 'docker',
+  TIMEZONE: 'America/Los_Angeles',
+  CONTAINER_MAX_OUTPUT_SIZE: 10_000_000,
+  CONTAINER_STARTUP_TIMEOUT: 30_000,
+  DATA_DIR: '/tmp/test-data',
+  GROUPS_DIR: '/tmp/test-data/groups',
+  STORE_DIR: '/tmp/test-data/store',
+  MAIN_GROUP_FOLDER: 'main',
+  MOUNT_ALLOWLIST_PATH: '/tmp/test-data/mount-allowlist.json',
+  ASSISTANT_NAME: 'Omni',
+  TRIGGER_PATTERN: /^@Omni\b/i,
+  POLL_INTERVAL: 2000,
+  SCHEDULER_POLL_INTERVAL: 60000,
+  IPC_POLL_INTERVAL: 1000,
+  SESSION_MAX_AGE: 14_400_000,
+  MAX_CONCURRENT_CONTAINERS: 8,
+  MAX_TASK_CONTAINERS: 7,
+  DISCORD_BOT_TOKEN: '',
+  TELEGRAM_BOT_TOKEN: '',
+  SLACK_BOT_TOKEN: '',
+  SLACK_APP_TOKEN: '',
+  ANTHROPIC_MODEL: undefined,
+  escapeRegex: (str: string) => str.replace(/[.*+?^${}()|[\]\\]/g, '\\$&'),
+  buildTriggerPattern: () => /^@Omni\b/i,
+};
+
+mock.module('../config.js', () => mockConfig);
+
+// Import after mocking
+const { buildContainerArgs } = await import('./local-backend.js');
+
+describe('buildContainerArgs network isolation', () => {
+  beforeEach(() => {
+    mockConfig.LOCAL_RUNTIME = 'docker';
+  });
+
+  it('non-main containers get --network none by default', () => {
+    const args = buildContainerArgs({
+      mounts: [],
+      containerName: 'test-container',
+      isMain: false,
+    });
+    expect(args).toContain('--network');
+    const networkIdx = args.indexOf('--network');
+    expect(args[networkIdx + 1]).toBe('none');
+  });
+
+  it('main containers get full network by default (no --network flag)', () => {
+    const args = buildContainerArgs({
+      mounts: [],
+      containerName: 'test-container',
+      isMain: true,
+    });
+    expect(args).not.toContain('--network');
+  });
+
+  it('non-main containers can override to full network via networkMode', () => {
+    const args = buildContainerArgs({
+      mounts: [],
+      containerName: 'test-container',
+      isMain: false,
+      networkMode: 'full',
+    });
+    expect(args).not.toContain('--network');
+  });
+
+  it('main containers can override to no network via networkMode', () => {
+    const args = buildContainerArgs({
+      mounts: [],
+      containerName: 'test-container',
+      isMain: true,
+      networkMode: 'none',
+    });
+    expect(args).toContain('--network');
+    const networkIdx = args.indexOf('--network');
+    expect(args[networkIdx + 1]).toBe('none');
+  });
+
+  it('Docker containers always have --pids-limit and --no-new-privileges', () => {
+    const args = buildContainerArgs({
+      mounts: [],
+      containerName: 'test-container',
+      isMain: false,
+    });
+    expect(args).toContain('--pids-limit');
+    const pidsIdx = args.indexOf('--pids-limit');
+    expect(args[pidsIdx + 1]).toBe('256');
+
+    expect(args).toContain('--security-opt');
+    const secIdx = args.indexOf('--security-opt');
+    expect(args[secIdx + 1]).toBe('no-new-privileges:true');
+  });
+});

--- a/src/types.ts
+++ b/src/types.ts
@@ -38,6 +38,7 @@ export interface ContainerConfig {
   additionalMounts?: AdditionalMount[];
   timeout?: number; // Default: 300000 (5 minutes)
   memory?: number;  // Container memory in MB. Default: 4096
+  networkMode?: 'full' | 'none'; // Default: 'none' for non-main, 'full' for main
 }
 
 export interface HeartbeatConfig {


### PR DESCRIPTION
## Summary

• [Upstream PR #460] Non-main Docker containers now run with `--network none` by default, preventing data exfiltration
• Main containers retain full network access (needed for WebFetch/WebSearch tools)
• Per-group override via `containerConfig.networkMode: 'full' | 'none'`

## Motivation

Containers currently have unrestricted network access. Combined with `bypassPermissions` mode, a prompt-injected agent can exfiltrate mounted filesystem data and API credentials to attacker-controlled servers. Docker's `--network none` completely disables container networking at the kernel level — the simplest and most robust mitigation.

## Behavior

| Group type | Default networkMode | Network access |
|------------|-------------------|----------------|
| Main | `'full'` | Unrestricted (WebFetch/WebSearch work) |
| Non-main | `'none'` | Disabled (no outbound/inbound) |

Override per-group:
```json
{ "containerConfig": { "networkMode": "full" } }
```

## Fork Adaptations

- Integrated into `buildContainerArgs()` in `local-backend.ts` (not upstream's `container-runner.ts`)
- Docker-only: Apple Container uses vmnet for networking, not Docker `--network` flag
- `buildContainerArgs` refactored to accept options object (isMain, networkMode) instead of positional args

## Breaking Change

Non-main groups that rely on `WebFetch`, `WebSearch`, or outbound HTTP from Bash will need to explicitly set `networkMode: 'full'` in their `containerConfig`.

## Test plan

- [x] `npx tsc --noEmit` — clean
- [x] `bun test` — 624/624 tests pass (619 existing + 5 new)
- [x] 5 new tests: default non-main (none), default main (full), non-main override to full, main override to none, Docker security flags

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Containers now support network isolation. Non-main containers default to blocked network access while main containers retain full access, with per-group override capability.
  * Implemented resource limits including process count limits and privilege restrictions for containers.

* **Documentation**
  * Updated security documentation to describe network isolation behavior and resource limit configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->