### PR TITLE
Add Rust toolchain and define container dev tool-pack plan

### DIFF
--- a/container/Dockerfile
+++ b/container/Dockerfile
@@ -4,7 +4,7 @@
 FROM oven/bun:slim
 
 # Install Node.js (agents expect node/npm/npx to be available alongside bun)
-# and essential system tools including Go
+# and essential system tools including Go and Rust (cargo/rustc)
 RUN apt-get update && apt-get install -y --no-install-recommends \
     nodejs \
     npm \
@@ -15,6 +15,8 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     jq \
     ripgrep \
     build-essential \
+    cargo \
+    rustc \
     && rm -rf /var/lib/apt/lists/*
 
 # Install yq (YAML processor, like jq for YAML)

--- a/docs/CONTAINER-DEV-TOOL-PACKS.md
+++ b/docs/CONTAINER-DEV-TOOL-PACKS.md
@@ -1,0 +1,87 @@
+# Container Dev Tool Packs
+
+## Why this exists
+
+OmniClaw agents currently share one container image. That keeps operations simple, but it creates two problems:
+
+- Agents that need language toolchains (Rust, Go, etc.) often install them at runtime, increasing boot latency and variability.
+- As more teams use OmniClaw for different workloads, a one-size-fits-all image either grows too large or remains underpowered.
+
+Issue #191 starts by adding Rust (`cargo`/`rustc`) to the base image and defines a path toward configurable toolchains.
+
+## Current baseline (Mar 2026)
+
+- Base image includes Bun, Node/npm, Go, GitHub CLI, Graphite CLI, and agent-browser.
+- Rust (`cargo` and `rustc`) is now included in base image for immediate productivity.
+- Container startup remains deterministic (no runtime language bootstrap required for Go/Rust workflows).
+
+## Design goals
+
+- Keep default setup fast for new users.
+- Allow per-agent toolchain customization without ad-hoc runtime installs.
+- Avoid combinatorial image explosion.
+- Preserve reproducibility and security (pinned versions where practical, explicit install paths).
+
+## Proposed model
+
+Use a layered, build-time pack system with a small set of curated packs.
+
+1. Keep a stable `base` image with core utilities.
+2. Define pack install modules (for example `rust`, `go`, `web`) as build fragments.
+3. Let each agent group declare required packs in config.
+4. Build or reuse a cached image keyed by pack set (sorted deterministic key).
+
+This combines predictable build output with flexible composition, while avoiding bespoke Dockerfiles per agent.
+
+## Pack declaration
+
+Proposed channel/group config shape:
+
+```yaml
+container:
+  toolPacks:
+    - rust
+    - web
+```
+
+Rules:
+
+- Unknown packs fail validation early.
+- Pack names are normalized and deduplicated.
+- Pack order does not affect cache key.
+
+## Build strategy
+
+### Phase 1 (now)
+
+- Keep one base image and include commonly needed tools (Go + Rust).
+- No behavior change in container runner.
+
+### Phase 2
+
+- Add pack definitions under `container/packs/`.
+- Add a small build orchestrator that generates or selects image variants by pack key.
+- Cache built images locally to avoid repeated rebuilds.
+
+### Phase 3
+
+- Add eviction policy and observability (image size, build duration, hit rate).
+- Consider remote prebuilds for common pack combinations if needed.
+
+## Scope boundaries
+
+- Packs are for language/runtime toolchains and related build tools.
+- App-specific dependencies stay in project repositories.
+- Keep official pack catalog intentionally small; avoid every-language-by-default sprawl.
+
+## Risks and mitigations
+
+- Image size growth: track size deltas per pack and enforce review threshold.
+- Build complexity: centralize pack schema and deterministic key generation.
+- Security drift: pin versions for externally downloaded binaries and keep update cadence.
+
+## Open questions
+
+- Should we expose pack config globally per channel, per agent, or both?
+- Should `full` be a first-class pack alias (`go + rust + web`) for convenience?
+- Should pack images be prebuilt in CI or built lazily on first use?


### PR DESCRIPTION
## Summary
- add Rust toolchain support to the base agent container by installing `cargo` and `rustc` in `container/Dockerfile`
- keep #191 short-term acceptance criteria unblocked so Rust projects can run without per-session bootstrap
- add a design doc (`docs/CONTAINER-DEV-TOOL-PACKS.md`) that proposes a phased, build-time tool-pack model for per-agent toolchain customization

## Testing
- `bun run build`

## Notes
- this change keeps current behavior simple (single base image) while documenting a low-risk migration path to pack-based image composition


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Rust toolchain (cargo and rustc) to the development container.

* **Documentation**
  * Introduced Container Dev Tool Packs documentation covering the layered toolchain approach, pack declaration schema, and phased implementation strategy.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->