### PR TITLE
fix(container): preinstall agent-browser Chromium deps

### DIFF
--- a/container/Dockerfile
+++ b/container/Dockerfile
@@ -59,8 +59,15 @@ ARG GRAPHITE_VERSION=1.7.16
 RUN npm install -g @withgraphite/graphite-cli@${GRAPHITE_VERSION}
 
 # Install claude-code globally (default agent runtime)
-# Note: agent-browser is available as an on-demand skill (installed on first use)
 RUN bun install -g @anthropic-ai/claude-code
+
+# Pre-install agent-browser with Chromium for browser automation
+# Store browsers in a shared location accessible to both root and bun user.
+# --with-deps installs all required Chromium system libraries (libnss3, libgbm1, etc.)
+ENV PLAYWRIGHT_BROWSERS_PATH=/opt/pw-browsers
+RUN bun install -g agent-browser \
+    && npx playwright install --with-deps chromium \
+    && chmod -R 755 $PLAYWRIGHT_BROWSERS_PATH
 
 # Install OpenCode CLI (alternative agent runtime)
 # Pin version to prevent supply-chain attacks via unsigned curl|bash.

--- a/container/Dockerfile
+++ b/container/Dockerfile
@@ -64,11 +64,9 @@ RUN bun install -g @anthropic-ai/claude-code
 # Pre-install agent-browser with Chromium for browser automation
 # Store browsers in a shared location accessible to both root and bun user.
 # --with-deps installs all required Chromium system libraries (libnss3, libgbm1, etc.)
-# Keep Playwright in the range expected by agent-browser's playwright-core dependency.
 ARG AGENT_BROWSER_VERSION=0.15.1
-ARG PLAYWRIGHT_VERSION=1.58.2
 ENV PLAYWRIGHT_BROWSERS_PATH=/opt/pw-browsers
-RUN bun install -g "agent-browser@${AGENT_BROWSER_VERSION}" "playwright@${PLAYWRIGHT_VERSION}" \
+RUN bun install -g "agent-browser@${AGENT_BROWSER_VERSION}" \
     && agent-browser install --with-deps \
     && chmod -R 755 $PLAYWRIGHT_BROWSERS_PATH
 

--- a/container/Dockerfile
+++ b/container/Dockerfile
@@ -64,9 +64,12 @@ RUN bun install -g @anthropic-ai/claude-code
 # Pre-install agent-browser with Chromium for browser automation
 # Store browsers in a shared location accessible to both root and bun user.
 # --with-deps installs all required Chromium system libraries (libnss3, libgbm1, etc.)
+# Keep Playwright in the range expected by agent-browser's playwright-core dependency.
+ARG AGENT_BROWSER_VERSION=0.15.1
+ARG PLAYWRIGHT_VERSION=1.58.2
 ENV PLAYWRIGHT_BROWSERS_PATH=/opt/pw-browsers
-RUN bun install -g agent-browser \
-    && npx playwright install --with-deps chromium \
+RUN bun install -g "agent-browser@${AGENT_BROWSER_VERSION}" "playwright@${PLAYWRIGHT_VERSION}" \
+    && agent-browser install --with-deps \
     && chmod -R 755 $PLAYWRIGHT_BROWSERS_PATH
 
 # Install OpenCode CLI (alternative agent runtime)

--- a/container/skills/agent-browser/SKILL.md
+++ b/container/skills/agent-browser/SKILL.md
@@ -1,20 +1,10 @@
 ---
 name: agent-browser
-description: Browse the web for any task — research topics, read articles, interact with web apps, fill forms, take screenshots, extract data, and test web pages. Use whenever a browser would be useful, not just when the user explicitly asks. Note - First use requires one-time setup (run install command).
+description: Browse the web for any task — research topics, read articles, interact with web apps, fill forms, take screenshots, extract data, and test web pages. Use whenever a browser would be useful, not just when the user explicitly asks.
 allowed-tools: Bash(agent-browser:*)
 ---
 
 # Browser Automation with agent-browser
-
-## First-time setup
-
-agent-browser is **not pre-installed** to keep container startup fast. On first use, run:
-
-```bash
-bun install -g agent-browser && bunx playwright install chromium
-```
-
-This downloads Chromium (~350MB) and takes ~30 seconds. Only needed once per container.
 
 ## Quick start
 


### PR DESCRIPTION
## Summary
- install `agent-browser` during container build instead of relying on first-use setup
- run `playwright install --with-deps chromium` at build time so required Linux system libraries are present
- set a shared Playwright browser path and permissions so the non-root `bun` runtime user can use the preinstalled Chromium binary

## Why
The runtime container user cannot escalate to root, so `playwright install --with-deps chromium` fails when executed on demand. Preinstalling Chromium and its OS dependencies during image build removes that failure mode and makes browser automation work out of the box.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Browser tooling (agent-browser and Playwright) is pre-installed during image build; browser binaries are placed in a shared, permissioned location and required system libraries are ensured. Retains existing CLI installation path and version pinning for tools.

* **Documentation**
  * Removed first-time setup instructions for agent-browser to simplify onboarding.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->