### PR TITLE
fix: force-exit opencode runtime after session ends to prevent hang

### DIFF
--- a/.claude/skills/migrate-to-channels/SKILL.md
+++ b/.claude/skills/migrate-to-channels/SKILL.md
@@ -37,9 +37,9 @@ In older OmniClaw setups, each channel got its own agent entry (e.g., `landing-a
 
 ```sql
 -- Example: landing-astro-discord was just another PeytonOmni channel
--- Move its subs to ditto-discord (if not already there)
+-- Move its subs to clayton-discord (if not already there)
 INSERT OR IGNORE INTO channel_subscriptions (channel_jid, agent_id, trigger_pattern, requires_trigger, priority, is_primary, discord_bot_id, discord_guild_id, created_at)
-SELECT channel_jid, 'ditto-discord', trigger_pattern, requires_trigger, priority, is_primary, discord_bot_id, discord_guild_id, created_at
+SELECT channel_jid, 'clayton-discord', trigger_pattern, requires_trigger, priority, is_primary, discord_bot_id, discord_guild_id, created_at
 FROM channel_subscriptions WHERE agent_id = 'landing-astro-discord';
 
 DELETE FROM channel_subscriptions WHERE agent_id = 'landing-astro-discord';
@@ -55,7 +55,7 @@ Set this immediately after adding the agent identity file:
 
 ```sql
 UPDATE agents SET agent_context_folder = 'agents/peytonomi'
-WHERE id IN ('ditto-discord', 'landing-astro-discord');
+WHERE id IN ('clayton-discord', 'landing-astro-discord');
 ```
 
 ### 3. Internal bot key vs Discord snowflake ID — never confuse them
@@ -89,14 +89,14 @@ sqlite3 store/messages.db "UPDATE channel_subscriptions SET discord_bot_id = 'OC
 - Which agent's name is used as the display name when building channel lists
 - Which subscriptions fire as a fallback when no trigger is explicitly matched
 
-In a multi-agent channel (e.g., PeytonOmni + OCPeyton both in `#spec`), set `is_primary = 1` **only on the human-persona agent** (e.g., `ditto-discord`). The tool agent (`ocpeyton-discord`) should have `is_primary = 0` so it only responds to explicit `@OCPeyton` mentions and never fires via fallback.
+In a multi-agent channel (e.g., PeytonOmni + OCPeyton both in `#spec`), set `is_primary = 1` **only on the human-persona agent** (e.g., `clayton-discord`). The tool agent (`ocpeyton-discord`) should have `is_primary = 0` so it only responds to explicit `@OCPeyton` mentions and never fires via fallback.
 
 If `is_primary` is wrong, you'll see another agent's name appear as a channel name in the multi-channel list (e.g., "OCPeyton" showing up as a channel name in PeytonOmni's channel list).
 
 ```sql
 -- Set primary correctly for each channel
 UPDATE channel_subscriptions SET is_primary = 1
-WHERE agent_id = 'ditto-discord';  -- persona agent owns the channel
+WHERE agent_id = 'clayton-discord';  -- persona agent owns the channel
 
 UPDATE channel_subscriptions SET is_primary = 0
 WHERE agent_id = 'ocpeyton-discord';  -- tool agent never owns
@@ -187,21 +187,21 @@ If containers are running, use `AskUserQuestion` to ask:
 **If wait:** re-run the container list check and loop until clear, then delete without stopping the service:
 
 ```bash
-rm -rf groups/spec-discord groups/agentflow-discord groups/ditto-discord # etc.
+rm -rf groups/spec-discord groups/agentflow-discord groups/clayton-discord # etc.
 ```
 
 **If stop the service:** unload, delete, reload:
 
 ```bash
 launchctl unload ~/Library/LaunchAgents/com.omniclaw.plist
-rm -rf groups/spec-discord groups/agentflow-discord groups/ditto-discord # etc.
+rm -rf groups/spec-discord groups/agentflow-discord groups/clayton-discord # etc.
 launchctl load ~/Library/LaunchAgents/com.omniclaw.plist
 ```
 
 **If no containers running:** delete directly:
 
 ```bash
-rm -rf groups/spec-discord groups/agentflow-discord groups/ditto-discord # etc.
+rm -rf groups/spec-discord groups/agentflow-discord groups/clayton-discord # etc.
 ```
 
 **If no:** print a summary table of old → new paths so the user knows where to look:
@@ -210,7 +210,7 @@ rm -rf groups/spec-discord groups/agentflow-discord groups/ditto-discord # etc.
 Legacy folder                          → New location
 groups/spec-discord/                   → groups/servers/omni-aura/ditto-assistant/spec/
 groups/agentflow-discord/              → groups/servers/omni-aura/omniaura/agentflow/
-groups/ditto-discord/                  → groups/servers/omni-aura/omniaura/agent-debug/
+groups/clayton-discord/                  → groups/servers/omni-aura/omniaura/agent-debug/
 ...
 ```
 
@@ -233,14 +233,14 @@ done
 UPDATE channel_subscriptions
 SET channel_folder = 'servers/omni-aura/ditto-assistant/spec',
     category_folder = 'servers/omni-aura/ditto-assistant'
-WHERE channel_jid = 'dc:...' AND agent_id = 'ditto-discord';
+WHERE channel_jid = 'dc:...' AND agent_id = 'clayton-discord';
 ```
 
 ### Step 7: Set `is_primary` correctly
 
 ```sql
 -- Persona agent owns all channels
-UPDATE channel_subscriptions SET is_primary = 1 WHERE agent_id = 'ditto-discord';
+UPDATE channel_subscriptions SET is_primary = 1 WHERE agent_id = 'clayton-discord';
 -- Tool agents never own
 UPDATE channel_subscriptions SET is_primary = 0 WHERE agent_id = 'ocpeyton-discord';
 ```

--- a/.claude/skills/setup/SKILL.md
+++ b/.claude/skills/setup/SKILL.md
@@ -491,7 +491,7 @@ Use the **AskUserQuestion** tool to show the user the status of each agent and a
 
 > **Agent Status:**
 > - **main** — last active 2 min ago
-> - **ditto-discord** — last active 3 hours ago
+> - **clayton-discord** — last active 3 hours ago
 > - **bot-commands** — no recent activity
 >
 > Which agents do you want to reboot?

--- a/container/agent-runner/src/index.ts
+++ b/container/agent-runner/src/index.ts
@@ -1005,7 +1005,7 @@ async function main(): Promise<void> {
   if (runtime === 'opencode') {
     const { runOpenCodeRuntime } = await import('./opencode-runtime.js');
     await runOpenCodeRuntime(containerInput);
-    return;
+    process.exit(0);
   }
   if (runtime !== 'claude-agent-sdk') {
     writeOutput({

--- a/container/agent-runner/src/ipc-mcp-stdio.ts
+++ b/container/agent-runner/src/ipc-mcp-stdio.ts
@@ -495,7 +495,7 @@ You can also share files to another agent or request files from them.
 The request is sent to the target agent (or admin if no target specified) who can then share the relevant context.`,
   {
     description: z.string().describe('What context or information you need and why'),
-    target_agent: z.string().optional().describe('Agent ID to request from (e.g., "main", "ditto-discord"). Check agent_registry.json for available agents.'),
+    target_agent: z.string().optional().describe('Agent ID to request from (e.g., "main", "clayton-discord"). Check agent_registry.json for available agents.'),
     scope: z.enum(['channel', 'server', 'auto']).default('auto')
       .describe('Where the shared context should go: channel (just this channel), server (all channels in this Discord server), or auto (let admin decide)'),
     files: z.array(z.string()).optional().describe('Paths to SHARE (send TO target agent). Relative to /workspace/group/.'),

--- a/src/db.migrations.test.ts
+++ b/src/db.migrations.test.ts
@@ -197,7 +197,7 @@ describe('db migrations (bun:sqlite)', () => {
     `,
     ).run(
       'dc:940321040482074705',
-      'ditto-discord',
+      'clayton-discord',
       '@Omni',
       1,
       '753336633083953213',
@@ -210,7 +210,7 @@ describe('db migrations (bun:sqlite)', () => {
     `,
     ).run(
       'dc:1475568899452964874',
-      'ditto-discord',
+      'clayton-discord',
       '@Omni',
       1,
       '753336633083953213',
@@ -223,7 +223,7 @@ describe('db migrations (bun:sqlite)', () => {
     `,
     ).run(
       'dc:1475601379400745101',
-      'ditto-discord',
+      'clayton-discord',
       '@Omni',
       1,
       '753336633083953213',
@@ -237,10 +237,10 @@ describe('db migrations (bun:sqlite)', () => {
       VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
     `,
     ).run(
-      'ditto-discord',
+      'clayton-discord',
       'Ditto Discord',
       'discord agent',
-      'ditto-discord',
+      'clayton-discord',
       'apple-container',
       null,
       null,
@@ -272,7 +272,7 @@ describe('db migrations (bun:sqlite)', () => {
 
     expect(migratedRows).toHaveLength(3);
     for (const row of migratedRows) {
-      expect(row.agent_id).toBe('ditto-discord');
+      expect(row.agent_id).toBe('clayton-discord');
       expect(row.trigger_pattern).toBe('@Omni');
       expect(row.requires_trigger).toBe(1);
       expect(row.priority).toBe(100);
@@ -433,10 +433,10 @@ describe('db migrations (bun:sqlite)', () => {
       VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
     `);
     insertAgent.run(
-      'ditto-discord',
+      'clayton-discord',
       'Ditto Discord',
       'frontend/backend',
-      'ditto-discord',
+      'clayton-discord',
       'apple-container',
       null,
       null,
@@ -471,7 +471,7 @@ describe('db migrations (bun:sqlite)', () => {
     insertGroup.run(
       'dc:940321040482074705',
       'Ditto Discord',
-      'ditto-discord',
+      'clayton-discord',
       '@PeytonOmni',
       '2026-02-11T00:00:00.000Z',
       1,
@@ -533,14 +533,14 @@ describe('db migrations (bun:sqlite)', () => {
       GUILD,
     );
 
-    // channel_routes: ditto-discord owns 3 channels, landing-astro-discord owns 1
+    // channel_routes: clayton-discord owns 3 channels, landing-astro-discord owns 1
     const insertRoute = db.prepare(`
       INSERT INTO channel_routes (channel_jid, agent_id, trigger_pattern, requires_trigger, discord_guild_id, created_at)
       VALUES (?, ?, ?, ?, ?, ?)
     `);
     insertRoute.run(
       'dc:940321040482074705',
-      'ditto-discord',
+      'clayton-discord',
       '@PeytonOmni',
       1,
       GUILD,
@@ -548,7 +548,7 @@ describe('db migrations (bun:sqlite)', () => {
     );
     insertRoute.run(
       'dc:1475568899452964874',
-      'ditto-discord',
+      'clayton-discord',
       '@PeytonOmni',
       1,
       GUILD,
@@ -556,7 +556,7 @@ describe('db migrations (bun:sqlite)', () => {
     );
     insertRoute.run(
       'dc:1475601379400745101',
-      'ditto-discord',
+      'clayton-discord',
       '@PeytonOmni',
       1,
       GUILD,
@@ -609,9 +609,9 @@ describe('db migrations (bun:sqlite)', () => {
     const byChannel = Object.fromEntries(
       subs.map((r) => [r.channel_jid, r.agent_id]),
     );
-    expect(byChannel['dc:940321040482074705']).toBe('ditto-discord');
-    expect(byChannel['dc:1475568899452964874']).toBe('ditto-discord');
-    expect(byChannel['dc:1475601379400745101']).toBe('ditto-discord');
+    expect(byChannel['dc:940321040482074705']).toBe('clayton-discord');
+    expect(byChannel['dc:1475568899452964874']).toBe('clayton-discord');
+    expect(byChannel['dc:1475601379400745101']).toBe('clayton-discord');
     expect(byChannel['dc:1475576563176181964']).toBe('landing-astro-discord');
 
     // Legacy-only channels must NOT have leaked into channel_subscriptions


### PR DESCRIPTION
## Problem

When an opencode container finishes a task and goes idle, it waits for the next IPC message via `waitForIpcMessage()`. If the idle limit is exceeded, the host sends a close sentinel to preempt it. The container's opencode runtime receives the sentinel, calls `stopOpenCodeServer()`, and falls through — but the process never exits.

The opencode HTTP server's `close()` only stops accepting new connections. Lingering keep-alive connections hold the Bun event loop open indefinitely.

**What this looked like in practice:**
- Container printed `"Stopping opencode server..."` → process hung
- Host's `GroupQueue` kept `messageActive = true` for the dead container
- Follow-up messages were "piped" (returning true), cursor advanced, messages silently dropped
- User had to resend; container had to be force-killed (`container stop`)

## Fix

Replace `return` with `process.exit(0)` after `await runOpenCodeRuntime()` completes in the agent-runner's `main()`. This forces the process to exit cleanly regardless of any open HTTP connections or other dangling handles.

## Also included

Renames `ditto-discord` → `clayton-discord` in skills documentation, MCP tool descriptions, and migration test fixtures to match the current agent identity.

## Test plan

- [ ] Send a message to OCPeyton, wait for it to complete and go idle
- [ ] Trigger idle preemption (or wait for IDLE_TIMEOUT)
- [ ] Verify container exits cleanly — no lingering process in `container list`
- [ ] Verify follow-up messages spin up a fresh container instead of silently dropping

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated agent and channel configuration references across setup and migration guides.
  * Refreshed agent status options in setup documentation.

* **Bug Fixes**
  * Corrected process termination behavior in the agent runtime to properly exit after execution.

* **Chores**
  * Updated test data to reflect current agent configuration standards.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->