### PR TITLE
fix: container ContainerInput missing fields and SessionMessagesResponse type

### DIFF
--- a/container/agent-runner/src/index.ts
+++ b/container/agent-runner/src/index.ts
@@ -32,7 +32,6 @@ interface ContainerInput {
   prompt: string;
   sessionId?: string;
   resumeAt?: string;
-  agentName?: string;
   groupFolder: string;
   chatJid: string;
   isMain: boolean;
@@ -50,6 +49,9 @@ interface ContainerInput {
   discordBotId?: string;
   /** Agent's trigger word/phrase (e.g. "@OCPeyton"). */
   agentTrigger?: string;
+  agentContextFolder?: string;
+  channelFolder?: string;
+  categoryFolder?: string;
 }
 
 interface ContainerOutput {

--- a/container/agent-runner/src/opencode-runtime.ts
+++ b/container/agent-runner/src/opencode-runtime.ts
@@ -14,6 +14,7 @@ import {
   OpencodeClient,
   type Part,
   type ReasoningPart,
+  type SessionMessagesResponse,
   type TextPart,
 } from '@opencode-ai/sdk';
 import fs from 'fs';
@@ -47,6 +48,9 @@ interface ContainerInput {
   agentName?: string;
   discordBotId?: string;
   agentTrigger?: string;
+  agentContextFolder?: string;
+  channelFolder?: string;
+  categoryFolder?: string;
 }
 
 interface ContainerOutput {
@@ -260,17 +264,6 @@ type OpenCodePromptResult = Awaited<
   ReturnType<OpencodeClient['session']['prompt']>
 >;
 
-type SessionMessagesData = Awaited<
-  ReturnType<OpencodeClient['session']['messages']>
->['data'];
-
-type SessionMessage =
-  SessionMessagesData extends ReadonlyArray<infer T> ? T : never;
-
-/**
- * Extract text from an OpenCode SDK prompt result.
- * The response shape can vary — try common patterns.
- */
 /** @internal exported for testing */
 export function extractTextFromParts(parts: Array<Part>): string | null {
   const texts = parts
@@ -292,11 +285,11 @@ export function extractResponseText(
 }
 
 function extractLatestAssistantFromSessionMessages(
-  messages: Array<SessionMessage>,
+  messages: SessionMessagesResponse,
 ): string | null {
   for (let i = messages.length - 1; i >= 0; i--) {
     const msg = messages[i];
-    if (msg.info.role !== 'assistant') continue;
+    if (msg?.info?.role !== 'assistant') continue;
     const text = extractTextFromParts(msg.parts);
     if (text) return text;
   }
@@ -304,8 +297,8 @@ function extractLatestAssistantFromSessionMessages(
 }
 
 function getMessagesFromPayload(
-  payload: SessionMessagesData,
-): Array<SessionMessage> {
+  payload: SessionMessagesResponse | undefined,
+): SessionMessagesResponse {
   if (Array.isArray(payload)) return payload;
   return [];
 }
@@ -382,7 +375,7 @@ async function runOpenCodePrompt(
       const resp = await client.session.messages({ path: { id: sessionId } });
       const messages = getMessagesFromPayload(resp.data);
       for (const msg of messages) {
-        if (msg.info.role !== 'assistant') continue;
+        if (msg?.info?.role !== 'assistant') continue;
         const parts = msg.parts;
         parts.forEach((p, i) => {
           if (p.type !== 'tool') return;


### PR DESCRIPTION
## Summary

- **Remove duplicate `agentName`** in `container/agent-runner/src/index.ts` `ContainerInput` — caused `TS2300: Duplicate identifier 'agentName'`
- **Add missing fields** `agentContextFolder`, `channelFolder`, `categoryFolder` to both `index.ts` and `opencode-runtime.ts` inline `ContainerInput` interfaces — these are now sent by the host since PR #155 (scheduled tasks 4-layer context)
- **Fix `SessionMessagesResponse` type** in `opencode-runtime.ts` — import it directly from `@opencode-ai/sdk` instead of deriving via conditional type on `ReturnType<>`, which resolved to `never` and caused `TS2339`/`TS2322` errors
- **Optional chaining** `msg?.info?.role` for defensive access in session message polling

## Root cause

PR #155 added `channelFolder`/`categoryFolder`/`agentContextFolder` to `ContainerInput` on the **host** side but didn't update the container-side inline type definitions. PR #153 (which would have fixed this via `@omniclaw/protocol`) was not merged — a more targeted fix was merged instead (#154), leaving the container-side interfaces stale.

The `SessionMessagesResponse` issue was introduced in PR #154's SDK-type cleanup: the derived type `SessionMessagesData extends ReadonlyArray<infer T> ? T : never` resolved to `never` at compile time because TypeScript couldn't infer through the `ReturnType<>` conditional.

## Test plan

- [x] `bun run --cwd container/agent-runner tsc --noEmit` — no errors
- [x] `bun run build` — host build clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)