### PR TITLE
Add webhook-driven GitHub context updates for watched agents

### DIFF
--- a/docs/GITHUB-WEBHOOKS.md
+++ b/docs/GITHUB-WEBHOOKS.md
@@ -1,0 +1,41 @@
+# GitHub Webhooks (Fast Follow to #192)
+
+GitHub context injection (#192) uses polling. This adds an optional webhook server so agents can react quickly to review feedback and CI updates while polling remains the fallback.
+
+## Enable
+
+Set these environment variables in `.env`:
+
+```bash
+GITHUB_WEBHOOK_PORT=8787
+GITHUB_WEBHOOK_SECRET=your_webhook_secret
+# optional
+GITHUB_WEBHOOK_PATH=/webhooks/github
+```
+
+`GITHUB_WEBHOOK_SECRET` is required whenever the webhook server is enabled.
+
+## Endpoint
+
+- Method: `POST`
+- Path: `GITHUB_WEBHOOK_PATH` (default `/webhooks/github`)
+- Signature: `x-hub-signature-256` HMAC SHA-256 verification
+
+## Supported events
+
+- `pull_request_review_comment`
+- `pull_request_review`
+- `issues`
+- `issue_comment`
+- `check_suite`
+
+Only watched repositories from `data/github-watches.json` are routed. Events for unwatched repos are ignored.
+
+## Runtime behavior
+
+- deduplicates deliveries by `x-github-delivery` (10-minute in-memory window)
+- invalidates cached GitHub context for affected agents immediately
+- posts a synthetic system message into each affected agent's primary subscribed channel
+- enqueues the agent run so it can react without waiting for the next manual prompt
+
+Polling from #192 remains active as a resilience path if webhook delivery is delayed or unavailable.

--- a/src/config.ts
+++ b/src/config.ts
@@ -172,3 +172,11 @@ export const ANTHROPIC_MODEL = process.env.ANTHROPIC_MODEL || undefined;
 // Uses system timezone by default
 export const TIMEZONE =
   process.env.TZ || Intl.DateTimeFormat().resolvedOptions().timeZone;
+
+export const GITHUB_WEBHOOK_SECRET = process.env.GITHUB_WEBHOOK_SECRET || '';
+export const GITHUB_WEBHOOK_PORT = parseInt(
+  process.env.GITHUB_WEBHOOK_PORT || '0',
+  10,
+);
+export const GITHUB_WEBHOOK_PATH =
+  process.env.GITHUB_WEBHOOK_PATH || '/webhooks/github';

--- a/src/github-webhooks.test.ts
+++ b/src/github-webhooks.test.ts
@@ -1,0 +1,122 @@
+import { afterEach, beforeEach, describe, expect, it } from 'bun:test';
+import { createHmac } from 'crypto';
+import fs from 'fs';
+import path from 'path';
+
+import { DATA_DIR } from './config.js';
+import {
+  buildGitHubWebhookNotification,
+  verifyGitHubWebhookSignature,
+} from './github-webhooks.js';
+
+describe('github webhooks', () => {
+  const secret = 'super-secret-key';
+  const configPath = path.join(DATA_DIR, 'github-watches.json');
+  let backupConfig: string | null = null;
+
+  beforeEach(() => {
+    fs.mkdirSync(DATA_DIR, { recursive: true });
+    backupConfig = fs.existsSync(configPath)
+      ? fs.readFileSync(configPath, 'utf8')
+      : null;
+    fs.writeFileSync(
+      configPath,
+      JSON.stringify(
+        {
+          watches: [
+            {
+              agentId: 'agent-a',
+              repos: [{ owner: 'omniaura', repo: 'omniclaw' }],
+            },
+          ],
+        },
+        null,
+        2,
+      ),
+      'utf8',
+    );
+  });
+
+  afterEach(() => {
+    if (backupConfig !== null) {
+      fs.writeFileSync(configPath, backupConfig, 'utf8');
+    } else if (fs.existsSync(configPath)) {
+      fs.rmSync(configPath, { force: true });
+    }
+  });
+
+  it('verifies valid webhook signature', () => {
+    const body = JSON.stringify({ hello: 'world' });
+    const digest = createHmac('sha256', secret).update(body).digest('hex');
+
+    const valid = verifyGitHubWebhookSignature(body, `sha256=${digest}`, secret);
+    expect(valid).toBe(true);
+  });
+
+  it('rejects invalid webhook signature', () => {
+    const body = JSON.stringify({ hello: 'world' });
+    const valid = verifyGitHubWebhookSignature(
+      body,
+      'sha256=deadbeef',
+      secret,
+    );
+    expect(valid).toBe(false);
+  });
+
+  it('builds notification for watched PR review comment', () => {
+    const notification = buildGitHubWebhookNotification(
+      'pull_request_review_comment',
+      'delivery-1',
+      {
+        action: 'created',
+        repository: {
+          owner: { login: 'omniaura' },
+          name: 'omniclaw',
+          full_name: 'omniaura/omniclaw',
+        },
+        sender: { login: 'reviewer' },
+        pull_request: {
+          number: 195,
+          title: 'GitHub context injection',
+          html_url: 'https://github.com/omniaura/omniclaw/pull/195',
+        },
+        comment: {
+          body: 'Please simplify this branch selection logic.',
+          html_url: 'https://github.com/omniaura/omniclaw/pull/195#discussion_r1',
+          path: 'src/index.ts',
+          line: 120,
+        },
+      },
+    );
+
+    expect(notification).not.toBeNull();
+    expect(notification?.owner).toBe('omniaura');
+    expect(notification?.repo).toBe('omniclaw');
+    expect(notification?.agentIds).toEqual(['agent-a']);
+    expect(notification?.summary).toContain('PR #195');
+    expect(notification?.summary).toContain('@reviewer');
+  });
+
+  it('ignores events for repos with no watchers', () => {
+    const notification = buildGitHubWebhookNotification(
+      'issues',
+      'delivery-2',
+      {
+        action: 'opened',
+        repository: {
+          owner: { login: 'otherorg' },
+          name: 'otherrepo',
+          full_name: 'otherorg/otherrepo',
+        },
+        sender: { login: 'someone' },
+        issue: {
+          number: 1,
+          title: 'hello',
+          html_url: 'https://github.com/otherorg/otherrepo/issues/1',
+        },
+      },
+    );
+
+    expect(notification).toBeNull();
+  });
+});

--- a/src/github-webhooks.ts
+++ b/src/github-webhooks.ts
@@ -1,0 +1,314 @@
+import { createHmac, timingSafeEqual } from 'crypto';
+
+import {
+  getWatchingAgentsForRepo,
+  invalidateGitHubContextCacheForAgents,
+  loadGitHubWatchesConfig,
+} from './github.js';
+import { logger } from './logger.js';
+
+const DEFAULT_PATH = '/webhooks/github';
+const DELIVERY_TTL_MS = 10 * 60_000;
+
+interface GitHubRepoRef {
+  owner: { login: string };
+  name: string;
+  full_name: string;
+}
+
+interface GitHubSender {
+  login: string;
+}
+
+type GitHubWebhookPayload = {
+  action?: string;
+  repository?: GitHubRepoRef;
+  sender?: GitHubSender;
+  pull_request?: {
+    number: number;
+    title: string;
+    html_url?: string;
+  };
+  review?: {
+    state?: string;
+    html_url?: string;
+    body?: string;
+  };
+  comment?: {
+    body?: string;
+    html_url?: string;
+    path?: string;
+    line?: number | null;
+  };
+  issue?: {
+    number: number;
+    title: string;
+    html_url?: string;
+  };
+  check_suite?: {
+    head_branch?: string;
+    status?: string;
+    conclusion?: string | null;
+    html_url?: string;
+  };
+};
+
+export interface GitHubWebhookNotification {
+  event: string;
+  action: string;
+  deliveryId: string;
+  owner: string;
+  repo: string;
+  summary: string;
+  url?: string;
+  agentIds: string[];
+  cacheEntriesInvalidated: number;
+}
+
+interface ParsedWebhook {
+  event: string;
+  action: string;
+  owner: string;
+  repo: string;
+  summary: string;
+  url?: string;
+}
+
+function truncate(text: string | undefined, maxLen: number): string {
+  if (!text) return '';
+  const clean = text.replace(/\s+/g, ' ').trim();
+  if (clean.length <= maxLen) return clean;
+  return `${clean.slice(0, maxLen)}...`;
+}
+
+function parseWebhookPayload(
+  event: string,
+  payload: GitHubWebhookPayload,
+): ParsedWebhook | null {
+  const repository = payload.repository;
+  if (!repository?.owner?.login || !repository?.name) return null;
+
+  const owner = repository.owner.login;
+  const repo = repository.name;
+  const action = payload.action || 'updated';
+  const sender = payload.sender?.login || 'unknown';
+
+  if (event === 'pull_request_review_comment' && payload.pull_request) {
+    const pr = payload.pull_request;
+    const comment = payload.comment;
+    const fileLoc = comment?.path
+      ? `${comment.path}${comment.line ? `:${comment.line}` : ''}`
+      : 'unknown file';
+    return {
+      event,
+      action,
+      owner,
+      repo,
+      summary:
+        `GitHub webhook: ${owner}/${repo} PR #${pr.number} received ` +
+        `a review comment by @${sender} on ${fileLoc} (${truncate(comment?.body, 180)})`,
+      url: comment?.html_url || pr.html_url,
+    };
+  }
+
+  if (event === 'pull_request_review' && payload.pull_request) {
+    const pr = payload.pull_request;
+    const reviewState = payload.review?.state?.toLowerCase() || action;
+    return {
+      event,
+      action,
+      owner,
+      repo,
+      summary:
+        `GitHub webhook: ${owner}/${repo} PR #${pr.number} review is ${reviewState} ` +
+        `by @${sender} (${truncate(payload.review?.body, 180)})`,
+      url: payload.review?.html_url || pr.html_url,
+    };
+  }
+
+  if (event === 'issues' && payload.issue) {
+    const issue = payload.issue;
+    return {
+      event,
+      action,
+      owner,
+      repo,
+      summary:
+        `GitHub webhook: ${owner}/${repo} issue #${issue.number} ${action} ` +
+        `by @${sender} (${issue.title})`,
+      url: issue.html_url,
+    };
+  }
+
+  if (event === 'issue_comment' && payload.issue) {
+    const issue = payload.issue;
+    return {
+      event,
+      action,
+      owner,
+      repo,
+      summary:
+        `GitHub webhook: ${owner}/${repo} issue #${issue.number} comment ${action} ` +
+        `by @${sender} (${truncate(payload.comment?.body, 180)})`,
+      url: payload.comment?.html_url || issue.html_url,
+    };
+  }
+
+  if (event === 'check_suite' && payload.check_suite) {
+    const suite = payload.check_suite;
+    const conclusion = suite.conclusion || suite.status || action;
+    return {
+      event,
+      action,
+      owner,
+      repo,
+      summary:
+        `GitHub webhook: ${owner}/${repo} CI check suite is ${conclusion} ` +
+        `on branch ${suite.head_branch || 'unknown'}`,
+      url: suite.html_url,
+    };
+  }
+
+  return null;
+}
+
+export function verifyGitHubWebhookSignature(
+  rawBody: string,
+  signatureHeader: string | null,
+  secret: string,
+): boolean {
+  if (!signatureHeader || !signatureHeader.startsWith('sha256=')) return false;
+  const expected = createHmac('sha256', secret).update(rawBody).digest('hex');
+  const provided = signatureHeader.slice('sha256='.length);
+  const expectedBuf = Buffer.from(expected, 'utf8');
+  const providedBuf = Buffer.from(provided, 'utf8');
+  if (expectedBuf.length !== providedBuf.length) return false;
+  return timingSafeEqual(expectedBuf, providedBuf);
+}
+
+const recentlyProcessedDeliveries = new Map<string, number>();
+
+function cleanupDeliveryCache(now = Date.now()): void {
+  for (const [deliveryId, ts] of recentlyProcessedDeliveries) {
+    if (now - ts > DELIVERY_TTL_MS) {
+      recentlyProcessedDeliveries.delete(deliveryId);
+    }
+  }
+}
+
+function markDeliveryProcessed(deliveryId: string): boolean {
+  const now = Date.now();
+  cleanupDeliveryCache(now);
+  if (recentlyProcessedDeliveries.has(deliveryId)) return false;
+  recentlyProcessedDeliveries.set(deliveryId, now);
+  return true;
+}
+
+export function buildGitHubWebhookNotification(
+  event: string,
+  deliveryId: string,
+  payload: GitHubWebhookPayload,
+): GitHubWebhookNotification | null {
+  const parsed = parseWebhookPayload(event, payload);
+  if (!parsed) return null;
+
+  const config = loadGitHubWatchesConfig();
+  if (!config) return null;
+
+  const agentIds = getWatchingAgentsForRepo(config, parsed.owner, parsed.repo);
+  if (agentIds.length === 0) return null;
+
+  const cacheEntriesInvalidated = invalidateGitHubContextCacheForAgents(agentIds);
+
+  return {
+    event: parsed.event,
+    action: parsed.action,
+    deliveryId,
+    owner: parsed.owner,
+    repo: parsed.repo,
+    summary: parsed.summary,
+    url: parsed.url,
+    agentIds,
+    cacheEntriesInvalidated,
+  };
+}
+
+export interface GitHubWebhookServerOptions {
+  secret: string;
+  port: number;
+  path?: string;
+  onNotification: (notification: GitHubWebhookNotification) => Promise<void>;
+}
+
+export function startGitHubWebhookServer(
+  options: GitHubWebhookServerOptions,
+): { stop: () => void } {
+  const pathname = options.path || DEFAULT_PATH;
+  const server = Bun.serve({
+    port: options.port,
+    async fetch(req) {
+      const url = new URL(req.url);
+      if (req.method !== 'POST' || url.pathname !== pathname) {
+        return new Response('Not Found', { status: 404 });
+      }
+
+      const deliveryId = req.headers.get('x-github-delivery') || 'unknown-delivery';
+      const event = req.headers.get('x-github-event') || '';
+      const signature = req.headers.get('x-hub-signature-256');
+      const rawBody = await req.text();
+
+      if (!verifyGitHubWebhookSignature(rawBody, signature, options.secret)) {
+        logger.warn({ deliveryId, event }, 'Invalid GitHub webhook signature');
+        return new Response('Invalid signature', { status: 401 });
+      }
+
+      if (!markDeliveryProcessed(deliveryId)) {
+        return new Response('Duplicate delivery ignored', { status: 202 });
+      }
+
+      let payload: GitHubWebhookPayload;
+      try {
+        payload = JSON.parse(rawBody) as GitHubWebhookPayload;
+      } catch (err) {
+        logger.warn({ err, deliveryId, event }, 'Invalid GitHub webhook JSON payload');
+        return new Response('Bad payload', { status: 400 });
+      }
+
+      const notification = buildGitHubWebhookNotification(event, deliveryId, payload);
+      if (!notification) {
+        return new Response('Ignored', { status: 202 });
+      }
+
+      try {
+        await options.onNotification(notification);
+      } catch (err) {
+        logger.error({ err, event, deliveryId }, 'Failed handling GitHub webhook notification');
+        return new Response('Handler error', { status: 500 });
+      }
+
+      logger.info(
+        {
+          event: notification.event,
+          action: notification.action,
+          deliveryId,
+          owner: notification.owner,
+          repo: notification.repo,
+          agentCount: notification.agentIds.length,
+          cacheEntriesInvalidated: notification.cacheEntriesInvalidated,
+        },
+        'Processed GitHub webhook',
+      );
+
+      return new Response('OK', { status: 200 });
+    },
+  });
+
+  logger.info(
+    { port: options.port, path: pathname },
+    'GitHub webhook server started',
+  );
+
+  return {
+    stop: () => server.stop(true),
+  };
+}

--- a/src/github.test.ts
+++ b/src/github.test.ts
@@ -122,6 +122,42 @@ describe('github', () => {
     });
   });
 
