### PR TITLE
fix: set permission: allow in opencode config to prevent stalls

### DIFF
--- a/container/agent-runner/src/opencode-runtime.ts
+++ b/container/agent-runner/src/opencode-runtime.ts
@@ -195,7 +195,19 @@ async function startOpenCodeServer(
   // --dangerously-skip-permissions). Without this the opencode server can
   // stall waiting for interactive approval that never comes in a headless
   // container environment.
-  config.permission = 'allow';
+  //
+  // external_directory grants access to paths outside the project root
+  // (/workspace/group). The agent needs IPC, context layers, temp files,
+  // and the MCP server source — all of which live outside the cwd.
+  config.permission = {
+    '*': 'allow',
+    external_directory: {
+      '/workspace/**': 'allow',
+      '/tmp/**': 'allow',
+      '/app/**': 'allow',
+      '/home/bun/**': 'allow',
+    },
+  };
   if (model) config.model = model;
   if (mcpEnv) {
     config.mcp = {

--- a/container/agent-runner/src/opencode-runtime.ts
+++ b/container/agent-runner/src/opencode-runtime.ts
@@ -191,6 +191,11 @@ async function startOpenCodeServer(
 ): Promise<OpenCodeClient> {
   const mcpServerPath = path.join(import.meta.dir, 'ipc-mcp-stdio.ts');
   const config: Record<string, unknown> = {};
+  // Allow all tool operations without prompting (equivalent to Claude Code's
+  // --dangerously-skip-permissions). Without this the opencode server can
+  // stall waiting for interactive approval that never comes in a headless
+  // container environment.
+  config.permission = 'allow';
   if (model) config.model = model;
   if (mcpEnv) {
     config.mcp = {


### PR DESCRIPTION
## Summary

- Sets `permission: "allow"` in the config passed to `createOpencode()` in `opencode-runtime.ts`
- This is the OpenCode equivalent of Claude Code's `--dangerously-skip-permissions` flag
- Without this, the opencode server can stall waiting for interactive permission approval that never comes in a headless container environment — this is likely why `ocpeyton` gets stuck sometimes

## Change

```diff
  const config: Record<string, unknown> = {};
+ // Allow all tool operations without prompting (equivalent to Claude Code's
+ // --dangerously-skip-permissions). Without this the opencode server can
+ // stall waiting for interactive approval that never comes in a headless
+ // container environment.
+ config.permission = 'allow';
  if (model) config.model = model;
```

## References

- [OpenCode Permissions docs](https://opencode.ai/docs/permissions/)
- OpenCode default is to allow all operations, but explicitly setting this ensures no regressions from SDK version changes or container-level config overrides

## Test plan

- [ ] Deploy to a test container and verify ocpeyton no longer stalls on permission prompts
- [ ] Confirm opencode tools (bash, edit, read, etc.) execute without approval prompts

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Enabled headless operation so tools can proceed without interactive permission prompts.
  * Added broad, explicit allowances for common external directories (e.g., workspace, tmp, app, home) to support non-interactive runs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->