### PR TITLE
fix: prevent negative active container count from duplicate idle notifications

### DIFF
--- a/src/group-queue.test.ts
+++ b/src/group-queue.test.ts
@@ -818,7 +818,9 @@ describe('GroupQueue', () => {
 
       // Invariant: active - idle must never be negative
       const stats = queue.getStats();
-      expect(stats.activeContainers - stats.idleContainers).toBeGreaterThanOrEqual(0);
+      expect(
+        stats.activeContainers - stats.idleContainers,
+      ).toBeGreaterThanOrEqual(0);
 
       processResolve!();
       await Bun.sleep(5);

--- a/src/group-queue.test.ts
+++ b/src/group-queue.test.ts
@@ -792,4 +792,41 @@ describe('GroupQueue', () => {
 
     expect(taskRunCount).toBe(1);
   });
+
+  describe('notifyIdle', () => {
+    it('should never let active - idle go negative after container exits', async () => {
+      let processResolve: (() => void) | null = null;
+      queue.setProcessMessagesFn(
+        () =>
+          new Promise<boolean>((resolve) => {
+            processResolve = () => resolve(true);
+          }),
+      );
+
+      queue.enqueueMessageCheck('group1@g.us');
+      await Bun.sleep(5);
+
+      expect(queue.getStats().activeContainers).toBe(1);
+
+      // Simulate multiple idle notifications from the same container
+      // (the IPC stream can emit multiple 'success' statuses).
+      // With MAX_IDLE_CONTAINERS=0, each notifyIdle triggers immediate preemption,
+      // but without the duplicate guard the idleCount could drift.
+      queue.notifyIdle('group1@g.us');
+      queue.notifyIdle('group1@g.us');
+      queue.notifyIdle('group1@g.us');
+
+      // Invariant: active - idle must never be negative
+      const stats = queue.getStats();
+      expect(stats.activeContainers - stats.idleContainers).toBeGreaterThanOrEqual(0);
+
+      processResolve!();
+      await Bun.sleep(5);
+
+      // After container exits, counts should be balanced
+      const final = queue.getStats();
+      expect(final.activeContainers).toBe(0);
+      expect(final.idleContainers).toBe(0);
+    });
+  });
 });

--- a/src/group-queue.ts
+++ b/src/group-queue.ts
@@ -316,6 +316,21 @@ export class GroupQueue {
   notifyIdle(groupJid: string): void {
     const state = this.getGroup(groupJid);
     const folderKey = this.resolveFolder(groupJid);
+
+    // Guard against duplicate idle notifications from the same container.
+    // The IPC stream can emit multiple 'success' statuses during a container's
+    // lifetime (idle → woken → idle again), each calling notifyIdle. Without
+    // this guard, idleCount drifts up because _clearIdleState only decrements
+    // once (gated on the boolean flag), causing negative "active containers"
+    // in the dashboard.
+    if (state.idleWaiting) {
+      logger.debug(
+        { groupJid, folderKey },
+        'notifyIdle: already idle, skipping duplicate',
+      );
+      return;
+    }
+
     state.idleWaiting = true;
     this.idleCount++;
     if (!this.idleGroups.includes(folderKey)) {
@@ -486,7 +501,7 @@ export class GroupQueue {
   ): Promise<void> {
     const state = this.getGroup(groupJid);
     state.messageActive = true;
-    state.idleWaiting = false;
+    this._clearIdleState(groupJid);
     // Remove this JID from pending (it's being processed now)
     state.pendingMessageJids = state.pendingMessageJids.filter(
       (j) => j !== groupJid,

--- a/src/web/dashboard.ts
+++ b/src/web/dashboard.ts
@@ -321,7 +321,7 @@ export function renderDashboard(state: WebStateProvider): string {
 <main>
   <div class="stats-grid">
     <div class="stat-card"><div class="label">Agents</div><div class="value" id="stat-agents">${agents.length}</div></div>
-    <div class="stat-card"><div class="label">Active Containers</div><div class="value" id="stat-active">${stats.activeContainers - stats.idleContainers}/${stats.maxActive}</div></div>
+    <div class="stat-card"><div class="label">Active Containers</div><div class="value" id="stat-active">${Math.max(0, stats.activeContainers - stats.idleContainers)}/${stats.maxActive}</div></div>
     <div class="stat-card"><div class="label">Idle Containers</div><div class="value" id="stat-idle">${stats.idleContainers}/${stats.maxIdle}</div></div>
     <div class="stat-card"><div class="label">Active Tasks</div><div class="value" id="stat-tasks">${tasks.filter((t) => t.status === 'active').length}</div></div>
   </div>
@@ -486,7 +486,7 @@ export function renderDashboard(state: WebStateProvider): string {
           var s = evt.data;
           var el = function(id) { return document.getElementById(id); };
           if (s.activeContainers != null && s.idleContainers != null && s.maxActive != null) {
-            el('stat-active').textContent = (s.activeContainers - s.idleContainers) + '/' + s.maxActive;
+            el('stat-active').textContent = Math.max(0, s.activeContainers - s.idleContainers) + '/' + s.maxActive;
           }
           if (s.idleContainers != null && s.maxIdle != null) {
             el('stat-idle').textContent = s.idleContainers + '/' + s.maxIdle;


### PR DESCRIPTION
## Summary

Fixes the web dashboard showing *-1 active containers* by preventing `idleCount` drift from duplicate idle notifications.

• `notifyIdle()` is called on every `status: 'success'` from the IPC stream, but containers can emit multiple success messages (idle → woken → idle). Each call incremented `idleCount` unconditionally, while `_clearIdleState` only decremented once (gated on the `idleWaiting` boolean). This caused `idleCount > activeCount` → negative display.
• Added early-return guard in `notifyIdle` when `state.idleWaiting` is already true
• Replaced direct `state.idleWaiting = false` in `runForGroup` with `_clearIdleState()` to prevent orphaned idle counts
• Added `Math.max(0, ...)` safety net in dashboard computation (both SSR and WebSocket paths)

## Test plan

- [x] Added regression test: multiple `notifyIdle` calls for same container → counts stay balanced
- [x] All 944 existing tests pass (0 failures)
- [ ] Manual verification: web dashboard no longer shows negative active containers

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Dashboard Active Containers stat now never shows negative values.
  * Idle notification handling now ignores duplicate idle events, preventing invalid container state transitions.

* **Tests**
  * Added tests that validate idle-notification behavior under repeated/ concurrent notifications to ensure counts remain non-negative and recover correctly.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->