### PR TITLE
feat(setup): split setup skill into lazy-loaded guides

### DIFF
--- a/.claude/skills/setup/SKILL.md
+++ b/.claude/skills/setup/SKILL.md
@@ -28,8 +28,9 @@ description: Run initial OmniClaw setup. Use when user wants to install dependen
 # 1. Which agents are registered?
 sqlite3 store/messages.db "SELECT folder, name FROM registered_groups"
 
-# 2. Is the service running?
-launchctl list | grep omniclaw
+# 2. Is the service running? (pick one)
+launchctl list | grep omniclaw          # macOS
+systemctl --user status omniclaw        # Linux
 
 # 3. Recent activity per agent
 for folder in $(sqlite3 store/messages.db "SELECT folder FROM registered_groups"); do
@@ -43,10 +44,17 @@ tail -20 logs/omniclaw.log
 
 Present agent status to user and ask which to reboot (all vs specific). Use **AskUserQuestion**.
 
-**Reboot all:**
+**Reboot all — macOS:**
 ```bash
 launchctl kickstart -k gui/$(id -u)/com.omniclaw
 sleep 3 && launchctl list | grep omniclaw
+tail -5 logs/omniclaw.log
+```
+
+**Reboot all — Linux:**
+```bash
+systemctl --user restart omniclaw
+sleep 3 && systemctl --user is-active omniclaw
 tail -5 logs/omniclaw.log
 ```
 

--- a/.claude/skills/setup/SKILL.md
+++ b/.claude/skills/setup/SKILL.md
@@ -5,516 +5,59 @@ description: Run initial OmniClaw setup. Use when user wants to install dependen
 
 # OmniClaw Setup
 
-Run setup scripts automatically. Only pause when user action is required (WhatsApp authentication, configuration choices). Scripts live in `.claude/skills/setup/scripts/` and emit structured status blocks to stdout. Verbose logs go to `logs/setup.log`.
+**Read the user's request first. Most requests are lightweight — handle them directly without loading any guide.**
 
-**Principle:** When something is broken or missing, fix it. Don't tell the user to go fix it themselves unless it genuinely requires their manual action (e.g. scanning a QR code, pasting a secret token). If a dependency is missing, install it. If a service won't start, diagnose and repair. Ask the user for permission when needed, then do the work.
+## Route by intent
 