+  describe('repo watch matching helpers', () => {
+    it('matches watchers case-insensitively by owner/repo', () => {
+      const { getWatchingAgentsForRepo } = require('./github.js');
+      const config: GitHubWatchesConfig = {
+        watches: [
+          {
+            agentId: 'agent-a',
+            repos: [{ owner: 'OmniAura', repo: 'OmniClaw' }],
+          },
+          {
+            agentId: 'agent-b',
+            repos: [{ owner: 'other', repo: 'repo' }],
+          },
+        ],
+      };
+
+      expect(getWatchingAgentsForRepo(config, 'omniaura', 'omniclaw')).toEqual([
+        'agent-a',
+      ]);
+    });
+
+    it('returns no watchers when repo is not configured', () => {
+      const { getWatchingAgentsForRepo } = require('./github.js');
+      const config: GitHubWatchesConfig = {
+        watches: [
+          {
+            agentId: 'agent-a',
+            repos: [{ owner: 'omniaura', repo: 'omniclaw' }],
+          },
+        ],
+      };
+
+      expect(getWatchingAgentsForRepo(config, 'omniaura', 'backend')).toEqual([]);
+    });
+  });
+
   describe('fetchGitHubContext', () => {
     it('returns null when GITHUB_TOKEN is not set', async () => {
       const { getGitHubContextForAgent } = require('./github.js');

--- a/src/github.ts
+++ b/src/github.ts
@@ -83,6 +83,32 @@ function getCacheKey(agentId: string): string {
   return `github:${agentId}`;
 }
 
+export function invalidateGitHubContextCacheForAgents(agentIds: string[]): number {
+  let removed = 0;
+  for (const agentId of agentIds) {
+    if (cache.delete(getCacheKey(agentId))) removed++;
+  }
+  return removed;
+}
+
+export function getWatchingAgentsForRepo(
+  config: GitHubWatchesConfig,
+  owner: string,
+  repo: string,
+): string[] {
+  const ownerLc = owner.toLowerCase();
+  const repoLc = repo.toLowerCase();
+  return config.watches
+    .filter((watch) =>
+      watch.repos.some(
+        (watchedRepo) =>
+          watchedRepo.owner.toLowerCase() === ownerLc &&
+          watchedRepo.repo.toLowerCase() === repoLc,
+      ),
+    )
+    .map((watch) => watch.agentId);
+}
+
 // --- Config loading ---
 
 const CONFIG_FILENAME = 'github-watches.json';

--- a/src/index.ts
+++ b/src/index.ts
@@ -9,6 +9,9 @@ import {
   DISPATCH_RUNTIME_SEP,
   DISCORD_BOTS,
   DISCORD_DEFAULT_BOT_ID,
+  GITHUB_WEBHOOK_PATH,
+  GITHUB_WEBHOOK_PORT,
+  GITHUB_WEBHOOK_SECRET,
   GROUPS_DIR,
   IDLE_TIMEOUT,
   MAIN_GROUP_FOLDER,
@@ -82,6 +85,8 @@ import {
 } from './types.js';
 import { findMainGroupJid } from './group-helpers.js';
 import { getGitHubContextForAgent } from './github.js';
+import { startGitHubWebhookServer } from './github-webhooks.js';
+import type { GitHubWebhookNotification } from './github-webhooks.js';
 import { logger } from './logger.js';
 import { assertPathWithin } from './path-security.js';
 import { Effect } from 'effect';
@@ -154,6 +159,7 @@ const MAX_CONSECUTIVE_ERRORS = 3;
 let whatsapp: WhatsAppChannel | null = null;
 let channels: Channel[] = [];
 const queue = new GroupQueue();
+let githubWebhookServer: { stop: () => void } | null = null;
 
 const MAX_CHANNEL_AGENT_FANOUT = parseInt(
   process.env.MAX_CHANNEL_AGENT_FANOUT || '3',
@@ -1809,6 +1815,10 @@ async function main(): Promise<void> {
   // Graceful shutdown handlers
   const shutdown = async (signal: string) => {
     logger.info({ signal }, 'Shutdown signal received');
+    if (githubWebhookServer) {
+      githubWebhookServer.stop();
+      githubWebhookServer = null;
+    }
     await queue.shutdown(10000);
     await shutdownBackends();
     for (const ch of channels) {
@@ -1824,6 +1834,60 @@ async function main(): Promise<void> {
 
   // --- Startup: initialize backends first, then start message loop, then connect channels ---
   const startupT0 = Date.now();
+
+  if (GITHUB_WEBHOOK_PORT > 0 && GITHUB_WEBHOOK_SECRET) {
+    const dispatchGitHubWebhook = async (
+      notification: GitHubWebhookNotification,
+    ): Promise<void> => {
+      const targets = Object.entries(channelSubscriptions).flatMap(
+        ([chatJid, subs]) => {
+          const matches = subs.filter((s) =>
+            notification.agentIds.includes(s.agentId),
+          );
+          return matches
+            .sort((a, b) =>
+              Number(Boolean(b.isPrimary)) - Number(Boolean(a.isPrimary)),
+            )
+            .map((sub) => ({ chatJid, sub }));
+        },
+      );
+
+      // Route one notification per agent to avoid flooding multi-channel agents.
+      const delivered = new Set<string>();
+      for (const { chatJid, sub } of targets) {
+        if (delivered.has(sub.agentId)) continue;
+        const group = buildRegisteredGroupFromSubscription(chatJid, sub);
+        if (!group) continue;
+        const trigger = group.trigger || `@${ASSISTANT_NAME}`;
+        const withLink = notification.url
+          ? `${notification.summary}\n${notification.url}`
+          : notification.summary;
+        storeMessage({
+          id: `ghhook-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`,
+          chat_jid: chatJid,
+          sender: 'system',
+          sender_name: 'GitHub Webhook',
+          content: `${trigger} ${withLink}`,
+          timestamp: new Date().toISOString(),
+          is_from_me: false,
+        });
+        queue.enqueueMessageCheck(makeDispatchKey(chatJid, sub.agentId));
+        delivered.add(sub.agentId);
+      }
+    };
+
+    githubWebhookServer = startGitHubWebhookServer({
+      secret: GITHUB_WEBHOOK_SECRET,
+      port: GITHUB_WEBHOOK_PORT,
+      path: GITHUB_WEBHOOK_PATH,
+      onNotification: dispatchGitHubWebhook,
+    });
+  } else if (GITHUB_WEBHOOK_PORT > 0 && !GITHUB_WEBHOOK_SECRET) {
+    logger.warn(
+      { port: GITHUB_WEBHOOK_PORT },
+      'GITHUB_WEBHOOK_PORT set without GITHUB_WEBHOOK_SECRET; webhook server disabled',
+    );
+  }
 
   // Backends MUST be initialized before the message loop starts, because
   // processGroupMessages → runAgent → resolveBackend() needs them.


### PR DESCRIPTION
## Summary
- add an optional signed GitHub webhook server (`GITHUB_WEBHOOK_PORT` + `GITHUB_WEBHOOK_SECRET`) with configurable path (`GITHUB_WEBHOOK_PATH`, default `/webhooks/github`)
- process key GitHub events (`pull_request_review_comment`, `pull_request_review`, `issues`, `issue_comment`, `check_suite`) and map them to watched agents from `data/github-watches.json`
- invalidate cached #192 GitHub context for affected agents and enqueue synthetic trigger-prefixed system messages so agents can react immediately
- keep polling as fallback by design; webhooks are additive and can be enabled incrementally

## Testing
- `bun test src/github.test.ts src/github-webhooks.test.ts`
- `bun run build`

## Docs
- add `docs/GITHUB-WEBHOOKS.md` with env vars, supported events, and runtime behavior

## Stack
- base branch: `feat/github-context-injection` (#195)
- this PR is intended as the #193 fast-follow on top of #192
