### PR TITLE
docs(setup): update skill guides for dev cycle merges

### DIFF
--- a/.claude/skills/setup/SKILL.md
+++ b/.claude/skills/setup/SKILL.md
@@ -15,8 +15,8 @@ description: Run initial OmniClaw setup. Use when user wants to install dependen
 | verify, status, health check | → run `09-verify.sh` directly |
 | update, upgrade, pulled latest, auto-update | → read [guides/upgrade.md](guides/upgrade.md) |
 | install, fresh setup, first time, configure | → read [guides/fresh-install.md](guides/fresh-install.md) |
-| github, discord bot/agent | → read [guides/advanced-setup.md](guides/advanced-setup.md) |
-| agent identity, context, workspace mounts, agent-to-agent routing, triggers, wrong identity | → read [guides/agents-and-context.md](guides/agents-and-context.md) |
+| github, discord bot/agent, webhooks, github watches | → read [guides/advanced-setup.md](guides/advanced-setup.md) |
+| agent identity, context, workspace mounts, agent-to-agent routing, triggers, wrong identity, sender identity, channel context | → read [guides/agents-and-context.md](guides/agents-and-context.md) |
 | broken, not working, error, troubleshoot | → read [guides/troubleshooting.md](guides/troubleshooting.md) |
 
 ---

--- a/.claude/skills/setup/guides/advanced-setup.md
+++ b/.claude/skills/setup/guides/advanced-setup.md
@@ -13,6 +13,55 @@ GITHUB_TOKEN=<token>
 
 Optionally: `GIT_AUTHOR_NAME` / `GIT_AUTHOR_EMAIL` (defaults: `OmniClaw Agent` / `omniclaw@users.noreply.github.com`)
 
+## GitHub Context Injection
+
+Agents can see open PRs, issues, and review comments injected into their system prompt. Requires `GITHUB_TOKEN` in `.env`.
+
+Create `data/github-watches.json`:
+
+```json
+{
+  "cacheTtlMs": 300000,
+  "watches": [
+    {
+      "agentId": "<agent-folder-name>",
+      "repos": [
+        {
+          "owner": "<org>",
+          "repo": "<repo>",
+          "openPrs": { "limit": 10, "includeReviewComments": true },
+          "recentIssues": { "limit": 10 }
+        }
+      ]
+    }
+  ]
+}
+```
+
+- `agentId` matches the agent's folder name (the `folder` column in the `agents` table)
+- Multiple agents can watch different sets of repos
+- Cache TTL defaults to 5 minutes; override per-config with `cacheTtlMs`
+- The `# GitHub Context` block appears in the agent's system prompt automatically
+
+## GitHub Webhooks (Optional)
+
+For real-time GitHub event notifications (instead of waiting for cache expiry), set up a webhook:
+
+1. Add webhook secret to `.env`:
+   ```dotenv
+   GITHUB_WEBHOOK_SECRET=<your-secret>
+   ```
+
+2. In your GitHub repo settings → Webhooks → Add webhook:
+   - Payload URL: `https://<your-host>/webhooks/github`
+   - Content type: `application/json`
+   - Secret: same value as `GITHUB_WEBHOOK_SECRET`
+   - Events: select `Pull requests`, `Pull request reviews`, `Pull request review comments`, `Issues`, `Issue comments`, `Check suites`
+
+3. Restart the service. The webhook server starts automatically when `GITHUB_WEBHOOK_SECRET` is configured.
+
+Events trigger immediate cache invalidation and synthetic messages to watching agents. Polling via `data/github-watches.json` is kept as fallback.
+
 ## Discord Agent
 
 Ask: Do you want to add a Discord agent?
