### PR TITLE
test: add deterministic share-request boundary coverage

### DIFF
--- a/src/ipc-share-request.test.ts
+++ b/src/ipc-share-request.test.ts
@@ -150,7 +150,10 @@ describe('share request tracking', () => {
         }),
       );
 
-      trackShareRequest('trigger-cleanup', makeMeta({ timestamp: 1_000_000_000 }));
+      trackShareRequest(
+        'trigger-cleanup',
+        makeMeta({ timestamp: 1_000_000_000 }),
+      );
 
       expect(consumeShareRequest('boundary')).toBeDefined();
     } finally {

--- a/src/ipc-share-request.test.ts
+++ b/src/ipc-share-request.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, beforeEach } from 'bun:test';
+import { describe, it, expect, beforeEach, spyOn } from 'bun:test';
 
 import {
   trackShareRequest,
@@ -39,6 +39,11 @@ describe('share request tracking', () => {
     consumeShareRequest('once-only');
     consumeShareRequest('tracked');
     consumeShareRequest('nonexistent');
+    consumeShareRequest('boundary');
+    consumeShareRequest('trigger-cleanup');
+    for (let i = 0; i <= 1000; i++) {
+      consumeShareRequest(`cap-${i}`);
+    }
   });
 
   // --- Basic track/consume ---
@@ -133,6 +138,39 @@ describe('share request tracking', () => {
     // The recent entry should still be present
     const recent = consumeShareRequest('msg-1');
     expect(recent).toBeDefined();
+  });
+
+  it('keeps entries exactly at the TTL boundary', () => {
+    const nowSpy = spyOn(Date, 'now').mockReturnValue(1_000_000_000);
+    try {
+      trackShareRequest(
+        'boundary',
+        makeMeta({
+          timestamp: 1_000_000_000 - 24 * 60 * 60 * 1000,
+        }),
+      );
+
+      trackShareRequest('trigger-cleanup', makeMeta({ timestamp: 1_000_000_000 }));
+
+      expect(consumeShareRequest('boundary')).toBeDefined();
+    } finally {
+      nowSpy.mockRestore();
+    }
+  });
+
+  it('evicts oldest tracked request when cap is exceeded', () => {
+    const base = Date.now();
+
+    for (let i = 0; i < 1001; i++) {
+      trackShareRequest(
+        `cap-${i}`,
+        makeMeta({ timestamp: base + i, description: `req-${i}` }),
+      );
+    }
+
+    expect(consumeShareRequest('cap-0')).toBeUndefined();
+    expect(consumeShareRequest('cap-1')?.description).toBe('req-1');
+    expect(consumeShareRequest('cap-1000')?.description).toBe('req-1000');
   });
 
   // --- serverFolder tracking ---


### PR DESCRIPTION
## Summary
- add deterministic tests for `trackShareRequest` TTL boundary behavior using a `Date.now` monkey-patch so exactly-24h entries are retained
- add cap-eviction coverage for pending share requests (1000 limit) to verify oldest-entry eviction under flood conditions
- extend test cleanup to drain synthetic IDs used by the new cap and boundary scenarios

## Test Count
- before: 807 tests
- after: 809 tests

## Verification
- `bun test src/ipc-share-request.test.ts`
- `bun test`

## Coverage Notes
- improved coverage for pending share-request retention logic in `src/ipc.ts` via `src/ipc-share-request.test.ts`
- remaining source files without adjacent `*.test.ts`: `src/index.ts`, `src/ipc.ts`, `src/whatsapp-auth.ts` (ipc behavior is still covered through split test files)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added test cases for TTL boundary handling and cache eviction when capacity limits are exceeded.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->