### PR TITLE
chore(setup): switch setup scripts to bun run

### DIFF
--- a/.claude/skills/setup/scripts/04-auth-whatsapp.sh
+++ b/.claude/skills/setup/scripts/04-auth-whatsapp.sh
@@ -114,7 +114,7 @@ case "$METHOD" in
     clean_stale_state
 
     # Start auth in background
-    npm run auth >> "$LOG_FILE" 2>&1 &
+    bun run auth >> "$LOG_FILE" 2>&1 &
     AUTH_PID=$!
     log "Auth process started (PID $AUTH_PID)"
 

--- a/.claude/skills/setup/scripts/05-sync-groups.sh
+++ b/.claude/skills/setup/scripts/05-sync-groups.sh
@@ -16,7 +16,7 @@ cd "$PROJECT_ROOT"
 # Build TypeScript
 log "Building TypeScript"
 BUILD="failed"
-if npm run build >> "$LOG_FILE" 2>&1; then
+if bun run build >> "$LOG_FILE" 2>&1; then
   BUILD="success"
   log "Build succeeded"
 else

--- a/.claude/skills/setup/scripts/08-setup-service.sh
+++ b/.claude/skills/setup/scripts/08-setup-service.sh
@@ -39,7 +39,7 @@ log "Setting up service: platform=$PLATFORM node=$NODE_PATH project=$PROJECT_PAT
 
 # Build first
 log "Building TypeScript"
-if ! npm run build >> "$LOG_FILE" 2>&1; then
+if ! bun run build >> "$LOG_FILE" 2>&1; then
   log "Build failed"
   cat <<EOF
 === OMNICLAW SETUP: SETUP_SERVICE ===


### PR DESCRIPTION
## Summary
- Replace `npm run auth` with `bun run auth` in WhatsApp auth setup script.
- Replace `npm run build` with `bun run build` in group sync and service setup scripts.
- Keep setup automation aligned with the project's Bun-first execution model.

## Testing
- Not run (script-only command substitutions).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated setup scripts to use an optimized package runner for build and initialization operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->