### PR TITLE
test: add deterministic scheduler loop coverage

### DIFF
--- a/src/task-scheduler-loop.test.ts
+++ b/src/task-scheduler-loop.test.ts
@@ -13,6 +13,8 @@ const dueTasks: ScheduledTask[] = [
     schedule_value: '60000',
     context_mode: 'group',
     next_run: '2026-01-01T00:00:00.000Z',
+    last_run: null,
+    last_result: null,
     status: 'active',
     created_at: '2026-01-01T00:00:00.000Z',
   },
@@ -25,6 +27,8 @@ const dueTasks: ScheduledTask[] = [
     schedule_value: '2026-01-01T00:00:00.000Z',
     context_mode: 'isolated',
     next_run: '2026-01-01T00:00:00.000Z',
+    last_run: null,
+    last_result: null,
     status: 'active',
     created_at: '2026-01-01T00:00:00.000Z',
   },
@@ -118,21 +122,23 @@ describe('startSchedulerLoop', () => {
 
     const originalSetTimeout = globalThis.setTimeout;
     const originalClearTimeout = globalThis.clearTimeout;
+    type TimeoutHandler = Parameters<typeof setTimeout>[0];
 
-    (globalThis as { setTimeout: typeof setTimeout }).setTimeout = (
-      (_fn: TimerHandler, ms?: number) => {
-        timeoutCalls.push(ms ?? 0);
-        const token = timeoutTokens[timeoutIndex] ?? { id: timeoutIndex };
-        timeoutIndex += 1;
-        return token as unknown as ReturnType<typeof setTimeout>;
-      }
-    ) as typeof setTimeout;
+    (globalThis as { setTimeout: typeof setTimeout }).setTimeout = ((
+      _fn: TimeoutHandler,
+      ms?: number,
+    ) => {
+      timeoutCalls.push(ms ?? 0);
+      const token = timeoutTokens[timeoutIndex] ?? { id: timeoutIndex };
+      timeoutIndex += 1;
+      return token as unknown as ReturnType<typeof setTimeout>;
+    }) as typeof setTimeout;
 
-    (globalThis as { clearTimeout: typeof clearTimeout }).clearTimeout = (
-      (timeout: ReturnType<typeof setTimeout>) => {
-        clearedTimeouts.push(timeout);
-      }
-    ) as typeof clearTimeout;
+    (globalThis as { clearTimeout: typeof clearTimeout }).clearTimeout = ((
+      timeout: ReturnType<typeof setTimeout>,
+    ) => {
+      clearedTimeouts.push(timeout);
+    }) as typeof clearTimeout;
 
     try {
       const deps = {


### PR DESCRIPTION
## Summary
- Add `src/task-scheduler-loop.test.ts` with deterministic simulation + monkey-patch coverage for `startSchedulerLoop` and queued task execution callbacks.
- Mock scheduler dependencies (`db`, backend resolver, logger, snapshot writer) to validate active/paused/missing-group task handling without live containers.
- Verify duplicate loop-start protection, task pre-advancement, streamed output handling, and timer behavior (`SCHEDULER_POLL_INTERVAL` + task close delay).

## Test Count
- Before: `Ran 931 tests across 44 files.`
- After: `Ran 932 tests across 45 files.`

## Coverage Impact
- `src/task-scheduler.ts`: **0.00% funcs / 4.24% lines** -> **81.82% funcs / 89.53% lines**
- Overall repository coverage: **76.39% funcs / 71.68% lines** -> **77.71% funcs / 72.73% lines**

## Files Covered
- `src/task-scheduler.ts`

## Remaining Coverage Gaps
- Major low-coverage integration-heavy modules still include:
  - `src/index.ts`
  - `src/channels/discord.ts`
  - `src/channels/slack.ts`
  - `src/channels/telegram.ts`
  - `src/backends/local-backend.ts`

## Validation
- `bun test`
- `bun test --coverage`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added a comprehensive unit test suite for the task scheduler loop, validating scheduling, task enqueueing, timeout handling, idempotent startup, backend interaction, task state updates, and cleanup behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->