### PR TITLE
feat: add sender_platform to NewMessage schema

### DIFF
--- a/src/channels/discord.ts
+++ b/src/channels/discord.ts
@@ -821,6 +821,7 @@ export class DiscordChannel implements Channel {
       content,
       timestamp,
       is_from_me: false,
+      sender_platform: 'discord',
       sender_user_id: sender, // Discord user ID
       mentions: mentions.length > 0 ? mentions : undefined,
     });

--- a/src/channels/slack.ts
+++ b/src/channels/slack.ts
@@ -373,6 +373,7 @@ export class SlackChannel implements Channel {
       content,
       timestamp,
       is_from_me: false,
+      sender_platform: 'slack',
       sender_user_id: senderUserId,
       mentions: mentions.map((m) => ({ ...m, platform: 'slack' as const })),
     });

--- a/src/channels/telegram.ts
+++ b/src/channels/telegram.ts
@@ -211,6 +211,7 @@ export class TelegramChannel implements Channel {
         content,
         timestamp,
         is_from_me: false,
+        sender_platform: 'telegram',
       });
 
       logger.info(
@@ -242,6 +243,7 @@ export class TelegramChannel implements Channel {
         content: `${placeholder}${caption}`,
         timestamp,
         is_from_me: false,
+        sender_platform: 'telegram',
       });
     };
 

--- a/src/channels/whatsapp.ts
+++ b/src/channels/whatsapp.ts
@@ -389,6 +389,7 @@ export class WhatsAppChannel implements Channel {
               // WhatsApp's fromMe is true for ALL self-chat messages (protocol quirk),
               // which would cause the DB query to drop real user messages.
               is_from_me: false,
+              sender_platform: 'whatsapp',
             });
           }
         } catch (err) {

--- a/src/db.test.ts
+++ b/src/db.test.ts
@@ -136,6 +136,100 @@ describe('storeMessage', () => {
   });
 });
 
