### PR TITLE
chore(setup): migrate npm/npx → bun across setup scripts

### DIFF
--- a/.claude/skills/setup/guides/fresh-install.md
+++ b/.claude/skills/setup/guides/fresh-install.md
@@ -84,7 +84,7 @@ AskUserQuestion: QR code in browser (recommended) vs pairing code vs QR code in 
 
 - **QR browser:** `./.claude/skills/setup/scripts/04-auth-whatsapp.sh --method qr-browser` (timeout: 150000ms)
 - **Pairing code:** Ask for phone number first (country code, no + or spaces). `./.claude/skills/setup/scripts/04-auth-whatsapp.sh --method pairing-code --phone NUMBER` (timeout: 150000ms). Display PAIRING_CODE.
-- **QR terminal:** Run script, tell user to run `cd PROJECT_PATH && npm run auth` in another terminal.
+- **QR terminal:** Run script, tell user to run `cd PROJECT_PATH && bun run auth` in another terminal.
 
 If AUTH_STATUS=already_authenticated → skip ahead.
 

--- a/.claude/skills/setup/guides/troubleshooting.md
+++ b/.claude/skills/setup/guides/troubleshooting.md
@@ -28,7 +28,7 @@ WhatsApp may use LID (Linked Identity) JIDs. Check logs for LID translation. Ver
 ## WhatsApp disconnected
 
 ```bash
-npm run auth   # re-authenticate
+bun run auth   # re-authenticate
 bun run build && launchctl kickstart -k gui/$(id -u)/com.omniclaw
 ```
 

--- a/.claude/skills/setup/scripts/02-install-deps.sh
+++ b/.claude/skills/setup/scripts/02-install-deps.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 set -euo pipefail
 
-# 02-install-deps.sh — Run npm install and verify key packages
+# 02-install-deps.sh — Run bun install and verify key packages
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 PROJECT_ROOT="$(cd "$SCRIPT_DIR/../../../.." && pwd)"
@@ -13,17 +13,17 @@ log() { echo "[$(date '+%Y-%m-%d %H:%M:%S')] [install-deps] $*" >> "$LOG_FILE"; 
 
 cd "$PROJECT_ROOT"
 
-log "Running npm install"
+log "Running bun install"
 
-if npm install >> "$LOG_FILE" 2>&1; then
-  log "npm install succeeded"
+if bun install >> "$LOG_FILE" 2>&1; then
+  log "bun install succeeded"
 else
-  log "npm install failed"
+  log "bun install failed"
   cat <<EOF
 === OMNICLAW SETUP: INSTALL_DEPS ===
 PACKAGES: failed
 STATUS: failed
-ERROR: npm_install_failed
+ERROR: bun_install_failed
 LOG: logs/setup.log
 === END ===
 EOF

--- a/.claude/skills/setup/scripts/04-auth-whatsapp.sh
+++ b/.claude/skills/setup/scripts/04-auth-whatsapp.sh
@@ -249,7 +249,7 @@ EOF
     clean_stale_state
 
     # Start auth with pairing code in background
-    npx tsx src/whatsapp-auth.ts --pairing-code --phone "$PHONE" >> "$LOG_FILE" 2>&1 &
+    bunx tsx src/whatsapp-auth.ts --pairing-code --phone "$PHONE" >> "$LOG_FILE" 2>&1 &
     AUTH_PID=$!
     log "Auth process started (PID $AUTH_PID)"
 

--- a/.claude/skills/setup/scripts/04-auth-whatsapp.sh
+++ b/.claude/skills/setup/scripts/04-auth-whatsapp.sh
@@ -114,7 +114,7 @@ case "$METHOD" in
     clean_stale_state
 
     # Start auth in background
-    npm run auth >> "$LOG_FILE" 2>&1 &
+    bun run auth >> "$LOG_FILE" 2>&1 &
     AUTH_PID=$!
     log "Auth process started (PID $AUTH_PID)"
 

--- a/.claude/skills/setup/scripts/05-sync-groups.sh
+++ b/.claude/skills/setup/scripts/05-sync-groups.sh
@@ -16,7 +16,7 @@ cd "$PROJECT_ROOT"
 # Build TypeScript
 log "Building TypeScript"
 BUILD="failed"
-if npm run build >> "$LOG_FILE" 2>&1; then
+if bun run build >> "$LOG_FILE" 2>&1; then
   BUILD="success"
   log "Build succeeded"
 else

--- a/.claude/skills/setup/scripts/08-setup-service.sh
+++ b/.claude/skills/setup/scripts/08-setup-service.sh
@@ -39,7 +39,7 @@ log "Setting up service: platform=$PLATFORM node=$NODE_PATH project=$PROJECT_PAT
 
 # Build first
 log "Building TypeScript"
-if ! npm run build >> "$LOG_FILE" 2>&1; then
+if ! bun run build >> "$LOG_FILE" 2>&1; then
   log "Build failed"
   cat <<EOF
 === OMNICLAW SETUP: SETUP_SERVICE ===


### PR DESCRIPTION
## Summary

Align all setup scripts and guides from `npm`/`npx` to `bun`/`bunx` for full consistency with the rest of the project.

### Scripts
- `04-auth-whatsapp.sh`: `npm run auth` → `bun run auth`, `npx tsx` → `bunx tsx`
- `05-sync-groups.sh`: `npm run build` → `bun run build`
- `08-setup-service.sh`: `npm run build` → `bun run build`
- `02-install-deps.sh`: `npm install` → `bun install` (+ comments and error codes)

### Guides
- `fresh-install.md`: `npm run auth` → `bun run auth`
- `troubleshooting.md`: `npm run auth` → `bun run auth`

## Verification

After changes, `grep -r 'npm\|npx' .claude/skills/setup/` returns zero matches.

## Test plan

- [ ] Verify `bun run auth` starts auth flow correctly
- [ ] Verify `bun run build` produces dist/ output
- [ ] Verify `bun install` installs key packages (baileys, better-sqlite3, pino, qrcode)
