### PR TITLE
fix(security): validate discord_guild_id and add defense-in-depth path checks

### DIFF
--- a/src/backends/local-backend.ts
+++ b/src/backends/local-backend.ts
@@ -643,6 +643,7 @@ export class LocalBackend implements AgentBackend {
     opts?: { chatJid?: string },
   ): boolean {
     const inputDir = path.join(DATA_DIR, 'ipc', groupFolder, 'input');
+    assertPathWithin(inputDir, path.join(DATA_DIR, 'ipc'), 'sendMessage');
     try {
       fs.mkdirSync(inputDir, { recursive: true });
       const filename = `${Date.now()}-${Math.random().toString(36).slice(2, 6)}.json`;
@@ -665,6 +666,7 @@ export class LocalBackend implements AgentBackend {
 
   closeStdin(groupFolder: string, inputSubdir: string = 'input'): void {
     const inputDir = path.join(DATA_DIR, 'ipc', groupFolder, inputSubdir);
+    assertPathWithin(inputDir, path.join(DATA_DIR, 'ipc'), 'closeStdin');
     try {
       fs.mkdirSync(inputDir, { recursive: true });
       fs.writeFileSync(path.join(inputDir, '_close'), '');
@@ -675,8 +677,11 @@ export class LocalBackend implements AgentBackend {
 
   writeIpcData(groupFolder: string, filename: string, data: string): void {
     const groupIpcDir = path.join(DATA_DIR, 'ipc', groupFolder);
+    assertPathWithin(groupIpcDir, path.join(DATA_DIR, 'ipc'), 'writeIpcData');
+    const targetFile = path.join(groupIpcDir, filename);
+    assertPathWithin(targetFile, groupIpcDir, 'writeIpcData filename');
     fs.mkdirSync(groupIpcDir, { recursive: true });
-    fs.writeFileSync(path.join(groupIpcDir, filename), data);
+    fs.writeFileSync(targetFile, data);
   }
 
   async readFile(

--- a/src/index.ts
+++ b/src/index.ts
@@ -75,6 +75,7 @@ import {
 } from './types.js';
 import { findMainGroupJid } from './group-helpers.js';
 import { logger } from './logger.js';
+import { assertPathWithin } from './path-security.js';
 import { Effect } from 'effect';
 
 // Global error handlers to prevent crashes from unhandled rejections/exceptions
@@ -296,7 +297,9 @@ function slugifyGuildName(guildName: string): string {
 
 /** Ensure the server-level shared directory exists and has a CLAUDE.md */
 function ensureServerDirectory(serverFolder: string): void {
-  const serverDir = path.join(DATA_DIR, '..', 'groups', serverFolder);
+  const groupsBase = path.join(DATA_DIR, '..', 'groups');
+  const serverDir = path.join(groupsBase, serverFolder);
+  assertPathWithin(serverDir, groupsBase, 'ensureServerDirectory');
   fs.mkdirSync(serverDir, { recursive: true });
 
   const claudeMdPath = path.join(serverDir, 'CLAUDE.md');

--- a/src/ipc-processing.test.ts
+++ b/src/ipc-processing.test.ts
@@ -548,7 +548,7 @@ describe('processTaskIpc: register_group with discord', () => {
         name: 'Discord Channel',
         folder: 'dc-channel',
         trigger: '@Bot',
-        discord_guild_id: 'guild456',
+        discord_guild_id: '123456789012345678',
       },
       'main',
       true,
@@ -556,8 +556,26 @@ describe('processTaskIpc: register_group with discord', () => {
     );
 
     expect(groups['dc:channel123']).toBeDefined();
-    expect(groups['dc:channel123'].discordGuildId).toBe('guild456');
-    expect(groups['dc:channel123'].serverFolder).toBe('servers/guild456');
+    expect(groups['dc:channel123'].discordGuildId).toBe('123456789012345678');
+    expect(groups['dc:channel123'].serverFolder).toBe('servers/123456789012345678');
+  });
+
+  it('rejects non-numeric discord_guild_id to prevent path traversal', async () => {
+    await processTaskIpc(
+      {
+        type: 'register_group',
+        jid: 'dc:evil123',
+        name: 'Evil Channel',
+        folder: 'evil-channel',
+        trigger: '@Bot',
+        discord_guild_id: '../../etc',
+      },
+      'main',
+      true,
+      deps,
+    );
+
+    expect(groups['dc:evil123']).toBeUndefined();
   });
 
   it('sets backend when provided', async () => {

--- a/src/ipc-processing.test.ts
+++ b/src/ipc-processing.test.ts
@@ -557,7 +557,9 @@ describe('processTaskIpc: register_group with discord', () => {
 
     expect(groups['dc:channel123']).toBeDefined();
     expect(groups['dc:channel123'].discordGuildId).toBe('123456789012345678');
-    expect(groups['dc:channel123'].serverFolder).toBe('servers/123456789012345678');
+    expect(groups['dc:channel123'].serverFolder).toBe(
+      'servers/123456789012345678',
+    );
   });
 
   it('rejects non-numeric discord_guild_id to prevent path traversal', async () => {

--- a/src/ipc-snapshots.ts
+++ b/src/ipc-snapshots.ts
@@ -9,6 +9,7 @@ import fs from 'fs';
 import path from 'path';
 
 import { DATA_DIR } from './config.js';
+import { assertPathWithin } from './path-security.js';
 import type { ScheduledTask } from './types.js';
 
 export interface AvailableGroup {
@@ -44,7 +45,9 @@ export function writeTasksSnapshot(
     next_run: string | null;
   }>,
 ): void {
-  const groupIpcDir = path.join(DATA_DIR, 'ipc', groupFolder);
+  const ipcBase = path.join(DATA_DIR, 'ipc');
+  const groupIpcDir = path.join(ipcBase, groupFolder);
+  assertPathWithin(groupIpcDir, ipcBase, 'writeTasksSnapshot');
   fs.mkdirSync(groupIpcDir, { recursive: true });
 
   const filteredTasks = isMain
@@ -61,7 +64,9 @@ export function writeGroupsSnapshot(
   groups: AvailableGroup[],
   registeredJids: Set<string>,
 ): void {
-  const groupIpcDir = path.join(DATA_DIR, 'ipc', groupFolder);
+  const ipcBase = path.join(DATA_DIR, 'ipc');
+  const groupIpcDir = path.join(ipcBase, groupFolder);
+  assertPathWithin(groupIpcDir, ipcBase, 'writeGroupsSnapshot');
   fs.mkdirSync(groupIpcDir, { recursive: true });
 
   const visibleGroups = isMain ? groups : [];


### PR DESCRIPTION
## Summary

Addresses multiple path traversal vectors across IPC write operations:

• **discord_guild_id injection** (High): The IPC `register_group` handler accepted arbitrary strings as `discord_guild_id`, which flows into `serverFolder = servers/${id}` → `ensureServerDirectory()`. A value like `../../etc` would create directories and write files outside the groups directory. Now validates guild IDs are numeric snowflakes (`/^\d+$/`).

• **Defense-in-depth on IPC write functions** (Medium): `writeIpcData`, `sendMessage`, `closeStdin` in local-backend.ts all construct paths from `groupFolder` without re-validation. While folder names are validated at registration time, a single bypass would cascade into arbitrary writes. Added `assertPathWithin` checks at each write point.

• **Snapshot path validation** (Medium): `writeTasksSnapshot` and `writeGroupsSnapshot` in ipc-snapshots.ts used `groupFolder` from directory enumeration without validation. Added `assertPathWithin`.

• **Share request map cap** (Low): `pendingShareRequests` had no size limit — a flooding agent could grow it unboundedly for 24 hours. Capped at 1000 entries with LRU eviction.

## Test plan

- [x] All 668 tests pass (1 new test added)
- [x] TypeScript compiles cleanly (`tsc --noEmit`)
- [ ] New test verifies non-numeric `discord_guild_id` is rejected
- [ ] Verify existing Discord registration still works with numeric IDs

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Require numeric Discord guild IDs to prevent invalid group identifiers.
  * Strengthen path-security for inter-process communication and server directory handling to enforce directory boundaries.
  * Add a cap on pending share requests with eviction to limit resource usage.

* **Tests**
  * Added a test to reject non-numeric Discord guild IDs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->