@@ -55,7 +104,29 @@ Restart the service:
 launchctl kickstart -k gui/$(id -u)/com.omniclaw
 ```
 
-Verify by sending a message in the channel and checking `tail -f logs/omniclaw.log`.
+After registering, set the context layer folders (the register script doesn't set these automatically yet):
+
+```bash
+# Set agent identity folder
+sqlite3 store/messages.db \
+  "UPDATE agents SET agent_context_folder = 'agents/<name>' WHERE folder = '<FOLDER_NAME>'"
+
+# Set channel and category context folders
+sqlite3 store/messages.db \
+  "UPDATE channel_subscriptions
+   SET channel_folder = 'servers/<server>/<category>/<channel>',
+       category_folder = 'servers/<server>/<category>'
+   WHERE agent_id = '<agent-id>' AND channel_jid = 'dc:<CHANNEL_ID>'"
+```
+
+Create the corresponding directories under `groups/`:
+```bash
+mkdir -p groups/agents/<name>
+mkdir -p groups/servers/<server>/<category>/<channel>
+mkdir -p groups/servers/<server>/<category>
+```
+
+Restart the service and verify by sending a message in the channel and checking `tail -f logs/omniclaw.log`.
 
 ### Internal bot key vs Discord snowflake ID
 

--- a/.claude/skills/setup/guides/agents-and-context.md
+++ b/.claude/skills/setup/guides/agents-and-context.md
@@ -155,6 +155,72 @@ If an agent addresses itself by name, it consumes its own trigger → the messag
 
 ---
 
+## Channel context injection
+
+Every agent automatically receives a `## Channel Context` block in their system prompt when a container starts.
+
+**Multi-channel agents** see all subscribed channels:
+
+```
+## Channel Context
+You are subscribed to multiple channels:
+- **#omniclaw** (`dc:1475009887846010963`)
+- **#agent-debug** (`dc:1476469986024489081`) **(current)**
+- **#landing-page** (`dc:1475913343817748600`)
+```
+
+**Single-channel agents** see just their channel:
+
+```
+## Channel Context
+You are responding in **#omniclaw** (dc:1475009887846010963)
+```
+
+This is automatic — no configuration needed. The data comes from the agent's `channel_subscriptions` rows.
+
+---
+
+## Sender identity
+
+Messages now carry structured sender identity fields:
+
+| Field | Column | Example |
+|-------|--------|---------|
+| Platform | `sender_platform` | `discord`, `whatsapp`, `telegram`, `slack`, `ipc`, `system` |
+| Immutable ID | `sender_user_id` | `discord:123456789`, `whatsapp:15551234567` |
+| Display name | `sender_name` | `Peyton` (mutable, for display only) |
+
+Sender IDs are canonicalized to `<platform>:<immutable-id>` format across all adapters. The `sender_id` attribute is also exposed in the `<message>` XML that agents receive, alongside `sender` (display name).
+
+The participant roster in conversation context deduplicates by immutable sender ID rather than display name, preventing phantom participants when users change their display name.
+
+**Diagnostics:**
+
+```bash
+# Check recent sender identity data
+sqlite3 store/messages.db \
+  "SELECT sender, sender_platform, sender_user_id FROM messages ORDER BY rowid DESC LIMIT 10"
+
+# Check instrumentation counters in logs
+grep 'senderIdentity' logs/omniclaw.log | tail -20
+```
+
+---
+
+## GitHub context injection
+
+Agents can receive a `# GitHub Context` block in their system prompt showing open PRs, issues, and review comments for configured repos.
+
+Requires:
+- `GITHUB_TOKEN` in `.env`
+- `data/github-watches.json` with agent → repo mappings (see [advanced-setup.md](advanced-setup.md))
+
+The context block is fetched by the host process and passed into the container via the `githubContext` field. Cache TTL is 5 minutes by default.
+
+For real-time updates, configure GitHub webhooks (see [advanced-setup.md](advanced-setup.md)).
+
+---
+
 ## Full consistency check
 
 Run this to verify all the pieces align:
@@ -186,7 +252,7 @@ grep "DISCORD_BOT_IDS\|DISCORD_BOT_DEFAULT" .env 2>/dev/null
 - [ ] Row in `agents` with correct `agent_context_folder`
 - [ ] Row in `channel_subscriptions` for each channel it should join
 - [ ] `discord_bot_id` in that row matches a key in `DISCORD_BOT_IDS`
-- [ ] `channel_folder` and `category_folder` directories exist under `groups/`
+- [ ] `channel_folder` and `category_folder` set in `channel_subscriptions` and directories exist under `groups/`
 - [ ] `groups/<agent_context_folder>/CLAUDE.md` says `You are <AgentName>` and lists co-agents' triggers
 - [ ] All co-agents' identity files mention each other's triggers
 
