### PR TITLE
fix: decouple message loop from channel connection success

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1325,7 +1325,6 @@ async function main(): Promise<void> {
   // and should NOT block message processing for IPC/scheduled messages.
   // See: https://github.com/qwibitai/nanoclaw/issues/553
   queue.setProcessMessagesFn(processGroupMessages);
-  recoverPendingMessages();
   startMessageLoop().catch((err) => {
     logger.fatal({ err }, 'Message loop crashed unexpectedly');
     process.exit(1);
@@ -1392,6 +1391,11 @@ async function main(): Promise<void> {
         );
       }
     }
+
+    // Recover pending messages AFTER channels are connected so that
+    // findChannel() can route recovered output to the correct channel.
+    // (startMessageLoop already runs above for IPC/scheduled task responsiveness.)
+    recoverPendingMessages();
   };
 
   // Fire-and-forget: channels connect in background while message loop already runs

--- a/src/index.ts
+++ b/src/index.ts
@@ -1345,15 +1345,6 @@ async function main(): Promise<void> {
     if (discord) channels.push(discord);
     if (telegram) channels.push(telegram);
 
-    logger.info(
-      {
-        op: 'startup',
-        durationMs: Date.now() - startupT0,
-        channelCount: channels.length,
-      },
-      'Channel connections complete',
-    );
-
     // Conditionally connect Slack (requires both bot token and app-level socket-mode token)
     if (SLACK_BOT_TOKEN && SLACK_APP_TOKEN) {
       try {
@@ -1391,6 +1382,15 @@ async function main(): Promise<void> {
         );
       }
     }
+
+    logger.info(
+      {
+        op: 'startup',
+        durationMs: Date.now() - startupT0,
+        channelCount: channels.length,
+      },
+      'Channel connections complete',
+    );
 
     // Recover pending messages AFTER channels are connected so that
     // findChannel() can route recovered output to the correct channel.

--- a/src/index.ts
+++ b/src/index.ts
@@ -1336,7 +1336,9 @@ async function main(): Promise<void> {
   // the message loop reads from the DB and works without them.
   const connectChannels = async () => {
     const [wa, discord, telegram] = await Effect.runPromise(
-      Effect.all([connectWhatsApp, connectDiscord, connectTelegram], { concurrency: 'unbounded' }),
+      Effect.all([connectWhatsApp, connectDiscord, connectTelegram], {
+        concurrency: 'unbounded',
+      }),
     );
 
     whatsapp = wa;
@@ -1484,7 +1486,6 @@ async function main(): Promise<void> {
       );
     },
   });
-
 }
 
 // Guard: only run when executed directly, not when imported by tests


### PR DESCRIPTION
## Summary

- Reorder startup so the message loop starts immediately after backend initialization, before channel connections. The loop polls the DB and spawns containers — it only needs backends (for `resolveBackend()`), not channels.
- Connect WhatsApp/Discord/Telegram/Slack concurrently in the background via fire-and-forget. Channels are only needed for sending responses and typing indicators, which gracefully handle missing channels (`findChannel()` returns `undefined`).
- Add a 30s timeout to WhatsApp's `connect()` as defense-in-depth. On timeout, it resolves (not rejects) so the caller isn't blocked. The socket continues connecting in the background via `connectInternal`'s reconnect logic, and outgoing messages queue in `outgoingQueue` until it succeeds.

**Before:** If WhatsApp's TLS handshake stalled or any channel was unreachable, the entire system — including IPC messages, scheduled tasks, and the message loop — would hang indefinitely.

**After:** Backends initialize → message loop starts polling → channels connect in background. The system is fully operational within seconds even if all channels are down.

Refs: qwibitai/nanoclaw#553

## Changes

| File | Change |
|------|--------|
| `src/index.ts` | Await `initializeBackends()` separately, start message loop before `Effect.all()` channel connections, wrap channel connections in fire-and-forget `connectChannels()` |
| `src/channels/whatsapp.ts` | Add 30s `CONNECT_TIMEOUT_MS` that resolves on expiry (defense-in-depth) |

## Test plan

- [ ] Verify `bun run build` succeeds (confirmed: 16.43 MB bundle)
- [ ] Verify `bun run typecheck` shows no new errors (confirmed: only pre-existing `findLast` lib issue)
- [ ] Verify `bun test` shows no regressions (confirmed: 113 pass, 3 skip, 1 pre-existing fail)
- [ ] Manual: Start with WhatsApp credentials removed — message loop should start, scheduled tasks should fire, IPC should work
- [ ] Manual: Start with valid WhatsApp credentials — WhatsApp connects within 30s, messages flow normally
- [ ] Manual: Simulate network issue (block WhatsApp servers) — 30s timeout fires, system continues, WhatsApp reconnects when network restores

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Startup reordered: backends initialize first, then message processing starts while channels connect in the background.
  * Added backend initialization and channel-connection logging (including duration and “Channel connections complete”).
  * WhatsApp connection now uses a non-blocking startup path with a startup timeout and background retry so it won’t stall startup.
  * Recovery of pending messages occurs once channel connections complete.
  * Slack/Discord/Telegram reaction and message handling preserved and adapted to background channel orchestration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->