### PR TITLE
fix(scheduler): re-check task status before execution

### DIFF
--- a/src/task-scheduler.ts
+++ b/src/task-scheduler.ts
@@ -197,6 +197,16 @@ async function runTask(
   task: ScheduledTask,
   deps: SchedulerDependencies,
 ): Promise<void> {
+  // Re-check task status: may have been cancelled/paused while queued
+  const freshTask = getTaskById(task.id);
+  if (!freshTask || freshTask.status !== 'active') {
+    logger.info(
+      { taskId: task.id, status: freshTask?.status ?? 'deleted' },
+      'Task no longer active, skipping',
+    );
+    return;
+  }
+
   const startTime = Date.now();
   const groupDir = path.join(GROUPS_DIR, task.group_folder);
   fs.mkdirSync(groupDir, { recursive: true });


### PR DESCRIPTION
## Summary
[Upstream PR #539] Defense-in-depth fix: re-read task status from DB at the start of `runTask()` to catch tasks that were cancelled or paused between being enqueued and actually executing.

## Problem
When a task is cancelled or paused after being enqueued but before execution starts, the task still runs because `runTask()` operates on the stale task snapshot captured at enqueue time.

## Fix
Add a freshness check at the top of `runTask()` that re-reads the task from the DB and skips execution if it's no longer active.

Note: Our scheduler already advances `next_run` before enqueuing (preventing duplicate discovery by `getDueTasks`), so the `enqueuedTaskIds` Set from upstream PR #539 is redundant for our implementation. This PR adopts only the freshness re-check (the remaining gap).

• +10 LOC, 1 file (`src/task-scheduler.ts`)

## Test plan
- [ ] Cancel a queued task before it starts executing — verify it is skipped
- [ ] Pause a task while it's queued — verify it does not execute
- [ ] Normal scheduled tasks still execute on time

Upstream: https://github.com/qwibitai/nanoclaw/pull/539

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Task scheduler now re-validates task status before execution, automatically skipping tasks that are no longer active to prevent unnecessary processing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->