@@ -222,11 +288,25 @@ grep "DISCORD_BOT_IDS\|DISCORD_BOT_DEFAULT" .env 2>/dev/null
 
    This creates the `agents` row and `channel_subscriptions` row.
 
-4. **Set `agent_context_folder`** (the register script may not set this automatically):
+4. **Set context layer folders** (the register script doesn't set these automatically yet):
 
    ```bash
+   # Agent identity folder
    sqlite3 store/messages.db \
      "UPDATE agents SET agent_context_folder = 'agents/<name>' WHERE id = '<agent-id>'"
+
+   # Channel and category context folders
+   sqlite3 store/messages.db \
+     "UPDATE channel_subscriptions
+      SET channel_folder = 'servers/<server>/<category>/<channel>',
+          category_folder = 'servers/<server>/<category>'
+      WHERE agent_id = '<agent-id>' AND channel_jid = 'dc:<CHANNEL_ID>'"
+   ```
+
+   Create the directories:
+   ```bash
+   mkdir -p groups/agents/<name>
+   mkdir -p groups/servers/<server>/<category>/<channel>
    ```
 
 5. **Update co-agents' identity files** to mention the new agent's trigger.

--- a/.claude/skills/setup/guides/fresh-install.md
+++ b/.claude/skills/setup/guides/fresh-install.md
@@ -76,6 +76,31 @@ Ask: Do you want the agent to push branches and create pull requests?
 
 If yes: user needs a classic GitHub token with `repo` scope from https://github.com/settings/tokens. Once they provide it, use the Write tool to append to `.env` (never echo tokens via shell). Optionally collect `GIT_AUTHOR_NAME` / `GIT_AUTHOR_EMAIL`.
 
+### GitHub Context Injection (Optional)
+
+If the user wants agents to see open PRs, issues, and review comments in their system prompt, create `data/github-watches.json`:
+
+```json
+{
+  "cacheTtlMs": 300000,
+  "watches": [
+    {
+      "agentId": "<agent-folder-name>",
+      "repos": [
+        {
+          "owner": "<github-org>",
+          "repo": "<repo-name>",
+          "openPrs": { "limit": 10, "includeReviewComments": true },
+          "recentIssues": { "limit": 10 }
+        }
+      ]
+    }
+  ]
+}
+```
+
+Requires `GITHUB_TOKEN` in `.env`. Context is cached for 5 minutes by default. For real-time updates via webhooks, see [advanced-setup.md](advanced-setup.md).
+
 ## 5. WhatsApp Authentication
 
 If HAS_AUTH=true, confirm to keep or re-authenticate.

--- a/.claude/skills/setup/guides/troubleshooting.md
+++ b/.claude/skills/setup/guides/troubleshooting.md
@@ -60,6 +60,34 @@ Test the script directly (both platforms):
 bash container/auto-update.sh
 ```
 
+## Sender identity issues
+
+If agents are confusing who sent a message, or messages route to the wrong agent:
+
+```bash
+# Check sender identity counters in logs
+grep 'senderIdentity' logs/omniclaw.log | tail -20
+
+# Verify sender canonicalization (should be <platform>:<id> format)
+sqlite3 store/messages.db \
+  "SELECT sender, sender_platform, sender_user_id FROM messages ORDER BY rowid DESC LIMIT 10"
+```
+
+Sender IDs are now canonicalized to `<platform>:<immutable-id>` format (e.g. `discord:123456`, `whatsapp:15551234567`). If you see old-format sender keys, the adapter hasn't processed messages since the upgrade.
+
+## GitHub context not appearing
+
+If agents aren't seeing PR/issue context in their system prompt:
+
+1. Verify `GITHUB_TOKEN` is in `.env`
+2. Verify `data/github-watches.json` exists and the `agentId` matches the agent's folder name
+3. Check logs for GitHub API errors: `grep 'github' logs/omniclaw.log | tail -10`
+4. Cache TTL is 5 minutes by default — wait or restart to force refresh
+
+## Live log streaming
+
+The web dashboard supports real-time log streaming. If the dashboard log panel isn't showing logs, verify the service is running and the WebSocket connection is established.
+
 ## Useful commands
 
 ```bash
@@ -74,4 +102,12 @@ tail -f logs/omniclaw.log
 
 # Tail auto-update log
 tail -f logs/auto-update.log
+
+# Check sender identity pipeline
+grep 'senderIdentity' logs/omniclaw.log | tail -20
+
+# Verify agent channel subscriptions
+sqlite3 store/messages.db \
+  "SELECT cs.channel_jid, a.name, cs.trigger_pattern, cs.channel_folder
+   FROM channel_subscriptions cs JOIN agents a ON a.id = cs.agent_id"
 ```

--- a/.claude/skills/setup/guides/upgrade.md
+++ b/.claude/skills/setup/guides/upgrade.md
@@ -61,9 +61,52 @@ systemctl --user restart omniclaw
 
 Schema changes are additive — rolling back code is safe even after migrations ran.
 
+## What's new (automatic)
+
+These features activate automatically after upgrading — no action required.
+
+### Sender identity pipeline
+
+Messages now carry `sender_platform` (discord, whatsapp, telegram, slack, ipc, system) and sender IDs are canonicalized to `<platform>:<immutable-id>` format across all adapters. The `sender_id` attribute is exposed in the `<message>` XML agents receive. DB migrations add `sender_platform` and `sender_user_id` columns to `messages` automatically.
+
+### Channel context injection
+
+Agents now receive a `## Channel Context` block in their system prompt listing all channels they're subscribed to, with the current channel marked. Multi-channel agents see the full list; single-channel agents see just their channel name and JID.
+
+### Live log streaming
+
+The web dashboard now supports real-time log streaming via WebSocket. Access it from the dashboard log panel — logs show level badges and color coding.
+
+### Rust toolchain in container
+
+`cargo` and `rustc` are now included in the base container image.
+
 ## New opt-in capabilities
 
 These require explicit action — existing agents are unaffected by default.
+
+### GitHub context injection
+
+Agents can see open PRs, issues, and review comments in their system prompt. See [advanced-setup.md](advanced-setup.md) for full config.
+
+Quick setup:
+1. Ensure `GITHUB_TOKEN` is in `.env`
+2. Create `data/github-watches.json` with agent → repo mappings
+3. Restart the service
+
+### GitHub webhooks
+
+For real-time GitHub event notifications, add `GITHUB_WEBHOOK_SECRET` to `.env` and configure a webhook in your GitHub repo. See [advanced-setup.md](advanced-setup.md).
+
+### Persistent resume position store
+
+Feature-flagged (off by default). When enabled, scheduled task resume positions survive service restarts. To enable, add to `.env`:
+
+```dotenv
+PERSISTENT_TASK_STATE=true
+```
+
+Currently in preview — fail-open on persistence errors (falls back to in-memory).
 
 ### OpenCode runtime
 


### PR DESCRIPTION
## Summary

Updates the `/setup` skill guides to reflect all features merged in the recent dev cycle (PRs #188–#210).

• *SKILL.md* — added route keywords for webhooks, github watches, sender identity, channel context
• *fresh-install.md* — added GitHub context injection (`data/github-watches.json`) as optional step under 4b
• *advanced-setup.md* — added full GitHub context injection config, GitHub webhook setup, and context layer folder setup (`channel_folder`, `category_folder`, `agent_context_folder`) for Discord agents
• *upgrade.md* — added "What's new (automatic)" section covering sender identity pipeline, channel context injection, live log streaming, Rust toolchain; added opt-in section for GitHub context, webhooks, and `PERSISTENT_TASK_STATE`
• *troubleshooting.md* — added sender identity diagnostics, GitHub context debugging, live log streaming troubleshooting, and new useful commands
• *agents-and-context.md* — added channel context injection, sender identity, and GitHub context injection sections; expanded "Adding a new agent" to include `channel_folder`/`category_folder` setup

## Test plan

- [ ] Read through each guide and verify accuracy against merged source code
- [ ] Verify `data/github-watches.json` schema matches `src/github.ts` types
- [ ] Verify `PERSISTENT_TASK_STATE` env var matches `src/config.ts`
- [ ] Run `/setup verify` and confirm skill routes correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)
