### PR TITLE
fix: adopt upstream bug fixes (PRs #530, #513, #528)

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -847,8 +847,10 @@ async function startMessageLoop(): Promise<void> {
             chatJid,
             lastAgentTimestamp[chatJid] || '',
           );
-          const messagesToSend =
-            allPending.length > 0 ? allPending : groupMessages;
+          // If no new messages after cursor, skip — falling back to
+          // groupMessages would re-send already-processed messages.
+          if (allPending.length === 0) continue;
+          const messagesToSend = allPending;
           const formatted = formatMessages(messagesToSend);
 
           if (await queue.sendMessage(chatJid, formatted)) {


### PR DESCRIPTION
## Summary

Adopts three upstream bug fixes from qwibitai/nanoclaw:

- **[Upstream PR #530]** Prevent duplicate messages from message loop piping fallback. When allPending is empty (all messages already processed), the old code fell back to groupMessages which re-sent already-processed messages. Now skips the iteration entirely.

- **[Upstream PR #513]** Pin WA Web protocol version to [2, 3000, 1034074495] in both makeWASocket() calls. Prevents 405 Method Not Allowed connection errors when WhatsApp deprecates the old Baileys-hardcoded version.

- **[Upstream PR #528]** Wrap WhatsApp messages.upsert handler loop body in try-catch. A single malformed message no longer crashes all message processing — errors are logged and processing continues for remaining messages.

## Changes

| File | Fix | LOC |
|------|-----|-----|
| src/index.ts | Duplicate message prevention (#530) | +4/-2 |
| src/channels/whatsapp.ts | Protocol version (#513) + error handling (#528) | +70/-63 |
| src/whatsapp-auth.ts | Protocol version (#513) | +1/-0 |

## Test plan

- [x] bun run typecheck — no new errors
- [x] bun test — 113 pass, 3 skip (same as main)
- [ ] Verify WhatsApp connection with new protocol version
- [ ] Send rapid successive messages to confirm no duplicates

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error handling to prevent crashes during message processing.
  * Enhanced error diagnostics with additional details logged when processing failures occur.
  * Fixed inefficient message reprocessing by skipping groups without new messages instead of resending previously processed messages.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->