+// --- storeMessage (sender_platform) ---
+
+describe('storeMessage with sender_platform', () => {
+  it('persists and retrieves sender_platform', () => {
+    storeChatMetadata('group@g.us', '2024-01-01T00:00:00.000Z');
+
+    storeMessage({
+      id: 'dc-plat-1',
+      chat_jid: 'group@g.us',
+      sender: '123456789012345678',
+      sender_name: 'Alice',
+      content: 'hello from discord',
+      timestamp: '2024-01-01T00:00:01.000Z',
+      is_from_me: false,
+      sender_platform: 'discord',
+    });
+
+    const messages = getMessagesSince('group@g.us', '2024-01-01T00:00:00.000Z');
+    expect(messages).toHaveLength(1);
+    expect(messages[0].sender_platform).toBe('discord');
+  });
+
+  it('returns undefined sender_platform for legacy messages without it', () => {
+    storeChatMetadata('group@g.us', '2024-01-01T00:00:00.000Z');
+
+    storeMessage({
+      id: 'legacy-1',
+      chat_jid: 'group@g.us',
+      sender: '15551234567@s.whatsapp.net',
+      sender_name: 'Bob',
+      content: 'old message',
+      timestamp: '2024-01-01T00:00:01.000Z',
+      is_from_me: false,
+    });
+
+    const messages = getMessagesSince('group@g.us', '2024-01-01T00:00:00.000Z');
+    expect(messages).toHaveLength(1);
+    expect(messages[0].sender_platform).toBeUndefined();
+  });
+
+  it('persists all platform types correctly', () => {
+    storeChatMetadata('group@g.us', '2024-01-01T00:00:00.000Z');
+
+    const platforms = [
+      'discord',
+      'whatsapp',
+      'telegram',
+      'slack',
+      'ipc',
+      'system',
+    ] as const;
+    for (const [i, platform] of platforms.entries()) {
+      storeMessage({
+        id: `plat-${platform}`,
+        chat_jid: 'group@g.us',
+        sender: `sender-${i}`,
+        sender_name: `User ${i}`,
+        content: `from ${platform}`,
+        timestamp: `2024-01-01T00:00:0${i + 1}.000Z`,
+        is_from_me: false,
+        sender_platform: platform,
+      });
+    }
+
+    const messages = getMessagesSince('group@g.us', '2024-01-01T00:00:00.000Z');
+    expect(messages).toHaveLength(platforms.length);
+    for (const [i, platform] of platforms.entries()) {
+      expect(messages[i].sender_platform).toBe(platform);
+    }
+  });
+
+  it('includes sender_platform in getNewMessages results', () => {
+    storeChatMetadata('group@g.us', '2024-01-01T00:00:00.000Z');
+
+    storeMessage({
+      id: 'gnm-1',
+      chat_jid: 'group@g.us',
+      sender: '999',
+      sender_name: 'TgUser',
+      content: 'telegram msg',
+      timestamp: '2024-01-01T00:00:01.000Z',
+      is_from_me: false,
+      sender_platform: 'telegram',
+    });
+
+    const { messages } = getNewMessages(
+      ['group@g.us'],
+      '2024-01-01T00:00:00.000Z',
+    );
+    expect(messages).toHaveLength(1);
+    expect(messages[0].sender_platform).toBe('telegram');
+  });
+});
+
 // --- storeMessage (sender_user_id + mentions) ---
 
 describe('storeMessage with sender_user_id and mentions', () => {

--- a/src/db.ts
+++ b/src/db.ts
@@ -595,12 +595,22 @@ type MessageRow = NewMessage & {
   sender_platform: string | null;
 };
 
+const VALID_SENDER_PLATFORMS = new Set<
+  NonNullable<NewMessage['sender_platform']>
+>(['discord', 'whatsapp', 'telegram', 'slack', 'ipc', 'system']);
+
 /** Convert a raw DB message row to a NewMessage (parse mentions JSON, null→undefined) */
 function mapMessageRow(row: MessageRow): NewMessage {
+  const platform = row.sender_platform;
   return {
     ...row,
     sender_platform:
-      (row.sender_platform as NewMessage['sender_platform']) ?? undefined,
+      platform &&
+      VALID_SENDER_PLATFORMS.has(
+        platform as NonNullable<NewMessage['sender_platform']>,
+      )
+        ? (platform as NonNullable<NewMessage['sender_platform']>)
+        : undefined,
     sender_user_id: row.sender_user_id ?? undefined,
     mentions: row.mentions ? JSON.parse(row.mentions) : undefined,
   };

--- a/src/db.ts
+++ b/src/db.ts
@@ -301,6 +301,7 @@ export function createSchema(database: Database): void {
   );
   addColumnIfNotExists(database, 'registered_groups', 'server_folder', 'TEXT');
   addColumnIfNotExists(database, 'messages', 'sender_user_id', 'TEXT');
+  addColumnIfNotExists(database, 'messages', 'sender_platform', 'TEXT');
   addColumnIfNotExists(database, 'messages', 'mentions', 'TEXT');
   addColumnIfNotExists(database, 'chats', 'discord_guild_id', 'TEXT');
   // Note: SQLite ALTER TABLE requires constant defaults; new sessions get datetime('now') via INSERT in setSession().
@@ -572,7 +573,7 @@ export function setLastGroupSync(): void {
  */
 export function storeMessage(msg: NewMessage): void {
   db.query(
-    `INSERT OR REPLACE INTO messages (id, chat_jid, sender, sender_name, content, timestamp, is_from_me, sender_user_id, mentions) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+    `INSERT OR REPLACE INTO messages (id, chat_jid, sender, sender_name, content, timestamp, is_from_me, sender_platform, sender_user_id, mentions) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
   ).run(
     msg.id,
     msg.chat_jid,
@@ -581,6 +582,7 @@ export function storeMessage(msg: NewMessage): void {
     msg.content,
     msg.timestamp,
     msg.is_from_me ? 1 : 0,
+    msg.sender_platform ?? null,
     msg.sender_user_id ?? null,
     msg.mentions ? JSON.stringify(msg.mentions) : null,
   );
@@ -590,12 +592,15 @@ export function storeMessage(msg: NewMessage): void {
 type MessageRow = NewMessage & {
   mentions: string | null;
   sender_user_id: string | null;
+  sender_platform: string | null;
 };
 
 /** Convert a raw DB message row to a NewMessage (parse mentions JSON, null→undefined) */
 function mapMessageRow(row: MessageRow): NewMessage {
   return {
     ...row,
+    sender_platform:
+      (row.sender_platform as NewMessage['sender_platform']) ?? undefined,
     sender_user_id: row.sender_user_id ?? undefined,
     mentions: row.mentions ? JSON.parse(row.mentions) : undefined,
   };
@@ -610,7 +615,7 @@ export function getNewMessages(
   const placeholders = jids.map(() => '?').join(',');
   // Filter out bot's own messages using is_from_me field
   const sql = `
-    SELECT id, chat_jid, sender, sender_name, content, timestamp, sender_user_id, mentions
+    SELECT id, chat_jid, sender, sender_name, content, timestamp, sender_platform, sender_user_id, mentions
     FROM messages
     WHERE timestamp > ? AND chat_jid IN (${placeholders}) AND (is_from_me IS NULL OR is_from_me = 0)
     ORDER BY timestamp
@@ -634,7 +639,7 @@ export function getMessagesSince(
 ): NewMessage[] {
   // Filter out bot's own messages using is_from_me field
   const sql = `
-    SELECT id, chat_jid, sender, sender_name, content, timestamp, sender_user_id, mentions
+    SELECT id, chat_jid, sender, sender_name, content, timestamp, sender_platform, sender_user_id, mentions
     FROM messages
     WHERE chat_jid = ? AND timestamp > ? AND (is_from_me IS NULL OR is_from_me = 0)
     ORDER BY timestamp

--- a/src/index.ts
+++ b/src/index.ts
@@ -1739,6 +1739,7 @@ function handleShareRequestApproval(
     content: syntheticContent,
     timestamp: new Date().toISOString(),
     is_from_me: false,
+    sender_platform: 'system',
   });
 
   queue.enqueueMessageCheck(mainJid);
@@ -1788,6 +1789,7 @@ async function handleReactionNotification(
     content: reactionContent,
     timestamp: new Date().toISOString(),
     is_from_me: false,
+    sender_platform: 'system' as const,
   };
 
   const piped = await queue.sendMessage(
@@ -1873,6 +1875,7 @@ async function main(): Promise<void> {
           content: `${trigger} ${withLink}`,
           timestamp: new Date().toISOString(),
           is_from_me: false,
+          sender_platform: 'system',
         });
         queue.enqueueMessageCheck(makeDispatchKey(chatJid, sub.agentId));
         delivered.add(sub.agentId);
@@ -2183,6 +2186,7 @@ async function main(): Promise<void> {
         content: `${trigger} ${text}`,
         timestamp: new Date().toISOString(),
         is_from_me: false,
+        sender_platform: 'ipc',
       });
       queue.enqueueMessageCheck(jid);
     },

--- a/src/types.ts
+++ b/src/types.ts
@@ -70,14 +70,44 @@ export interface RegisteredGroup {
   agentContextFolder?: string; // e.g., 'agents/peytonomi'
 }
 
+/**
+ * Inbound message envelope.
+ *
+ * Sender identity contract (see docs/nanoclaw-sender-identity-pipeline.md):
+ *
+ *   sender           — Immutable platform ID (e.g. Discord snowflake, WhatsApp JID).
+ *                       Used as the authoritative identity key for routing, filtering,
+ *                       and dedup.  NEVER derived from a display name.
+ *
+ *   sender_name      — Human-readable display label (mutable, user-changeable).
+ *                       Used ONLY for presentation (XML prompt, logs).
+ *                       Must NEVER be used for authorization or dedup.
+ *
+ *   sender_platform  — Origin platform tag.  Together with `sender`, forms the
+ *                       canonical sender key (`<platform>:<sender>`).  Populated by
+ *                       adapters; synthetic messages use 'system' or 'ipc'.
+ */
 export interface NewMessage {
   id: string;
   chat_jid: string;
+  /** Immutable platform-specific sender ID (authoritative key). */
   sender: string;
+  /** Human-readable display name (presentation only — do not use for auth or dedup). */
   sender_name: string;
   content: string;
   timestamp: string;
   is_from_me?: boolean;
+  /**
+   * Origin platform.  Set by the adapter that ingested the message.
+   * Synthetic messages use 'system'; IPC-relayed messages use 'ipc'.
+   */
+  sender_platform?:
+    | 'discord'
+    | 'whatsapp'
+    | 'telegram'
+    | 'slack'
+    | 'ipc'
+    | 'system';
   /** Platform-specific sender ID (e.g., Discord user ID, WhatsApp JID) */
   sender_user_id?: string;
   /** Array of mentioned users with their IDs and display names */


### PR DESCRIPTION
## Summary

Adds `sender_platform` to the `NewMessage` type — the first concrete step toward the [sender identity pipeline](docs/nanoclaw-sender-identity-pipeline.md). **No behavior changes.**

### What changed

- **`src/types.ts`** — New optional `sender_platform` field on `NewMessage` with inline documentation of the key/label contract:
  - `sender` = immutable platform ID (authoritative key)
  - `sender_name` = mutable display label (presentation only)
  - `sender_platform` = origin platform tag (`discord | whatsapp | telegram | slack | ipc | system`)
- **All 4 adapters** (Discord, WhatsApp, Telegram, Slack) — populate `sender_platform` on every inbound message
- **`src/index.ts`** — tag synthetic messages (`system`) and IPC-relayed notifications (`ipc`)
- **`src/db.ts`** — migration adds `sender_platform` TEXT column; INSERT/SELECT queries updated
- **`src/db.test.ts`** — 4 new tests: round-trip persistence, legacy message compat (undefined), all 6 platform values, `getNewMessages` integration

### Why this is safe

- Field is optional — legacy messages without it parse as `undefined`
- No routing, formatting, or authorization logic reads `sender_platform` yet
- All existing tests pass unchanged (335 pass, 0 new failures)
- `tsc --noEmit` clean

### What's next (separate PRs)

- PR 2: Use `sender` (immutable ID) alongside `sender_name` in XML prompt output
- PR 3: Fix WhatsApp/Telegram fallback to store phone/numeric ID in `sender`, not `sender_name`
- PR 4: Tolerant parsing for legacy messages without platform-prefixed IDs
- PR 5: Observability counters for malformed/missing identity fields

## Test plan

- [x] `bun test src/db.test.ts src/formatting.test.ts` — 60 pass, 0 fail
- [x] `bun test` — 335 pass (21 pre-existing failures from missing optional deps)
- [x] `tsc --noEmit` — 0 errors
- [ ] Manual: verify stored messages include `sender_platform` in SQLite after deploy


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Messages now include platform origin information, indicating whether they originated from Discord, Slack, Telegram, WhatsApp, or internal systems.
  * Platform metadata is persistently stored and retrieved with all messages for enhanced origin tracking.

* **Tests**
  * Added comprehensive test coverage for platform metadata handling across storage and retrieval operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->