### PR TITLE
fix: prevent message loss on send failure + timestamp comparison

### DIFF
--- a/src/channels/whatsapp.ts
+++ b/src/channels/whatsapp.ts
@@ -505,8 +505,9 @@ export class WhatsAppChannel implements Channel {
         'Flushing outgoing message queue',
       );
       while (this.outgoingQueue.length > 0) {
-        const item = this.outgoingQueue.shift()!;
+        const item = this.outgoingQueue[0];
         await this.sendMessage(item.jid, item.text);
+        this.outgoingQueue.shift();
       }
     } finally {
       this.flushing = false;

--- a/src/db.ts
+++ b/src/db.ts
@@ -483,7 +483,8 @@ export function getNewMessages(
 
   let newTimestamp = lastTimestamp;
   const messages: NewMessage[] = rows.map((row) => {
-    if (row.timestamp > newTimestamp) newTimestamp = row.timestamp;
+    if (new Date(row.timestamp) > new Date(newTimestamp))
+      newTimestamp = row.timestamp;
     return {
       ...row,
       sender_user_id: row.sender_user_id ?? undefined,


### PR DESCRIPTION
## Summary
[Upstream PR #532] Two targeted bug fixes:

• *WhatsApp queue*: dequeue message only after successful send — prevents silent message loss when sendMessage() throws (network error, socket closed)
• *Timestamp comparison*: use Date object comparison instead of string `>` for ISO 8601 timestamps — handles differing precision (e.g. `Z` vs `.000Z`)

## Test plan
- [ ] Verify WhatsApp message sending still works normally
- [ ] Verify queue retains messages on send failure
- [ ] Verify timestamp-based message polling handles mixed precision

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved WhatsApp message delivery reliability by enhancing queue handling to properly retry failed messages.
  * Fixed message timestamp comparison to ensure accurate chronological ordering of messages in conversations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->