### PR TITLE
test: add 75 channel adapter tests (discord, slack, telegram)

### DIFF
--- a/src/channels/discord.test.ts
+++ b/src/channels/discord.test.ts
@@ -1,0 +1,225 @@
+import { describe, it, expect } from 'bun:test';
+
+import { jidToChannelId, DiscordChannel } from './discord.js';
+import type { RegisteredGroup } from '../types.js';
+
+// --- jidToChannelId ---
+
+describe('Discord jidToChannelId', () => {
+  it('extracts channel ID from guild channel JID', () => {
+    expect(jidToChannelId('dc:1234567890')).toBe('1234567890');
+  });
+
+  it('returns null for DM JIDs (dc:dm: prefix)', () => {
+    expect(jidToChannelId('dc:dm:9876543210')).toBeNull();
+  });
+
+  it('returns null for non-Discord JIDs', () => {
+    expect(jidToChannelId('slack:C12345')).toBeNull();
+    expect(jidToChannelId('tg:12345')).toBeNull();
+    expect(jidToChannelId('main@g.us')).toBeNull();
+  });
+
+  it('returns null for empty string', () => {
+    expect(jidToChannelId('')).toBeNull();
+  });
+
+  it('handles JID with just the dc: prefix', () => {
+    expect(jidToChannelId('dc:')).toBe('');
+  });
+
+  it('handles JID with extra colons', () => {
+    // dc:some:thing — starts with dc: but not dc:dm:, so slices after "dc:"
+    expect(jidToChannelId('dc:some:thing')).toBe('some:thing');
+  });
+});
+
+// --- DiscordChannel.ownsJid ---
+
+describe('DiscordChannel.ownsJid', () => {
+  // We can't instantiate DiscordChannel without a real token, but the method
+  // is simple enough to verify from the source: it checks jid.startsWith('dc:')
+  // So we test the pattern directly.
+
+  it('matches dc: prefixed JIDs', () => {
+    expect('dc:123456'.startsWith('dc:')).toBe(true);
+  });
+
+  it('matches dc:dm: prefixed JIDs', () => {
+    expect('dc:dm:user123'.startsWith('dc:')).toBe(true);
+  });
+
+  it('does not match non-Discord JIDs', () => {
+    expect('slack:C123'.startsWith('dc:')).toBe(false);
+    expect('tg:123'.startsWith('dc:')).toBe(false);
+    expect('main@g.us'.startsWith('dc:')).toBe(false);
+  });
+});
+
+// --- shouldAutoRespond ---
+
+describe('Discord shouldAutoRespond', () => {
+  // shouldAutoRespond is an instance method, but we need a DiscordChannel instance.
+  // Since the constructor requires a token, we create a minimal instance with a dummy token.
+  // The method only uses `content` and `group` parameters — no actual Discord connection needed.
+  const channel = new DiscordChannel({ token: 'test-token-not-used' });
+
+  function makeGroup(
+    overrides: Partial<RegisteredGroup> = {},
+  ): RegisteredGroup {
+    return {
+      name: 'Test',
+      folder: 'test',
+      trigger: '@Bot',
+      added_at: '2025-01-01T00:00:00.000Z',
+      ...overrides,
+    };
+  }
+
+  describe('question detection (autoRespondToQuestions)', () => {
+    it('responds to messages ending with ?', () => {
+      const group = makeGroup({ autoRespondToQuestions: true });
+      expect(channel.shouldAutoRespond('What time is it?', group)).toBe(true);
+    });
+
+    it('trims content before checking for trailing ?', () => {
+      const group = makeGroup({ autoRespondToQuestions: true });
+      // content.trim().endsWith('?') — trailing whitespace is trimmed first
+      expect(channel.shouldAutoRespond('What time is it?  ', group)).toBe(
+        true,
+      );
+      expect(channel.shouldAutoRespond('  What time is it?  ', group)).toBe(
+        true,
+      );
+    });
+
+    it('does not respond to questions when autoRespondToQuestions is false', () => {
+      const group = makeGroup({ autoRespondToQuestions: false });
+      expect(channel.shouldAutoRespond('What time is it?', group)).toBe(false);
+    });
+
+    it('does not respond to questions when autoRespondToQuestions is undefined', () => {
+      const group = makeGroup();
+      expect(channel.shouldAutoRespond('What time is it?', group)).toBe(false);
+    });
+
+    it('does not respond to non-question messages', () => {
+      const group = makeGroup({ autoRespondToQuestions: true });
+      expect(channel.shouldAutoRespond('Hello world', group)).toBe(false);
+    });
+
+    it('does not respond to empty content', () => {
+      const group = makeGroup({ autoRespondToQuestions: true });
+      expect(channel.shouldAutoRespond('', group)).toBe(false);
+    });
+
+    it('responds to multi-line messages ending with ?', () => {
+      const group = makeGroup({ autoRespondToQuestions: true });
+      expect(
+        channel.shouldAutoRespond('Line one\nLine two\nQuestion?', group),
+      ).toBe(true);
+    });
+  });
+
+  describe('keyword matching (autoRespondKeywords)', () => {
+    it('matches keyword with word boundary (case-insensitive)', () => {
+      const group = makeGroup({ autoRespondKeywords: ['help'] });
+      expect(channel.shouldAutoRespond('I need help with this', group)).toBe(
+        true,
+      );
+    });
+
+    it('is case-insensitive', () => {
+      const group = makeGroup({ autoRespondKeywords: ['help'] });
+      expect(channel.shouldAutoRespond('HELP me please', group)).toBe(true);
+      expect(channel.shouldAutoRespond('Help Me', group)).toBe(true);
+    });
+
+    it('does not match partial words (word boundary)', () => {
+      const group = makeGroup({ autoRespondKeywords: ['help'] });
+      expect(channel.shouldAutoRespond('That was helpful', group)).toBe(false);
+      expect(channel.shouldAutoRespond('The helper arrived', group)).toBe(
+        false,
+      );
+    });
+
+    it('matches when keyword is the entire message', () => {
+      const group = makeGroup({ autoRespondKeywords: ['status'] });
+      expect(channel.shouldAutoRespond('status', group)).toBe(true);
+    });
+
+    it('matches multiple keywords (any match)', () => {
+      const group = makeGroup({
+        autoRespondKeywords: ['hello', 'help', 'status'],
+      });
+      expect(channel.shouldAutoRespond('Can you help', group)).toBe(true);
+      expect(channel.shouldAutoRespond('Check the status', group)).toBe(true);
+      expect(channel.shouldAutoRespond('Say hello', group)).toBe(true);
+    });
+
+    it('does not match when no keywords match', () => {
+      const group = makeGroup({ autoRespondKeywords: ['help', 'status'] });
+      expect(channel.shouldAutoRespond('Just chatting here', group)).toBe(
+        false,
+      );
+    });
+
+    it('escapes special regex characters in keywords', () => {
+      // The regex escapes special chars, but \b after non-word chars like '+'
+      // has a known edge case: \b between non-word chars doesn't always trigger.
+      // Test with a keyword containing a dot (also special but works with \b).
+      const group = makeGroup({ autoRespondKeywords: ['file.txt'] });
+      expect(channel.shouldAutoRespond('Open file.txt now', group)).toBe(true);
+      // Dot is escaped — should not match "fileXtxt"
+      expect(channel.shouldAutoRespond('Open fileXtxt now', group)).toBe(false);
+    });
+
+    it('handles keyword with dots', () => {
+      const group = makeGroup({ autoRespondKeywords: ['v2.0'] });
+      expect(channel.shouldAutoRespond('Released v2.0 today', group)).toBe(
+        true,
+      );
+      // Dot is escaped — should not match "v2X0"
+      expect(channel.shouldAutoRespond('Released v2X0 today', group)).toBe(
+        false,
+      );
+    });
+
+    it('returns false when autoRespondKeywords is undefined', () => {
+      const group = makeGroup();
+      expect(channel.shouldAutoRespond('help me', group)).toBe(false);
+    });
+
+    it('returns false when autoRespondKeywords is empty', () => {
+      const group = makeGroup({ autoRespondKeywords: [] });
+      expect(channel.shouldAutoRespond('help me', group)).toBe(false);
+    });
+  });
+
+  describe('combined behavior', () => {
+    it('question detection takes priority over keywords', () => {
+      const group = makeGroup({
+        autoRespondToQuestions: true,
+        autoRespondKeywords: ['help'],
+      });
+      // Question without keyword — still matches via question detection
+      expect(channel.shouldAutoRespond('How are you?', group)).toBe(true);
+    });
+
+    it('falls back to keyword matching when not a question', () => {
+      const group = makeGroup({
+        autoRespondToQuestions: true,
+        autoRespondKeywords: ['help'],
+      });
+      expect(channel.shouldAutoRespond('I need help', group)).toBe(true);
+    });
+
+    it('returns false when neither condition matches', () => {
+      const group = makeGroup({
+        autoRespondToQuestions: true,
+        autoRespondKeywords: ['help'],
+      });
+      expect(channel.shouldAutoRespond('Just chatting', group)).toBe(false);
+    });
+  });
+});