-> **Upgrading an existing multi-agent Discord/Slack setup?** Run `/migrate-to-channels` to restructure workspaces into the new agent/server/category/channel context architecture.
+| User says | Action |
+|-----------|--------|
+| restart, reboot, kick, kickstart | → [Reboot](#reboot-service) below |
+| verify, status, health check | → run `09-verify.sh` directly |
+| update, upgrade, pulled latest, auto-update | → read [guides/upgrade.md](guides/upgrade.md) |
+| install, fresh setup, first time, configure | → read [guides/fresh-install.md](guides/fresh-install.md) |
+| github, discord bot/agent | → read [guides/advanced-setup.md](guides/advanced-setup.md) |
+| broken, not working, error, troubleshoot | → read [guides/troubleshooting.md](guides/troubleshooting.md) |
 
-**UX Note:** Use `AskUserQuestion` for all user-facing questions.
+---
 
-## 1. Check Environment
+## Reboot service
 
-Run `./.claude/skills/setup/scripts/01-check-environment.sh` and parse the status block.
-
-- If HAS_AUTH=true → note that WhatsApp auth exists, offer to skip step 5
-- If HAS_REGISTERED_GROUPS=true → note existing config, offer to skip or reconfigure
-- Record PLATFORM, APPLE_CONTAINER, and DOCKER values for step 3
-
-**If NODE_OK=false:**
-
-Node.js is missing or too old. Ask the user if they'd like you to install it. Offer options based on platform:
-
-- macOS: `brew install node@22` (if brew available) or install nvm then `nvm install 22`
-- Linux: `curl -fsSL https://deb.nodesource.com/setup_22.x | sudo -E bash - && sudo apt-get install -y nodejs`, or nvm
-
-If brew/nvm aren't installed, install them first (`/bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"` for brew, `curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.40.1/install.sh | bash` for nvm). After installing Node, re-run the environment check to confirm NODE_OK=true.
-
-## 2. Install Dependencies
-
-Run `./.claude/skills/setup/scripts/02-install-deps.sh` and parse the status block.
-
-**If failed:** Read the tail of `logs/setup.log` to diagnose. Common fixes to try automatically:
-1. Delete `node_modules` and `package-lock.json`, then re-run the script
-2. If permission errors: suggest running with corrected permissions
-3. If specific package fails to build (native modules like better-sqlite3): install build tools (`xcode-select --install` on macOS, `build-essential` on Linux), then retry
-
-Only ask the user for help if multiple retries fail with the same error.
-
-## 2b. Initialize Database Schema
-
-The database schema and migrations now run automatically on service startup via `initDatabase()`. No separate script is needed — just ensure `bun run build` succeeds and the service can start.
-
-- Schema + migrations apply automatically on first startup.
-- If startup fails with DB errors, inspect `logs/omniclaw.error.log` for the root cause.
-
-## 3. Container Runtime
-
-Use the environment check results from step 1 to decide which runtime to use:
-
-- PLATFORM=linux → Docker will be used. If the source code still references Apple Container (check for `container system status` in `src/index.ts`), run the `/convert-to-docker` skill first, then continue.
-- PLATFORM=macos + APPLE_CONTAINER=installed → use apple-container
-- PLATFORM=macos + DOCKER=running + APPLE_CONTAINER=not_found → use Docker. If the source code still references Apple Container, run the `/convert-to-docker` skill first.
-- PLATFORM=macos + DOCKER=installed_not_running → start Docker for them: `open -a Docker`. Wait 15s, re-check with `docker info`. If still not running, tell the user Docker is starting up and poll a few more times. Then apply `/convert-to-docker` if source code needs it.
-- Neither available → AskUserQuestion: Apple Container (recommended for macOS) vs Docker?
-  - **If Docker chosen:** install it, then run the `/convert-to-docker` skill to update the source code.
-  - Apple Container: tell user to download from https://github.com/apple/container/releases and install the .pkg. Wait for confirmation, then verify with `container --version`.
-  - Docker on macOS: install via `brew install --cask docker`, then `open -a Docker` and wait for it to start. If brew not available, direct to Docker Desktop download.
-  - Docker on Linux: install with `curl -fsSL https://get.docker.com | sh && sudo usermod -aG docker $USER`. Note: user may need to log out/in for group membership.
-
-Run `./.claude/skills/setup/scripts/03-setup-container.sh --runtime <chosen>` and parse the status block.
-
-**If BUILD_OK=false:** Read `logs/setup.log` tail for the build error.
-- If it's a cache issue (stale layers): run `container builder stop && container builder rm && container builder start` (Apple Container) or `docker builder prune -f` (Docker), then retry.
-- If Dockerfile syntax or missing files: diagnose from the log and fix.
-- Retry the build script after fixing.
-
-**If TEST_OK=false but BUILD_OK=true:** The image built but won't run. Check logs — common cause is runtime not fully started. Wait a moment and retry the test.
-
-## 4. Claude Authentication (No Script)
-
-If HAS_ENV=true from step 1, read `.env` and check if it already has `CLAUDE_CODE_OAUTH_TOKEN` or `ANTHROPIC_API_KEY`. If so, confirm with user: "You already have Claude credentials configured. Want to keep them or reconfigure?" If keeping, skip to step 5.
-
-AskUserQuestion: Claude subscription (Pro/Max) vs Anthropic API key?
-
-**Subscription:** Tell the user:
-1. Open another terminal and run: `claude setup-token`
-2. Copy the token it outputs
-3. Add it to the `.env` file in the project root: `CLAUDE_CODE_OAUTH_TOKEN=<token>`
-4. Let me know when done
-
-Do NOT ask the user to paste the token into the chat. Do NOT use AskUserQuestion to collect the token. Just tell them what to do, then wait for confirmation that they've added it to `.env`. Once confirmed, verify the `.env` file has the key.
-
-**API key:** Tell the user to add `ANTHROPIC_API_KEY=<key>` to the `.env` file in the project root, then let you know when done. Once confirmed, verify the `.env` file has the key.
-
-## 5. WhatsApp Authentication
-
-If HAS_AUTH=true from step 1, confirm with user: "WhatsApp credentials already exist. Want to keep them or re-authenticate?" If keeping, skip to step 6.
-
-AskUserQuestion: QR code in browser (recommended) vs pairing code vs QR code in terminal?
-
-- **QR browser:** Run `./.claude/skills/setup/scripts/04-auth-whatsapp.sh --method qr-browser` (Bash timeout: 150000ms)
-- **Pairing code:** Ask for phone number first (country code, no + or spaces, e.g. 14155551234). Run `./.claude/skills/setup/scripts/04-auth-whatsapp.sh --method pairing-code --phone NUMBER` (Bash timeout: 150000ms). Display the PAIRING_CODE from the status block with instructions.
-- **QR terminal:** Run `./.claude/skills/setup/scripts/04-auth-whatsapp.sh --method qr-terminal`. Tell user to run `cd PROJECT_PATH && npm run auth` in another terminal. Wait for confirmation.
-
-If AUTH_STATUS=already_authenticated → skip ahead.
-
-**If failed:**
-- qr_timeout → QR expired. Automatically re-run the auth script to generate a fresh QR. Tell user a new QR is ready.
-- logged_out → Delete `store/auth/` and re-run auth automatically.
-- 515 → Stream error during pairing. The auth script handles reconnection, but if it persists, re-run the auth script.
-- timeout → Auth took too long. Ask user if they scanned/entered the code, offer to retry.
-
-## 6. Configure Trigger and Channel Type
-
-First, determine the phone number situation. Get the bot's WhatsApp number from `store/auth/creds.json`:
-`node -e "const c=require('./store/auth/creds.json');console.log(c.me.id.split(':')[0].split('@')[0])"`
-
-AskUserQuestion: Does the bot share your personal WhatsApp number, or does it have its own dedicated phone number?
-
-AskUserQuestion: What trigger word? (default: Andy). In group chats, messages starting with @TriggerWord go to Claude. In the main channel, no prefix needed.
-
-AskUserQuestion: Main channel type? (options depend on phone number setup)
-
-**If bot shares user's number (same phone):**
-1. Self-chat (chat with yourself) — Recommended. You message yourself and the bot responds.
-2. Solo group (just you) — A group where you're the only member. Good if you want message history separate from self-chat.
-
-**If bot has its own dedicated phone number:**
-1. DM with the bot — Recommended. You message the bot's number directly.
-2. Solo group with the bot — A group with just you and the bot, no one else.
-
-Do NOT show options that don't apply to the user's setup. For example, don't offer "DM with the bot" if the bot shares the user's number (you can't DM yourself on WhatsApp).
-
-## 7. Sync and Select Group (If Group Channel)
-
-**For personal chat:** The JID is the bot's own phone number from step 6. Construct as `NUMBER@s.whatsapp.net`.
-
-**For DM with bot's dedicated number:** Ask for the bot's phone number, construct JID as `NUMBER@s.whatsapp.net`.
-
-**For group (solo or with bot):**
-1. Run `./.claude/skills/setup/scripts/05-sync-groups.sh` (Bash timeout: 60000ms)
-2. **If BUILD=failed:** Read `logs/setup.log`, fix the TypeScript error, re-run.
-3. **If GROUPS_IN_DB=0:** Check `logs/setup.log` for the sync output. Common causes: WhatsApp auth expired (re-run step 5), connection timeout (re-run sync script with longer timeout).
-4. Run `./.claude/skills/setup/scripts/05b-list-groups.sh` to get groups (pipe-separated JID|name lines). Do NOT display the output to the user.
-5. Pick the most likely candidates (e.g. groups with the trigger word or "OmniClaw" in the name, small/solo groups) and present them as AskUserQuestion options — show names only, not JIDs. Include an "Other" option if their group isn't listed. If they pick Other, search by name in the DB or re-run with a higher limit.
-
-## 8. Register Channel
-
-Run `./.claude/skills/setup/scripts/06-register-channel.sh` with args:
-- `--jid "JID"` — from step 7
-- `--name "main"` — always "main" for the first channel
-- `--trigger "@TriggerWord"` — from step 6
-- `--folder "main"` — always "main" for the first channel
-- `--no-trigger-required` — if personal chat, DM, or solo group
-- `--assistant-name "Name"` — if trigger word differs from "Andy"
-
-## 9. Mount Allowlist
-
-AskUserQuestion: Want the agent to access directories outside the OmniClaw project? (Git repos, project folders, documents, etc.)
-
-**If no:** Run `./.claude/skills/setup/scripts/07-configure-mounts.sh --empty`
-
-**If yes:** Collect directory paths and permissions (read-write vs read-only). Ask about non-main group read-only restriction (recommended: yes). Build the JSON and pipe it to the script:
-
-`echo '{"allowedRoots":[...],"blockedPatterns":[],"nonMainReadOnly":true}' | ./.claude/skills/setup/scripts/07-configure-mounts.sh`
-
-Tell user how to grant a group access: add `containerConfig.additionalMounts` to their entry in `data/registered_groups.json`.
-
-## 10. Start Service
-
-If the service is already running (check `launchctl list | grep omniclaw` on macOS), unload it first: `launchctl unload ~/Library/LaunchAgents/com.omniclaw.plist` — then proceed with a clean install.
-
-Run `./.claude/skills/setup/scripts/08-setup-service.sh` and parse the status block.
-
-**If SERVICE_LOADED=false:**
-- Read `logs/setup.log` for the error.
-- Common fix: plist already loaded with different path. Unload the old one first, then re-run.
-- On macOS: check `launchctl list | grep omniclaw` to see if it's loaded with an error status. If the PID column is `-` and the status column is non-zero, the service is crashing. Read `logs/omniclaw.error.log` for the crash reason and fix it (common: wrong Node path, missing .env, missing auth).
-- On Linux: check `systemctl --user status omniclaw` for the error and fix accordingly.
-- Re-run the setup-service script after fixing.
-
-## 11. Verify
-
-Run `./.claude/skills/setup/scripts/09-verify.sh` and parse the status block.
-
-**If STATUS=failed, fix each failing component:**
-- SERVICE=stopped → run `npm run build` first, then restart: `launchctl kickstart -k gui/$(id -u)/com.omniclaw` (macOS) or `systemctl --user restart omniclaw` (Linux). Re-check.
-- SERVICE=not_found → re-run step 10.
-- CREDENTIALS=missing → re-run step 4.
-- WHATSAPP_AUTH=not_found → re-run step 5.
-- REGISTERED_GROUPS=0 → re-run steps 7-8.
-- MOUNT_ALLOWLIST=missing → run `./.claude/skills/setup/scripts/07-configure-mounts.sh --empty` to create a default.
-
-After fixing, re-run `09-verify.sh` to confirm everything passes.
-
-Tell user to test: send a message in their registered chat (with or without trigger depending on channel type).
-
-Show the log tail command: `tail -f logs/omniclaw.log`
-
-## Troubleshooting
-
-**Service not starting:** Check `logs/omniclaw.error.log`. Common causes: wrong Node path in plist (re-run step 10), missing `.env` (re-run step 4), missing WhatsApp auth (re-run step 5).
-
-**Container agent fails ("Claude Code process exited with code 1"):** Ensure the container runtime is running — start it: `container system start` (Apple Container) or `open -a Docker` (macOS Docker). Check container logs in `groups/main/logs/container-*.log`.
-
-**No response to messages:** Verify the trigger pattern matches. Main channel and personal/solo chats don't need a prefix. Check the registered JID in the database: `sqlite3 store/messages.db "SELECT * FROM registered_groups"`. Check `logs/omniclaw.log`.
-
-**Messages sent but not received (DMs):** WhatsApp may use LID (Linked Identity) JIDs. Check logs for LID translation. Verify the registered JID has no device suffix (should be `number@s.whatsapp.net`, not `number:0@s.whatsapp.net`).
-
-**WhatsApp disconnected:** Run `npm run auth` to re-authenticate, then `npm run build && launchctl kickstart -k gui/$(id -u)/com.omniclaw`.
-
-**Unload service:** `launchctl unload ~/Library/LaunchAgents/com.omniclaw.plist`
-
-## Advanced Setup
-
-### GitHub Integration (Optional)
-
-After step 4 (Claude Authentication), optionally configure GitHub integration for the agent to push branches and create pull requests.
-
-Ask the user:
-> Do you want the agent to be able to **push branches and create pull requests** on GitHub?
->
-> This requires a GitHub Personal Access Token (classic). You can skip this and add it later.
-
-If **no**, skip to the next step.
-
-If **yes**:
-
-Tell the user:
-> 1. Go to https://github.com/settings/tokens (click **Tokens (classic)**)
-> 2. Generate a new **classic** token with the **`repo`** scope
-> 3. If you need access to multiple orgs, classic tokens work across all orgs you're a member of (fine-grained tokens are limited to a single owner)
-
-Ask them to paste the token or confirm they've added it to `.env` themselves.
-
-If they paste the token, append it to `.env`:
+**Check status first, then act.**
 
 ```bash
-echo "GITHUB_TOKEN=<token>" >> .env
-```
+# 1. Which agents are registered?
+sqlite3 store/messages.db "SELECT folder, name FROM registered_groups"
 
-**Optional:** Ask if they want to customize the git identity used for commits:
-
-```bash
-echo "GIT_AUTHOR_NAME=<name>" >> .env
-echo "GIT_AUTHOR_EMAIL=<email>" >> .env
-```
-
-If they skip, defaults are used: `OmniClaw Agent` / `omniclaw@users.noreply.github.com`.
-
-### Discord Agent (Optional)
-
-After completing the main setup, optionally add a Discord agent to respond in Discord channels.
-
-Ask the user:
-> Do you want to add a **Discord agent**? This creates a separate agent that responds in Discord channels.
-
-If **no**, skip this section.
-
-If **yes**, follow these steps:
-
-#### Discord Bot Token
-
-Ask the user:
-> Provide your Discord bot token. If you don't have one:
-> 1. Go to https://discord.com/developers/applications
-> 2. Create a new application → Bot → Reset Token → Copy it
-> 3. Under **Bot → Privileged Gateway Intents**, enable BOTH:
->    - **Presence Intent**
->    - **Message Content Intent** (required to read message text)
-> 4. Invite the bot to your server using OAuth2 → URL Generator (scopes: `bot`, permissions: `Send Messages`, `Read Message History`)
-
-If they paste the token, use the Write tool or a text editor to append `DISCORD_BOT_TOKEN=<token>` to `.env`. Do **not** echo the token via shell command, as it would leak into shell history.
-
-For multi-bot support (recommended), collect:
-- A bot ID (uppercase letters/numbers/underscores), e.g. `CLAUDE` or `OPENCODE`
-- Optional runtime default for that bot ID: `claude-agent-sdk` or `opencode`
-- Whether this bot should be the default for unassigned Discord channels
-
-Then update `.env`:
-- Ensure `DISCORD_BOT_IDS` includes the bot ID (comma-separated list)
-- Set `DISCORD_BOT_<BOT_ID>_TOKEN=<token>`
-- Optionally set `DISCORD_BOT_<BOT_ID>_RUNTIME=<runtime>`
-- Optionally set `DISCORD_BOT_DEFAULT=<BOT_ID>` for default Discord routing
-
-Backwards compatibility rule:
-- Never remove or overwrite an existing `DISCORD_BOT_TOKEN` unless user explicitly asks.
-
-#### Register Discord Channel
-
-The Discord channel JID format is `dc:<channel_id>`. Ask the user for the Discord channel ID:
-> Right-click the channel in Discord → **Copy Channel ID** (enable Developer Mode in Discord Settings → Advanced if you don't see this option).
-
-Register the group in the database. First derive the backend value (fallback to runtime choice if table is empty):
-```bash
-BACKEND=$(sqlite3 store/messages.db "SELECT backend FROM registered_groups LIMIT 1")
-[ -z "$BACKEND" ] && BACKEND="<apple-container|docker>"
-```
-```bash
-sqlite3 store/messages.db "INSERT OR REPLACE INTO registered_groups (jid, name, folder, trigger_pattern, requires_trigger, backend, added_at) VALUES ('dc:<CHANNEL_ID>', '<AGENT_NAME>', '<FOLDER_NAME>', '@<TRIGGER>', 1, '$BACKEND', datetime('now'))"
-```
-
-Create the group folder:
-```bash
-mkdir -p groups/<FOLDER_NAME>/logs
-```
-
-Preferred registration path (keeps agents/channel_routes in sync):
-```bash
-./.claude/skills/setup/scripts/06-register-channel.sh \
-  --jid "dc:<CHANNEL_ID>" \
-  --name "<AGENT_NAME>" \
-  --trigger "@<TRIGGER>" \
-  --folder "<FOLDER_NAME>" \
-  --discord-bot-id "<BOT_ID>" \
-  --agent-runtime "<claude-agent-sdk|opencode>" \
-  --assistant-name "<AssistantName>"
-```
-
-Restart the service to connect to Discord:
-```bash
-launchctl kickstart -k gui/$(id -u)/com.omniclaw
-```
-
-Verify the agent is working by checking logs after sending a message in the Discord channel:
-```bash
-tail -f logs/omniclaw.log
-```
-
-## Upgrading OmniClaw
-
-When the user says they're upgrading, just updated their OmniClaw, pulled the latest code, or something seems broken after a git pull, follow this path.
-
-### What auto-update handles automatically
-
-The `container/auto-update.sh` script (run by scheduled tasks or manually) does all of this without user intervention:
-
-1. `git pull --ff-only origin main` — pulls latest code
-2. `bun run build` — rebuilds host TypeScript
-3. `bash container/build.sh` — rebuilds the container image
-4. Waits for agents to be idle, then restarts the service
-
-If any step fails (build errors, network issues), it exits before restarting — the running service and old container image stay up safely.
-
-**DB migrations run automatically on service start.** New columns/tables are additive with safe defaults, so existing setups are never broken by a migration.
-
-### When to use this upgrade path
-
-Use this section when the user:
-- Pulled latest code and something broke
-- Just had auto-update run and wants to verify everything is healthy
-- Wants to manually upgrade and is unsure what to do
-
-### Upgrade checklist
-
-**Step 1 — Check if the container is up to date**
-
-```bash
-container run -i --rm --entrypoint wc omniclaw-agent:latest -l /app/src/index.ts
-```
-
-If this errors or shows a stale line count, the container image is stale. Rebuild it:
-
-```bash
-container builder stop && container builder rm && container builder start
-./container/build.sh
-```
-
-> The `container builder stop/rm/start` cache bust is required when COPY steps serve stale files. `--no-cache` alone doesn't fix this with Apple Container's buildkit.
-
-**Step 2 — Verify the DB schema is current**
-
-The DB schema and migrations run automatically on service startup via `initDatabase()`. To verify manually, just restart the service — it applies additive-only changes (new tables/columns) on boot, never drops data.
-
-**Step 3 — Restart the service**
-
-```bash
-launchctl kickstart -k gui/$(id -u)/com.omniclaw
-```
-
-**Step 4 — Verify**
-
-Run `./.claude/skills/setup/scripts/09-verify.sh` and confirm all checks pass.
-
-### After upgrading: new capabilities (opt-in)
-
-The following features are available after upgrading but require explicit configuration — **existing agents are completely unaffected by default**.
-
-#### OpenCode runtime (alternative to Claude Agent SDK)
-
-To run a specific agent on OpenCode instead of Claude Agent SDK:
-
-```bash
-./.claude/skills/setup/scripts/06-register-channel.sh \
-  --jid "dc:<CHANNEL_ID>" \
-  --name "<AGENT_NAME>" \
-  --trigger "@<TRIGGER>" \
-  --folder "<FOLDER_NAME>" \
-  --discord-bot-id "<BOT_ID>" \
-  --agent-runtime opencode
-```
-
-Or update an existing agent in the DB directly:
-
-```bash
-sqlite3 store/messages.db "UPDATE registered_groups SET container_config = json_set(COALESCE(container_config,'{}'), '$.agentRuntime', 'opencode') WHERE folder = '<FOLDER_NAME>'"
-```
-
-OpenCode needs its own API key/credentials. Add to `.env`:
-```
-OPENCODE_MODEL=anthropic/claude-sonnet-4-5   # or openai/gpt-4o, etc.
-```
-
-#### Multiple Discord bots
-
-To configure a second Discord bot with its own token and runtime:
-
-Add to `.env`:
-```
-DISCORD_BOT_IDS=CLAUDE,OPENCODE
-DISCORD_BOT_CLAUDE_TOKEN=<existing token>
-DISCORD_BOT_OPENCODE_TOKEN=<new token>
-DISCORD_BOT_OPENCODE_RUNTIME=opencode
-DISCORD_BOT_DEFAULT=CLAUDE
-```
-
-Then re-register channels that should use the new bot with `--discord-bot-id OPENCODE`.
-
-**Critical — internal bot key vs Discord snowflake ID:**
-
-`DISCORD_BOT_IDS` uses **human-readable keys you define** (e.g., `PRIMARY`, `OCPEYTON`, `CLAUDE`). These are completely different from the numeric Discord bot IDs you see in the Developer Portal (e.g., `1476396931709276191`).
-
-| Identifier | Where it lives | Example | Used for |
-|---|---|---|---|
-| **Internal bot key** | `DISCORD_BOT_IDS` in `.env` | `PRIMARY`, `OCPEYTON` | OmniClaw routing |
-| **Discord snowflake ID** | Discord Developer Portal → App → General | `1476396931709276191` | Discord's own API |
-
-The value stored in `channel_subscriptions.discord_bot_id` in SQLite **must** be the internal bot key, never the numeric snowflake ID. If you ever manually edit that column, use the key from `DISCORD_BOT_IDS`, not the ID from Discord's portal.
-
-### Rollback
-
-If something goes wrong after upgrading:
-
-```bash
-# Roll back to previous commit
-git log --oneline -5   # find the previous commit hash
-git reset --hard <HASH>
-bun run build
-./container/build.sh
-launchctl kickstart -k gui/$(id -u)/com.omniclaw
-```
-
-The DB schema changes are additive — rolling back the code is safe even if the migration has already run. The extra columns/tables are harmless on older code.
-
-## Reboot Agents
-
-When the user asks to reboot or restart their agents, **check status first** before restarting anything.
-
-### 1. Check which agents are registered
-
-```bash
-sqlite3 store/messages.db "SELECT folder, name, backend FROM registered_groups"
-```
-
-### 2. Check if the OmniClaw service is running
-
-```bash
+# 2. Is the service running?
 launchctl list | grep omniclaw
-```
 
-A running service shows a PID in the first column. `-` means it's not running.
-
-### 3. Check recent activity per agent
-
-For each registered group folder, check the most recent container log timestamp to determine if it's been active:
-
-```bash
+# 3. Recent activity per agent
 for folder in $(sqlite3 store/messages.db "SELECT folder FROM registered_groups"); do
   LATEST=$(ls -t "groups/$folder/logs/" 2>/dev/null | head -1)
-  if [ -n "$LATEST" ]; then
-    echo "$folder: last active $(echo "$LATEST" | sed 's/container-//;s/\.log//' | tr 'T' ' ')"
-  else
-    echo "$folder: no recent activity"
-  fi
+  [ -n "$LATEST" ] && echo "$folder: $(echo "$LATEST" | sed 's/container-//;s/\.log//')" || echo "$folder: no activity"
 done
-```
 
-Also check the main log for recent errors:
-```bash
+# 4. Recent errors
 tail -20 logs/omniclaw.log
 ```
 
-### 4. Present status and ask
+Present agent status to user and ask which to reboot (all vs specific). Use **AskUserQuestion**.
 
-Use the **AskUserQuestion** tool to show the user the status of each agent and ask which ones to reboot. Example:
-
-> **Agent Status:**
-> - **main** — last active 2 min ago
-> - **clayton-discord** — last active 3 hours ago
-> - **bot-commands** — no recent activity
->
-> Which agents do you want to reboot?
->
-> Options:
-> 1. Reboot all (restart OmniClaw service)
-> 2. Let me pick specific ones
-
-### 5. Reboot
-
-**Reboot all** (restarts the entire OmniClaw service, which reconnects all channels):
+**Reboot all:**
 ```bash
 launchctl kickstart -k gui/$(id -u)/com.omniclaw
-```
-
-After restarting, verify it came back up:
-```bash
 sleep 3 && launchctl list | grep omniclaw
-```
-
-Then check the log for successful startup:
-```bash
 tail -5 logs/omniclaw.log
 ```
 
-Tell the user the result — whether the service restarted successfully and is processing messages again.
+Report whether the service came back up successfully.
+
+---
+
+## Verify
+
+```bash
+./.claude/skills/setup/scripts/09-verify.sh
+```
+
+Fix any failures per [guides/troubleshooting.md](guides/troubleshooting.md).

--- a/.claude/skills/setup/guides/advanced-setup.md
+++ b/.claude/skills/setup/guides/advanced-setup.md
@@ -1,0 +1,64 @@
+# Advanced Setup Guide
+
+## GitHub Integration
+
+Ask: Do you want the agent to push branches and create pull requests?
+
+If yes: user needs a GitHub **classic** token with `repo` scope from https://github.com/settings/tokens
+
+Once they provide it, use the **Write tool** to append to `.env` (never echo tokens via shell — it leaks into shell history):
+```
+GITHUB_TOKEN=<token>
+```
+
+Optionally: `GIT_AUTHOR_NAME` / `GIT_AUTHOR_EMAIL` (defaults: `OmniClaw Agent` / `omniclaw@users.noreply.github.com`)
+
+## Discord Agent
+
+Ask: Do you want to add a Discord agent?
+
+### Bot token
+
+User needs a Discord bot token:
+1. https://discord.com/developers/applications → New application → Bot → Reset Token
+2. Under Bot → Privileged Gateway Intents, enable **Presence Intent** AND **Message Content Intent**
+3. Invite via OAuth2 → URL Generator (scopes: `bot`, permissions: `Send Messages`, `Read Message History`)
+
+Use the **Write tool** to append to `.env` (never echo tokens):
+```
+DISCORD_BOT_IDS=<BOT_ID>
+DISCORD_BOT_<BOT_ID>_TOKEN=<token>
+DISCORD_BOT_DEFAULT=<BOT_ID>
+```
+
+Optionally: `DISCORD_BOT_<BOT_ID>_RUNTIME=opencode`
+
+**Never remove an existing `DISCORD_BOT_TOKEN` unless user explicitly asks.**
+
+### Register Discord channel
+
+JID format: `dc:<channel_id>`. Ask user to right-click the channel → Copy Channel ID (needs Developer Mode in Discord Settings → Advanced).
+
+```bash
+./.claude/skills/setup/scripts/06-register-channel.sh \
+  --jid "dc:<CHANNEL_ID>" \
+  --name "<AGENT_NAME>" \
+  --trigger "@<TRIGGER>" \
+  --folder "<FOLDER_NAME>" \
+  --discord-bot-id "<BOT_ID>" \
+  --agent-runtime "<claude-agent-sdk|opencode>" \
+  --assistant-name "<AssistantName>"
+```
+
+Restart the service:
+```bash
+launchctl kickstart -k gui/$(id -u)/com.omniclaw
+```
+
+Verify by sending a message in the channel and checking `tail -f logs/omniclaw.log`.
+
+### Internal bot key vs Discord snowflake ID
+
+`DISCORD_BOT_IDS` uses **human-readable keys you define** (e.g. `PRIMARY`, `OCPEYTON`). These are completely different from the numeric IDs in the Discord Developer Portal.
+
+The value in `channel_subscriptions.discord_bot_id` in SQLite **must** be the internal key, never the numeric snowflake ID.

--- a/.claude/skills/setup/guides/advanced-setup.md
+++ b/.claude/skills/setup/guides/advanced-setup.md
@@ -7,7 +7,7 @@ Ask: Do you want the agent to push branches and create pull requests?
 If yes: user needs a GitHub **classic** token with `repo` scope from https://github.com/settings/tokens
 
 Once they provide it, use the **Write tool** to append to `.env` (never echo tokens via shell — it leaks into shell history):
-```
+```dotenv
 GITHUB_TOKEN=<token>
 ```
 
@@ -25,7 +25,7 @@ User needs a Discord bot token:
 3. Invite via OAuth2 → URL Generator (scopes: `bot`, permissions: `Send Messages`, `Read Message History`)
 
 Use the **Write tool** to append to `.env` (never echo tokens):
-```
+```dotenv
 DISCORD_BOT_IDS=<BOT_ID>
 DISCORD_BOT_<BOT_ID>_TOKEN=<token>
 DISCORD_BOT_DEFAULT=<BOT_ID>

--- a/.claude/skills/setup/guides/fresh-install.md
+++ b/.claude/skills/setup/guides/fresh-install.md
@@ -140,7 +140,9 @@ AskUserQuestion: Want the agent to access directories outside OmniClaw? (Git rep
 
 ## 10. Start Service
 
-Check if already running: `launchctl list | grep omniclaw`. If yes, unload first: `launchctl unload ~/Library/LaunchAgents/com.omniclaw.plist`
+Check if already running and unload if so:
+- **macOS:** `launchctl list | grep omniclaw` — if running, `launchctl unload ~/Library/LaunchAgents/com.omniclaw.plist`
+- **Linux:** `systemctl --user is-active --quiet omniclaw` — if running, `systemctl --user stop omniclaw && systemctl --user disable omniclaw`
 
 Run `./.claude/skills/setup/scripts/08-setup-service.sh` and parse.
 

--- a/.claude/skills/setup/guides/fresh-install.md
+++ b/.claude/skills/setup/guides/fresh-install.md
@@ -1,0 +1,226 @@
+# OmniClaw Fresh Install Guide
+
+Run setup scripts automatically. Only pause when user action is required (WhatsApp authentication, configuration choices). Scripts live in `.claude/skills/setup/scripts/` and emit structured status blocks to stdout. Verbose logs go to `logs/setup.log`.
+
+**Principle:** When something is broken or missing, fix it. Don't tell the user to go fix it themselves unless it genuinely requires their manual action (e.g. scanning a QR code, pasting a secret token). If a dependency is missing, install it. If a service won't start, diagnose and repair.
+
+**UX Note:** Use `AskUserQuestion` for all user-facing questions.
+
+> **Upgrading an existing multi-agent Discord/Slack setup?** Run `/migrate-to-channels` first.
+
+## 1. Check Environment
+
+Run `./.claude/skills/setup/scripts/01-check-environment.sh` and parse the status block.
+
+- If HAS_AUTH=true → note that WhatsApp auth exists, offer to skip step 5
+- If HAS_REGISTERED_GROUPS=true → note existing config, offer to skip or reconfigure
+- Record PLATFORM, APPLE_CONTAINER, and DOCKER values for step 3
+
+**If NODE_OK=false:** Ask user if they'd like you to install it:
+- macOS: `brew install node@22` or nvm → `nvm install 22`
+- Linux: `curl -fsSL https://deb.nodesource.com/setup_22.x | sudo -E bash - && sudo apt-get install -y nodejs`
+
+Install brew/nvm first if needed. Re-run environment check after to confirm NODE_OK=true.
+
+## 2. Install Dependencies
+
+Run `./.claude/skills/setup/scripts/02-install-deps.sh` and parse the status block.
+
+**If failed:** Read `logs/setup.log` tail. Common fixes:
+1. Delete `node_modules` and `package-lock.json`, re-run
+2. Permission errors: suggest corrected permissions
+3. Native module build fail: install `xcode-select --install` (macOS) or `build-essential` (Linux), retry
+
+## 2b. Database Schema
+
+Schema + migrations run automatically on service startup via `initDatabase()`. No action needed — just ensure `bun run build` succeeds. If startup fails with DB errors, check `logs/omniclaw.error.log`.
+
+## 3. Container Runtime
+
+Use environment check results:
+
+- PLATFORM=linux → Docker. If source references Apple Container, run `/convert-to-docker` first.
+- PLATFORM=macos + APPLE_CONTAINER=installed → apple-container
+- PLATFORM=macos + DOCKER=running + APPLE_CONTAINER=not_found → Docker, run `/convert-to-docker` if needed
+- PLATFORM=macos + DOCKER=installed_not_running → `open -a Docker`, wait 15s, re-check
+- Neither → AskUserQuestion: Apple Container (recommended for macOS) vs Docker?
+  - Docker: install then run `/convert-to-docker`
+  - Apple Container: download from https://github.com/apple/container/releases
+
+Run `./.claude/skills/setup/scripts/03-setup-container.sh --runtime <chosen>` and parse.
+
+**If BUILD_OK=false:** Check `logs/setup.log`.
+- Cache issue: `container builder stop && container builder rm && container builder start` (Apple) or `docker builder prune -f` (Docker), retry.
+
+**If TEST_OK=false but BUILD_OK=true:** Runtime not fully started. Wait and retry.
+
+## 4. Claude Authentication
+
+If HAS_ENV=true, check `.env` for `CLAUDE_CODE_OAUTH_TOKEN` or `ANTHROPIC_API_KEY`. If present, confirm to keep or reconfigure.
+
+AskUserQuestion: Claude subscription (Pro/Max) vs Anthropic API key?
+
+**Subscription:** Tell user:
+1. Open another terminal: `claude setup-token`
+2. Copy the token
+3. Add to `.env`: `CLAUDE_CODE_OAUTH_TOKEN=<token>`
+4. Let you know when done
+
+Do NOT ask user to paste the token into chat. Once confirmed, verify the key exists in `.env`.
+
+**API key:** Tell user to add `ANTHROPIC_API_KEY=<key>` to `.env`, confirm when done.
+
+## 4b. GitHub Integration (Optional)
+
+Ask: Do you want the agent to push branches and create pull requests?
+
+If yes: user needs a classic GitHub token with `repo` scope from https://github.com/settings/tokens. Once they provide it, use the Write tool to append to `.env` (never echo tokens via shell). Optionally collect `GIT_AUTHOR_NAME` / `GIT_AUTHOR_EMAIL`.
+
+## 5. WhatsApp Authentication
+
+If HAS_AUTH=true, confirm to keep or re-authenticate.
+
+AskUserQuestion: QR code in browser (recommended) vs pairing code vs QR code in terminal?
+
+- **QR browser:** `./.claude/skills/setup/scripts/04-auth-whatsapp.sh --method qr-browser` (timeout: 150000ms)
+- **Pairing code:** Ask for phone number first (country code, no + or spaces). `./.claude/skills/setup/scripts/04-auth-whatsapp.sh --method pairing-code --phone NUMBER` (timeout: 150000ms). Display PAIRING_CODE.
+- **QR terminal:** Run script, tell user to run `cd PROJECT_PATH && npm run auth` in another terminal.
+
+If AUTH_STATUS=already_authenticated → skip ahead.
+
+**If failed:**
+- qr_timeout → Re-run auth script automatically for fresh QR
+- logged_out → Delete `store/auth/` and re-run
+- 515 → Stream error; re-run if it persists
+- timeout → Ask if they scanned/entered the code, offer to retry
+
+## 6. Configure Trigger and Channel Type
+
+Get bot's WhatsApp number: `node -e "const c=require('./store/auth/creds.json');console.log(c.me.id.split(':')[0].split('@')[0])"`
+
+AskUserQuestion: Does the bot share your personal WhatsApp number, or does it have its own dedicated number?
+
+AskUserQuestion: What trigger word? (default: Andy)
+
+AskUserQuestion: Main channel type?
+
+**Shared number:** Self-chat (recommended) or Solo group (just you).
+
+**Dedicated number:** DM with the bot (recommended) or Solo group with the bot.
+
+## 7. Sync and Select Group (If Group Channel)
+
+**Personal chat / DM:** Construct JID as `NUMBER@s.whatsapp.net`.
+
+**Group:**
+1. `./.claude/skills/setup/scripts/05-sync-groups.sh` (timeout: 60000ms)
+2. If BUILD=failed: fix TS error, re-run
+3. If GROUPS_IN_DB=0: check `logs/setup.log` — auth expired or timeout
+4. `./.claude/skills/setup/scripts/05b-list-groups.sh` — do NOT show raw output to user
+5. Present likely candidates (groups with trigger word or "OmniClaw" in name) as AskUserQuestion
+
+## 8. Register Channel
+
+`./.claude/skills/setup/scripts/06-register-channel.sh` with:
+- `--jid "JID"`
+- `--name "main"`
+- `--trigger "@TriggerWord"`
+- `--folder "main"`
+- `--no-trigger-required` (if personal chat, DM, or solo group)
+- `--assistant-name "Name"` (if trigger differs from "Andy")
+
+## 9. Mount Allowlist
+
+AskUserQuestion: Want the agent to access directories outside OmniClaw? (Git repos, project folders, etc.)
+
+**No:** `./.claude/skills/setup/scripts/07-configure-mounts.sh --empty`
+
+**Yes:** Collect paths + permissions. Build JSON and pipe to script:
+`echo '{"allowedRoots":[...],"blockedPatterns":[],"nonMainReadOnly":true}' | ./.claude/skills/setup/scripts/07-configure-mounts.sh`
+
+## 10. Start Service
+
+Check if already running: `launchctl list | grep omniclaw`. If yes, unload first: `launchctl unload ~/Library/LaunchAgents/com.omniclaw.plist`
+
+Run `./.claude/skills/setup/scripts/08-setup-service.sh` and parse.
+
+**If SERVICE_LOADED=false:** Check `logs/setup.log`. Common fix: old plist loaded. Unload it, re-run. If crashing: check `logs/omniclaw.error.log` for crash reason (wrong Node path, missing .env, missing auth). On Linux: `systemctl --user status omniclaw`.
+
+## 10b. Auto-Updates (Optional)
+
+AskUserQuestion: Do you want OmniClaw to automatically update itself nightly?
+
+When enabled, `container/auto-update.sh` runs nightly at 3 AM. It fetches `origin/main`, exits immediately if already up to date, otherwise rebuilds host + container, waits up to 10 min for agents to go idle, then restarts.
+
+**macOS — if yes:**
+
+```bash
+REPO_DIR=$(pwd)
+BUN_PATH=$(which bun || echo "$HOME/.bun/bin/bun")
+BUN_DIR=$(dirname "$BUN_PATH")
+```
+
+Write `~/Library/LaunchAgents/com.omniclaw.autoupdate.plist` (replacing REPO_DIR, HOME_DIR, BUN_DIR with actual paths):
+
+```xml
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>Label</key><string>com.omniclaw.autoupdate</string>
+	<key>ProgramArguments</key>
+	<array>
+		<string>/bin/bash</string>
+		<string>REPO_DIR/container/auto-update.sh</string>
+	</array>
+	<key>WorkingDirectory</key><string>REPO_DIR</string>
+	<key>EnvironmentVariables</key>
+	<dict>
+		<key>HOME</key><string>HOME_DIR</string>
+		<key>PATH</key><string>BUN_DIR:/usr/local/bin:/usr/bin:/bin</string>
+	</dict>
+	<key>StartCalendarInterval</key>
+	<dict><key>Hour</key><integer>3</integer><key>Minute</key><integer>0</integer></dict>
+	<key>StandardOutPath</key><string>REPO_DIR/logs/auto-update.log</string>
+	<key>StandardErrorPath</key><string>REPO_DIR/logs/auto-update.log</string>
+	<key>RunAtLoad</key><false/>
+</dict>
+</plist>
+```
+
+```bash
+launchctl load ~/Library/LaunchAgents/com.omniclaw.autoupdate.plist
+launchctl list | grep omniclaw.autoupdate   # '-' PID is correct
+```
+
+**Linux — if yes:**
+
+Write `~/.config/systemd/user/omniclaw-autoupdate.service` and `omniclaw-autoupdate.timer`, then:
+```bash
+systemctl --user daemon-reload
+systemctl --user enable --now omniclaw-autoupdate.timer
+```
+
+**If no:** Skip. Run `bash container/auto-update.sh` manually anytime.
+
+Logs: `logs/auto-update.log`
+
+## 11. Verify
+
+Run `./.claude/skills/setup/scripts/09-verify.sh` and parse.
+
+**Fix each failure:**
+- SERVICE=stopped → `bun run build`, then `launchctl kickstart -k gui/$(id -u)/com.omniclaw` (macOS) or `systemctl --user restart omniclaw` (Linux). Re-check.
+- SERVICE=not_found → re-run step 10
+- CREDENTIALS=missing → re-run step 4
+- WHATSAPP_AUTH=not_found → re-run step 5
+- REGISTERED_GROUPS=0 → re-run steps 7-8
+- MOUNT_ALLOWLIST=missing → `./.claude/skills/setup/scripts/07-configure-mounts.sh --empty`
+
+Re-run `09-verify.sh` after fixes to confirm all pass.
+
+Tell user to test: send a message in their registered chat. Log tail: `tail -f logs/omniclaw.log`
+
+## Discord Agent Setup (Optional)
+
+See [advanced-setup.md](advanced-setup.md) for adding a Discord agent bot.

--- a/.claude/skills/setup/guides/troubleshooting.md
+++ b/.claude/skills/setup/guides/troubleshooting.md
@@ -34,17 +34,28 @@ bun run build && launchctl kickstart -k gui/$(id -u)/com.omniclaw
 
 ## Auto-update not running
 
-Check `logs/auto-update.log`. Verify the launchd job is loaded:
+Check `logs/auto-update.log`. Then verify the scheduler is loaded:
+
+**macOS:**
 ```bash
 launchctl list | grep omniclaw.autoupdate
-```
-
-If missing: re-run step 10b of fresh install, or load manually:
-```bash
+# If missing, load it:
 launchctl load ~/Library/LaunchAgents/com.omniclaw.autoupdate.plist
 ```
 
-Test the script directly:
+**Linux:**
+```bash
+systemctl --user status omniclaw-autoupdate.timer
+systemctl --user list-timers | grep omniclaw
+# If missing, re-enable:
+systemctl --user enable --now omniclaw-autoupdate.timer
+# To trigger immediately:
+systemctl --user start omniclaw-autoupdate.service
+```
+
+If the scheduler is missing entirely: re-run step 10b of fresh install.
+
+Test the script directly (both platforms):
 ```bash
 bash container/auto-update.sh
 ```

--- a/.claude/skills/setup/guides/troubleshooting.md
+++ b/.claude/skills/setup/guides/troubleshooting.md
@@ -1,0 +1,66 @@
+# Troubleshooting Guide
+
+## Service not starting
+
+Check `logs/omniclaw.error.log`. Common causes:
+- Wrong Node/bun path in plist → re-run step 10 of fresh install
+- Missing `.env` → re-run step 4
+- Missing WhatsApp auth → re-run step 5
+
+## Container agent fails ("Claude Code process exited with code 1")
+
+Ensure container runtime is running:
+- Apple Container: `container system start`
+- Docker: `open -a Docker`
+
+Check container logs: `groups/main/logs/container-*.log`
+
+## No response to messages
+
+- Verify the trigger pattern matches (main channel / personal / solo chats don't need a prefix)
+- Check registered JID: `sqlite3 store/messages.db "SELECT * FROM registered_groups"`
+- Check `logs/omniclaw.log`
+
+## Messages sent but not received (DMs)
+
+WhatsApp may use LID (Linked Identity) JIDs. Check logs for LID translation. Verify registered JID has no device suffix — should be `number@s.whatsapp.net`, not `number:0@s.whatsapp.net`.
+
+## WhatsApp disconnected
+
+```bash
+npm run auth   # re-authenticate
+bun run build && launchctl kickstart -k gui/$(id -u)/com.omniclaw
+```
+
+## Auto-update not running
+
+Check `logs/auto-update.log`. Verify the launchd job is loaded:
+```bash
+launchctl list | grep omniclaw.autoupdate
+```
+
+If missing: re-run step 10b of fresh install, or load manually:
+```bash
+launchctl load ~/Library/LaunchAgents/com.omniclaw.autoupdate.plist
+```
+
+Test the script directly:
+```bash
+bash container/auto-update.sh
+```
+
+## Useful commands
+
+```bash
+# Unload service
+launchctl unload ~/Library/LaunchAgents/com.omniclaw.plist
+
+# Restart service
+launchctl kickstart -k gui/$(id -u)/com.omniclaw
+
+# Tail main log
+tail -f logs/omniclaw.log
+
+# Tail auto-update log
+tail -f logs/auto-update.log
+```

--- a/.claude/skills/setup/guides/upgrade.md
+++ b/.claude/skills/setup/guides/upgrade.md
@@ -1,0 +1,85 @@
+# OmniClaw Upgrade Guide
+
+Use this when: pulled latest code, auto-update ran, something broke after a git pull, or want to manually upgrade.
+
+## What auto-update does
+
+`container/auto-update.sh` (set up in step 10b of fresh install, or run manually):
+
+1. `git pull --ff-only origin main` — exits immediately if already up to date
+2. `bun run build` — rebuilds host TypeScript
+3. `bash container/build.sh` — rebuilds container image
+4. Waits for agents to go idle (up to 10 min), then restarts
+
+If any step fails, it exits without restarting — old service + image stay up safely.
+
+**DB migrations run automatically on service start** — additive only, never drops data.
+
+## Upgrade checklist
+
+**Step 1 — Is the container up to date?**
+
+```bash
+container run -i --rm --entrypoint wc omniclaw-agent:latest -l /app/src/index.ts
+```
+
+Stale or errors → flush cache and rebuild:
+```bash
+container builder stop && container builder rm && container builder start
+./container/build.sh
+```
+
+> `--no-cache` alone doesn't fix this with Apple Container's buildkit — the cache bust is required.
+
+**Step 2 — Restart the service**
+
+```bash
+launchctl kickstart -k gui/$(id -u)/com.omniclaw
+```
+
+**Step 3 — Verify**
+
+```bash
+./.claude/skills/setup/scripts/09-verify.sh
+```
+
+## Rollback
+
+```bash
+git log --oneline -5        # find the previous commit
+git reset --hard <HASH>
+bun run build
+./container/build.sh
+launchctl kickstart -k gui/$(id -u)/com.omniclaw
+```
+
+Schema changes are additive — rolling back code is safe even after migrations ran.
+
+## New opt-in capabilities
+
+These require explicit action — existing agents are unaffected by default.
+
+### OpenCode runtime
+
+Run a specific agent on OpenCode instead of Claude Agent SDK:
+
+```bash
+sqlite3 store/messages.db "UPDATE registered_groups SET container_config = json_set(COALESCE(container_config,'{}'), '$.agentRuntime', 'opencode') WHERE folder = '<FOLDER_NAME>'"
+```
+
+Add to `.env`: `OPENCODE_MODEL=anthropic/claude-sonnet-4-5`
+
+### Multiple Discord bots
+
+Add to `.env`:
+```
+DISCORD_BOT_IDS=CLAUDE,OPENCODE
+DISCORD_BOT_CLAUDE_TOKEN=<existing>
+DISCORD_BOT_OPENCODE_TOKEN=<new>
+DISCORD_BOT_OPENCODE_RUNTIME=opencode
+DISCORD_BOT_DEFAULT=CLAUDE
+```
+
+Then re-register channels with `--discord-bot-id OPENCODE`.
+
+**Internal bot key vs Discord snowflake ID:** `DISCORD_BOT_IDS` uses human-readable keys you define (e.g. `PRIMARY`, `OCPEYTON`). Never use the numeric Discord Developer Portal IDs in `channel_subscriptions.discord_bot_id`.

--- a/.claude/skills/setup/guides/upgrade.md
+++ b/.claude/skills/setup/guides/upgrade.md
@@ -34,7 +34,10 @@ container builder stop && container builder rm && container builder start
 **Step 2 — Restart the service**
 
 ```bash
+# macOS
 launchctl kickstart -k gui/$(id -u)/com.omniclaw
+# Linux
+systemctl --user restart omniclaw
 ```
 
 **Step 3 — Verify**
@@ -50,7 +53,10 @@ git log --oneline -5        # find the previous commit
 git reset --hard <HASH>
 bun run build
 ./container/build.sh
+# macOS
 launchctl kickstart -k gui/$(id -u)/com.omniclaw
+# Linux
+systemctl --user restart omniclaw
 ```
 
 Schema changes are additive — rolling back code is safe even after migrations ran.


### PR DESCRIPTION
## Summary

- `SKILL.md` was 521 lines loaded into context on **every** invocation, even for lightweight tasks like \"restart omniclaw\"
- Now `SKILL.md` is **63 lines** and handles restart/verify inline — no file loading needed for the most common requests
- Heavy content lives in `guides/` and is only read when the task actually requires it

## Guide files

| File | Lines | Loaded when |
|------|-------|-------------|
| `SKILL.md` | 63 | Always |
| `guides/fresh-install.md` | 226 | First-time setup / install |
| `guides/upgrade.md` | 85 | Upgrade / update / auto-update |
| `guides/advanced-setup.md` | 64 | GitHub integration / Discord agent |
| `guides/troubleshooting.md` | 66 | Broken / not working / errors |

## Also included

- Auto-update is now a proper setup step (10b) — new installs get prompted to enable nightly auto-updates via launchd (macOS) or systemd (Linux). Previously the script existed but was never wired up during setup.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Reorganized setup documentation with an intent-driven approach to guide users to relevant resources.
  * Added comprehensive fresh install guide with step-by-step workflows and verification procedures.
  * Created dedicated troubleshooting guide with common issues, diagnostics, and remediation commands.
  * Added advanced setup guide for GitHub and Discord integrations with environment configuration details.
  * Introduced upgrade and rollback procedures with auto-update and multi-service support guidance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->