### PR TITLE
fix: clean up stale dispatch IPC folders instead of quarantining

### DIFF
--- a/src/ipc.ts
+++ b/src/ipc.ts
@@ -477,8 +477,8 @@ export function startIpcWatcher(deps: IpcDeps): void {
         try {
           fs.rmSync(staleDir, { recursive: true, force: true });
           logger.debug({ sourceGroup }, 'Cleaned up stale dispatch IPC folder');
-        } catch {
-          /* ignore — will retry next poll */
+        } catch (err) {
+          logger.debug({ sourceGroup, err }, 'Failed to clean up stale dispatch IPC folder — will retry next poll');
         }
       }
     }


### PR DESCRIPTION
## Summary

- Fixes a race condition where dispatch runtime IPC folders were falsely quarantined after a container exited
- Stale dispatch folders (valid owner, container just finished) now have their remaining files processed before being deleted — nothing is lost
- Truly unknown folders (unrecognized owner or malformed digest) are still quarantined as before

## Root Cause

When a container exits, `activeRuntimeFolders.delete(runtimeFolder)` runs in the `finally` block of `runAgent`. On the next IPC poll (1s later), the watcher found the orphaned `{agent}__dispatch__{digest}` directory still on disk but no longer in the allowlist → spurious `warn` log and quarantine.

## Fix

Separates two concerns that were conflated in `resolveOwnerGroupFolder`:

1. **Ownership validation** (stays in `resolveOwnerGroupFolder`): known owner + valid 16-char hex digest → return owner. Unknown/malformed → return null → quarantine.

2. **Liveness / cleanup** (moves to `startIpcWatcher`): after resolving ownership, detect stale dispatch folders (`DISPATCH_RUNTIME_SEP` present, valid owner, not in `activeRuntimeFolders`). Process any remaining IPC files, then `rmSync` the directory. Debug log only.

## Test plan

- [ ] All 807 existing tests pass (`bun test`)
- [ ] No more `Skipping IPC from unrecognized source folder — quarantining` warnings in logs after containers exit normally
- [ ] Truly rogue/unknown folders (e.g. `omniaura-discord` from old migration) still get quarantined

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Simplified IPC identity validation to validate owners and digests only, decoupling it from runtime liveness checks.

* **New Features**
  * Added detection of stale dispatch IPC folders and automatic cleanup after processing, removing orphaned directories and retrying cleanup on subsequent polls if removal fails.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->