--- a/src/channels/discord.test.ts
+++ b/src/channels/discord.test.ts
@@ -37,22 +37,20 @@ describe('Discord jidToChannelId', () => {
 // --- DiscordChannel.ownsJid ---
 
 describe('DiscordChannel.ownsJid', () => {
-  // We can't instantiate DiscordChannel without a real token, but the method
-  // is simple enough to verify from the source: it checks jid.startsWith('dc:')
-  // So we test the pattern directly.
+  const channel = new DiscordChannel({ token: 'test-token-not-used' });
 
   it('matches dc: prefixed JIDs', () => {
-    expect('dc:123456'.startsWith('dc:')).toBe(true);
+    expect(channel.ownsJid('dc:123456')).toBe(true);
   });
 
   it('matches dc:dm: prefixed JIDs', () => {
-    expect('dc:dm:user123'.startsWith('dc:')).toBe(true);
+    expect(channel.ownsJid('dc:dm:user123')).toBe(true);
   });
 
   it('does not match non-Discord JIDs', () => {
-    expect('slack:C123'.startsWith('dc:')).toBe(false);
-    expect('tg:123'.startsWith('dc:')).toBe(false);
-    expect('main@g.us'.startsWith('dc:')).toBe(false);
+    expect(channel.ownsJid('slack:C123')).toBe(false);
+    expect(channel.ownsJid('tg:123')).toBe(false);
+    expect(channel.ownsJid('main@g.us')).toBe(false);
   });
 });
 

--- a/src/channels/discord.test.ts
+++ b/src/channels/discord.test.ts
@@ -83,9 +83,7 @@ describe('Discord shouldAutoRespond', () => {
     it('trims content before checking for trailing ?', () => {
       const group = makeGroup({ autoRespondToQuestions: true });
       // content.trim().endsWith('?') — trailing whitespace is trimmed first
-      expect(channel.shouldAutoRespond('What time is it?  ', group)).toBe(
-        true,
-      );
+      expect(channel.shouldAutoRespond('What time is it?  ', group)).toBe(true);
       expect(channel.shouldAutoRespond('  What time is it?  ', group)).toBe(
         true,
       );

--- a/src/channels/discord.ts
+++ b/src/channels/discord.ts
@@ -318,7 +318,7 @@ export class DiscordChannel implements Channel {
   /**
    * Check if message should auto-respond based on group config
    */
-  private shouldAutoRespond(content: string, group: RegisteredGroup): boolean {
+  shouldAutoRespond(content: string, group: RegisteredGroup): boolean {
     // Check for question ending with '?'
     if (group.autoRespondToQuestions && content.trim().endsWith('?')) {
       return true;
@@ -764,7 +764,7 @@ export class DiscordChannel implements Channel {
 }
 
 /** Convert a dc: JID to a Discord channel ID (guild channels only) */
-function jidToChannelId(jid: string): string | null {
+export function jidToChannelId(jid: string): string | null {
   if (jid.startsWith('dc:dm:')) return null; // DMs use user ID, not channel ID
   if (jid.startsWith('dc:')) return jid.slice(3);
   return null;

--- a/src/channels/slack.test.ts
+++ b/src/channels/slack.test.ts
@@ -1,0 +1,85 @@
+import { describe, it, expect } from 'bun:test';
+
+import { jidToChannelId, channelIdToJid } from './slack.js';
+
+// --- jidToChannelId ---
+
+describe('Slack jidToChannelId', () => {
+  it('extracts channel ID from slack: JID', () => {
+    expect(jidToChannelId('slack:C12345678')).toBe('C12345678');
+  });
+
+  it('extracts DM channel ID from slack: JID', () => {
+    expect(jidToChannelId('slack:D98765432')).toBe('D98765432');
+  });
+
+  it('returns null for non-Slack JIDs', () => {
+    expect(jidToChannelId('dc:123456')).toBeNull();
+    expect(jidToChannelId('tg:123456')).toBeNull();
+    expect(jidToChannelId('main@g.us')).toBeNull();
+  });
+
+  it('returns null for empty string', () => {
+    expect(jidToChannelId('')).toBeNull();
+  });
+
+  it('handles JID with just the slack: prefix', () => {
+    expect(jidToChannelId('slack:')).toBe('');
+  });
+
+  it('preserves special characters in channel ID', () => {
+    expect(jidToChannelId('slack:C_ABC-123')).toBe('C_ABC-123');
+  });
+});
+
+// --- channelIdToJid ---
+
+describe('Slack channelIdToJid', () => {
+  it('creates a slack: JID from channel ID', () => {
+    expect(channelIdToJid('C12345678')).toBe('slack:C12345678');
+  });
+
+  it('creates a slack: JID from DM channel ID', () => {
+    expect(channelIdToJid('D98765432')).toBe('slack:D98765432');
+  });
+
+  it('handles empty channel ID', () => {
+    expect(channelIdToJid('')).toBe('slack:');
+  });
+});
+
+// --- Roundtrip ---
+
+describe('Slack JID roundtrip', () => {
+  it('jidToChannelId and channelIdToJid are inverses', () => {
+    const channelId = 'C12345678';
+    const jid = channelIdToJid(channelId);
+    expect(jidToChannelId(jid)).toBe(channelId);
+  });
+
+  it('roundtrips DM channel IDs', () => {
+    const channelId = 'D98765432';
+    expect(jidToChannelId(channelIdToJid(channelId))).toBe(channelId);
+  });
+
+  it('roundtrips various channel types', () => {
+    for (const id of ['C001', 'D002', 'G003']) {
+      expect(jidToChannelId(channelIdToJid(id))).toBe(id);
+    }
+  });
+});
+
+// --- ownsJid pattern ---
+
+describe('Slack ownsJid pattern', () => {
+  it('matches slack: prefixed JIDs', () => {
+    expect('slack:C123'.startsWith('slack:')).toBe(true);
+    expect('slack:D456'.startsWith('slack:')).toBe(true);
+  });
+
+  it('does not match non-Slack JIDs', () => {
+    expect('dc:123'.startsWith('slack:')).toBe(false);
+    expect('tg:456'.startsWith('slack:')).toBe(false);
+    expect('main@g.us'.startsWith('slack:')).toBe(false);
+  });
+});

--- a/src/channels/slack.test.ts
+++ b/src/channels/slack.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect } from 'bun:test';
 
-import { jidToChannelId, channelIdToJid } from './slack.js';
+import { jidToChannelId, channelIdToJid, SlackChannel } from './slack.js';
 
 // --- jidToChannelId ---
 
@@ -69,17 +69,20 @@ describe('Slack JID roundtrip', () => {
   });
 });
 
-// --- ownsJid pattern ---
+// --- SlackChannel.ownsJid ---
 
-describe('Slack ownsJid pattern', () => {
+describe('SlackChannel.ownsJid', () => {
+  const ownsJid = (jid: string) =>
+    SlackChannel.prototype.ownsJid.call({} as SlackChannel, jid);
+
   it('matches slack: prefixed JIDs', () => {
-    expect('slack:C123'.startsWith('slack:')).toBe(true);
-    expect('slack:D456'.startsWith('slack:')).toBe(true);
+    expect(ownsJid('slack:C123')).toBe(true);
+    expect(ownsJid('slack:D456')).toBe(true);
   });
 
   it('does not match non-Slack JIDs', () => {
-    expect('dc:123'.startsWith('slack:')).toBe(false);
-    expect('tg:456'.startsWith('slack:')).toBe(false);
-    expect('main@g.us'.startsWith('slack:')).toBe(false);
+    expect(ownsJid('dc:123')).toBe(false);
+    expect(ownsJid('tg:456')).toBe(false);
+    expect(ownsJid('main@g.us')).toBe(false);
   });
 });

--- a/src/channels/slack.ts
+++ b/src/channels/slack.ts
@@ -14,12 +14,12 @@ import { splitMessage as splitMessageShared } from './utils.js';
 // JID format: "slack:{channelId}" for channels/DMs
 // e.g. "slack:C12345678" for a channel, "slack:D12345678" for a DM
 
-function jidToChannelId(jid: string): string | null {
+export function jidToChannelId(jid: string): string | null {
   if (!jid.startsWith('slack:')) return null;
   return jid.slice('slack:'.length);
 }
 
-function channelIdToJid(channelId: string): string {
+export function channelIdToJid(channelId: string): string {
   return `slack:${channelId}`;
 }
 

--- a/src/channels/telegram.test.ts
+++ b/src/channels/telegram.test.ts
@@ -1,0 +1,170 @@
+import { describe, it, expect } from 'bun:test';
+
+import {
+  isTelegramReactionEmoji,
+  VALID_TELEGRAM_REACTIONS,
+} from './telegram.js';
+
+// --- isTelegramReactionEmoji ---
+
+describe('isTelegramReactionEmoji', () => {
+  describe('valid emojis', () => {
+    it('accepts thumbs up', () => {
+      expect(isTelegramReactionEmoji('👍')).toBe(true);
+    });
+
+    it('accepts thumbs down', () => {
+      expect(isTelegramReactionEmoji('👎')).toBe(true);
+    });
+
+    it('accepts heart', () => {
+      expect(isTelegramReactionEmoji('❤')).toBe(true);
+    });
+
+    it('accepts fire', () => {
+      expect(isTelegramReactionEmoji('🔥')).toBe(true);
+    });
+
+    it('accepts party popper', () => {
+      expect(isTelegramReactionEmoji('🎉')).toBe(true);
+    });
+
+    it('accepts 100', () => {
+      expect(isTelegramReactionEmoji('💯')).toBe(true);
+    });
+
+    it('accepts thinking face', () => {
+      expect(isTelegramReactionEmoji('🤔')).toBe(true);
+    });
+
+    it('accepts clown', () => {
+      expect(isTelegramReactionEmoji('🤡')).toBe(true);
+    });
+
+    it('accepts poop', () => {
+      expect(isTelegramReactionEmoji('💩')).toBe(true);
+    });
+
+    it('accepts eyes', () => {
+      expect(isTelegramReactionEmoji('👀')).toBe(true);
+    });
+
+    it('accepts combined emoji (heart on fire)', () => {
+      expect(isTelegramReactionEmoji('❤‍🔥')).toBe(true);
+    });
+
+    it('accepts combined emoji (programmer)', () => {
+      expect(isTelegramReactionEmoji('👨‍💻')).toBe(true);
+    });
+
+    it('accepts shrug variants', () => {
+      expect(isTelegramReactionEmoji('🤷‍♂')).toBe(true);
+      expect(isTelegramReactionEmoji('🤷')).toBe(true);
+      expect(isTelegramReactionEmoji('🤷‍♀')).toBe(true);
+    });
+  });
+
+  describe('invalid emojis', () => {
+    it('rejects taco emoji (not in Telegram list)', () => {
+      expect(isTelegramReactionEmoji('🌮')).toBe(false);
+    });
+
+    it('rejects pizza emoji', () => {
+      expect(isTelegramReactionEmoji('🍕')).toBe(false);
+    });
+
+    it('rejects soccer ball', () => {
+      expect(isTelegramReactionEmoji('⚽')).toBe(false);
+    });
+
+    it('rejects flag emoji', () => {
+      expect(isTelegramReactionEmoji('🇺🇸')).toBe(false);
+    });
+
+    it('rejects non-emoji strings', () => {
+      expect(isTelegramReactionEmoji('hello')).toBe(false);
+      expect(isTelegramReactionEmoji('thumbsup')).toBe(false);
+    });
+
+    it('rejects empty string', () => {
+      expect(isTelegramReactionEmoji('')).toBe(false);
+    });
+
+    it('rejects whitespace', () => {
+      expect(isTelegramReactionEmoji(' ')).toBe(false);
+      expect(isTelegramReactionEmoji('\n')).toBe(false);
+    });
+
+    it('rejects emoji shortcodes', () => {
+      expect(isTelegramReactionEmoji(':thumbsup:')).toBe(false);
+      expect(isTelegramReactionEmoji(':heart:')).toBe(false);
+    });
+
+    it('rejects numbers and special characters', () => {
+      expect(isTelegramReactionEmoji('1')).toBe(false);
+      expect(isTelegramReactionEmoji('!')).toBe(false);
+      expect(isTelegramReactionEmoji('#')).toBe(false);
+    });
+  });
+
+  describe('boundary cases', () => {
+    it('rejects emoji with trailing space', () => {
+      expect(isTelegramReactionEmoji('👍 ')).toBe(false);
+    });
+
+    it('rejects emoji with leading space', () => {
+      expect(isTelegramReactionEmoji(' 👍')).toBe(false);
+    });
+
+    it('rejects multiple valid emojis combined', () => {
+      expect(isTelegramReactionEmoji('👍👎')).toBe(false);
+    });
+  });
+});
+
+// --- VALID_TELEGRAM_REACTIONS ---
+
+describe('VALID_TELEGRAM_REACTIONS', () => {
+  it('contains exactly 73 entries', () => {
+    expect(VALID_TELEGRAM_REACTIONS.length).toBe(73);
+  });
+
+  it('contains common reaction emojis', () => {
+    const commonEmojis = ['👍', '👎', '❤', '🔥', '🎉', '💯', '🤔'];
+    for (const emoji of commonEmojis) {
+      expect(VALID_TELEGRAM_REACTIONS).toContain(emoji);
+    }
+  });
+
+  it('has no duplicates', () => {
+    const unique = new Set(VALID_TELEGRAM_REACTIONS);
+    expect(unique.size).toBe(VALID_TELEGRAM_REACTIONS.length);
+  });
+
+  it('every entry passes isTelegramReactionEmoji', () => {
+    for (const emoji of VALID_TELEGRAM_REACTIONS) {
+      expect(isTelegramReactionEmoji(emoji)).toBe(true);
+    }
+  });
+
+  it('is frozen (readonly)', () => {
+    // The array is declared as readonly — attempting to push should be a type error.
+    // At runtime, readonly arrays in TS are regular arrays, so we verify the const assertion.
+    expect(Array.isArray(VALID_TELEGRAM_REACTIONS)).toBe(true);
+  });
+});
+
+// --- TelegramChannel.ownsJid pattern ---
+
+describe('Telegram ownsJid pattern', () => {
+  it('matches tg: prefixed JIDs', () => {
+    expect('tg:12345'.startsWith('tg:')).toBe(true);
+    expect('tg:-100123456789'.startsWith('tg:')).toBe(true);
+  });
+
+  it('does not match non-Telegram JIDs', () => {
+    expect('dc:123'.startsWith('tg:')).toBe(false);
+    expect('slack:C123'.startsWith('tg:')).toBe(false);
+    expect('main@g.us'.startsWith('tg:')).toBe(false);
+  });
+});

--- a/src/channels/telegram.test.ts
+++ b/src/channels/telegram.test.ts
@@ -3,6 +3,7 @@ import { describe, it, expect } from 'bun:test';
 import {
   isTelegramReactionEmoji,
   VALID_TELEGRAM_REACTIONS,
+  TelegramChannel,
 } from './telegram.js';
 
 // --- isTelegramReactionEmoji ---
@@ -130,7 +131,7 @@ describe('VALID_TELEGRAM_REACTIONS', () => {
   });
 
   it('contains common reaction emojis', () => {
-    const commonEmojis = ['👍', '👎', '❤', '🔥', '🎉', '💯', '🤔'];
+    const commonEmojis = ['👍', '👎', '❤', '🔥', '🎉', '💯', '🤔'] as const;
     for (const emoji of commonEmojis) {
       expect(VALID_TELEGRAM_REACTIONS).toContain(emoji);
     }
@@ -147,24 +148,27 @@ describe('VALID_TELEGRAM_REACTIONS', () => {
     }
   });
 
-  it('is frozen (readonly)', () => {
-    // The array is declared as readonly — attempting to push should be a type error.
-    // At runtime, readonly arrays in TS are regular arrays, so we verify the const assertion.
+  it('is an array (readonly at type level)', () => {
+    // The array is declared as `readonly` via `as const` — a compile-time guarantee.
+    // At runtime we can only verify it's an array.
     expect(Array.isArray(VALID_TELEGRAM_REACTIONS)).toBe(true);
   });
 });
 
-// --- TelegramChannel.ownsJid pattern ---
+// --- TelegramChannel.ownsJid ---
 
-describe('Telegram ownsJid pattern', () => {
+describe('TelegramChannel.ownsJid', () => {
+  const ownsJid = (jid: string) =>
+    TelegramChannel.prototype.ownsJid.call({} as TelegramChannel, jid);
+
   it('matches tg: prefixed JIDs', () => {
-    expect('tg:12345'.startsWith('tg:')).toBe(true);
-    expect('tg:-100123456789'.startsWith('tg:')).toBe(true);
+    expect(ownsJid('tg:12345')).toBe(true);
+    expect(ownsJid('tg:-100123456789')).toBe(true);
   });
 
   it('does not match non-Telegram JIDs', () => {
-    expect('dc:123'.startsWith('tg:')).toBe(false);
-    expect('slack:C123'.startsWith('tg:')).toBe(false);
-    expect('main@g.us'.startsWith('tg:')).toBe(false);
+    expect(ownsJid('dc:123')).toBe(false);
+    expect(ownsJid('slack:C123')).toBe(false);
+    expect(ownsJid('main@g.us')).toBe(false);
   });
 });

--- a/src/channels/telegram.ts
+++ b/src/channels/telegram.ts
@@ -12,7 +12,7 @@ import { splitMessage } from './utils.js';
 
 type TelegramReactionEmoji =
   import('@grammyjs/types').ReactionTypeEmoji['emoji'];
-const VALID_TELEGRAM_REACTIONS: readonly TelegramReactionEmoji[] = [
+export const VALID_TELEGRAM_REACTIONS: readonly TelegramReactionEmoji[] = [
   '👍',
   '👎',
   '❤',
@@ -87,7 +87,7 @@ const VALID_TELEGRAM_REACTIONS: readonly TelegramReactionEmoji[] = [
   '🤷‍♀',
   '😡',
 ];
-function isTelegramReactionEmoji(v: string): v is TelegramReactionEmoji {
+export function isTelegramReactionEmoji(v: string): v is TelegramReactionEmoji {
   return (VALID_TELEGRAM_REACTIONS as readonly string[]).includes(v);
 }
 


### PR DESCRIPTION
## Summary

• Export pure utility functions from Discord, Slack, and Telegram channel adapters for testability
• Add 75 new tests covering previously untested channel logic
• Test count: 677 → 752 (+75 tests, 0 failures)

## New Test Coverage

*Discord* (`discord.test.ts` — 28 tests):
• `jidToChannelId`: guild channels, DM JIDs, non-Discord JIDs, edge cases
• `shouldAutoRespond`: question detection (trailing ?, trimming, multiline), keyword matching (word boundaries, case-insensitive, regex escaping, empty/undefined config), combined behavior

*Slack* (`slack.test.ts` — 16 tests):
• `jidToChannelId`: channel extraction, DM channels, non-Slack JIDs
• `channelIdToJid`: JID construction, empty input
• Roundtrip verification: both functions are inverses

*Telegram* (`telegram.test.ts` — 31 tests):
• `isTelegramReactionEmoji`: valid emojis (thumbs, hearts, combined/ZWJ emojis, shrug variants), invalid emojis (non-Telegram emojis, strings, shortcodes, numbers), boundary cases (spaces, multiple emojis)
• `VALID_TELEGRAM_REACTIONS`: count, common emojis, no duplicates, consistency with type guard

## Source Changes (minimal)

• `discord.ts`: `export` on `jidToChannelId`, `shouldAutoRespond` changed from `private` to public
• `slack.ts`: `export` on `jidToChannelId`, `channelIdToJid`
• `telegram.ts`: `export` on `isTelegramReactionEmoji`, `VALID_TELEGRAM_REACTIONS`

No behavioral changes — only visibility modifiers for testability.

## Test plan
- [x] All 752 tests pass (`bun test`)
- [x] No regressions in existing 677 tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added extensive tests for Discord, Slack, and Telegram integrations covering ID parsing, ownership detection, auto-response logic (question vs. keyword handling), and Telegram reaction/emoji validation across many edge cases.

* **Chores**
  * Made several channel utilities and the Telegram reaction list publicly accessible to improve testability and future extensibility.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->