### PR TITLE
fix(discord): remove @AllAgents feature and GuildMembers intent

### DIFF
--- a/.claude/skills/setup/SKILL.md
+++ b/.claude/skills/setup/SKILL.md
@@ -251,9 +251,8 @@ Ask the user:
 > Provide your Discord bot token. If you don't have one:
 > 1. Go to https://discord.com/developers/applications
 > 2. Create a new application → Bot → Reset Token → Copy it
-> 3. Under **Bot → Privileged Gateway Intents**, enable ALL THREE:
+> 3. Under **Bot → Privileged Gateway Intents**, enable BOTH:
 >    - **Presence Intent**
->    - **Server Members Intent** (required for `@AllAgents` feature)
 >    - **Message Content Intent** (required to read message text)
 > 4. Invite the bot to your server using OAuth2 → URL Generator (scopes: `bot`, permissions: `Send Messages`, `Read Message History`)
 

--- a/src/channels/discord.ts
+++ b/src/channels/discord.ts
@@ -106,7 +106,6 @@ export class DiscordChannel implements Channel {
         GatewayIntentBits.MessageContent,
         GatewayIntentBits.DirectMessages,
         GatewayIntentBits.GuildMessageReactions,
-        GatewayIntentBits.GuildMembers, // Required for guild.members.fetch() in @AllAgents feature
       ],
       partials: [Partials.Channel, Partials.Message, Partials.Reaction],
     });
@@ -343,48 +342,6 @@ export class DiscordChannel implements Channel {
     if (message.author.id === this.client.user?.id) return;
 
     let content = message.content;
-
-    // **NEW**: @AllAgents shortcut - pings all Discord agent bots in the server
-    if (content.includes('@AllAgents') || content.includes('@allagents')) {
-      const registeredGroups = getAllRegisteredGroups();
-      const agentMentions: string[] = [];
-
-      // Find all Discord agents (dc: or dc:dm: JIDs)
-      for (const [jid, group] of Object.entries(registeredGroups)) {
-        if (jid.startsWith('dc:') && !jid.includes(':dm:')) {
-          // Get channel and fetch bot members
-          try {
-            const channelId = jidToChannelId(jid);
-            if (channelId && message.guildId) {
-              const guild = message.client.guilds.cache.get(message.guildId);
-              const members = await guild?.members.fetch();
-              const botMembers = members?.filter(
-                (m) => m.user.bot && m.user.id !== this.client.user?.id,
-              );
-
-              botMembers?.forEach((bot) => {
-                agentMentions.push(`<@${bot.user.id}>`);
-              });
-            }
-          } catch (err) {
-            logger.warn(
-              { jid, err },
-              'Failed to fetch bot members for @AllAgents',
-            );
-          }
-        }
-      }
-
-      // Replace @AllAgents with actual mentions
-      const uniqueMentions = [...new Set(agentMentions)];
-      const mentionString = uniqueMentions.join(' ');
-      content = content.replace(/@AllAgents|@allagents/gi, mentionString);
-
-      logger.info(
-        { agentCount: uniqueMentions.length },
-        'Expanded @AllAgents shortcut',
-      );
-    }
 
     // Translate @bot mention into trigger format
     // FIX: Determine agent name from the channel's registered group, not global ASSISTANT_NAME


### PR DESCRIPTION
## Summary

- Remove the `@AllAgents` expansion block from Discord handler (~40 LOC deleted)
- Remove `GatewayIntentBits.GuildMembers` privileged intent from the Discord client constructor
- Update setup SKILL.md to no longer require Server Members Intent (3→2 required intents)

### Why

The `@AllAgents` feature called `guild.members.fetch()` — a heavy privileged API call that:
1. Required the **Server Members Intent** (a privileged gateway intent that must be manually enabled)
2. Fetched the *entire* member list of the guild on every `@AllAgents` message
3. Could hit rate limits on large servers
4. Provided marginal value — users can simply `@mention` each agent individually

### What Changed

| File | Change |
|------|--------|
| `src/channels/discord.ts` | Removed `@AllAgents` expansion block (lines 347-387) and `GuildMembers` intent |
| `.claude/skills/setup/SKILL.md` | Updated intent instructions from "ALL THREE" to "BOTH" |

No new code added — purely a deletion PR.

## Test plan

- [x] `tsc --noEmit` passes (0 errors)
- [x] All 677 tests pass
- [x] Verified `getAllRegisteredGroups` import still used in 3 other locations
- [x] No other code in discord.ts calls `guild.members.fetch()`
- [ ] Deploy and verify Discord bot connects without GuildMembers intent

Closes #121, #123, #124, #125

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Simplified Discord bot setup requirements—now requires 2 gateway intents instead of 3

* **Refactor**
  * Removed @AllAgents automatic mention expansion feature

<!-- end of auto-generated comment: release notes by coderabbit.ai -->