### PR TITLE
fix: route IPC messages through the sending agent's Discord bot

### DIFF
--- a/container/agent-runner/src/ipc-mcp-stdio.ts
+++ b/container/agent-runner/src/ipc-mcp-stdio.ts
@@ -181,6 +181,7 @@ Note: when running as a scheduled task, your final output is NOT sent to the use
       text: args.text,
       sender: args.sender || undefined,
       groupFolder,
+      discord_bot_id: process.env.OMNICLAW_AGENT_BOT_ID || undefined,
       timestamp: new Date().toISOString(),
     };
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -2059,11 +2059,13 @@ async function main(): Promise<void> {
     onSubscriptionChanged: invalidateChannelSubscriptions,
     activeRuntimeFolders: () => activeRuntimeFolders,
     agentFolders: () => new Set(Object.values(agents).map((a) => a.folder)),
-    getSubscriptions: (jid) =>
-      (channelSubscriptions[jid] ?? []).map((s) => ({
+    getSubscriptions: (jid) => {
+      refreshChannelSubscriptions();
+      return (channelSubscriptions[jid] ?? []).map((s) => ({
         agentId: s.agentId,
         agentFolder: agents[s.agentId]?.folder ?? s.agentId,
-      })),
+      }));
+    },
   });
 }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -2059,7 +2059,11 @@ async function main(): Promise<void> {
     onSubscriptionChanged: invalidateChannelSubscriptions,
     activeRuntimeFolders: () => activeRuntimeFolders,
     agentFolders: () => new Set(Object.values(agents).map((a) => a.folder)),
-    getSubscriptions: (jid) => channelSubscriptions[jid] ?? [],
+    getSubscriptions: (jid) =>
+      (channelSubscriptions[jid] ?? []).map((s) => ({
+        agentId: s.agentId,
+        agentFolder: agents[s.agentId]?.folder ?? s.agentId,
+      })),
   });
 }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -2007,8 +2007,8 @@ async function main(): Promise<void> {
     findChannel: (jid, discordBotId) => findChannelForJid(jid, discordBotId),
   });
   startIpcWatcher({
-    sendMessage: async (jid, rawText) => {
-      const ch = findChannelForJid(jid);
+    sendMessage: async (jid, rawText, discordBotId) => {
+      const ch = findChannelForJid(jid, discordBotId);
       if (!ch) {
         logger.warn({ jid }, 'No channel found for IPC message');
         return;
@@ -2059,6 +2059,7 @@ async function main(): Promise<void> {
     onSubscriptionChanged: invalidateChannelSubscriptions,
     activeRuntimeFolders: () => activeRuntimeFolders,
     agentFolders: () => new Set(Object.values(agents).map((a) => a.folder)),
+    getSubscriptions: (jid) => channelSubscriptions[jid] ?? [],
   });
 }
 

--- a/src/ipc.ts
+++ b/src/ipc.ts
@@ -43,7 +43,11 @@ import {
 } from './types.js';
 
 export interface IpcDeps {
-  sendMessage: (jid: string, text: string, discordBotId?: string) => Promise<string | void>;
+  sendMessage: (
+    jid: string,
+    text: string,
+    discordBotId?: string,
+  ) => Promise<string | void>;
   /** Store a message in a group's DB and enqueue it for agent processing.
    * Pass sourceFolder to tag the message so the source agent doesn't echo it. */
   notifyGroup: (jid: string, text: string, sourceFolder?: string) => void;
@@ -68,7 +72,9 @@ export interface IpcDeps {
   /** All known agent folders (including secondary agents not in registeredGroups). */
   agentFolders?: () => ReadonlySet<string>;
   /** Return all channel subscriptions for a JID (used to check if sourceGroup is a subscriber). */
-  getSubscriptions?: (jid: string) => Array<{ agentId: string }>;
+  getSubscriptions?: (
+    jid: string,
+  ) => Array<{ agentId: string; agentFolder: string }>;
 }
 
 /**
@@ -299,7 +305,7 @@ export async function processMessageIpc(
     const channelSubs = deps.getSubscriptions?.(msgChatJid) ?? [];
     const isSelf =
       (targetGroup && targetGroup.folder === sourceGroup) ||
-      channelSubs.some((s) => s.agentId === sourceGroup);
+      channelSubs.some((s) => s.agentFolder === sourceGroup);
     const isRegisteredTarget = !!targetGroup;
     if (isMain || isSelf || isRegisteredTarget) {
       await deps.sendMessage(msgChatJid, msgText, data.discord_bot_id);

--- a/src/ipc.ts
+++ b/src/ipc.ts
@@ -43,7 +43,7 @@ import {
 } from './types.js';
 
 export interface IpcDeps {
-  sendMessage: (jid: string, text: string) => Promise<string | void>;
+  sendMessage: (jid: string, text: string, discordBotId?: string) => Promise<string | void>;
   /** Store a message in a group's DB and enqueue it for agent processing.
    * Pass sourceFolder to tag the message so the source agent doesn't echo it. */
   notifyGroup: (jid: string, text: string, sourceFolder?: string) => void;
@@ -67,6 +67,8 @@ export interface IpcDeps {
   activeRuntimeFolders?: () => ReadonlySet<string>;
   /** All known agent folders (including secondary agents not in registeredGroups). */
   agentFolders?: () => ReadonlySet<string>;
+  /** Return all channel subscriptions for a JID (used to check if sourceGroup is a subscriber). */
+  getSubscriptions?: (jid: string) => Array<{ agentId: string }>;
 }
 
 /**
@@ -291,14 +293,20 @@ export async function processMessageIpc(
     }
     // Authorization: any registered agent can message any other registered agent
     const targetGroup = registeredGroups[msgChatJid];
-    const isSelf = targetGroup && targetGroup.folder === sourceGroup;
+    // isSelf: sourceGroup is the primary agent OR any subscriber of this channel.
+    // Prevents secondary agents (e.g. OCPeyton) posting to a shared channel from
+    // triggering notifyGroup, which would wake up the primary agent (Clayton) to respond.
+    const channelSubs = deps.getSubscriptions?.(msgChatJid) ?? [];
+    const isSelf =
+      (targetGroup && targetGroup.folder === sourceGroup) ||
+      channelSubs.some((s) => s.agentId === sourceGroup);
     const isRegisteredTarget = !!targetGroup;
     if (isMain || isSelf || isRegisteredTarget) {
-      await deps.sendMessage(msgChatJid, msgText);
+      await deps.sendMessage(msgChatJid, msgText, data.discord_bot_id);
       // Cross-group message: also wake up the target agent.
       // Pass sourceGroup so the notify message is tagged — the source
       // agent won't see its own IPC message echoed back at it.
-      if (targetGroup && targetGroup.folder !== sourceGroup) {
+      if (targetGroup && !isSelf) {
         deps.notifyGroup(msgChatJid, msgText, sourceGroup);
       }
       logger.info({ chatJid: data.chatJid, sourceGroup }, 'IPC message sent');

--- a/src/types.ts
+++ b/src/types.ts
@@ -262,6 +262,7 @@ export interface IpcMessagePayload {
   platform?: string;
   requestId?: string;
   pubkey?: string;
+  discord_bot_id?: string;
 }
 
 /** IPC task payloads sent by agents to the orchestrator. */


### PR DESCRIPTION
## Summary

Two bugs caused secondary agents (e.g. OCPeyton) that send IPC messages to have their messages routed through the primary bot (Clayton) and then trigger Clayton to respond as if it received a user message.

**Bug 1 — IPC message missing `discord_bot_id`:** The `send_message` MCP tool in the container didn't include `OMNICLAW_AGENT_BOT_ID` in the written JSON. The host `ipc.ts` called `findChannelForJid` without a preferred bot and fell back to the primary bot (Clayton). Fix: include `discord_bot_id` in the IPC payload and thread it through `IpcDeps.sendMessage` → `findChannelForJid`.

**Bug 2 — `notifyGroup` incorrectly fired for same-channel subscribers:** The `isSelf` check only compared `sourceGroup` to the primary registered group's folder. For shared channels (Clayton + OCPeyton both subscribed), OCPeyton posting triggered `notifyGroup`, waking Clayton to respond with a reply to OCPeyton's task result. Fix: check if `sourceGroup` is *any* subscriber of the target JID via new `getSubscriptions` dep.

## Test plan

- [ ] Schedule a task assigned to OCPeyton in a channel where Clayton is also subscribed
- [ ] Verify the task announcement and result both come from OCPeyton's bot account
- [ ] Verify Clayton does NOT send a follow-up reply to the task result

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added bot identifier support in messaging to enable multi-bot scenarios
  * Implemented subscription-aware message routing for accurate source identification
  * Extended messaging API with bot identification parameters and subscription query capabilities
<!-- end of auto-generated comment: release notes by coderabbit.ai -->