### PR TITLE
fix: require trigger for Discord channels, add plaintext name detection

### DIFF
--- a/src/channels/discord.ts
+++ b/src/channels/discord.ts
@@ -417,6 +417,19 @@ export class DiscordChannel implements Channel {
   }
 
   /**
+   * Check if message contains the bot's name in plaintext (without @ prefix).
+   * Matches the group's trigger name with word boundaries, case-insensitive.
+   * e.g., "hey NicholasOmni what do you think" matches if trigger is "@NicholasOmni".
+   */
+  private containsPlaintextName(content: string, group: RegisteredGroup): boolean {
+    const name = (group?.trigger || `@${ASSISTANT_NAME}`).replace(/^@/, '');
+    if (!name) return false;
+    const escaped = name.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+    const pattern = new RegExp(`\\b${escaped}\\b`, 'i');
+    return pattern.test(content);
+  }
+
+  /**
    * Check if message should auto-respond based on group config
    */
   shouldAutoRespond(content: string, group: RegisteredGroup): boolean {
@@ -767,6 +780,14 @@ export class DiscordChannel implements Channel {
         if (!hasGroupTrigger) {
           content = `@${agentName} ${content}`;
         }
+      } else if (this.containsPlaintextName(content, group)) {
+        // Plaintext name mention — user referred to the bot by name without @
+        const agentName = group?.trigger?.replace(/^@/, '') || ASSISTANT_NAME;
+        logger.info(
+          { chatJid, sender: senderName },
+          'Plaintext name mention — treating as triggered',
+        );
+        content = `@${agentName} ${content}`;
       } else if (this.shouldAutoRespond(content, group)) {
         logger.debug(
           {

--- a/src/channels/discord.ts
+++ b/src/channels/discord.ts
@@ -421,7 +421,10 @@ export class DiscordChannel implements Channel {
    * Matches the group's trigger name with word boundaries, case-insensitive.
    * e.g., "hey NicholasOmni what do you think" matches if trigger is "@NicholasOmni".
    */
-  private containsPlaintextName(content: string, group: RegisteredGroup): boolean {
+  private containsPlaintextName(
+    content: string,
+    group: RegisteredGroup,
+  ): boolean {
     const name = (group?.trigger || `@${ASSISTANT_NAME}`).replace(/^@/, '');
     if (!name) return false;
     const escaped = name.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');

--- a/src/channels/discord.ts
+++ b/src/channels/discord.ts
@@ -482,7 +482,8 @@ export class DiscordChannel implements Channel {
     // Ignore own messages
     if (message.author.id === this.client.user?.id) return;
 
-    let content = message.content;
+    const rawContent = message.content;
+    let content = rawContent;
 
     // Translate @bot mention into trigger format
     // FIX: Determine agent name from the channel's registered group, not global ASSISTANT_NAME
@@ -780,7 +781,7 @@ export class DiscordChannel implements Channel {
         if (!hasGroupTrigger) {
           content = `@${agentName} ${content}`;
         }
-      } else if (this.containsPlaintextName(content, group)) {
+      } else if (this.containsPlaintextName(rawContent, group)) {
         // Plaintext name mention — user referred to the bot by name without @
         const agentName = group?.trigger?.replace(/^@/, '') || ASSISTANT_NAME;
         logger.info(

--- a/src/db.ts
+++ b/src/db.ts
@@ -345,6 +345,29 @@ export function createSchema(database: Database): void {
     // columns may not exist on very old DBs — harmless
   }
 
+  // One-time fix: Discord server channels (dc: but not dc:dm:) should require trigger.
+  // Previously these were misconfigured with requires_trigger=0, causing bots to respond
+  // to every message even when not mentioned. Uses router_state to ensure single execution.
+  {
+    const migrationKey = 'fix_discord_requires_trigger_v1';
+    const applied = database.prepare(
+      'SELECT value FROM router_state WHERE key = ?',
+    ).get(migrationKey) as { value: string } | null;
+    if (!applied) {
+      const result = database.prepare(
+        `UPDATE registered_groups SET requires_trigger = 1
+         WHERE jid LIKE 'dc:%' AND jid NOT LIKE 'dc:dm:%' AND requires_trigger = 0`,
+      ).run();
+      database.prepare(
+        'INSERT OR REPLACE INTO router_state (key, value) VALUES (?, ?)',
+      ).run(migrationKey, '1');
+      logger.info(
+        { updatedCount: result.changes },
+        'Migration: Discord server channels now require trigger',
+      );
+    }
+  }
+
   // --- Agent-Channel Decoupling tables ---
   database.exec(`
     CREATE TABLE IF NOT EXISTS agents (

--- a/src/db.ts
+++ b/src/db.ts
@@ -345,29 +345,6 @@ export function createSchema(database: Database): void {
     // columns may not exist on very old DBs — harmless
   }
 
-  // One-time fix: Discord server channels (dc: but not dc:dm:) should require trigger.
-  // Previously these were misconfigured with requires_trigger=0, causing bots to respond
-  // to every message even when not mentioned. Uses router_state to ensure single execution.
-  {
-    const migrationKey = 'fix_discord_requires_trigger_v1';
-    const applied = database.prepare(
-      'SELECT value FROM router_state WHERE key = ?',
-    ).get(migrationKey) as { value: string } | null;
-    if (!applied) {
-      const result = database.prepare(
-        `UPDATE registered_groups SET requires_trigger = 1
-         WHERE jid LIKE 'dc:%' AND jid NOT LIKE 'dc:dm:%' AND requires_trigger = 0`,
-      ).run();
-      database.prepare(
-        'INSERT OR REPLACE INTO router_state (key, value) VALUES (?, ?)',
-      ).run(migrationKey, '1');
-      logger.info(
-        { updatedCount: result.changes },
-        'Migration: Discord server channels now require trigger',
-      );
-    }
-  }
-
   // --- Agent-Channel Decoupling tables ---
   database.exec(`
     CREATE TABLE IF NOT EXISTS agents (
@@ -445,6 +422,30 @@ export function createSchema(database: Database): void {
   migrateRoutesToSubscriptions(database);
 }
 
+// One-time fix: Discord server channels (dc: but not dc:dm:) should require trigger.
+// Previously these were misconfigured with requires_trigger=0, causing bots to respond
+// to every message even when not mentioned. Must run after migrateJsonState() so that
+// legacy groups imported from JSON are also patched.
+function applyDiscordRequiresTriggerFix(database: Database): void {
+  const migrationKey = 'fix_discord_requires_trigger_v1';
+  const applied = database.prepare(
+    'SELECT value FROM router_state WHERE key = ?',
+  ).get(migrationKey) as { value: string } | null;
+  if (applied) return;
+
+  const result = database.prepare(
+    `UPDATE registered_groups SET requires_trigger = 1
+     WHERE jid LIKE 'dc:%' AND jid NOT LIKE 'dc:dm:%' AND requires_trigger = 0`,
+  ).run();
+  database.prepare(
+    'INSERT OR REPLACE INTO router_state (key, value) VALUES (?, ?)',
+  ).run(migrationKey, '1');
+  logger.info(
+    { updatedCount: result.changes },
+    'Migration: Discord server channels now require trigger',
+  );
+}
+
 export function initDatabase(): void {
   const dbPath = path.join(STORE_DIR, 'messages.db');
   fs.mkdirSync(path.dirname(dbPath), { recursive: true });
@@ -454,6 +455,7 @@ export function initDatabase(): void {
 
   // Migrate from JSON files if they exist
   migrateJsonState();
+  applyDiscordRequiresTriggerFix(db);
 }
 
 /** @internal - for tests only. Creates a fresh in-memory database. */

--- a/src/db.ts
+++ b/src/db.ts
@@ -428,18 +428,20 @@ export function createSchema(database: Database): void {
 // legacy groups imported from JSON are also patched.
 function applyDiscordRequiresTriggerFix(database: Database): void {
   const migrationKey = 'fix_discord_requires_trigger_v1';
-  const applied = database.prepare(
-    'SELECT value FROM router_state WHERE key = ?',
-  ).get(migrationKey) as { value: string } | null;
+  const applied = database
+    .prepare('SELECT value FROM router_state WHERE key = ?')
+    .get(migrationKey) as { value: string } | null;
   if (applied) return;
 
-  const result = database.prepare(
-    `UPDATE registered_groups SET requires_trigger = 1
+  const result = database
+    .prepare(
+      `UPDATE registered_groups SET requires_trigger = 1
      WHERE jid LIKE 'dc:%' AND jid NOT LIKE 'dc:dm:%' AND requires_trigger = 0`,
-  ).run();
-  database.prepare(
-    'INSERT OR REPLACE INTO router_state (key, value) VALUES (?, ?)',
-  ).run(migrationKey, '1');
+    )
+    .run();
+  database
+    .prepare('INSERT OR REPLACE INTO router_state (key, value) VALUES (?, ?)')
+    .run(migrationKey, '1');
   logger.info(
     { updatedCount: result.changes },
     'Migration: Discord server channels now require trigger',


### PR DESCRIPTION
## Summary
- **Root cause**: All Discord server channels had `requires_trigger=0` in the database, completely bypassing the trigger check. This caused bots to process and respond to every message, even when not mentioned.
- **DB migration**: One-time migration sets `requires_trigger=1` for all Discord server channels (`dc:*` but not `dc:dm:*`). Uses `router_state` flag to ensure single execution.
- **Plaintext name detection**: New `containsPlaintextName()` method in Discord handler detects when users mention the bot by name without the `@` prefix (e.g., "hey NicholasOmni what do you think?"). Uses word-boundary matching, case-insensitive.

After this fix, bots only respond when:
- Explicitly @mentioned (Discord mention or `@Name` text)
- Mentioned by plaintext name (word-boundary match)
- Replied to (reply-to-bot detection)
- In a bot-created thread

## Test plan
- [x] Build succeeds (`bun run build`)
- [x] All existing tests pass (3 pre-existing failures in unrelated `collectLogFiles` tests)
- [ ] Verify bot no longer responds to unprompted messages in Discord
- [ ] Verify bot still responds when @mentioned
- [ ] Verify bot responds when mentioned by plaintext name (e.g., "NicholasOmni")
- [ ] Verify bot responds to replies to its own messages
- [ ] Verify bot still works in bot-created threads

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * The bot now recognizes its plain name in Discord messages (no @ required) and treats those mentions as triggers.

* **Bug Fixes**
  * Fixed trigger handling so commands work consistently across Discord channel types; a one-time backend update migrates existing channel settings to apply the fix.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->