### PR TITLE
fix: force-exit claude-code runtime after session ends to prevent hang

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -63,6 +63,8 @@ container builder stop && container builder rm && container builder start
 
 Always verify after rebuild: `container run -i --rm --entrypoint wc omniclaw-agent:latest -l /app/src/index.ts`
 
+**Always flush the builder cache** before rebuilding if you changed `container/agent-runner/` source files — buildkit caches `COPY` steps aggressively and will silently keep stale files otherwise.
+
 ## Git Remotes & Pull Requests
 
 This repo is `omniaura/omniclaw`. Always pass `--repo omniaura/omniclaw --base main` when creating PRs with `gh pr create`.

--- a/container/agent-runner/src/index.ts
+++ b/container/agent-runner/src/index.ts
@@ -1166,5 +1166,9 @@ Please review these changes to understand your new capabilities and fixes.
 
 // Only run main() when this file is the entry point, not when imported as a module
 if (import.meta.main) {
-  main();
+  // Force-exit after main() completes: claude-code leaves dangling handles
+  // (WebSockets, HTTP connections, timers) that prevent a natural bun exit.
+  // Without this the container stays alive after the agent loop ends, causing
+  // OmniClaw to keep piping new messages to a dead IPC listener.
+  main().then(() => process.exit(0)).catch(() => process.exit(1));
 }


### PR DESCRIPTION
## Summary

- After the claude-agent-sdk runtime's loop exits (close sentinel received), `bun` stays alive because `claude-code` leaves dangling handles (WebSockets, HTTP connections, timers)
- The container VM never exits, so OmniClaw's queue still treats it as active and keeps piping new messages to a dead IPC listener — messages are stored but never trigger a new agent run
- Fix: explicitly call `process.exit(0)` after `main()` completes, same pattern as the opencode fix in PR #166
- Also updates CLAUDE.md: always flush buildkit builder cache before rebuilding when agent-runner source files change (COPY steps are aggressively cached)

## Test plan

- [ ] Send a message to a Telegram group that uses the claude-agent-sdk runtime (e.g. LocalPeyton)
- [ ] Agent responds, session completes, close sentinel received
- [ ] Verify container stops cleanly (exits 0, not killed after timeout)
- [ ] Send another message — agent should spawn a fresh container and respond

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Agent-runner container now properly terminates after execution completion.

* **Documentation**
  * Added guidance on cache management for container builds.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->