### PR TITLE
Cleanup quick wins for GitHub watch and webhook modules

### DIFF
--- a/src/github-webhooks.test.ts
+++ b/src/github-webhooks.test.ts
@@ -1,39 +1,21 @@
-import { describe, expect, it, mock } from 'bun:test';
+import { describe, expect, it } from 'bun:test';
 import { createHmac } from 'crypto';
-
-const loadGitHubWatchesConfig = mock(() => ({
-  watches: [
-    {
-      agentId: 'agent-a',
-      repos: [{ owner: 'omniaura', repo: 'omniclaw' }],
-    },
-  ],
-}));
-
-const getWatchingAgentsForRepo = mock(
-  (_config: unknown, owner: string, repo: string) => {
-    return owner.toLowerCase() === 'omniaura' &&
-      repo.toLowerCase() === 'omniclaw'
-      ? ['agent-a']
-      : [];
-  },
-);
-
-const invalidateGitHubContextCacheForAgents = mock((_agentIds: string[]) => 0);
-
-mock.module('./github.js', () => ({
-  loadGitHubWatchesConfig,
-  getWatchingAgentsForRepo,
-  invalidateGitHubContextCacheForAgents,
-}));
-
 import {
   buildGitHubWebhookNotification,
   verifyGitHubWebhookSignature,
 } from './github-webhooks.js';
