### PR TITLE
fix: give scheduled tasks full 4-layer channel context

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1085,6 +1085,28 @@ async function processGroupMessages(dispatchJid: string): Promise<boolean> {
  * Build the channels array for a multi-channel agent ID.
  * Returns undefined if the agent only has one channel (no routing needed).
  */
+/**
+ * Resolve the RegisteredGroup for a scheduled task.
+ * Prefers the channel subscription for (chatJid, agentFolder) so that
+ * channelFolder/categoryFolder/agentContextFolder reflect the target channel's
+ * 4-layer hierarchy rather than the agent's own primary channel.
+ */
+function getGroupForTask(
+  chatJid: string,
+  agentFolder: string,
+): RegisteredGroup | undefined {
+  const subs = channelSubscriptions[chatJid] || [];
+  const matchingSub = subs.find((s) => {
+    const agent = agents[s.agentId];
+    return s.agentId === agentFolder || agent?.folder === agentFolder;
+  });
+  if (matchingSub) {
+    return buildRegisteredGroupFromSubscription(chatJid, matchingSub);
+  }
+  // Fallback: direct lookup for agents without channel subscriptions
+  return Object.values(registeredGroups).find((g) => g.folder === agentFolder);
+}
+
 function buildChannelsForAgent(agentId: string): ChannelInfo[] | undefined {
   const agentToChannels =
     buildAgentToChannelsMapFromSubscriptions(channelSubscriptions);
@@ -1952,6 +1974,7 @@ async function main(): Promise<void> {
   // Start subsystems (independently of connection handler)
   startSchedulerLoop({
     registeredGroups: () => registeredGroups,
+    getGroupForTask,
     getSessions: () => sessions,
     getResumePositions: () => resumePositions,
     queue,

--- a/src/task-scheduler.ts
+++ b/src/task-scheduler.ts
@@ -33,6 +33,17 @@ import {
 
 export interface SchedulerDependencies {
   registeredGroups: () => Record<string, RegisteredGroup>;
+  /**
+   * Resolve the RegisteredGroup for a scheduled task, incorporating the full
+   * 4-layer channel context (agent → server → category → channel).
+   * Looks up the subscription for (chatJid, agentFolder) first so that
+   * channelFolder/categoryFolder/agentContextFolder reflect the target channel,
+   * not the agent's own primary channel.
+   */
+  getGroupForTask: (
+    chatJid: string,
+    agentFolder: string,
+  ) => RegisteredGroup | undefined;
   getSessions: () => Record<string, string>;
   getResumePositions: () => Record<string, string>;
   queue: GroupQueue;
@@ -72,10 +83,7 @@ async function runTask(
   });
   log.info('Running scheduled task');
 
-  const groups = deps.registeredGroups();
-  const group = Object.values(groups).find(
-    (g) => g.folder === task.group_folder,
-  );
+  const group = deps.getGroupForTask(task.chat_jid, task.group_folder);
 
   if (!group) {
     log.error('Group not found for task');
@@ -181,6 +189,12 @@ async function runTask(
         discordGuildId: group.discordGuildId,
         serverFolder: group.serverFolder,
         agentRuntime: group.agentRuntime,
+        agentName: group.name,
+        discordBotId: group.discordBotId,
+        agentTrigger: group.trigger,
+        channelFolder: group.channelFolder,
+        categoryFolder: group.categoryFolder,
+        agentContextFolder: group.agentContextFolder,
       },
       (proc, containerName) =>
         deps.onProcess(


### PR DESCRIPTION
## Summary

- **Group resolution**: adds `getGroupForTask(chatJid, agentFolder)` dep that looks up the channel subscription for `(chatJid, agent)` and calls `buildRegisteredGroupFromSubscription` — same path as message routing — so the resolved group has the correct `channelFolder`/`categoryFolder`/`agentContextFolder` for the target channel, not the agent's own primary channel. Falls back to direct `registeredGroups` lookup for agents without subscriptions.
- **Full context fields**: passes `agentName`, `discordBotId`, `agentTrigger`, `channelFolder`, `categoryFolder`, and `agentContextFolder` to `runAgent`, matching the complete set that message-triggered agents receive (`index.ts:1196-1198`).

Before this fix, scheduled tasks running in a migrated channel (e.g. `#omniclaw`) would either:
1. Fail with `Group not found for task` (if `group_folder` pointed to a legacy folder no longer in memory), or
2. Run with no agent/server/category/channel mounts (if they resolved at all), missing all CLAUDE.md context layers.

## Test plan

- [ ] Verify next scheduled task fires without "Group not found" error in logs
- [ ] Verify container mounts include `/workspace/agent`, `/workspace/server`, `/workspace/category`, `/workspace/group` (channel workspace)
- [ ] Verify fallback still works for agents without channel subscriptions (e.g. `local-omni`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved scheduled task routing with enhanced group resolution logic.
  * Tasks now include richer contextual information during execution for better context awareness.

* **Bug Fixes**
  * Enhanced error handling and logging for scheduled task assignment failures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->