### PR TITLE
refactor: use OpenCode SDK-native runtime types

### DIFF
--- a/container/agent-runner/src/__tests__/opencode-runtime.test.ts
+++ b/container/agent-runner/src/__tests__/opencode-runtime.test.ts
@@ -5,9 +5,6 @@ import path from 'path';
 import {
   extractResponseText,
   extractTextFromParts,
-  collectCandidateStrings,
-  extractTextFromMessage,
-  extractLatestAssistantFromMessages,
 } from '../opencode-runtime.js';
 
 // ---------------------------------------------------------------------------
@@ -49,137 +46,6 @@ describe('extractTextFromParts', () => {
     const parts = [{ type: 'tool', state: { output: 'some output' } }];
     expect(extractTextFromParts(parts)).toBeNull();
   });
-
-  it('skips parts with non-string text', () => {
-    const parts = [
-      { type: 'text', text: 123 },
-      { type: 'text', text: 'valid' },
-    ];
-    expect(extractTextFromParts(parts)).toBe('valid');
-  });
-
-  it('handles null/undefined elements gracefully', () => {
-    const parts = [null, undefined, { type: 'text', text: 'ok' }];
-    expect(extractTextFromParts(parts as any)).toBe('ok');
-  });
-});
-
-// ---------------------------------------------------------------------------
-// collectCandidateStrings
-// ---------------------------------------------------------------------------
-
-describe('collectCandidateStrings', () => {
-  it('collects top-level string', () => {
-    expect(collectCandidateStrings('hello')).toEqual(['hello']);
-  });
-
-  it('collects strings from arrays', () => {
-    expect(collectCandidateStrings(['a', 'b'])).toEqual(['a', 'b']);
-  });
-
-  it('prefers known keys in objects', () => {
-    const obj = { text: 'preferred', other: 'also here' };
-    const result = collectCandidateStrings(obj);
-    expect(result[0]).toBe('preferred');
-    expect(result).toContain('also here');
-  });
-
-  it('returns empty for null/undefined', () => {
-    expect(collectCandidateStrings(null)).toEqual([]);
-    expect(collectCandidateStrings(undefined)).toEqual([]);
-  });
-
-  it('respects max depth', () => {
-    // Build a deeply nested structure
-    let obj: any = { text: 'deep' };
-    for (let i = 0; i < 10; i++) obj = { nested: obj };
-    // Should stop at depth 5, so the deep text won't be found
-    const result = collectCandidateStrings(obj);
-    expect(result).not.toContain('deep');
-  });
-
-  it('skips empty/whitespace strings', () => {
-    expect(collectCandidateStrings(['', '  ', 'valid'])).toEqual(['valid']);
-  });
-});
-
-// ---------------------------------------------------------------------------
-// extractTextFromMessage
-// ---------------------------------------------------------------------------
-
-describe('extractTextFromMessage', () => {
-  it('returns null for null input', () => {
-    expect(extractTextFromMessage(null)).toBeNull();
-  });
-
-  it('extracts string content directly', () => {
-    expect(extractTextFromMessage({ content: 'hello' })).toBe('hello');
-  });
-
-  it('extracts from array content (parts format)', () => {
-    const msg = {
-      content: [
-        { type: 'text', text: 'first' },
-        { type: 'text', text: 'second' },
-      ],
-    };
-    expect(extractTextFromMessage(msg)).toBe('first\nsecond');
-  });
-
-  it('extracts from parts array (OpenCode format)', () => {
-    const msg = {
-      parts: [{ type: 'text', text: 'from parts' }],
-    };
-    expect(extractTextFromMessage(msg)).toBe('from parts');
-  });
-
-  it('returns null for message with no recognizable content', () => {
-    expect(extractTextFromMessage({ foo: 'bar' })).toBeNull();
-  });
-});
-
-// ---------------------------------------------------------------------------
-// extractLatestAssistantFromMessages
-// ---------------------------------------------------------------------------
-
-describe('extractLatestAssistantFromMessages', () => {
-  it('returns the last assistant message', () => {
-    const messages = [
-      { role: 'user', content: 'hello' },
-      { role: 'assistant', content: 'first response' },
-      { role: 'user', content: 'thanks' },
-      { role: 'assistant', content: 'second response' },
-    ];
-    expect(extractLatestAssistantFromMessages(messages)).toBe(
-      'second response',
-    );
-  });
-
-  it('returns null for empty messages', () => {
-    expect(extractLatestAssistantFromMessages([])).toBeNull();
-  });
-
-  it('returns null when no assistant messages', () => {
-    const messages = [{ role: 'user', content: 'hello' }];
-    expect(extractLatestAssistantFromMessages(messages)).toBeNull();
-  });
-
-  it('handles OpenCode info/parts format', () => {
-    const messages = [
-      {
-        info: { role: 'assistant' },
-        parts: [{ type: 'text', text: 'opencode response' }],
-      },
-    ];
-    expect(extractLatestAssistantFromMessages(messages)).toBe(
-      'opencode response',
-    );
-  });
-
-  it('handles type: assistant format', () => {
-    const messages = [{ type: 'assistant', content: 'typed response' }];
-    expect(extractLatestAssistantFromMessages(messages)).toBe('typed response');
-  });
 });
 
 // ---------------------------------------------------------------------------