+import type { GitHubWatchesConfig } from './types.js';
 
 describe('github webhooks', () => {
   const secret = 'super-secret-key';
+  const config: GitHubWatchesConfig = {
+    watches: [
+      {
+        agentId: 'agent-a',
+        repos: [{ owner: 'omniaura', repo: 'omniclaw' }],
+      },
+    ],
+  };
 
   it('verifies valid webhook signature', () => {
     const body = JSON.stringify({ hello: 'world' });
@@ -78,6 +60,7 @@ describe('github webhooks', () => {
           line: 120,
         },
       },
+      config,
     );
 
     expect(notification).not.toBeNull();
@@ -86,8 +69,6 @@ describe('github webhooks', () => {
     expect(notification?.agentIds).toEqual(['agent-a']);
     expect(notification?.summary).toContain('PR #195');
     expect(notification?.summary).toContain('@reviewer');
-    expect(getWatchingAgentsForRepo).toHaveBeenCalledTimes(1);
-    expect(loadGitHubWatchesConfig).toHaveBeenCalledTimes(1);
   });
 
   it('ignores events for repos with no watchers', () => {
@@ -108,6 +89,7 @@ describe('github webhooks', () => {
           html_url: 'https://github.com/otherorg/otherrepo/issues/1',
         },
       },
+      config,
     );
 
     expect(notification).toBeNull();

--- a/src/github-webhooks.ts
+++ b/src/github-webhooks.ts
@@ -6,6 +6,7 @@ import {
   loadGitHubWatchesConfig,
 } from './github.js';
 import { logger } from './logger.js';
+import type { GitHubWatchesConfig } from './types.js';
 
 const DEFAULT_PATH = '/webhooks/github';
 const DELIVERY_TTL_MS = 10 * 60_000;
@@ -208,11 +209,12 @@ export function buildGitHubWebhookNotification(
   event: string,
   deliveryId: string,
   payload: GitHubWebhookPayload,
+  configOverride?: GitHubWatchesConfig | null,
 ): GitHubWebhookNotification | null {
   const parsed = parseWebhookPayload(event, payload);
   if (!parsed) return null;
 
-  const config = loadGitHubWatchesConfig();
+  const config = configOverride ?? loadGitHubWatchesConfig();
   if (!config) return null;
 
   const agentIds = getWatchingAgentsForRepo(config, parsed.owner, parsed.repo);

--- a/src/github.test.ts
+++ b/src/github.test.ts
@@ -1,7 +1,4 @@
-import { describe, it, expect, beforeEach, afterEach, mock } from 'bun:test';
-import fs from 'fs';
-import path from 'path';
-import os from 'os';
+import { describe, it, expect } from 'bun:test';
 
 import type { GitHubAgentWatch, GitHubWatchesConfig } from './types.js';
 
@@ -9,18 +6,6 @@ import type { GitHubAgentWatch, GitHubWatchesConfig } from './types.js';
 
 describe('github', () => {
   describe('config loading', () => {
-    let tmpDir: string;
-    let originalDataDir: string;
-
-    beforeEach(async () => {
-      tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'omniclaw-gh-test-'));
-      // We'll test loadGitHubWatchesConfig by writing a config file to DATA_DIR
-    });
-
-    afterEach(() => {
-      fs.rmSync(tmpDir, { recursive: true, force: true });
-    });
-
     it('parses a valid config', () => {
       const config: GitHubWatchesConfig = {
         watches: [
@@ -157,6 +142,20 @@ describe('github', () => {
       expect(getWatchingAgentsForRepo(config, 'omniaura', 'backend')).toEqual(
         [],
       );
+    });
+  });
+
+  describe('normalizeLimit', () => {
+    it('uses fallback when value is undefined or invalid', () => {
+      const { normalizeLimit } = require('./github.js');
+      expect(normalizeLimit(undefined, 10)).toBe(10);
+      expect(normalizeLimit(0, 10)).toBe(10);
+      expect(normalizeLimit(-2, 10)).toBe(10);
+    });
+
+    it('clamps excessive values to max list limit', () => {
+      const { normalizeLimit } = require('./github.js');
+      expect(normalizeLimit(500, 10)).toBe(50);
     });
   });
 

--- a/src/github.ts
+++ b/src/github.ts
@@ -19,6 +19,7 @@ import type {
 const DEFAULT_CACHE_TTL_MS = 300_000; // 5 minutes
 const DEFAULT_PR_LIMIT = 10;
 const DEFAULT_ISSUE_LIMIT = 10;
+const MAX_LIST_LIMIT = 50;
 
 // --- Types for GitHub API responses ---
 
@@ -109,6 +110,16 @@ export function getWatchingAgentsForRepo(
       ),
     )
     .map((watch) => watch.agentId);
+}
+
+export function normalizeLimit(
+  value: number | undefined,
+  fallback: number,
+): number {
+  if (!Number.isFinite(value)) return fallback;
+  const rounded = Math.floor(value as number);
+  if (rounded <= 0) return fallback;
+  return Math.min(rounded, MAX_LIST_LIMIT);
 }
 
 // --- Config loading ---
@@ -295,8 +306,11 @@ function formatIssueMarkdown(issue: GitHubIssue): string {
 
 async function fetchRepoContext(watch: GitHubRepoWatch): Promise<string> {
   const { owner, repo } = watch;
-  const prLimit = watch.openPrs?.limit ?? DEFAULT_PR_LIMIT;
-  const issueLimit = watch.recentIssues?.limit ?? DEFAULT_ISSUE_LIMIT;
+  const prLimit = normalizeLimit(watch.openPrs?.limit, DEFAULT_PR_LIMIT);
+  const issueLimit = normalizeLimit(
+    watch.recentIssues?.limit,
+    DEFAULT_ISSUE_LIMIT,
+  );
   const includeReviewComments = watch.openPrs?.includeReviewComments ?? true;
 
   const sections: string[] = [];


### PR DESCRIPTION
## Summary
- clean up GitHub watcher tests by removing dead setup/teardown code and unused imports
- make webhook notification construction testable without filesystem coupling by allowing an optional in-memory watch config override
- add `normalizeLimit()` for watched repo limits so malformed values fall back safely and large values are capped to avoid accidental API overuse
- fix a flaky full-suite failure where webhook tests could race on shared `data/github-watches.json`

## Validation
- `bun run typecheck`
- `bun test src/github.test.ts src/github-webhooks.test.ts`
- `bun run test`
- `bun run build`

## Scope
- quick-win cleanup only (no behavior changes to enabled webhook runtime paths)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added optional configuration override support for GitHub webhook notification handling.
  * Implemented automatic limit normalization for repository context lists, capping at 50 items.

* **Tests**
  * Added test suite for the new limit normalization feature.
  * Refactored webhook notification tests to improve test structure and reduce mock dependencies.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->