### PR TITLE
fix: close quoted-path bypass in bash security hook

### DIFF
--- a/container/agent-runner/src/__tests__/security-hooks.test.ts
+++ b/container/agent-runner/src/__tests__/security-hooks.test.ts
@@ -42,6 +42,15 @@ describe('Security Hooks - Issue #79', () => {
       await expect(hook(input as any, 'id', {} as any)).rejects.toThrow(/restricted file/i);
     });
 
+    it('should block quoted access to /workspace/env-dir/', async () => {
+      const hook = createSanitizeBashHook();
+      const input = {
+        tool_name: 'Bash',
+        tool_input: { command: 'cat "/workspace/env-dir"/env' },
+      };
+      await expect(hook(input as any, 'id', {} as any)).rejects.toThrow(/restricted file/i);
+    });
+
     it('should block cat /workspace/project/.env', async () => {
       const hook = createSanitizeBashHook();
       const input = {
@@ -74,6 +83,15 @@ describe('Security Hooks - Issue #79', () => {
       const input = {
         tool_name: 'Bash',
         tool_input: { command: 'cat /workspace/project/.env>/tmp/out' },
+      };
+      await expect(hook(input as any, 'id', {} as any)).rejects.toThrow(/restricted file/i);
+    });
+
+    it('should block quoted access to /workspace/project/.env', async () => {
+      const hook = createSanitizeBashHook();
+      const input = {
+        tool_name: 'Bash',
+        tool_input: { command: 'cat "/workspace/project/.env"' },
       };
       await expect(hook(input as any, 'id', {} as any)).rejects.toThrow(/restricted file/i);
     });

--- a/container/agent-runner/src/index.ts
+++ b/container/agent-runner/src/index.ts
@@ -331,9 +331,23 @@ export function createSanitizeBashHook(): HookCallback {
     const command = (preInput.tool_input as { command?: string })?.command;
     if (!command) return {};
 
+    // Normalize shell quoting/escaping for path checks so patterns cannot be
+    // bypassed with variants like "/workspace/env-dir"/env or /workspace\/env-dir.
+    const normalizedForChecks = command
+      .replace(/\\([/"'])/g, '$1')
+      .replace(/["']/g, '');
+
     // Block commands accessing /proc/*/environ (any path component, not just numbered PIDs)
     // Broad match prevents traversal bypasses like /proc/self/../self/environ
     if (/\/proc\/[^ \t\n]*\/environ/.test(command)) {
+      throw new Error(
+        'Access to /proc/*/environ is not allowed for security reasons. ' +
+        'This file contains process environment variables which may include sensitive credentials. ' +
+        'See: https://github.com/omniaura/omniclaw/issues/79'
+      );
+    }
+
+    if (/\/proc\/[^ \t\n]*\/environ/.test(normalizedForChecks)) {
       throw new Error(
         'Access to /proc/*/environ is not allowed for security reasons. ' +
         'This file contains process environment variables which may include sensitive credentials. ' +
@@ -353,7 +367,7 @@ export function createSanitizeBashHook(): HookCallback {
     ];
 
     for (const pattern of blockedPaths) {
-      if (pattern.test(command)) {
+      if (pattern.test(command) || pattern.test(normalizedForChecks)) {
         throw new Error(
           'This command attempts to access a restricted file that could expose credentials. ' +
           'See: https://github.com/omniaura/omniclaw/issues/79'


### PR DESCRIPTION
## Summary
- harden `createSanitizeBashHook` by normalizing quoted and escaped path variants before blocked-path checks
- block bypass forms like `cat \"/workspace/env-dir\"/env` and `cat \"/workspace/project/.env\"` that previously evaded regex detection
- add regression tests in `security-hooks.test.ts` covering quoted env-dir and quoted `.env` access

## Security Impact
This closes a defense-in-depth bypass in the Bash pre-tool hook that could allow secret path access via shell quoting tricks.

## Validation
- `bun test ./container/agent-runner/src/__tests__/security-hooks.test.ts`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Expanded security test coverage for quoted path access restrictions.

* **Bug Fixes**
  * Enhanced command security checks to detect and block bypass attempts using quoted paths and escaped characters.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->