### PR TITLE
fix(container): fix agent-browser setup for Linux containers

### DIFF
--- a/container/Dockerfile
+++ b/container/Dockerfile
@@ -63,12 +63,23 @@ RUN bun install -g @anthropic-ai/claude-code
 
 # Pre-install agent-browser with Chromium for browser automation
 # Store browsers in a shared location accessible to both root and bun user.
-# --with-deps installs all required Chromium system libraries (libnss3, libgbm1, etc.)
+# bun blocks postinstall scripts by default (security policy). We must add agent-browser
+# to trustedDependencies in bunfig.toml BEFORE installing so bun runs its postinstall,
+# which downloads the platform-specific native binary (e.g. agent-browser-linux-arm64).
+# Without this, the binary is never downloaded and `agent-browser` silently does nothing.
+# `agent-browser install --with-deps` calls sudo internally which doesn't exist, so we
+# run `npx playwright install-deps` directly as root instead (no sudo needed).
+# The JS wrapper at /usr/local/bin/agent-browser uses Node's existsSync() which returns
+# false for paths under /root/.bun/ due to EACCES on access() in the container sandbox,
+# so we symlink the native binary directly to /usr/local/bin/agent-browser.
 ARG AGENT_BROWSER_VERSION=0.15.1
 ENV PLAYWRIGHT_BROWSERS_PATH=/opt/pw-browsers
-RUN bun install -g "agent-browser@${AGENT_BROWSER_VERSION}" \
-    && agent-browser install --with-deps \
-    && chmod -R 755 $PLAYWRIGHT_BROWSERS_PATH
+RUN echo 'trustedDependencies = ["agent-browser"]' >> /root/.bunfig.toml \
+    && bun install -g "agent-browser@${AGENT_BROWSER_VERSION}" \
+    && agent-browser install \
+    && npx playwright install-deps \
+    && chmod -R 755 $PLAYWRIGHT_BROWSERS_PATH \
+    && ln -sf $(find /root/.bun -name 'agent-browser-linux-*' -type f | head -1) /usr/local/bin/agent-browser
 
 # Install OpenCode CLI (alternative agent runtime)
 # Pin version to prevent supply-chain attacks via unsigned curl|bash.


### PR DESCRIPTION
## Summary

Three compounding issues prevented `agent-browser` from working in the container after PR #172:

- **bun postinstall blocked**: bun's default security policy blocks lifecycle scripts, so the platform-specific native binary (`agent-browser-linux-arm64`) was never downloaded. Fixed by writing `trustedDependencies = ["agent-browser"]` to `/root/.bunfig.toml` before installing.

- **`--with-deps` uses sudo**: `agent-browser install --with-deps` calls `sudo apt-get` internally, which doesn't exist in the container. System libraries (libnss3, libgbm1, libasound2, etc.) were silently never installed. Fixed by running `npx playwright install-deps` directly as root.

- **JS wrapper can't find native binary**: The JS wrapper at `/usr/local/bin/agent-browser` uses Node's `existsSync()` to locate the native binary, which returns false for paths under `/root/.bun/` due to `EACCES` on `access()` in the container sandbox (`stat`/`readdir` work but `access()` doesn't). Fixed by symlinking the native binary directly to `/usr/local/bin/agent-browser`.

## Test plan

- [x] `agent-browser --version` returns `0.15.1`
- [x] Chromium present at `/opt/pw-browsers/chromium-1208`
- [x] `libnss3`, `libgbm1`, `libasound2` confirmed installed via `dpkg -l`
- [x] End-to-end browser automation tested successfully in a live container

Closes #179

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved Docker build configuration for agent-browser installation. Updated the setup flow to remove sudo dependency during installation and ensure proper binary availability through simplified symlink setup. Enhanced dependency management configuration for cleaner builds.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->