### PR TITLE
feat: canonicalize adapter sender IDs

### DIFF
--- a/src/channels/discord.ts
+++ b/src/channels/discord.ts
@@ -635,7 +635,8 @@ export class DiscordChannel implements Channel {
       message.member?.displayName ||
       message.author.displayName ||
       message.author.username;
-    const sender = message.author.id;
+    const senderUserId = message.author.id;
+    const sender = `discord:${senderUserId}`;
     const msgId = message.id;
 
     // DMs always trigger — prepend trigger if not present
@@ -822,7 +823,7 @@ export class DiscordChannel implements Channel {
       timestamp,
       is_from_me: false,
       sender_platform: 'discord',
-      sender_user_id: sender, // Discord user ID
+      sender_user_id: senderUserId,
       mentions: mentions.length > 0 ? mentions : undefined,
     });
 

--- a/src/channels/slack.ts
+++ b/src/channels/slack.ts
@@ -314,7 +314,7 @@ export class SlackChannel implements Channel {
     const senderName = await resolveSlackUserName(
       this.client,
       senderUserId,
-      `User ${senderUserId}`,
+      'Unknown user',
     );
 
     // Resolve <@USERID> mentions to display names

--- a/src/channels/slack.ts
+++ b/src/channels/slack.ts
@@ -310,10 +310,11 @@ export class SlackChannel implements Channel {
     const timestamp = new Date(parseFloat(event.ts) * 1000).toISOString();
 
     const senderUserId = 'user' in event ? event.user : 'unknown';
+    const sender = `slack:${senderUserId}`;
     const senderName = await resolveSlackUserName(
       this.client,
       senderUserId,
-      senderUserId,
+      `User ${senderUserId}`,
     );
 
     // Resolve <@USERID> mentions to display names
@@ -368,7 +369,7 @@ export class SlackChannel implements Channel {
     this.opts.onMessage(chatJid, {
       id: msgId,
       chat_jid: chatJid,
-      sender: senderUserId,
+      sender,
       sender_name: senderName,
       content,
       timestamp,

--- a/src/channels/telegram.ts
+++ b/src/channels/telegram.ts
@@ -146,9 +146,7 @@ export class TelegramChannel implements Channel {
       const senderId = ctx.from?.id?.toString() || '';
       const sender = senderId ? `telegram:${senderId}` : '';
       const senderName =
-        ctx.from?.first_name ||
-        ctx.from?.username ||
-        (senderId ? `User ${senderId}` : 'Unknown');
+        ctx.from?.first_name || ctx.from?.username || 'Unknown';
       const msgId = ctx.message.message_id.toString();
 
       // Determine chat name
@@ -230,9 +228,7 @@ export class TelegramChannel implements Channel {
       const senderId = ctx.from?.id?.toString() || '';
       const sender = senderId ? `telegram:${senderId}` : '';
       const senderName =
-        ctx.from?.first_name ||
-        ctx.from?.username ||
-        (senderId ? `User ${senderId}` : 'Unknown');
+        ctx.from?.first_name || ctx.from?.username || 'Unknown';
       const caption = ctx.message.caption ? ` ${ctx.message.caption}` : '';
 
       this.opts.onChatMetadata(chatJid, timestamp);

--- a/src/channels/telegram.ts
+++ b/src/channels/telegram.ts
@@ -143,12 +143,12 @@ export class TelegramChannel implements Channel {
       const chatJid = `tg:${ctx.chat.id}`;
       let content = ctx.message.text;
       const timestamp = new Date(ctx.message.date * 1000).toISOString();
+      const senderId = ctx.from?.id?.toString() || '';
+      const sender = senderId ? `telegram:${senderId}` : '';
       const senderName =
         ctx.from?.first_name ||
         ctx.from?.username ||
-        ctx.from?.id.toString() ||
-        'Unknown';
-      const sender = ctx.from?.id.toString() || '';
+        (senderId ? `User ${senderId}` : 'Unknown');
       const msgId = ctx.message.message_id.toString();
 
       // Determine chat name
@@ -227,18 +227,19 @@ export class TelegramChannel implements Channel {
       if (!group) return;
 
       const timestamp = new Date(ctx.message.date * 1000).toISOString();
+      const senderId = ctx.from?.id?.toString() || '';
+      const sender = senderId ? `telegram:${senderId}` : '';
       const senderName =
         ctx.from?.first_name ||
         ctx.from?.username ||
-        ctx.from?.id?.toString() ||
-        'Unknown';
+        (senderId ? `User ${senderId}` : 'Unknown');
       const caption = ctx.message.caption ? ` ${ctx.message.caption}` : '';
 
       this.opts.onChatMetadata(chatJid, timestamp);
       this.opts.onMessage(chatJid, {
         id: ctx.message.message_id.toString(),
         chat_jid: chatJid,
-        sender: ctx.from?.id?.toString() || '',
+        sender,
         sender_name: senderName,
         content: `${placeholder}${caption}`,
         timestamp,

--- a/src/channels/whatsapp.ts
+++ b/src/channels/whatsapp.ts
@@ -351,7 +351,7 @@ export class WhatsAppChannel implements Channel {
 
             const rawSender = msg.key.participant || msg.key.remoteJid || '';
             const sender = rawSender ? `whatsapp:${rawSender}` : '';
-            const senderName = msg.pushName || 'WhatsApp User';
+            const senderName = msg.pushName?.trim() || '';
 
             // Prepend reply context so the agent knows what's being replied to
             const contextInfo = msg.message?.extendedTextMessage?.contextInfo;

--- a/src/channels/whatsapp.ts
+++ b/src/channels/whatsapp.ts
@@ -349,8 +349,9 @@ export class WhatsAppChannel implements Channel {
             // Skip protocol messages with no text content (encryption keys, read receipts, etc.)
             if (!content) continue;
 
-            const sender = msg.key.participant || msg.key.remoteJid || '';
-            const senderName = msg.pushName || sender.split('@')[0];
+            const rawSender = msg.key.participant || msg.key.remoteJid || '';
+            const sender = rawSender ? `whatsapp:${rawSender}` : '';
+            const senderName = msg.pushName || 'WhatsApp User';
 
             // Prepend reply context so the agent knows what's being replied to
             const contextInfo = msg.message?.extendedTextMessage?.contextInfo;

--- a/src/db.test.ts
+++ b/src/db.test.ts
@@ -56,7 +56,8 @@ describe('storeMessage', () => {
     const messages = getMessagesSince('group@g.us', '2024-01-01T00:00:00.000Z');
     expect(messages).toHaveLength(1);
     expect(messages[0].id).toBe('msg-1');
-    expect(messages[0].sender).toBe('123@s.whatsapp.net');
+    // Raw WhatsApp JID is canonicalized at read time via mapMessageRow
+    expect(messages[0].sender).toBe('whatsapp:123@s.whatsapp.net');
     expect(messages[0].sender_name).toBe('Alice');
     expect(messages[0].content).toBe('hello world');
   });
@@ -535,5 +536,164 @@ describe('task CRUD', () => {
 
     deleteTask('task-3');
     expect(getTaskById('task-3')).toBeNull();
+  });
+});
+
+// --- mapMessageRow sender canonicalization ---
+
+describe('mapMessageRow sender canonicalization', () => {
+  it('canonicalizes raw Discord sender using sender_platform', () => {
+    storeChatMetadata('dc:123456', '2024-01-01T00:00:00.000Z');
+
+    storeMessage({
+      id: 'canon-dc-1',
+      chat_jid: 'dc:123456',
+      sender: '999888777', // raw ID, pre-canonicalization
+      sender_name: 'Alice',
+      content: 'old discord msg',
+      timestamp: '2024-01-01T00:00:01.000Z',
+      is_from_me: false,
+      sender_platform: 'discord',
+    });
+
+    const messages = getMessagesSince('dc:123456', '2024-01-01T00:00:00.000Z');
+    expect(messages).toHaveLength(1);
+    expect(messages[0].sender).toBe('discord:999888777');
+  });
+
+  it('canonicalizes raw Telegram sender using sender_platform', () => {
+    storeChatMetadata('tg:55555', '2024-01-01T00:00:00.000Z');
+
+    storeMessage({
+      id: 'canon-tg-1',
+      chat_jid: 'tg:55555',
+      sender: '112233',
+      sender_name: 'Bob',
+      content: 'old telegram msg',
+      timestamp: '2024-01-01T00:00:01.000Z',
+      is_from_me: false,
+      sender_platform: 'telegram',
+    });
+
+    const messages = getMessagesSince('tg:55555', '2024-01-01T00:00:00.000Z');
+    expect(messages).toHaveLength(1);
+    expect(messages[0].sender).toBe('telegram:112233');
+  });
+
+  it('infers platform from WhatsApp chat_jid when sender_platform is missing', () => {
+    storeChatMetadata('group@g.us', '2024-01-01T00:00:00.000Z');
+
+    storeMessage({
+      id: 'canon-wa-1',
+      chat_jid: 'group@g.us',
+      sender: '15551234567',
+      sender_name: 'Carol',
+      content: 'legacy whatsapp msg',
+      timestamp: '2024-01-01T00:00:01.000Z',
+      is_from_me: false,
+      // no sender_platform — truly legacy
+    });
+
+    const messages = getMessagesSince('group@g.us', '2024-01-01T00:00:00.000Z');
+    expect(messages).toHaveLength(1);
+    expect(messages[0].sender).toBe('whatsapp:15551234567');
+  });
+
+  it('infers platform from Discord chat_jid when sender_platform is missing', () => {
+    storeChatMetadata('dc:777', '2024-01-01T00:00:00.000Z');
+
+    storeMessage({
+      id: 'canon-dc-infer',
+      chat_jid: 'dc:777',
+      sender: '444555666',
+      sender_name: 'Dave',
+      content: 'legacy discord msg',
+      timestamp: '2024-01-01T00:00:01.000Z',
+      is_from_me: false,
+    });
+
+    const messages = getMessagesSince('dc:777', '2024-01-01T00:00:00.000Z');
+    expect(messages).toHaveLength(1);
+    expect(messages[0].sender).toBe('discord:444555666');
+  });
+
+  it('does not double-prefix already-canonicalized senders', () => {
+    storeChatMetadata('dc:123', '2024-01-01T00:00:00.000Z');
+
+    storeMessage({
+      id: 'canon-noop',
+      chat_jid: 'dc:123',
+      sender: 'discord:999888777', // already canonicalized
+      sender_name: 'Eve',
+      content: 'new format msg',
+      timestamp: '2024-01-01T00:00:01.000Z',
+      is_from_me: false,
+      sender_platform: 'discord',
+    });
+
+    const messages = getMessagesSince('dc:123', '2024-01-01T00:00:00.000Z');
+    expect(messages).toHaveLength(1);
+    expect(messages[0].sender).toBe('discord:999888777');
+  });
+
+  it('does not canonicalize system or ipc senders', () => {
+    storeChatMetadata('dc:123', '2024-01-01T00:00:00.000Z');
+
+    storeMessage({
+      id: 'canon-sys',
+      chat_jid: 'dc:123',
+      sender: 'system',
+      sender_name: 'System',
+      content: 'system msg',
+      timestamp: '2024-01-01T00:00:01.000Z',
+      is_from_me: false,
+      sender_platform: 'system',
+    });
+
+    const messages = getMessagesSince('dc:123', '2024-01-01T00:00:00.000Z');
+    expect(messages).toHaveLength(1);
+    // 'system' contains no ':' but sender_platform is 'system' (not an adapter platform),
+    // and chat_jid 'dc:123' would infer 'discord'. However the sender_platform takes
+    // precedence and 'system' is not in ADAPTER_PLATFORMS, so it falls through to the
+    // JID inference. This is acceptable — 'discord:system' is harmless and won't collide
+    // with real user IDs. The important thing is system/ipc sender_platform doesn't cause issues.
+  });
+
+  it('deduplicates old and new format senders in the same conversation window', () => {
+    storeChatMetadata('dc:100', '2024-01-01T00:00:00.000Z');
+
+    // Pre-canonicalization message (raw sender)
+    storeMessage({
+      id: 'dedup-old',
+      chat_jid: 'dc:100',
+      sender: '42',
+      sender_name: 'Frank',
+      content: 'old format',
+      timestamp: '2024-01-01T00:00:01.000Z',
+      is_from_me: false,
+      sender_platform: 'discord',
+    });
+
+    // Post-canonicalization message (canonical sender)
+    storeMessage({
+      id: 'dedup-new',
+      chat_jid: 'dc:100',
+      sender: 'discord:42',
+      sender_name: 'Frank',
+      content: 'new format',
+      timestamp: '2024-01-01T00:00:02.000Z',
+      is_from_me: false,
+      sender_platform: 'discord',
+    });
+
+    const messages = getMessagesSince('dc:100', '2024-01-01T00:00:00.000Z');
+    expect(messages).toHaveLength(2);
+    // Both should now have the same canonical sender
+    expect(messages[0].sender).toBe('discord:42');
+    expect(messages[1].sender).toBe('discord:42');
+
+    // Verify dedup works: unique sender IDs should be 1
+    const uniqueSenders = new Set(messages.map((m) => m.sender));
+    expect(uniqueSenders.size).toBe(1);
   });
 });

--- a/src/db.test.ts
+++ b/src/db.test.ts
@@ -652,11 +652,11 @@ describe('mapMessageRow sender canonicalization', () => {
 
     const messages = getMessagesSince('dc:123', '2024-01-01T00:00:00.000Z');
     expect(messages).toHaveLength(1);
-    // 'system' contains no ':' but sender_platform is 'system' (not an adapter platform),
-    // and chat_jid 'dc:123' would infer 'discord'. However the sender_platform takes
-    // precedence and 'system' is not in ADAPTER_PLATFORMS, so it falls through to the
-    // JID inference. This is acceptable — 'discord:system' is harmless and won't collide
-    // with real user IDs. The important thing is system/ipc sender_platform doesn't cause issues.
+    // Non-adapter platforms (system, ipc) should NOT be canonicalized via JID inference
+    expect(messages[0].sender).toBe('system');
+    expect(messages[0].sender_platform).toBe('system');
+    expect(messages[0].sender_name).toBe('System');
+    expect(messages[0].content).toBe('system msg');
   });
 
   it('deduplicates old and new format senders in the same conversation window', () => {

--- a/src/db.ts
+++ b/src/db.ts
@@ -605,6 +605,7 @@ const ADAPTER_PLATFORMS = new Set(['discord', 'whatsapp', 'telegram', 'slack']);
 /** Infer platform from chat_jid for legacy messages missing sender_platform */
 function inferPlatformFromJid(chatJid: string): string | undefined {
   if (chatJid.startsWith('dc:')) return 'discord';
+  if (chatJid.startsWith('slack:')) return 'slack';
   if (chatJid.startsWith('tg:')) return 'telegram';
   if (chatJid.endsWith('@g.us') || chatJid.endsWith('@s.whatsapp.net'))
     return 'whatsapp';
@@ -627,12 +628,17 @@ function mapMessageRow(row: MessageRow): NewMessage {
   // messages already include the prefix (e.g. "discord:123456789").
   let sender = row.sender;
   if (sender && !sender.includes(':')) {
-    const adapterPlatform =
-      (validPlatform && ADAPTER_PLATFORMS.has(validPlatform)
-        ? validPlatform
-        : null) || inferPlatformFromJid(row.chat_jid);
-    if (adapterPlatform) {
-      sender = `${adapterPlatform}:${sender}`;
+    // Skip canonicalization for non-adapter platforms (system, ipc)
+    const isNonAdapterPlatform =
+      validPlatform && !ADAPTER_PLATFORMS.has(validPlatform);
+    if (!isNonAdapterPlatform) {
+      const adapterPlatform =
+        (validPlatform && ADAPTER_PLATFORMS.has(validPlatform)
+          ? validPlatform
+          : null) || inferPlatformFromJid(row.chat_jid);
+      if (adapterPlatform) {
+        sender = `${adapterPlatform}:${sender}`;
+      }
     }
   }
 

--- a/src/db.ts
+++ b/src/db.ts
@@ -599,18 +599,47 @@ const VALID_SENDER_PLATFORMS = new Set<
   NonNullable<NewMessage['sender_platform']>
 >(['discord', 'whatsapp', 'telegram', 'slack', 'ipc', 'system']);
 
+/** Adapter platforms whose sender IDs should be canonicalized to `<platform>:<id>` */
+const ADAPTER_PLATFORMS = new Set(['discord', 'whatsapp', 'telegram', 'slack']);
+
+/** Infer platform from chat_jid for legacy messages missing sender_platform */
+function inferPlatformFromJid(chatJid: string): string | undefined {
+  if (chatJid.startsWith('dc:')) return 'discord';
+  if (chatJid.startsWith('tg:')) return 'telegram';
+  if (chatJid.endsWith('@g.us') || chatJid.endsWith('@s.whatsapp.net'))
+    return 'whatsapp';
+  return undefined;
+}
+
 /** Convert a raw DB message row to a NewMessage (parse mentions JSON, null→undefined) */
 function mapMessageRow(row: MessageRow): NewMessage {
   const platform = row.sender_platform;
+  const validPlatform =
+    platform &&
+    VALID_SENDER_PLATFORMS.has(
+      platform as NonNullable<NewMessage['sender_platform']>,
+    )
+      ? (platform as NonNullable<NewMessage['sender_platform']>)
+      : undefined;
+
+  // Normalize legacy raw sender IDs to canonical <platform>:<id> format.
+  // Pre-canonicalization messages have bare IDs (e.g. "123456789"); post-canonicalization
+  // messages already include the prefix (e.g. "discord:123456789").
+  let sender = row.sender;
+  if (sender && !sender.includes(':')) {
+    const adapterPlatform =
+      (validPlatform && ADAPTER_PLATFORMS.has(validPlatform)
+        ? validPlatform
+        : null) || inferPlatformFromJid(row.chat_jid);
+    if (adapterPlatform) {
+      sender = `${adapterPlatform}:${sender}`;
+    }
+  }
+
   return {
     ...row,
-    sender_platform:
-      platform &&
-      VALID_SENDER_PLATFORMS.has(
-        platform as NonNullable<NewMessage['sender_platform']>,
-      )
-        ? (platform as NonNullable<NewMessage['sender_platform']>)
-        : undefined,
+    sender,
+    sender_platform: validPlatform,
     sender_user_id: row.sender_user_id ?? undefined,
     mentions: row.mentions ? JSON.parse(row.mentions) : undefined,
   };


### PR DESCRIPTION
## Summary
- Canonicalize inbound adapter sender keys to `<platform>:<immutable-id>` for Discord, Slack, Telegram, and WhatsApp.
- Preserve display-label semantics by avoiding raw-ID fallbacks in `sender_name` for Telegram/Slack/WhatsApp (`User <id>` / `WhatsApp User`).
- Keep `sender_user_id` as the raw Discord/Slack platform ID while `sender` becomes the canonical cross-platform key.

## Why
- Phase 0 identified cross-platform ambiguity in raw sender IDs and label/key conflation in fallback paths (R3-R5).
- This change makes identity keys unambiguous and keeps mutable display labels separate from immutable routing identity.

## Validation
- `bun test src/channels/discord.test.ts src/channels/slack.test.ts src/channels/telegram.test.ts src/channels/whatsapp.test.ts`
- `bun run typecheck`

Refs #204


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Sender IDs are now standardized with platform prefixes (discord:, slack:, telegram:, whatsapp:) across channels.
  * Legacy sender data is automatically canonicalized to the new format.

* **Behavior Change**
  * Slack inbound message payloads now deliver sender using the prefixed form (sender includes platform prefix).

* **Tests**
  * Added extensive tests covering sender canonicalization and message storage.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->