### PR TITLE
fix: route scheduled task messages through the task's assigned Discord bot

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1987,8 +1987,8 @@ async function main(): Promise<void> {
         undefined,
         lane,
       ),
-    sendMessage: async (jid, rawText) => {
-      const ch = findChannelForJid(jid);
+    sendMessage: async (jid, rawText, discordBotId?) => {
+      const ch = findChannelForJid(jid, discordBotId);
       if (!ch) {
         logger.warn({ jid }, 'No channel found for scheduled message');
         return;
@@ -2004,7 +2004,7 @@ async function main(): Promise<void> {
         return msgId ? String(msgId) : undefined;
       }
     },
-    findChannel: (jid) => findChannelForJid(jid),
+    findChannel: (jid, discordBotId?) => findChannelForJid(jid, discordBotId),
   });
   startIpcWatcher({
     sendMessage: async (jid, rawText) => {

--- a/src/index.ts
+++ b/src/index.ts
@@ -1987,7 +1987,7 @@ async function main(): Promise<void> {
         undefined,
         lane,
       ),
-    sendMessage: async (jid, rawText, discordBotId?) => {
+    sendMessage: async (jid, rawText, discordBotId) => {
       const ch = findChannelForJid(jid, discordBotId);
       if (!ch) {
         logger.warn({ jid }, 'No channel found for scheduled message');
@@ -2004,7 +2004,7 @@ async function main(): Promise<void> {
         return msgId ? String(msgId) : undefined;
       }
     },
-    findChannel: (jid, discordBotId?) => findChannelForJid(jid, discordBotId),
+    findChannel: (jid, discordBotId) => findChannelForJid(jid, discordBotId),
   });
   startIpcWatcher({
     sendMessage: async (jid, rawText) => {

--- a/src/ipc.ts
+++ b/src/ipc.ts
@@ -478,7 +478,10 @@ export function startIpcWatcher(deps: IpcDeps): void {
           fs.rmSync(staleDir, { recursive: true, force: true });
           logger.debug({ sourceGroup }, 'Cleaned up stale dispatch IPC folder');
         } catch (err) {
-          logger.debug({ sourceGroup, err }, 'Failed to clean up stale dispatch IPC folder — will retry next poll');
+          logger.debug(
+            { sourceGroup, err },
+            'Failed to clean up stale dispatch IPC folder — will retry next poll',
+          );
         }
       }
     }

--- a/src/task-scheduler.ts
+++ b/src/task-scheduler.ts
@@ -54,8 +54,8 @@ export interface SchedulerDependencies {
     groupFolder: string,
     lane: 'task',
   ) => void;
-  sendMessage: (jid: string, text: string) => Promise<string | void>;
-  findChannel: (jid: string) => Channel | undefined;
+  sendMessage: (jid: string, text: string, discordBotId?: string) => Promise<string | void>;
+  findChannel: (jid: string, discordBotId?: string) => Channel | undefined;
 }
 
 async function runTask(
@@ -144,7 +144,7 @@ async function runTask(
     }, TASK_CLOSE_DELAY_MS);
   };
 
-  const channel = deps.findChannel(task.chat_jid);
+  const channel = deps.findChannel(task.chat_jid, group.discordBotId);
   let parentMessageId: string | null = null;
 
   if (group.streamIntermediates && channel?.createThread) {
@@ -153,6 +153,7 @@ async function runTask(
       const msgId = await deps.sendMessage(
         task.chat_jid,
         `Running scheduled task: ${preview}...`,
+        group.discordBotId,
       );
       parentMessageId = msgId ? String(msgId) : null;
     } catch {
@@ -216,7 +217,7 @@ async function runTask(
 
         if (streamedOutput.result) {
           result = streamedOutput.result;
-          await deps.sendMessage(task.chat_jid, streamedOutput.result);
+          await deps.sendMessage(task.chat_jid, streamedOutput.result, group.discordBotId);
           scheduleClose();
         }
         if (streamedOutput.status === 'success') {

--- a/src/task-scheduler.ts
+++ b/src/task-scheduler.ts
@@ -54,7 +54,11 @@ export interface SchedulerDependencies {
     groupFolder: string,
     lane: 'task',
   ) => void;
-  sendMessage: (jid: string, text: string, discordBotId?: string) => Promise<string | void>;
+  sendMessage: (
+    jid: string,
+    text: string,
+    discordBotId?: string,
+  ) => Promise<string | void>;
   findChannel: (jid: string, discordBotId?: string) => Channel | undefined;
 }
 
@@ -217,7 +221,11 @@ async function runTask(
 
         if (streamedOutput.result) {
           result = streamedOutput.result;
-          await deps.sendMessage(task.chat_jid, streamedOutput.result, group.discordBotId);
+          await deps.sendMessage(
+            task.chat_jid,
+            streamedOutput.result,
+            group.discordBotId,
+          );
           scheduleClose();
         }
         if (streamedOutput.status === 'success') {


### PR DESCRIPTION
## Summary

- `SchedulerDependencies.sendMessage` and `findChannel` now accept an optional `discordBotId` parameter
- `runTask` passes `group.discordBotId` at all three call sites (channel lookup, thread announcement, result delivery)
- `index.ts` scheduler callbacks forward the bot ID to `findChannelForJid`

## Root cause

When a scheduled task fired, `sendMessage` called `findChannelForJid(jid)` with no preferred bot ID. `getDiscordBotIdForJid` resolved the channel's **primary** subscriber's bot ID (`'PRIMARY'` — a placeholder string, not a real snowflake), found no channel match, and fell back to `DISCORD_DEFAULT_BOT_ID` (PeytonOmni). Tasks assigned to OCPeyton were running in the right container but replying through PeytonOmni.

## DB fix (applied directly to live DB)

`channel_subscriptions.discord_bot_id` had placeholder strings for all 11 shared channels:
- `ditto-discord`: `'PRIMARY'` → `1471198154434154508`
- `ocpeyton-discord`: `'OCPEYTON'` → `1476396931709276191`

Also patched the 3 affected `channel_routes` rows.

## Test plan

- [ ] Deploy and trigger a scheduled task assigned to OCPeyton — confirm OCPeyton bot replies
- [ ] Confirm PeytonOmni-assigned tasks still reply through PeytonOmni
- [ ] `bun run typecheck` passes (verified locally)

🤖 Generated with [Claude Code](https://claude.com/claude-code)