### PR TITLE
feat(router): inject channel roster context into messages

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -123,6 +123,10 @@ export const SESSION_MAX_AGE = parseInt(
   process.env.SESSION_MAX_AGE || '14400000',
   10,
 ); // 4 hours — rotate sessions to prevent unbounded context growth
+export const ROSTER_REFRESH_INTERVAL = parseInt(
+  process.env.ROSTER_REFRESH_INTERVAL || '900000',
+  10,
+); // 15min default — how often to refresh Discord guild rosters
 /** Max containers actively processing messages or tasks. */
 export const MAX_ACTIVE_CONTAINERS = Math.max(
   1,

--- a/src/formatting.test.ts
+++ b/src/formatting.test.ts
@@ -58,13 +58,21 @@ describe('escapeXml', () => {
 // --- formatMessages ---
 
 describe('formatMessages', () => {
-  it('formats a single message as XML with participants attribute', () => {
+  it('formats a single message as XML with participant attributes', () => {
     const result = formatMessages([makeMsg()]);
     expect(result).toBe(
-      '<messages participants="Alice">\n' +
+      '<messages excerpt_participants="Alice" participants="Alice">\n' +
         '<message id="1" sender="Alice" sender_id="123@s.whatsapp.net" time="2024-01-01T00:00:00.000Z">hello</message>\n' +
         '</messages>',
     );
+  });
+
+  it('includes channel_roster when provided', () => {
+    const result = formatMessages([makeMsg()], {
+      channelRosterNames: ['Alice', 'BotOne', 'Alice'],
+    });
+    expect(result).toContain('channel_roster="Alice, BotOne"');
+    expect(result).toContain('excerpt_participants="Alice"');
   });
 
   it('formats multiple messages with participants roster', () => {

--- a/src/index.ts
+++ b/src/index.ts
@@ -53,6 +53,7 @@ import {
   getAllTasks,
   getAllGuildRosters,
   getChatGuildId,
+  getGuildRoster,
   getMessagesSince,
   storeGuildRoster,
   getNewMessages,
@@ -761,6 +762,28 @@ async function refreshGuildRosters(
   }
 }
 
+function getChannelRosterNames(
+  chatJid: string,
+  explicitGuildId?: string,
+): string[] {
+  const guildId = explicitGuildId || getChatGuildId(chatJid);
+  if (!guildId) return [];
+
+  const members = getGuildRoster(guildId);
+  if (members.length === 0) return [];
+
+  const seen = new Set<string>();
+  const names: string[] = [];
+  for (const member of members) {
+    if (seen.has(member.userId)) continue;
+    seen.add(member.userId);
+    const display = (member.displayName || member.username || '').trim();
+    if (!display) continue;
+    names.push(display);
+  }
+  return names;
+}
+
 /**
  * Get available groups list for the agent.
  * Returns groups ordered by most recent activity.
@@ -848,7 +871,9 @@ async function processGroupMessages(dispatchJid: string): Promise<boolean> {
     messageCount: missedMessages.length,
   });
 
-  let prompt = formatMessages(missedMessages);
+  let prompt = formatMessages(missedMessages, {
+    channelRosterNames: getChannelRosterNames(chatJid, group.discordGuildId),
+  });
 
   // Inject context about active background tasks
   const activeTask = queue.getActiveTaskInfo(dispatchJid);
@@ -1530,7 +1555,12 @@ async function startMessageLoop(): Promise<void> {
             );
             if (allPending.length === 0) continue;
             const messagesToSend = allPending;
-            const formatted = formatMessages(messagesToSend);
+            const formatted = formatMessages(messagesToSend, {
+              channelRosterNames: getChannelRosterNames(
+                chatJid,
+                group.discordGuildId,
+              ),
+            });
 
             if (await queue.sendMessage(chatJid, formatted)) {
               logger.info(
@@ -1573,7 +1603,12 @@ async function startMessageLoop(): Promise<void> {
             );
             if (filteredPending.length === 0) continue;
             const messagesToSend = filteredPending;
-            const formatted = formatMessages(messagesToSend);
+            const formatted = formatMessages(messagesToSend, {
+              channelRosterNames: getChannelRosterNames(
+                chatJid,
+                sub.discordGuildId,
+              ),
+            });
 
             if (await queue.sendMessage(dispatchJid, formatted)) {
               logger.info(

--- a/src/index.ts
+++ b/src/index.ts
@@ -17,6 +17,7 @@ import {
   MAIN_GROUP_FOLDER,
   PERSISTENT_TASK_STATE,
   POLL_INTERVAL,
+  ROSTER_REFRESH_INTERVAL,
   SESSION_MAX_AGE,
   SLACK_APP_TOKEN,
   SLACK_BOT_TOKEN,
@@ -687,9 +688,6 @@ async function backfillDiscordGuildIds(discord: DiscordChannel): Promise<void> {
     );
   }
 }
-
-/** Roster refresh interval: 15 minutes. */
-const ROSTER_REFRESH_INTERVAL_MS = 15 * 60 * 1000;
 
 /**
  * Refresh Discord guild rosters by fetching members from all known guilds.
@@ -2189,7 +2187,7 @@ async function main(): Promise<void> {
         refreshGuildRosters(discordChannels).catch((err) => {
           logger.warn({ err }, 'Periodic guild roster refresh failed');
         });
-      }, ROSTER_REFRESH_INTERVAL_MS);
+      }, ROSTER_REFRESH_INTERVAL);
     }
     if (telegram) channels.push(telegram);
 

--- a/src/router.ts
+++ b/src/router.ts
@@ -11,7 +11,14 @@ export function escapeXml(s: string): string {
     .replace(/"/g, '&quot;');
 }
 
-export function formatMessages(messages: NewMessage[]): string {
+export interface FormatMessagesOptions {
+  channelRosterNames?: string[];
+}
+
+export function formatMessages(
+  messages: NewMessage[],
+  options: FormatMessagesOptions = {},
+): string {
   const lines = messages.map(
     (m) =>
       `<message id="${m.id}" sender="${escapeXml(m.sender_name)}" sender_id="${escapeXml(m.sender)}" time="${m.timestamp}">${escapeXml(m.content)}</message>`,
@@ -51,10 +58,25 @@ export function formatMessages(messages: NewMessage[]): string {
     );
   }
 
+  const attrs: string[] = [];
+  if (senders.length > 0) {
+    const roster = senders.map(escapeXml).join(', ');
+    attrs.push(`excerpt_participants="${roster}"`);
+    // Backward-compatible alias for existing prompts/parsers.
+    attrs.push(`participants="${roster}"`);
+  }
+
+  const uniqueRosterNames = Array.from(
+    new Set((options.channelRosterNames || []).filter(Boolean)),
+  );
+  if (uniqueRosterNames.length > 0) {
+    attrs.push(
+      `channel_roster="${uniqueRosterNames.map(escapeXml).join(', ')}"`,
+    );
+  }
+
   const header =
-    senders.length > 0
-      ? `<messages participants="${senders.map(escapeXml).join(', ')}">`
-      : '<messages>';
+    attrs.length > 0 ? `<messages ${attrs.join(' ')}>` : '<messages>';
 
   return `${header}\n${lines.join('\n')}\n</messages>`;
 }


### PR DESCRIPTION
## Summary
- Inject `channel_roster` into formatted `<messages ...>` envelopes so agents receive channel-level humans+bots context, not only excerpt-local senders.
- Clarify participant semantics by adding `excerpt_participants` while keeping backward-compatible `participants` for existing prompts/parsers.
- Wire roster lookup at all message formatting callsites so both queued and fresh dispatch paths include roster context when Discord guild roster cache is available.

## Why
Cross-instance visibility needs two layers: shared roster data (Phase 1 in #230) and prompt-level context usage. This PR is the Phase 1B consumer layer so agents can actually use the roster for reasoning and participant attribution.

## Changes
- `src/router.ts`
  - Add `FormatMessagesOptions` with `channelRosterNames`.
  - Add `excerpt_participants` attribute.
  - Keep legacy `participants` attribute for compatibility.
  - Add `channel_roster` attribute when roster names are available.
- `src/index.ts`
  - Add `getChannelRosterNames(chatJid, explicitGuildId?)` helper using cached guild roster data.
  - Pass roster names into `formatMessages(...)` in all dispatch paths.
- `src/formatting.test.ts`
  - Update exact-header assertion for `excerpt_participants` + compatibility `participants`.
  - Add coverage for `channel_roster` formatting and dedup behavior.

## Validation
- `bun run typecheck`
- `bun test src/formatting.test.ts`
- `bunx prettier --check src/router.ts src/index.ts src/formatting.test.ts`

## Notes
- This branch is intended as a follow-up stacked on top of #230.
- Full `bun test` has an existing unrelated failure in `src/schedule-utils-dst.test.ts` in this environment.
