### PR TITLE
fix(security): centralize redaction and preserve JSON secret keys

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -83,6 +83,7 @@ import {
 import { findMainGroupJid } from './group-helpers.js';
 import { logger } from './logger.js';
 import { assertPathWithin } from './path-security.js';
+import { redactSensitiveData } from './security/redaction.js';
 import { Effect } from 'effect';
 
 // Global error handlers to prevent crashes from unhandled rejections/exceptions
@@ -824,32 +825,6 @@ async function processGroupMessages(dispatchJid: string): Promise<boolean> {
     /Invalid (?:API key|bearer token)/,
     /rate_limit_error/,
   ];
-
-  // Redact sensitive data from error messages before logging
-  function redactSensitiveData(text: string): string {
-    return (
-      text
-        // Redact bearer tokens
-        .replace(/Bearer\s+[A-Za-z0-9_\-\.]{20,}/gi, 'Bearer [REDACTED]')
-        // Redact API keys (common patterns: sk-..., key_..., etc.)
-        .replace(
-          /\b(?:sk|key|api)[_-][A-Za-z0-9_\-]{16,}/gi,
-          '[API_KEY_REDACTED]',
-        )
-        // Redact long hex strings (likely tokens/secrets)
-        .replace(/\b[a-f0-9]{32,}\b/gi, '[HEX_TOKEN_REDACTED]')
-        // Redact JWT tokens
-        .replace(
-          /eyJ[A-Za-z0-9_\-]+\.eyJ[A-Za-z0-9_\-]+\.[A-Za-z0-9_\-]+/g,
-          '[JWT_REDACTED]',
-        )
-        // Redact common password/secret field values in JSON
-        .replace(
-          /"(?:password|secret|token|apikey)":\s*"[^"]+"/gi,
-          '"$1":"[REDACTED]"',
-        )
-    );
-  }
 
   // Thread streaming via shared helper
   // Synthetic IDs (synth-*, react-*, notify-*) aren't real channel message IDs

--- a/src/security/redaction.test.ts
+++ b/src/security/redaction.test.ts
@@ -1,0 +1,45 @@
+import { describe, expect, it } from 'bun:test';
+
+import { redactSensitiveData } from './redaction.js';
+
+describe('redactSensitiveData', () => {
+  it('redacts bearer, API key, hex, and JWT tokens', () => {
+    const input = [
+      'Bearer abcdefghijklmnopqrstuvwxyz123456',
+      'sk-prod_abcdefghijklmnopqrstuvwxyz1234',
+      '0123456789abcdef0123456789abcdef',
+      'eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiIxMjM0In0.c2lnbmF0dXJlMTIz',
+    ].join(' | ');
+
+    const redacted = redactSensitiveData(input);
+    expect(redacted).toContain('Bearer [REDACTED]');
+    expect(redacted).toContain('[API_KEY_REDACTED]');
+    expect(redacted).toContain('[HEX_TOKEN_REDACTED]');
+    expect(redacted).toContain('[JWT_REDACTED]');
+  });
+
+  it('redacts JSON secret values while preserving keys', () => {
+    const input =
+      '{"password":"hunter2","token":"super-secret-token-value","api_key":"abc123","secret":"x"}';
+
+    const redacted = redactSensitiveData(input);
+    expect(redacted).toBe(
+      '{"password":"[REDACTED]","token":"[REDACTED]","api_key":"[REDACTED]","secret":"[REDACTED]"}',
+    );
+  });
+
+  it('handles mixed text and JSON snippets without key loss', () => {
+    const input =
+      'request failed: {"token":"tok_abcdefghijklmnopqrstuvwxyz1234"} while using Bearer abcdefghijklmnopqrstuvwxyz123456';
+
+    const redacted = redactSensitiveData(input);
+    expect(redacted).toContain('{"token":"[REDACTED]"}');
+    expect(redacted).toContain('Bearer [REDACTED]');
+    expect(redacted).not.toContain('"":"[REDACTED]"');
+  });
+
+  it('does not change benign text', () => {
+    const input = 'Normal status update with no credentials included.';
+    expect(redactSensitiveData(input)).toBe(input);
+  });
+});

--- a/src/security/redaction.ts
+++ b/src/security/redaction.ts
@@ -1,0 +1,15 @@
+const BEARER_TOKEN_RE = /Bearer\s+[A-Za-z0-9_\-.]{20,}/gi;
+const API_KEY_RE = /\b(?:sk|key|api)[_-][A-Za-z0-9_\-]{16,}/gi;
+const HEX_TOKEN_RE = /\b[a-f0-9]{32,}\b/gi;
+const JWT_RE = /eyJ[A-Za-z0-9_\-]+\.eyJ[A-Za-z0-9_\-]+\.[A-Za-z0-9_\-]+/g;
+const JSON_SECRET_VALUE_RE =
+  /("(?:password|secret|token|api[_-]?key)"\s*:\s*)"[^"]+"/gi;
+
+export function redactSensitiveData(text: string): string {
+  return text
+    .replace(BEARER_TOKEN_RE, 'Bearer [REDACTED]')
+    .replace(API_KEY_RE, '[API_KEY_REDACTED]')
+    .replace(HEX_TOKEN_RE, '[HEX_TOKEN_REDACTED]')
+    .replace(JWT_RE, '[JWT_REDACTED]')
+    .replace(JSON_SECRET_VALUE_RE, '$1"[REDACTED]"');
+}


### PR DESCRIPTION
## Summary
- Fixes a security redaction bug that could emit malformed JSON fragments by dropping key names during replacement.
- Moves secret redaction into a shared utility so host-side suppression logs use one consistent policy.
- Adds focused tests for bearer/API/JWT/hex token redaction, JSON key preservation, mixed content, and benign no-op behavior.

## Security Impact
- Severity: Medium
- Prevents log corruption during error sanitization and keeps incident/debug payloads parseable while still masking secrets.

## Validation
- `bun test src/security/redaction.test.ts`
- `bunx tsc --noEmit`

Closes #182


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added sensitive data redaction for error logging. System now automatically masks tokens, API keys, and secrets before logging to prevent accidental exposure of sensitive credentials.

* **Tests**
  * Added comprehensive test coverage for data redaction, verifying proper masking of various credential formats while preserving legitimate log content.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->