### PR TITLE
feat(web): Task CRUD — create, update, pause/resume, delete tasks from dashboard

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -51,6 +51,9 @@ import {
   getNewMessages,
   getRouterState,
   getTaskById,
+  createTask as dbCreateTask,
+  updateTask as dbUpdateTask,
+  deleteTask as dbDeleteTask,
   initDatabase,
   setAgent,
   setChannelSubscription,
@@ -85,6 +88,7 @@ import {
   registeredGroupToRoute,
 } from './types.js';
 import { findMainGroupJid } from './group-helpers.js';
+import { calculateNextRun } from './schedule-utils.js';
 import { logger } from './logger.js';
 import { assertPathWithin } from './path-security.js';
 import { startWebServer, type WebServerHandle } from './web/index.js';
@@ -1751,6 +1755,10 @@ async function main(): Promise<void> {
         },
         getChats: () => getAllChats(),
         getQueueStats: () => queue.getStats(),
+        createTask: (task) => dbCreateTask(task),
+        updateTask: (id, updates) => dbUpdateTask(id, updates),
+        deleteTask: (id) => dbDeleteTask(id),
+        calculateNextRun: (type, value) => calculateNextRun(type, value),
       },
     );
   }

--- a/src/web/dashboard.ts
+++ b/src/web/dashboard.ts
@@ -44,7 +44,9 @@ export function renderDashboard(state: WebStateProvider): string {
       const lastRun = t.last_run
         ? new Date(t.last_run).toLocaleString()
         : '—';
-      return `<tr>
+      const toggleLabel = t.status === 'active' ? 'Pause' : 'Resume';
+      const toggleStatus = t.status === 'active' ? 'paused' : 'active';
+      return `<tr data-task-id="${escapeHtml(t.id)}">
         <td title="${escapeHtml(t.id)}">${escapeHtml(t.id.slice(0, 8))}…</td>
         <td>${escapeHtml(t.group_folder)}</td>
         <td><span class="badge ${statusClass}">${escapeHtml(t.status)}</span></td>
@@ -52,8 +54,26 @@ export function renderDashboard(state: WebStateProvider): string {
         <td title="${escapeHtml(t.prompt)}">${escapeHtml(t.prompt.slice(0, 80))}${t.prompt.length > 80 ? '…' : ''}</td>
         <td>${nextRun}</td>
         <td>${lastRun}</td>
+        <td class="actions">
+          <button class="btn btn-sm btn-toggle" data-action="toggle" data-status="${toggleStatus}" title="${toggleLabel}">${toggleLabel}</button>
+          <button class="btn btn-sm btn-danger" data-action="delete" title="Delete">Delete</button>
+        </td>
       </tr>`;
     })
+    .join('\n');
+
+  // Build agent options for the create-task form dropdown
+  const agentOptions = agents
+    .map((a) => {
+      const jids = Object.entries(subs)
+        .filter(([, s]) => s.some((sub) => sub.agentId === a.id))
+        .map(([jid]) => jid);
+      return jids.map(
+        (jid) =>
+          `<option value="${escapeHtml(a.folder)}|${escapeHtml(jid)}">${escapeHtml(a.name)} (${escapeHtml(jid)})</option>`,
+      );
+    })
+    .flat()
     .join('\n');
 
   return `<!DOCTYPE html>
@@ -115,6 +135,8 @@ export function renderDashboard(state: WebStateProvider): string {
   .stat-card .value { font-size: 1.5rem; font-weight: 700; margin-top: 0.25rem; }
   section { margin-bottom: 2rem; }
   section h2 { font-size: 1rem; font-weight: 600; margin-bottom: 0.75rem; color: var(--text-dim); text-transform: uppercase; letter-spacing: 0.05em; }
+  .section-header { display: flex; align-items: center; justify-content: space-between; margin-bottom: 0.75rem; }
+  .section-header h2 { margin-bottom: 0; }
   table {
     width: 100%;
     border-collapse: collapse;
@@ -143,6 +165,7 @@ export function renderDashboard(state: WebStateProvider): string {
     white-space: nowrap;
   }
   td.channels { white-space: normal; font-size: 0.75rem; color: var(--text-dim); }
+  td.actions { white-space: nowrap; }
   .badge {
     display: inline-block;
     padding: 0.125rem 0.5rem;
@@ -157,6 +180,26 @@ export function renderDashboard(state: WebStateProvider): string {
   .status-active { background: #14532d; color: var(--green); }
   .status-paused { background: #422006; color: var(--yellow); }
   .status-completed { background: #1e1e1e; color: var(--text-dim); }
+  .btn {
+    padding: 0.375rem 0.75rem;
+    border: 1px solid var(--border);
+    border-radius: 4px;
+    background: var(--surface);
+    color: var(--text);
+    cursor: pointer;
+    font-size: 0.75rem;
+    font-weight: 500;
+    transition: background 0.15s, border-color 0.15s;
+  }
+  .btn:hover { border-color: var(--accent); background: #1e2030; }
+  .btn:disabled { opacity: 0.5; cursor: not-allowed; }
+  .btn-primary { background: var(--accent); border-color: var(--accent); color: #fff; }
+  .btn-primary:hover { background: #4f46e5; }
+  .btn-sm { padding: 0.2rem 0.5rem; font-size: 0.7rem; }
+  .btn-danger { color: var(--red); border-color: #5c1818; }
+  .btn-danger:hover { background: #2a0f0f; border-color: var(--red); }
+  .btn-toggle { color: var(--yellow); border-color: #5c4a08; }
+  .btn-toggle:hover { background: #2a2208; border-color: var(--yellow); }
   #log-container {
     background: var(--surface);
     border: 1px solid var(--border);
@@ -172,6 +215,70 @@ export function renderDashboard(state: WebStateProvider): string {
   .log-line .ts { color: var(--text-dim); }
   .log-line.error { color: var(--red); }
   .log-line.warn { color: var(--yellow); }
+  /* Modal */
+  .modal-overlay {
+    display: none;
+    position: fixed;
+    inset: 0;
+    background: rgba(0,0,0,0.6);
+    z-index: 100;
+    align-items: center;
+    justify-content: center;
+  }
+  .modal-overlay.open { display: flex; }
+  .modal {
+    background: var(--surface);
+    border: 1px solid var(--border);
+    border-radius: 8px;
+    padding: 1.5rem;
+    width: 480px;
+    max-width: 90vw;
+    max-height: 90vh;
+    overflow-y: auto;
+  }
+  .modal h3 { font-size: 1rem; font-weight: 600; margin-bottom: 1rem; }
+  .form-group { margin-bottom: 0.75rem; }
+  .form-group label {
+    display: block;
+    font-size: 0.75rem;
+    color: var(--text-dim);
+    text-transform: uppercase;
+    letter-spacing: 0.05em;
+    margin-bottom: 0.25rem;
+  }
+  .form-group input,
+  .form-group select,
+  .form-group textarea {
+    width: 100%;
+    padding: 0.5rem;
+    background: var(--bg);
+    border: 1px solid var(--border);
+    border-radius: 4px;
+    color: var(--text);
+    font-family: inherit;
+    font-size: 0.85rem;
+  }
+  .form-group textarea { min-height: 80px; resize: vertical; }
+  .form-group input:focus,
+  .form-group select:focus,
+  .form-group textarea:focus { outline: none; border-color: var(--accent); }
+  .form-actions { display: flex; gap: 0.5rem; justify-content: flex-end; margin-top: 1rem; }
+  .form-error { color: var(--red); font-size: 0.75rem; margin-top: 0.25rem; }
+  .toast {
+    position: fixed;
+    bottom: 1.5rem;
+    right: 1.5rem;
+    padding: 0.75rem 1rem;
+    background: var(--surface);
+    border: 1px solid var(--border);
+    border-radius: 6px;
+    font-size: 0.8rem;
+    z-index: 200;
+    animation: fadeIn 0.2s;
+  }
+  .toast.success { border-color: var(--green); color: var(--green); }
+  .toast.error { border-color: var(--red); color: var(--red); }
+  @keyframes fadeIn { from { opacity: 0; transform: translateY(8px); } to { opacity: 1; transform: translateY(0); } }
 </style>
 </head>
 <body>
@@ -196,9 +303,12 @@ export function renderDashboard(state: WebStateProvider): string {
   </section>
 
   <section>
-    <h2>Scheduled Tasks</h2>
+    <div class="section-header">
+      <h2>Scheduled Tasks</h2>
+      <button class="btn btn-primary" id="btn-create-task">+ New Task</button>
+    </div>
     <table>
-      <thead><tr><th>ID</th><th>Agent</th><th>Status</th><th>Schedule</th><th>Prompt</th><th>Next Run</th><th>Last Run</th></tr></thead>
+      <thead><tr><th>ID</th><th>Agent</th><th>Status</th><th>Schedule</th><th>Prompt</th><th>Next Run</th><th>Last Run</th><th>Actions</th></tr></thead>
       <tbody id="tasks-tbody">${taskRows}</tbody>
     </table>
   </section>
@@ -209,57 +319,214 @@ export function renderDashboard(state: WebStateProvider): string {
   </section>
 </main>
 
+<!-- Create Task Modal -->
+<div class="modal-overlay" id="create-task-modal">
+  <div class="modal">
+    <h3>Create Scheduled Task</h3>
+    <form id="create-task-form">
+      <div class="form-group">
+        <label for="ct-agent">Agent / Channel</label>
+        <select id="ct-agent" required>
+          <option value="">Select agent…</option>
+          ${agentOptions}
+        </select>
+      </div>
+      <div class="form-group">
+        <label for="ct-prompt">Prompt</label>
+        <textarea id="ct-prompt" placeholder="What should the agent do?" required></textarea>
+      </div>
+      <div class="form-group">
+        <label for="ct-schedule-type">Schedule Type</label>
+        <select id="ct-schedule-type" required>
+          <option value="cron">Cron</option>
+          <option value="interval">Interval (ms)</option>
+          <option value="once">Once (ISO timestamp)</option>
+        </select>
+      </div>
+      <div class="form-group">
+        <label for="ct-schedule-value">Schedule Value</label>
+        <input id="ct-schedule-value" type="text" placeholder="0 9 * * * (cron) | 3600000 (ms) | 2026-03-02T15:00:00" required>
+      </div>
+      <div class="form-group">
+        <label for="ct-context-mode">Context Mode</label>
+        <select id="ct-context-mode">
+          <option value="isolated">Isolated (fresh session)</option>
+          <option value="group">Group (with chat history)</option>
+        </select>
+      </div>
+      <div id="ct-error" class="form-error"></div>
+      <div class="form-actions">
+        <button type="button" class="btn" id="ct-cancel">Cancel</button>
+        <button type="submit" class="btn btn-primary" id="ct-submit">Create</button>
+      </div>
+    </form>
+  </div>
+</div>
+
 <script>
 (function() {
-  const proto = location.protocol === 'https:' ? 'wss:' : 'ws:';
-  const wsUrl = proto + '//' + location.host + '/ws';
-  const statusEl = document.getElementById('ws-status');
-  const logContainer = document.getElementById('log-container');
-  const MAX_LOG_LINES = 200;
+  // ---- WebSocket ----
+  var proto = location.protocol === 'https:' ? 'wss:' : 'ws:';
+  var wsUrl = proto + '//' + location.host + '/ws';
+  var statusEl = document.getElementById('ws-status');
+  var logContainer = document.getElementById('log-container');
+  var MAX_LOG_LINES = 200;
 
   function connect() {
-    const ws = new WebSocket(wsUrl);
-    ws.onopen = () => {
+    var ws = new WebSocket(wsUrl);
+    ws.onopen = function() {
       statusEl.textContent = 'connected';
       statusEl.className = 'ws-status connected';
       logContainer.innerHTML = '';
       ws.send(JSON.stringify({ subscribe: ['logs', 'stats'] }));
     };
-    ws.onclose = () => {
+    ws.onclose = function() {
       statusEl.textContent = 'disconnected';
       statusEl.className = 'ws-status disconnected';
       setTimeout(connect, 3000);
     };
-    ws.onerror = () => ws.close();
-    ws.onmessage = (e) => {
+    ws.onerror = function() { ws.close(); };
+    ws.onmessage = function(e) {
       try {
-        const evt = JSON.parse(e.data);
+        var evt = JSON.parse(e.data);
         if (evt.type === 'log') {
-          const line = document.createElement('div');
+          var line = document.createElement('div');
           line.className = 'log-line' + (evt.data.level === 'error' ? ' error' : evt.data.level === 'warn' ? ' warn' : '');
-          const ts = new Date(evt.data.ts).toLocaleTimeString();
+          var ts = new Date(evt.data.ts).toLocaleTimeString();
           line.innerHTML = '<span class="ts">' + ts + '</span> ' + escapeHtml(evt.data.msg || '');
           logContainer.appendChild(line);
           while (logContainer.children.length > MAX_LOG_LINES) logContainer.removeChild(logContainer.firstChild);
           logContainer.scrollTop = logContainer.scrollHeight;
         }
         if (evt.type === 'stats') {
-          const d = evt.data;
-          const el = (id) => document.getElementById(id);
+          var d = evt.data;
+          var el = function(id) { return document.getElementById(id); };
           if (d.activeContainers != null) el('stat-active').textContent = (d.activeContainers - d.idleContainers) + '/' + d.maxActive;
           if (d.idleContainers != null) el('stat-idle').textContent = d.idleContainers + '/' + d.maxIdle;
         }
-      } catch {}
+      } catch(ex) {}
     };
   }
 
   function escapeHtml(s) {
-    const d = document.createElement('div');
+    var d = document.createElement('div');
     d.textContent = s;
     return d.innerHTML;
   }
 
   connect();
+
+  // ---- Toast notifications ----
+  function showToast(message, type) {
+    var existing = document.querySelector('.toast');
+    if (existing) existing.remove();
+    var el = document.createElement('div');
+    el.className = 'toast ' + (type || 'success');
+    el.textContent = message;
+    document.body.appendChild(el);
+    setTimeout(function() { el.remove(); }, 3000);
+  }
+
+  // ---- Task actions (pause/resume/delete) ----
+  var tasksTable = document.getElementById('tasks-tbody');
+  tasksTable.addEventListener('click', function(e) {
+    var btn = e.target.closest('button[data-action]');
+    if (!btn) return;
+    var row = btn.closest('tr');
+    var taskId = row.getAttribute('data-task-id');
+    var action = btn.getAttribute('data-action');
+
+    if (action === 'toggle') {
+      var newStatus = btn.getAttribute('data-status');
+      btn.disabled = true;
+      fetch('/api/tasks/' + encodeURIComponent(taskId), {
+        method: 'PATCH',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ status: newStatus })
+      }).then(function(res) {
+        if (!res.ok) return res.json().then(function(d) { throw new Error(d.error); });
+        return res.json();
+      }).then(function(task) {
+        showToast('Task ' + (newStatus === 'paused' ? 'paused' : 'resumed'));
+        location.reload();
+      }).catch(function(err) {
+        showToast(err.message || 'Failed', 'error');
+        btn.disabled = false;
+      });
+    }
+
+    if (action === 'delete') {
+      if (!confirm('Delete this task? This cannot be undone.')) return;
+      btn.disabled = true;
+      fetch('/api/tasks/' + encodeURIComponent(taskId), {
+        method: 'DELETE'
+      }).then(function(res) {
+        if (!res.ok) return res.json().then(function(d) { throw new Error(d.error); });
+        return res.json();
+      }).then(function() {
+        showToast('Task deleted');
+        row.remove();
+      }).catch(function(err) {
+        showToast(err.message || 'Failed', 'error');
+        btn.disabled = false;
+      });
+    }
+  });
+
+  // ---- Create task modal ----
+  var modal = document.getElementById('create-task-modal');
+  var form = document.getElementById('create-task-form');
+  var errorEl = document.getElementById('ct-error');
+
+  document.getElementById('btn-create-task').addEventListener('click', function() {
+    modal.classList.add('open');
+    errorEl.textContent = '';
+  });
+  document.getElementById('ct-cancel').addEventListener('click', function() {
+    modal.classList.remove('open');
+  });
+  modal.addEventListener('click', function(e) {
+    if (e.target === modal) modal.classList.remove('open');
+  });
+
+  form.addEventListener('submit', function(e) {
+    e.preventDefault();
+    errorEl.textContent = '';
+    var submitBtn = document.getElementById('ct-submit');
+    submitBtn.disabled = true;
+
+    var agentVal = document.getElementById('ct-agent').value;
+    if (!agentVal) { errorEl.textContent = 'Select an agent'; submitBtn.disabled = false; return; }
+    var parts = agentVal.split('|');
+    var groupFolder = parts[0];
+    var chatJid = parts[1];
+
+    var payload = {
+      group_folder: groupFolder,
+      chat_jid: chatJid,
+      prompt: document.getElementById('ct-prompt').value,
+      schedule_type: document.getElementById('ct-schedule-type').value,
+      schedule_value: document.getElementById('ct-schedule-value').value,
+      context_mode: document.getElementById('ct-context-mode').value
+    };
+
+    fetch('/api/tasks', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(payload)
+    }).then(function(res) {
+      if (!res.ok) return res.json().then(function(d) { throw new Error(d.error); });
+      return res.json();
+    }).then(function(task) {
+      showToast('Task created: ' + task.id.slice(0, 12));
+      modal.classList.remove('open');
+      form.reset();
+      location.reload();
+    }).catch(function(err) {
+      errorEl.textContent = err.message || 'Failed to create task';
+      submitBtn.disabled = false;
+    });
+  });
 })();
 </script>
 </body>

--- a/src/web/routes.ts
+++ b/src/web/routes.ts
@@ -1,3 +1,4 @@
+import type { ScheduledTask } from '../types.js';
 import type { WebStateProvider } from './types.js';
 import { renderDashboard } from './dashboard.js';
 
@@ -8,13 +9,31 @@ import { renderDashboard } from './dashboard.js';
 export function handleRequest(
   req: Request,
   state: WebStateProvider,
-): Response {
+): Response | Promise<Response> {
   const url = new URL(req.url);
   const { pathname } = url;
+  const method = req.method;
 
   // --- API routes ---
   if (pathname === '/api/agents') return handleGetAgents(state);
-  if (pathname === '/api/tasks') return handleGetTasks(req, state);
+
+  // Tasks — CRUD
+  if (pathname === '/api/tasks') {
+    if (method === 'GET') return handleGetTasks(req, state);
+    if (method === 'POST') return handleCreateTask(req, state);
+    return json({ error: 'Method not allowed' }, 405);
+  }
+  if (pathname.startsWith('/api/tasks/')) {
+    const taskId = decodeURIComponent(
+      pathname.slice('/api/tasks/'.length),
+    );
+    if (!taskId) return json({ error: 'Missing task ID' }, 400);
+    if (method === 'GET') return handleGetSingleTask(taskId, state);
+    if (method === 'PATCH') return handleUpdateTask(taskId, req, state);
+    if (method === 'DELETE') return handleDeleteTask(taskId, state);
+    return json({ error: 'Method not allowed' }, 405);
+  }
+
   if (pathname === '/api/chats') return handleGetChats(state);
   if (pathname.startsWith('/api/messages/'))
     return handleGetMessages(url, state);
@@ -57,6 +76,186 @@ function handleGetTasks(req: Request, state: WebStateProvider): Response {
     tasks = tasks.filter((t) => t.status === statusFilter);
   }
   return json(tasks);
+}
+
+function handleGetSingleTask(
+  taskId: string,
+  state: WebStateProvider,
+): Response {
+  const task = state.getTaskById(taskId);
+  if (!task) return json({ error: 'Task not found' }, 404);
+  return json(task);
+}
+
+async function handleCreateTask(
+  req: Request,
+  state: WebStateProvider,
+): Promise<Response> {
+  let body: Record<string, unknown>;
+  try {
+    body = (await req.json()) as Record<string, unknown>;
+  } catch {
+    return json({ error: 'Invalid JSON body' }, 400);
+  }
+
+  // Validate required fields
+  const { group_folder, chat_jid, prompt, schedule_type, schedule_value, context_mode } = body;
+
+  if (!prompt || typeof prompt !== 'string') {
+    return json({ error: 'Missing or invalid "prompt" (string required)' }, 400);
+  }
+  if (!schedule_type || !['cron', 'interval', 'once'].includes(schedule_type as string)) {
+    return json({ error: 'Missing or invalid "schedule_type" (cron | interval | once)' }, 400);
+  }
+  if (!schedule_value || typeof schedule_value !== 'string') {
+    return json({ error: 'Missing or invalid "schedule_value" (string required)' }, 400);
+  }
+  if (!group_folder || typeof group_folder !== 'string') {
+    return json({ error: 'Missing or invalid "group_folder" (string required)' }, 400);
+  }
+  if (!chat_jid || typeof chat_jid !== 'string') {
+    return json({ error: 'Missing or invalid "chat_jid" (string required)' }, 400);
+  }
+
+  const validContextMode =
+    context_mode === 'group' || context_mode === 'isolated'
+      ? context_mode
+      : 'isolated';
+
+  // Validate the schedule produces a valid next_run
+  const nextRun = state.calculateNextRun(
+    schedule_type as 'cron' | 'interval' | 'once',
+    schedule_value as string,
+  );
+  if (nextRun === null) {
+    return json({ error: 'Invalid schedule: could not calculate next run time' }, 400);
+  }
+
+  const taskId = `task-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
+  const task: Omit<ScheduledTask, 'last_run' | 'last_result'> = {
+    id: taskId,
+    group_folder: group_folder as string,
+    chat_jid: chat_jid as string,
+    prompt: prompt as string,
+    schedule_type: schedule_type as 'cron' | 'interval' | 'once',
+    schedule_value: schedule_value as string,
+    context_mode: validContextMode,
+    next_run: nextRun,
+    status: 'active',
+    created_at: new Date().toISOString(),
+  };
+
+  try {
+    state.createTask(task);
+  } catch (err) {
+    return json(
+      { error: `Failed to create task: ${err instanceof Error ? err.message : String(err)}` },
+      500,
+    );
+  }
+
+  return json({ ...task, last_run: null, last_result: null }, 201);
+}
+
+async function handleUpdateTask(
+  taskId: string,
+  req: Request,
+  state: WebStateProvider,
+): Promise<Response> {
+  const existing = state.getTaskById(taskId);
+  if (!existing) return json({ error: 'Task not found' }, 404);
+
+  let body: Record<string, unknown>;
+  try {
+    body = (await req.json()) as Record<string, unknown>;
+  } catch {
+    return json({ error: 'Invalid JSON body' }, 400);
+  }
+
+  const updates: Partial<
+    Pick<
+      ScheduledTask,
+      'prompt' | 'schedule_type' | 'schedule_value' | 'next_run' | 'status'
+    >
+  > = {};
+
+  if (body.prompt !== undefined) {
+    if (typeof body.prompt !== 'string' || body.prompt.length === 0) {
+      return json({ error: '"prompt" must be a non-empty string' }, 400);
+    }
+    updates.prompt = body.prompt;
+  }
+  if (body.schedule_type !== undefined) {
+    if (!['cron', 'interval', 'once'].includes(body.schedule_type as string)) {
+      return json({ error: '"schedule_type" must be cron | interval | once' }, 400);
+    }
+    updates.schedule_type = body.schedule_type as 'cron' | 'interval' | 'once';
+  }
+  if (body.schedule_value !== undefined) {
+    if (typeof body.schedule_value !== 'string' || body.schedule_value.length === 0) {
+      return json({ error: '"schedule_value" must be a non-empty string' }, 400);
+    }
+    updates.schedule_value = body.schedule_value;
+  }
+  if (body.status !== undefined) {
+    if (!['active', 'paused'].includes(body.status as string)) {
+      return json({ error: '"status" must be active | paused' }, 400);
+    }
+    updates.status = body.status as 'active' | 'paused';
+  }
+
+  if (Object.keys(updates).length === 0) {
+    return json({ error: 'No valid fields to update' }, 400);
+  }
+
+  // Recalculate next_run when schedule changes or task is being resumed
+  const effectiveStatus = updates.status ?? existing.status;
+  const scheduleChanged = !!(updates.schedule_type || updates.schedule_value);
+  const beingResumed = updates.status === 'active' && existing.status !== 'active';
+
+  if (effectiveStatus === 'active' && (scheduleChanged || beingResumed)) {
+    const newType = (updates.schedule_type ?? existing.schedule_type) as
+      | 'cron'
+      | 'interval'
+      | 'once';
+    const newValue = updates.schedule_value ?? existing.schedule_value;
+    if (scheduleChanged || newType !== 'once') {
+      const nextRun = state.calculateNextRun(newType, newValue);
+      if (nextRun !== null) updates.next_run = nextRun;
+    }
+  }
+
+  try {
+    state.updateTask(taskId, updates);
+  } catch (err) {
+    return json(
+      { error: `Failed to update task: ${err instanceof Error ? err.message : String(err)}` },
+      500,
+    );
+  }
+
+  // Return updated task
+  const updated = state.getTaskById(taskId);
+  return json(updated ?? { id: taskId, ...updates });
+}
+
+function handleDeleteTask(
+  taskId: string,
+  state: WebStateProvider,
+): Response {
+  const existing = state.getTaskById(taskId);
+  if (!existing) return json({ error: 'Task not found' }, 404);
+
+  try {
+    state.deleteTask(taskId);
+  } catch (err) {
+    return json(
+      { error: `Failed to delete task: ${err instanceof Error ? err.message : String(err)}` },
+      500,
+    );
+  }
+
+  return json({ deleted: true, id: taskId });
 }
 
 function handleGetChats(state: WebStateProvider): Response {

--- a/src/web/server.test.ts
+++ b/src/web/server.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, afterEach, beforeEach } from 'bun:test';
+import { describe, it, expect, afterEach } from 'bun:test';
 
 import { startWebServer, type WebServerHandle } from './server.js';
 import type { WebStateProvider, QueueStats } from './types.js';
@@ -44,7 +44,28 @@ const defaultStats: QueueStats = {
   maxIdle: 4,
 };
 
+/** In-memory task store for mutation tests. */
+function makeTaskStore(initial: ScheduledTask[] = [makeTask(), makeTask({ id: 'task-002', status: 'paused' })]) {
+  const tasks = new Map<string, ScheduledTask>(initial.map((t) => [t.id, t]));
+  return {
+    tasks,
+    getAll: () => [...tasks.values()],
+    getById: (id: string) => tasks.get(id),
+    create: (task: Omit<ScheduledTask, 'last_run' | 'last_result'>) => {
+      const full: ScheduledTask = { ...task, last_run: null, last_result: null };
+      tasks.set(task.id, full);
+    },
+    update: (id: string, updates: Partial<Pick<ScheduledTask, 'prompt' | 'schedule_type' | 'schedule_value' | 'next_run' | 'status'>>) => {
+      const existing = tasks.get(id);
+      if (!existing) throw new Error('Task not found');
+      tasks.set(id, { ...existing, ...updates });
+    },
+    delete: (id: string) => { tasks.delete(id); },
+  };
+}
+
 function makeState(overrides: Partial<WebStateProvider> = {}): WebStateProvider {
+  const store = makeTaskStore();
   return {
     getAgents: () => ({
       'test-agent': makeAgent(),
@@ -63,9 +84,8 @@ function makeState(overrides: Partial<WebStateProvider> = {}): WebStateProvider 
         },
       ] as ChannelSubscription[],
     }),
-    getTasks: () => [makeTask(), makeTask({ id: 'task-002', status: 'paused' })],
-    getTaskById: (id) =>
-      id === 'task-001' ? makeTask() : undefined,
+    getTasks: () => store.getAll(),
+    getTaskById: (id) => store.getById(id),
     getMessages: () => [
       {
         id: 'msg-1',
@@ -80,6 +100,16 @@ function makeState(overrides: Partial<WebStateProvider> = {}): WebStateProvider 
       { jid: 'dc:123', name: 'test-channel', last_message_time: '2026-03-01T12:00:00.000Z' },
     ],
     getQueueStats: () => defaultStats,
+    createTask: (task) => store.create(task),
+    updateTask: (id, updates) => store.update(id, updates),
+    deleteTask: (id) => store.delete(id),
+    calculateNextRun: (type, value) => {
+      // Simplified for tests — return a fixed future time for valid inputs
+      if (type === 'cron') return '2026-03-03T09:00:00.000Z';
+      if (type === 'interval') return new Date(Date.now() + parseInt(value, 10)).toISOString();
+      if (type === 'once') return value; // trust the ISO string
+      return null;
+    },
     ...overrides,
   };
 }
@@ -191,7 +221,7 @@ describe('GET /api/agents', () => {
   });
 });
 
-// ---- API: /api/tasks ----
+// ---- API: GET /api/tasks ----
 
 describe('GET /api/tasks', () => {
   it('returns all tasks', async () => {
@@ -208,6 +238,401 @@ describe('GET /api/tasks', () => {
     const data = (await res.json()) as ScheduledTask[];
     expect(data.length).toBe(1);
     expect(data[0].status).toBe('active');
+  });
+});
+
+// ---- API: GET /api/tasks/:id ----
+
+describe('GET /api/tasks/:id', () => {
+  it('returns a single task by ID', async () => {
+    handle = startWebServer({ port: randomPort() }, makeState());
+    const res = await fetch(url('/api/tasks/task-001'));
+    expect(res.status).toBe(200);
+    const data = (await res.json()) as ScheduledTask;
+    expect(data.id).toBe('task-001');
+    expect(data.prompt).toBe('Run the daily check');
+  });
+
+  it('returns 404 for unknown task', async () => {
+    handle = startWebServer({ port: randomPort() }, makeState());
+    const res = await fetch(url('/api/tasks/nonexistent'));
+    expect(res.status).toBe(404);
+  });
+});
+
+// ---- API: POST /api/tasks ----
+
+describe('POST /api/tasks', () => {
+  it('creates a task with valid payload', async () => {
+    handle = startWebServer({ port: randomPort() }, makeState());
+    const res = await fetch(url('/api/tasks'), {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        group_folder: 'test-agent',
+        chat_jid: 'dc:123',
+        prompt: 'New scheduled task',
+        schedule_type: 'cron',
+        schedule_value: '0 12 * * *',
+        context_mode: 'isolated',
+      }),
+    });
+    expect(res.status).toBe(201);
+    const data = (await res.json()) as ScheduledTask;
+    expect(data.id).toStartWith('task-');
+    expect(data.prompt).toBe('New scheduled task');
+    expect(data.status).toBe('active');
+    expect(data.next_run).toBeTruthy();
+  });
+
+  it('creates a task with interval schedule', async () => {
+    handle = startWebServer({ port: randomPort() }, makeState());
+    const res = await fetch(url('/api/tasks'), {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        group_folder: 'test-agent',
+        chat_jid: 'dc:123',
+        prompt: 'Interval task',
+        schedule_type: 'interval',
+        schedule_value: '3600000',
+      }),
+    });
+    expect(res.status).toBe(201);
+    const data = (await res.json()) as ScheduledTask;
+    expect(data.schedule_type).toBe('interval');
+    expect(data.context_mode).toBe('isolated'); // default
+  });
+
+  it('defaults context_mode to isolated', async () => {
+    handle = startWebServer({ port: randomPort() }, makeState());
+    const res = await fetch(url('/api/tasks'), {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        group_folder: 'test-agent',
+        chat_jid: 'dc:123',
+        prompt: 'Test',
+        schedule_type: 'once',
+        schedule_value: '2026-12-31T23:59:00.000Z',
+      }),
+    });
+    expect(res.status).toBe(201);
+    const data = (await res.json()) as ScheduledTask;
+    expect(data.context_mode).toBe('isolated');
+  });
+
+  it('rejects missing prompt', async () => {
+    handle = startWebServer({ port: randomPort() }, makeState());
+    const res = await fetch(url('/api/tasks'), {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        group_folder: 'test-agent',
+        chat_jid: 'dc:123',
+        schedule_type: 'cron',
+        schedule_value: '0 9 * * *',
+      }),
+    });
+    expect(res.status).toBe(400);
+    const data = (await res.json()) as { error: string };
+    expect(data.error).toContain('prompt');
+  });
+
+  it('rejects invalid schedule_type', async () => {
+    handle = startWebServer({ port: randomPort() }, makeState());
+    const res = await fetch(url('/api/tasks'), {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        group_folder: 'test-agent',
+        chat_jid: 'dc:123',
+        prompt: 'Test',
+        schedule_type: 'weekly',
+        schedule_value: '0 9 * * *',
+      }),
+    });
+    expect(res.status).toBe(400);
+    const data = (await res.json()) as { error: string };
+    expect(data.error).toContain('schedule_type');
+  });
+
+  it('rejects missing group_folder', async () => {
+    handle = startWebServer({ port: randomPort() }, makeState());
+    const res = await fetch(url('/api/tasks'), {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        chat_jid: 'dc:123',
+        prompt: 'Test',
+        schedule_type: 'cron',
+        schedule_value: '0 9 * * *',
+      }),
+    });
+    expect(res.status).toBe(400);
+    const data = (await res.json()) as { error: string };
+    expect(data.error).toContain('group_folder');
+  });
+
+  it('rejects missing chat_jid', async () => {
+    handle = startWebServer({ port: randomPort() }, makeState());
+    const res = await fetch(url('/api/tasks'), {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        group_folder: 'test-agent',
+        prompt: 'Test',
+        schedule_type: 'cron',
+        schedule_value: '0 9 * * *',
+      }),
+    });
+    expect(res.status).toBe(400);
+    const data = (await res.json()) as { error: string };
+    expect(data.error).toContain('chat_jid');
+  });
+
+  it('rejects invalid JSON body', async () => {
+    handle = startWebServer({ port: randomPort() }, makeState());
+    const res = await fetch(url('/api/tasks'), {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: 'not json',
+    });
+    expect(res.status).toBe(400);
+    const data = (await res.json()) as { error: string };
+    expect(data.error).toContain('Invalid JSON');
+  });
+
+  it('rejects when calculateNextRun returns null', async () => {
+    const state = makeState({
+      calculateNextRun: () => null,
+    });
+    handle = startWebServer({ port: randomPort() }, state);
+    const res = await fetch(url('/api/tasks'), {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        group_folder: 'test-agent',
+        chat_jid: 'dc:123',
+        prompt: 'Test',
+        schedule_type: 'cron',
+        schedule_value: 'invalid-cron',
+      }),
+    });
+    expect(res.status).toBe(400);
+    const data = (await res.json()) as { error: string };
+    expect(data.error).toContain('Invalid schedule');
+  });
+
+  it('task is retrievable after creation', async () => {
+    handle = startWebServer({ port: randomPort() }, makeState());
+    const createRes = await fetch(url('/api/tasks'), {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        group_folder: 'test-agent',
+        chat_jid: 'dc:123',
+        prompt: 'Persistent task',
+        schedule_type: 'cron',
+        schedule_value: '0 9 * * *',
+      }),
+    });
+    const created = (await createRes.json()) as ScheduledTask;
+
+    // Fetch all tasks and verify the new one is included
+    const listRes = await fetch(url('/api/tasks'));
+    const tasks = (await listRes.json()) as ScheduledTask[];
+    expect(tasks.some((t) => t.id === created.id)).toBe(true);
+  });
+});
+
+// ---- API: PATCH /api/tasks/:id ----
+
+describe('PATCH /api/tasks/:id', () => {
+  it('updates task status to paused', async () => {
+    handle = startWebServer({ port: randomPort() }, makeState());
+    const res = await fetch(url('/api/tasks/task-001'), {
+      method: 'PATCH',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ status: 'paused' }),
+    });
+    expect(res.status).toBe(200);
+    const data = (await res.json()) as ScheduledTask;
+    expect(data.status).toBe('paused');
+  });
+
+  it('resumes a paused task', async () => {
+    handle = startWebServer({ port: randomPort() }, makeState());
+    const res = await fetch(url('/api/tasks/task-002'), {
+      method: 'PATCH',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ status: 'active' }),
+    });
+    expect(res.status).toBe(200);
+    const data = (await res.json()) as ScheduledTask;
+    expect(data.status).toBe('active');
+  });
+
+  it('updates task prompt', async () => {
+    handle = startWebServer({ port: randomPort() }, makeState());
+    const res = await fetch(url('/api/tasks/task-001'), {
+      method: 'PATCH',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ prompt: 'Updated prompt text' }),
+    });
+    expect(res.status).toBe(200);
+    const data = (await res.json()) as ScheduledTask;
+    expect(data.prompt).toBe('Updated prompt text');
+  });
+
+  it('updates schedule type and value', async () => {
+    handle = startWebServer({ port: randomPort() }, makeState());
+    const res = await fetch(url('/api/tasks/task-001'), {
+      method: 'PATCH',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        schedule_type: 'interval',
+        schedule_value: '7200000',
+      }),
+    });
+    expect(res.status).toBe(200);
+    const data = (await res.json()) as ScheduledTask;
+    expect(data.schedule_type).toBe('interval');
+    expect(data.schedule_value).toBe('7200000');
+  });
+
+  it('returns 404 for unknown task', async () => {
+    handle = startWebServer({ port: randomPort() }, makeState());
+    const res = await fetch(url('/api/tasks/nonexistent'), {
+      method: 'PATCH',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ status: 'paused' }),
+    });
+    expect(res.status).toBe(404);
+  });
+
+  it('rejects invalid status value', async () => {
+    handle = startWebServer({ port: randomPort() }, makeState());
+    const res = await fetch(url('/api/tasks/task-001'), {
+      method: 'PATCH',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ status: 'deleted' }),
+    });
+    expect(res.status).toBe(400);
+    const data = (await res.json()) as { error: string };
+    expect(data.error).toContain('status');
+  });
+
+  it('rejects invalid schedule_type', async () => {
+    handle = startWebServer({ port: randomPort() }, makeState());
+    const res = await fetch(url('/api/tasks/task-001'), {
+      method: 'PATCH',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ schedule_type: 'weekly' }),
+    });
+    expect(res.status).toBe(400);
+  });
+
+  it('rejects empty update body', async () => {
+    handle = startWebServer({ port: randomPort() }, makeState());
+    const res = await fetch(url('/api/tasks/task-001'), {
+      method: 'PATCH',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({}),
+    });
+    expect(res.status).toBe(400);
+    const data = (await res.json()) as { error: string };
+    expect(data.error).toContain('No valid fields');
+  });
+
+  it('rejects invalid JSON body', async () => {
+    handle = startWebServer({ port: randomPort() }, makeState());
+    const res = await fetch(url('/api/tasks/task-001'), {
+      method: 'PATCH',
+      headers: { 'Content-Type': 'application/json' },
+      body: 'not json',
+    });
+    expect(res.status).toBe(400);
+  });
+
+  it('rejects empty prompt string', async () => {
+    handle = startWebServer({ port: randomPort() }, makeState());
+    const res = await fetch(url('/api/tasks/task-001'), {
+      method: 'PATCH',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ prompt: '' }),
+    });
+    expect(res.status).toBe(400);
+    const data = (await res.json()) as { error: string };
+    expect(data.error).toContain('prompt');
+  });
+});
+
+// ---- API: DELETE /api/tasks/:id ----
+
+describe('DELETE /api/tasks/:id', () => {
+  it('deletes an existing task', async () => {
+    handle = startWebServer({ port: randomPort() }, makeState());
+    const res = await fetch(url('/api/tasks/task-001'), {
+      method: 'DELETE',
+    });
+    expect(res.status).toBe(200);
+    const data = (await res.json()) as { deleted: boolean; id: string };
+    expect(data.deleted).toBe(true);
+    expect(data.id).toBe('task-001');
+
+    // Verify task is gone
+    const checkRes = await fetch(url('/api/tasks/task-001'));
+    expect(checkRes.status).toBe(404);
+  });
+
+  it('returns 404 for unknown task', async () => {
+    handle = startWebServer({ port: randomPort() }, makeState());
+    const res = await fetch(url('/api/tasks/nonexistent'), {
+      method: 'DELETE',
+    });
+    expect(res.status).toBe(404);
+  });
+
+  it('task count decreases after deletion', async () => {
+    handle = startWebServer({ port: randomPort() }, makeState());
+
+    // Get initial count
+    const beforeRes = await fetch(url('/api/tasks'));
+    const before = (await beforeRes.json()) as ScheduledTask[];
+    const initialCount = before.length;
+
+    // Delete a task
+    await fetch(url('/api/tasks/task-001'), { method: 'DELETE' });
+
+    // Get updated count
+    const afterRes = await fetch(url('/api/tasks'));
+    const after = (await afterRes.json()) as ScheduledTask[];
+    expect(after.length).toBe(initialCount - 1);
+  });
+});
+
+// ---- API: Method not allowed ----
+
+describe('method not allowed', () => {
+  it('returns 405 for PUT on /api/tasks', async () => {
+    handle = startWebServer({ port: randomPort() }, makeState());
+    const res = await fetch(url('/api/tasks'), {
+      method: 'PUT',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({}),
+    });
+    expect(res.status).toBe(405);
+  });
+
+  it('returns 405 for POST on /api/tasks/:id', async () => {
+    handle = startWebServer({ port: randomPort() }, makeState());
+    const res = await fetch(url('/api/tasks/task-001'), {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({}),
+    });
+    expect(res.status).toBe(405);
   });
 });
 
@@ -399,6 +824,15 @@ describe('CORS', () => {
     const res = await fetch(url('/api/stats'));
     expect(res.headers.get('Access-Control-Allow-Origin')).toBe('*');
   });
+
+  it('CORS allows POST, PATCH, DELETE methods', async () => {
+    handle = startWebServer({ port: randomPort() }, makeState());
+    const res = await fetch(url('/api/tasks'), { method: 'OPTIONS' });
+    const methods = res.headers.get('Access-Control-Allow-Methods') || '';
+    expect(methods).toContain('POST');
+    expect(methods).toContain('PATCH');
+    expect(methods).toContain('DELETE');
+  });
 });
 
 // ---- Shutdown ----
@@ -422,5 +856,33 @@ describe('server shutdown', () => {
     } catch {
       // Expected: connection refused
     }
+  });
+});
+
+// ---- Dashboard content ----
+
+describe('dashboard', () => {
+  it('includes create task button', async () => {
+    handle = startWebServer({ port: randomPort() }, makeState());
+    const res = await fetch(url('/'));
+    const html = await res.text();
+    expect(html).toContain('btn-create-task');
+    expect(html).toContain('New Task');
+  });
+
+  it('includes task action buttons', async () => {
+    handle = startWebServer({ port: randomPort() }, makeState());
+    const res = await fetch(url('/'));
+    const html = await res.text();
+    expect(html).toContain('data-action="toggle"');
+    expect(html).toContain('data-action="delete"');
+  });
+
+  it('includes create task modal', async () => {
+    handle = startWebServer({ port: randomPort() }, makeState());
+    const res = await fetch(url('/'));
+    const html = await res.text();
+    expect(html).toContain('create-task-modal');
+    expect(html).toContain('create-task-form');
   });
 });

--- a/src/web/server.ts
+++ b/src/web/server.ts
@@ -59,14 +59,20 @@ export function startWebServer(
         });
       }
 
-      const response = handleRequest(req, state);
-      // Add CORS headers to API responses
-      if (url.pathname.startsWith('/api/')) {
-        for (const [k, v] of Object.entries(corsHeaders())) {
-          response.headers.set(k, v);
+      const result = handleRequest(req, state);
+      // handleRequest may return a Promise (for POST/PATCH with body parsing)
+      const addCors = (response: Response) => {
+        if (url.pathname.startsWith('/api/')) {
+          for (const [k, v] of Object.entries(corsHeaders())) {
+            response.headers.set(k, v);
+          }
         }
+        return response;
+      };
+      if (result instanceof Promise) {
+        return result.then(addCors);
       }
-      return response;
+      return addCors(result);
     },
 
     websocket: {
@@ -184,7 +190,7 @@ function timingSafeEqual(a: string, b: string): boolean {
 function corsHeaders(): Record<string, string> {
   return {
     'Access-Control-Allow-Origin': '*',
-    'Access-Control-Allow-Methods': 'GET, OPTIONS',
+    'Access-Control-Allow-Methods': 'GET, POST, PATCH, DELETE, OPTIONS',
     'Access-Control-Allow-Headers': 'Authorization, Content-Type',
   };
 }

--- a/src/web/types.ts
+++ b/src/web/types.ts
@@ -28,6 +28,24 @@ export interface WebStateProvider {
   }>;
   /** Live queue stats from GroupQueue. */
   getQueueStats(): QueueStats;
+
+  // ---- Task mutations ----
+  createTask(task: Omit<ScheduledTask, 'last_run' | 'last_result'>): void;
+  updateTask(
+    id: string,
+    updates: Partial<
+      Pick<
+        ScheduledTask,
+        'prompt' | 'schedule_type' | 'schedule_value' | 'next_run' | 'status'
+      >
+    >,
+  ): void;
+  deleteTask(id: string): void;
+  /** Calculate the next run time for a schedule. Returns null on invalid input. */
+  calculateNextRun(
+    scheduleType: 'cron' | 'interval' | 'once',
+    scheduleValue: string,
+  ): string | null;
 }
 
 export interface QueueStats {


### PR DESCRIPTION
## Summary

Adds full task management CRUD to the web UI, building on PR #169 (skeleton).

- *POST /api/tasks* — create scheduled tasks with full validation (prompt, schedule type/value, group_folder, chat_jid, context_mode)
- *PATCH /api/tasks/:id* — update prompt, schedule, or toggle pause/resume with automatic next_run recalculation
- *DELETE /api/tasks/:id* — delete tasks (with 404 for unknown IDs)
- *GET /api/tasks/:id* — fetch individual task details
- *Dashboard controls* — pause/resume and delete action buttons on every task row
- *"+ New Task" modal* — form with agent/channel dropdown, schedule type selector, prompt textarea, context mode picker
- *CORS* updated to allow POST, PATCH, DELETE
- *WebStateProvider* extended with `createTask`, `updateTask`, `deleteTask`, `calculateNextRun`

### Architecture

The route handler mirrors the same validation logic used by the IPC `schedule_task` / `edit_task` handlers — schedule changes trigger `calculateNextRun` recalculation, status transitions between active/paused are validated, and all fields are type-checked before mutation.

The dashboard uses vanilla JS with `fetch()` calls to the API — no build step, no framework dependencies. Toast notifications for success/error feedback.

### What's next

- [ ] Live log streaming (pipe logger output to WebSocket broadcast)
- [ ] Agent detail views with conversation history
- [ ] IPC traffic inspector

## Test plan

- [x] `bun run typecheck` — passes
- [x] `bun test` — 859 pass, 0 fail (31 new web tests, 52 total web tests)
- [x] POST: valid payloads, missing fields, invalid schedule_type, invalid JSON, null nextRun
- [x] PATCH: pause/resume, prompt update, schedule change, 404, invalid status, empty body
- [x] DELETE: existing task, 404, count verification
- [x] GET single: existing task, 404
- [x] Method not allowed (405): PUT on /api/tasks, POST on /api/tasks/:id
- [x] Dashboard: create button, action buttons, modal presence
- [x] CORS: POST/PATCH/DELETE in allowed methods
- [ ] Manual: create task via modal, verify it appears in task table
- [ ] Manual: pause/resume/delete tasks from dashboard

🤖 Generated with [Claude Code](https://claude.com/claude-code)