### PR TITLE
fix: align WhatsApp reconnect backoff with upstream

### DIFF
--- a/src/channels/whatsapp.ts
+++ b/src/channels/whatsapp.ts
@@ -43,8 +43,9 @@ export class WhatsAppChannel implements Channel {
   private static readonly MESSAGE_CACHE_MAX = 500;
   private static readonly MESSAGE_CACHE_TTL = 60 * 60 * 1000; // 1 hour
   // Reconnect backoff state — resets to 0 on successful open
+  // [Upstream PR #466] exponential backoff: 2s → 4s → 8s → ... capped at 5min
   private reconnectAttempt = 0;
-  private static readonly RECONNECT_BASE_MS = 3_000;
+  private static readonly RECONNECT_BASE_MS = 2_000;
   private static readonly RECONNECT_MAX_MS = 5 * 60_000; // 5 min cap
 
   // Track IDs of messages we sent so the upsert handler can ignore echoes (self-chat loop fix)


### PR DESCRIPTION
## Summary
* [Upstream PR #466] Aligns WhatsApp reconnect backoff base delay with upstream (3s to 2s)
* Fork already had exponential backoff implemented (with 3s base); this syncs to upstream's 2s base
* Backoff sequence: 2s -> 4s -> 8s -> 16s -> 32s -> 64s -> 128s -> 256s -> 300s (cap)
* Prevents log storms during DNS outages (production issue: 65K retries/min, 116MB logs)
* Counter resets to 0 on successful reconnection

## Context
The fork independently implemented exponential backoff before upstream PR #466. The fork's implementation is architecturally superior (graceful promise rejection instead of `process.exit(0)`, event listener cleanup, stale typing indicator clearing). This PR only syncs the base delay constant from 3s to 2s to match upstream.

## Changes
* `src/channels/whatsapp.ts` - Change `RECONNECT_BASE_MS` from `3_000` to `2_000`, add upstream PR reference comment

## Test plan
- [x] `tsc --noEmit` passes (0 errors)
- [x] All 624 tests pass
- [x] WhatsApp reconnects normally after brief disconnects
- [x] Reconnect rate is capped during extended outages

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance Improvements**
  * Reduced the initial reconnection retry delay for WhatsApp from 3 seconds to 2 seconds, enabling faster recovery from connection interruptions while maintaining the exponential backoff strategy.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->