### PR TITLE
fix(agent-runner): break for-await loop after result to unblock IPC handling

### DIFF
--- a/container/agent-runner/src/index.ts
+++ b/container/agent-runner/src/index.ts
@@ -927,6 +927,14 @@ async function runQuery(
         newSessionId
       });
       lastAssistantText = undefined;
+
+      // Break out of the for-await loop after receiving a result.
+      // This allows control to return to the outer while(true) loop where
+      // waitForIpcMessage() can properly handle follow-up messages.
+      // Without this break, the for-await loop hangs waiting for more stream
+      // input that the SDK will never process after yielding a result.
+      // See: https://github.com/qwibitai/nanoclaw/issues/233
+      break;
     }
   }
 


### PR DESCRIPTION
## Summary
[Upstream PR #550] Follow-up IPC messages sent to an active container were silently dropped after the agent produced a result.

## Problem
After the SDK yields a `result` message, the `for await (const message of query(...))` loop continued waiting for more stream input. `pollIpcDuringQuery()` pushed IPC messages into the stream, but the SDK had already finished processing. The outer `while(true)` loop with `waitForIpcMessage()` could never execute, causing follow-up messages to be silently dropped until the 25-minute idle timeout killed the container.

## Fix
Break out of the for-await loop immediately after receiving a `result` message. This allows control to return to the outer `while(true)` loop where `waitForIpcMessage()` properly handles follow-up messages.

• +8 LOC, 1 file (`container/agent-runner/src/index.ts`)

## Test plan
- [ ] Send a message that triggers a quick agent response
- [ ] Wait 1+ minutes after the response
- [ ] Send a follow-up message
- [ ] Verify the follow-up is processed (not dropped)
- [ ] Verify no 25-minute idle timeout delay

Upstream: https://github.com/qwibitai/nanoclaw/pull/550

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an issue where the agent runner could hang when processing results, preventing subsequent messages from being handled correctly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->