@@ -191,103 +57,35 @@ describe('extractResponseText', () => {
     expect(extractResponseText(null)).toBeNull();
   });
 
-  it('returns null for result without data', () => {
-    expect(extractResponseText({})).toBeNull();
-    expect(extractResponseText({ data: null })).toBeNull();
+  it('returns null for result without parts', () => {
+    expect(extractResponseText({ data: null } as any)).toBeNull();
+    expect(extractResponseText({ data: { info: {} } } as any)).toBeNull();
   });
 
-  it('extracts from data.text', () => {
-    expect(extractResponseText({ data: { text: 'hello' } })).toBe('hello');
-  });
-
-  it('extracts from data.content', () => {
-    expect(extractResponseText({ data: { content: 'hello' } })).toBe('hello');
-  });
-
-  it('extracts structured output', () => {
+  it('extracts text from parts array', () => {
     const result = {
       data: {
-        info: { structured_output: { key: 'value' } },
-      },
-    };
-    expect(extractResponseText(result)).toBe('{"key":"value"}');
-  });
-
-  it('extracts from parts array', () => {
-    const result = {
-      data: {
+        info: {},
         parts: [
           { type: 'text', text: 'part1' },
           { type: 'text', text: 'part2' },
         ],
       },
     };
-    expect(extractResponseText(result)).toBe('part1\npart2');
+    expect(extractResponseText(result as any)).toBe('part1\npart2');
   });
 
-  it('extracts from messages array (last assistant)', () => {
+  it('ignores non-text parts', () => {
     const result = {
       data: {
-        messages: [
-          { role: 'user', content: 'question' },
-          { role: 'assistant', content: 'answer' },
-        ],
-      },
-    };
-    expect(extractResponseText(result)).toBe('answer');
-  });
-
-  it('extracts from messages with array content', () => {
-    const result = {
-      data: {
-        messages: [
-          {
-            role: 'assistant',
-            content: [{ type: 'text', text: 'structured answer' }],
-          },
-        ],
-      },
-    };
-    expect(extractResponseText(result)).toBe('structured answer');
-  });
-
-  it('extracts from info + parts (SDK v1.2.x format)', () => {
-    const result = {
-      data: {
-        info: { role: 'assistant' },
-        parts: [{ type: 'text', text: 'sdk response' }],
-      },
-    };
-    expect(extractResponseText(result)).toBe('sdk response');
-  });
-
-  it('falls back to deep candidate collection for non-text parts', () => {
-    const result = {
-      data: {
-        info: { role: 'assistant' },
-        parts: [{ type: 'custom', content: 'deep text' }],
-      },
-    };
-    // collectCandidateStrings picks up all string values from object fields,
-    // including 'content' (preferred key) and 'type' (general walk).
-    expect(extractResponseText(result)).toBe('deep text\ncustom');
-  });
-
-  it('excludes tool parts from deep candidate fallback', () => {
-    const result = {
-      data: {
-        info: { role: 'assistant' },
+        info: {},
         parts: [
-          { type: 'tool', state: { output: 'SECRET_API_KEY=sk-xxx' } },
-          { type: 'tool-invocation', content: 'ls -la /etc/passwd' },
-          { type: 'custom', content: 'safe text' },
+          { type: 'tool', state: { output: 'some output' } },
+          { type: 'text', text: 'response' },
         ],
       },
     };
-    const text = extractResponseText(result);
-    expect(text).not.toContain('SECRET_API_KEY');
-    expect(text).not.toContain('/etc/passwd');
-    expect(text).toContain('safe text');
+    expect(extractResponseText(result as any)).toBe('response');
   });
 });
 

--- a/container/agent-runner/src/opencode-runtime.ts
+++ b/container/agent-runner/src/opencode-runtime.ts
@@ -9,6 +9,13 @@
  * natively, so we don't need to configure tools ourselves.
  */
 
+import {
+  createOpencode,
+  OpencodeClient,
+  type Part,
+  type ReasoningPart,
+  type TextPart,
+} from '@opencode-ai/sdk';
 import fs from 'fs';
 import path from 'path';
 
@@ -180,7 +187,9 @@ function waitForIpcMessage(): Promise<string | null> {
 // OpenCode server management
 // ---------------------------------------------------------------------------
 
-let openCodeServer: { close(): void } | null = null;
+let openCodeServer:
+  | Awaited<ReturnType<typeof createOpencode>>['server']
+  | null = null;
 
 /**
  * Start OpenCode server via SDK helper (spawns opencode CLI under the hood).
@@ -188,7 +197,7 @@ let openCodeServer: { close(): void } | null = null;
 async function startOpenCodeServer(
   model?: string,
   mcpEnv?: Record<string, string>,
-): Promise<OpenCodeClient> {
+) {
   const mcpServerPath = path.join(import.meta.dir, 'ipc-mcp-stdio.ts');
   const config: Record<string, unknown> = {};
   // Allow all tool operations without prompting (equivalent to Claude Code's
@@ -221,7 +230,6 @@ async function startOpenCodeServer(
     };
   }
 
-  const { createOpencode } = await import('@opencode-ai/sdk');
   const opencode = await createOpencode({
     hostname: OPENCODE_HOST,
     port: OPENCODE_PORT,
@@ -230,7 +238,7 @@ async function startOpenCodeServer(
   });
   openCodeServer = opencode.server;
   log(`OpenCode server is healthy at ${opencode.server.url}`);
-  return opencode.client as unknown as OpenCodeClient;
+  return opencode.client;
 }
 
 function stopOpenCodeServer(): void {
@@ -245,181 +253,65 @@ function stopOpenCodeServer(): void {
 }
 
 // ---------------------------------------------------------------------------
-// OpenCode SDK client
-// ---------------------------------------------------------------------------
-
-interface OpenCodeClient {
-  session: {
-    create(opts: {
-      body: Record<string, unknown>;
-    }): Promise<{ data?: { id: string } }>;
-    get(opts: { path: { id: string } }): Promise<{ data?: { id: string } }>;
-    prompt(opts: {
-      path: { id: string };
-      body: {
-        parts: Array<{ type: string; text: string }>;
-        noReply?: boolean;
-        model?: { providerID: string; modelID: string };
-      };
-    }): Promise<{ data?: any }>;
-    abort(opts: { path: { id: string } }): Promise<void>;
-    messages(opts: { path: { id: string } }): Promise<{ data?: any }>;
-    status(): Promise<{ data?: any }>;
-  };
-}
-
-// ---------------------------------------------------------------------------
 // Response extraction
 // ---------------------------------------------------------------------------
+
+type OpenCodePromptResult = Awaited<
+  ReturnType<OpencodeClient['session']['prompt']>
+>;
+
+type SessionMessagesData = Awaited<
+  ReturnType<OpencodeClient['session']['messages']>
+>['data'];
+
+type SessionMessage =
+  SessionMessagesData extends ReadonlyArray<infer T> ? T : never;
 
 /**
  * Extract text from an OpenCode SDK prompt result.
  * The response shape can vary — try common patterns.
  */
 /** @internal exported for testing */
-export function extractResponseText(result: any): string | null {
-  if (!result?.data) return null;
-  const data = result.data;
-
-  // Direct text field
-  if (typeof data.text === 'string') return data.text;
-  if (typeof data.content === 'string') return data.content;
-
-  // Structured output
-  if (data.info?.structured_output) {
-    return JSON.stringify(data.info.structured_output);
-  }
-
-  // Message parts array
-  if (Array.isArray(data.parts)) {
-    const textParts = data.parts
-      .filter((p: any) => p?.type === 'text' || p?.type === 'reasoning')
-      .map((p: any) => p.text);
-    if (textParts.length > 0) return textParts.join('\n');
-  }
-
-  // SDK v1.2.x typically returns { info, parts }
-  // where info is assistant metadata and parts carries message content.
-  if (data.info && Array.isArray(data.parts)) {
-    const text = extractTextFromParts(data.parts);
-    if (text) return text;
-    // Filter out tool parts before deep traversal to avoid surfacing
-    // sensitive tool output (command results, file contents) in user-facing text.
-    const nonToolParts = data.parts.filter(
-      (p: any) => p?.type !== 'tool' && p?.type !== 'tool-invocation',
-    );
-    const deepCandidates = collectCandidateStrings(nonToolParts).slice(0, 6);
-    if (deepCandidates.length > 0) return deepCandidates.join('\n');
-    const partTypes = data.parts
-      .map((p: any) => p?.type || 'unknown')
-      .join(', ');
-    log(`OpenCode prompt returned non-text parts only: [${partTypes}]`);
-    try {
-      log(`OpenCode info snapshot: ${JSON.stringify(data.info).slice(0, 800)}`);
-    } catch {
-      // ignore snapshot stringify errors
-    }
-  }
-
-  // Messages array — take last assistant message
-  if (Array.isArray(data.messages)) {
-    for (let i = data.messages.length - 1; i >= 0; i--) {
-      const msg = data.messages[i];
-      if (msg?.role === 'assistant' && msg.content) {
-        if (typeof msg.content === 'string') return msg.content;
-        if (Array.isArray(msg.content)) {
-          const text = msg.content
-            .filter((c: any) => c.type === 'text')
-            .map((c: any) => c.text)
-            .join('\n');
-          if (text) return text;
-        }
-      }
-    }
-  }
-
-  log(`Unknown OpenCode result shape, keys: ${Object.keys(data).join(', ')}`);
-  return null;
+export function extractTextFromParts(parts: Array<Part>): string | null {
+  const texts = parts
+    .filter(
+      (p): p is TextPart | ReasoningPart =>
+        p.type === 'text' || p.type === 'reasoning',
+    )
+    .map((p) => p.text);
+  return texts.length > 0 ? texts.join('\n') : null;
 }
 
 /** @internal exported for testing */
-export function extractTextFromParts(parts: any[]): string | null {
-  const extracted: string[] = [];
-  for (const p of parts) {
-    if (
-      (p?.type === 'text' || p?.type === 'reasoning') &&
-      typeof p.text === 'string'
-    ) {
-      extracted.push(p.text);
-    }
-    // Tool outputs (bash stdout, file contents, etc.) are intentionally excluded
-    // from the user-facing response — only text/reasoning parts are surfaced.
-  }
-  return extracted.length > 0 ? extracted.join('\n') : null;
+export function extractResponseText(
+  result: OpenCodePromptResult | null,
+): string | null {
+  const parts = result?.data?.parts;
+  if (!parts) return null;
+  return extractTextFromParts(parts);
 }
 
-/** @internal exported for testing */
-export function collectCandidateStrings(
-  value: any,
-  out: string[] = [],
-  depth: number = 0,
-): string[] {
-  if (value == null || depth > 5) return out;
-  if (typeof value === 'string') {
-    const trimmed = value.trim();
-    if (trimmed) out.push(trimmed);
-    return out;
-  }
-  if (Array.isArray(value)) {
-    for (const item of value) collectCandidateStrings(item, out, depth + 1);
-    return out;
-  }
-  if (typeof value === 'object') {
-    const preferredKeys = ['text', 'output', 'content', 'message', 'reason'];
-    for (const key of preferredKeys) {
-      if (key in value)
-        collectCandidateStrings((value as any)[key], out, depth + 1);
-    }
-    for (const [k, v] of Object.entries(value)) {
-      if (preferredKeys.includes(k)) continue;
-      collectCandidateStrings(v, out, depth + 1);
-    }
-  }
-  return out;
-}
-
-/** @internal exported for testing */
-export function extractTextFromMessage(msg: any): string | null {
-  if (!msg) return null;
-  if (typeof msg.content === 'string') return msg.content;
-  if (Array.isArray(msg.content)) return extractTextFromParts(msg.content);
-  if (Array.isArray(msg.parts)) return extractTextFromParts(msg.parts);
-  return null;
-}
-
-/** @internal exported for testing */
-export function extractLatestAssistantFromMessages(
-  messages: any[],
+function extractLatestAssistantFromSessionMessages(
+  messages: Array<SessionMessage>,
 ): string | null {
   for (let i = messages.length - 1; i >= 0; i--) {
     const msg = messages[i];
-    // OpenCode messages endpoint commonly returns [{ info, parts }]
-    if (msg?.info?.role === 'assistant') {
-      const text = extractTextFromParts(
-        Array.isArray(msg.parts) ? msg.parts : [],
-      );
-      if (text) return text;
-    }
-    if (msg?.role === 'assistant' || msg?.type === 'assistant') {
-      const text = extractTextFromMessage(msg);
-      if (text) return text;
-    }
+    if (msg.info.role !== 'assistant') continue;
+    const text = extractTextFromParts(msg.parts);
+    if (text) return text;
   }
   return null;
 }
 
+function getMessagesFromPayload(
+  payload: SessionMessagesData,
+): Array<SessionMessage> {
+  if (Array.isArray(payload)) return payload;
+  return [];
+}
+
 async function waitForAssistantText(
-  client: OpenCodeClient,
+  client: OpencodeClient,
   sessionId: string,
   timeoutMs: number = 60000,
 ): Promise<string | null> {
@@ -429,13 +321,8 @@ async function waitForAssistantText(
       const messagesResponse = await client.session.messages({
         path: { id: sessionId },
       });
-      const payload = messagesResponse.data;
-      const messages = Array.isArray(payload)
-        ? payload
-        : Array.isArray(payload?.messages)
-          ? payload.messages
-          : [];
-      const text = extractLatestAssistantFromMessages(messages);
+      const messages = getMessagesFromPayload(messagesResponse.data);
+      const text = extractLatestAssistantFromSessionMessages(messages);
       if (text) return text;
     } catch (err) {
       log(
@@ -456,7 +343,7 @@ async function waitForAssistantText(
  * Returns the session ID and whether _close was detected during the prompt.
  */
 async function runOpenCodePrompt(
-  client: OpenCodeClient,
+  client: OpencodeClient,
   sessionId: string,
   prompt: string,
   timeoutMs: number,
@@ -493,27 +380,20 @@ async function runOpenCodePrompt(
     if (!ipcPolling) return;
     try {
       const resp = await client.session.messages({ path: { id: sessionId } });
-      const payload = resp.data;
-      const messages: any[] = Array.isArray(payload)
-        ? payload
-        : Array.isArray(payload?.messages)
-          ? payload.messages
-          : [];
+      const messages = getMessagesFromPayload(resp.data);
       for (const msg of messages) {
-        if (msg?.info?.role !== 'assistant') continue;
-        const parts: any[] = Array.isArray(msg.parts) ? msg.parts : [];
+        if (msg.info.role !== 'assistant') continue;
+        const parts = msg.parts;
         parts.forEach((p, i) => {
-          if (p?.type !== 'tool') return;
-          const id = `${msg?.info?.id ?? 'msg'}:${i}`;
+          if (p.type !== 'tool') return;
+          const id = `${msg.info.id}:${i}`;
           if (loggedToolIds.has(id)) return;
-          const toolName: string = p.tool ?? p.name ?? p.toolName ?? 'tool';
-          const stateInput = p.state?.input;
+          const toolName = p.tool || 'tool';
+          const stateInput = p.state.input;
           const input =
             stateInput != null ? JSON.stringify(stateInput).slice(0, 120) : '';
           const output =
-            typeof p.state?.output === 'string'
-              ? p.state.output.slice(0, 200)
-              : '';
+            p.state.status === 'completed' ? p.state.output.slice(0, 200) : '';
           if (output) {
             log(`[tool] ${toolName}(${input}) → ${output}`);
             loggedToolIds.add(id);
@@ -736,7 +616,7 @@ export async function runOpenCodeRuntime(
   if (containerInput.agentTrigger)
     mcpEnv.OMNICLAW_AGENT_TRIGGER = containerInput.agentTrigger;
 
-  let client: OpenCodeClient;
+  let client: OpencodeClient;
   try {
     client = await startOpenCodeServer(model, mcpEnv);
     await client.session.status();


### PR DESCRIPTION
## Summary
- refactors `container/agent-runner/src/opencode-runtime.ts` to use `@opencode-ai/sdk` exported types (`OpencodeClient`, `Part`, `TextPart`, `ReasoningPart`) instead of hand-rolled SDK shape assumptions
- removes deep fallback parsing and legacy message-shape helpers, keeping response extraction strictly aligned to SDK `parts` contracts and completed tool states
- trims and updates `container/agent-runner/src/__tests__/opencode-runtime.test.ts` to validate the new typed extraction behavior only

## Validation
- `bun test src/__tests__/opencode-runtime.test.ts` (from `container/agent-runner/`)
- `bun run typecheck`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Enhanced internal type safety by standardizing OpenCode SDK integration.
  * Simplified text extraction logic and helper functions for SDK response handling.
  * Removed legacy interfaces in favor of SDK-aligned types.

* **Tests**
  * Removed test coverage for deprecated utility functions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->