### PR TITLE
refactor: unify 4-layer context resolution for Discord and Telegram

### DIFF
--- a/src/backends/local-backend.ts
+++ b/src/backends/local-backend.ts
@@ -225,13 +225,12 @@ function buildVolumeMounts(
     if (srvFolder) {
       const serverDir = path.join(GROUPS_DIR, srvFolder);
       assertPathWithin(serverDir, GROUPS_DIR, 'server folder');
-      if (fs.existsSync(serverDir)) {
-        mounts.push({
-          hostPath: serverDir,
-          containerPath: '/workspace/server',
-          readonly: false,
-        });
-      }
+      fs.mkdirSync(serverDir, { recursive: true });
+      mounts.push({
+        hostPath: serverDir,
+        containerPath: '/workspace/server',
+        readonly: false,
+      });
     }
   }
 

--- a/src/context-layers.test.ts
+++ b/src/context-layers.test.ts
@@ -1,0 +1,50 @@
+import { describe, expect, it } from 'bun:test';
+
+import { resolveContextLayers } from './context-layers.js';
+
+describe('resolveContextLayers', () => {
+  it('derives Discord server/category/channel layers', () => {
+    const layers = resolveContextLayers({
+      channelJid: 'dc:1234567890',
+      discordGuildId: '987654321',
+    });
+
+    expect(layers.serverFolder).toBe('servers/987654321');
+    expect(layers.categoryFolder).toBe('servers/987654321/channels');
+    expect(layers.channelFolder).toBe('servers/987654321/channels/1234567890');
+  });
+
+  it('respects explicit Discord folder overrides', () => {
+    const layers = resolveContextLayers({
+      channelJid: 'dc:1234567890',
+      discordGuildId: '987654321',
+      serverFolder: 'servers/custom',
+      categoryFolder: 'servers/custom/team-a',
+      channelFolder: 'servers/custom/team-a/spec',
+    });
+
+    expect(layers.serverFolder).toBe('servers/custom');
+    expect(layers.categoryFolder).toBe('servers/custom/team-a');
+    expect(layers.channelFolder).toBe('servers/custom/team-a/spec');
+  });
+
+  it('derives Telegram bot/chat layers from scoped JID', () => {
+    const layers = resolveContextLayers({
+      channelJid: 'tg:123456:-100123456789',
+    });
+
+    expect(layers.serverFolder).toBe('servers/tg-123456');
+    expect(layers.categoryFolder).toBe('servers/tg-123456/chats');
+    expect(layers.channelFolder).toBe('servers/tg-123456/chats/m100123456789');
+  });
+
+  it('does not auto-derive layers for legacy Telegram JID', () => {
+    const layers = resolveContextLayers({
+      channelJid: 'tg:-100123456789',
+    });
+
+    expect(layers.serverFolder).toBeUndefined();
+    expect(layers.categoryFolder).toBeUndefined();
+    expect(layers.channelFolder).toBeUndefined();
+  });
+});

--- a/src/context-layers.ts
+++ b/src/context-layers.ts
@@ -1,0 +1,65 @@
+export interface ContextLayerInput {
+  channelJid: string;
+  discordGuildId?: string;
+  serverFolder?: string;
+  categoryFolder?: string;
+  channelFolder?: string;
+}
+
+export interface ContextLayerOutput {
+  serverFolder?: string;
+  categoryFolder?: string;
+  channelFolder?: string;
+}
+
+export function resolveContextLayers(
+  input: ContextLayerInput,
+): ContextLayerOutput {
+  const discord = parseDiscordChannelJid(input.channelJid);
+  if (discord) {
+    const serverFolder =
+      input.serverFolder ||
+      (input.discordGuildId ? `servers/${input.discordGuildId}` : undefined);
+    const categoryFolder =
+      input.categoryFolder ||
+      (serverFolder && discord.channelId
+        ? `${serverFolder}/channels`
+        : undefined);
+    const channelFolder =
+      input.channelFolder ||
+      (categoryFolder && discord.channelId
+        ? `${categoryFolder}/${discord.channelId}`
+        : undefined);
+    return { serverFolder, categoryFolder, channelFolder };
+  }
+
+  const telegram = parseScopedTelegramJid(input.channelJid);
+  if (telegram) {
+    const serverFolder = input.serverFolder || `servers/tg-${telegram.botId}`;
+    const categoryFolder = input.categoryFolder || `${serverFolder}/chats`;
+    const chatSegment = telegram.chatId.replace(/^-/, 'm');
+    const channelFolder =
+      input.channelFolder || `${categoryFolder}/${chatSegment}`;
+    return { serverFolder, categoryFolder, channelFolder };
+  }
+
+  return {
+    serverFolder: input.serverFolder,
+    categoryFolder: input.categoryFolder,
+    channelFolder: input.channelFolder,
+  };
+}
+
+function parseDiscordChannelJid(jid: string): { channelId: string } | null {
+  const m = /^dc:(\d+)$/.exec(jid);
+  if (!m) return null;
+  return { channelId: m[1] };
+}
+
+function parseScopedTelegramJid(
+  jid: string,
+): { botId: string; chatId: string } | null {
+  const m = /^tg:([^:]+):(-?\d+)$/.exec(jid);
+  if (!m) return null;
+  return { botId: m[1], chatId: m[2] };
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -74,6 +74,7 @@ import {
   storeMessage,
 } from './db.js';
 import { buildAgentToChannelsMapFromSubscriptions } from './channel-routes.js';
+import { resolveContextLayers } from './context-layers.js';
 import { GroupQueue } from './group-queue.js';
 import { consumeShareRequest, startIpcWatcher } from './ipc.js';
 import {
@@ -241,6 +242,14 @@ function buildRegisteredGroupFromSubscription(
 
   const resolvedBotId = sub.discordBotId || fallback?.discordBotId;
   const runtimeDefault = getDiscordRuntimeDefault(resolvedBotId);
+  const discordGuildId = sub.discordGuildId || fallback?.discordGuildId;
+  const layers = resolveContextLayers({
+    channelJid,
+    discordGuildId,
+    serverFolder: agent?.serverFolder || fallback?.serverFolder,
+    categoryFolder: sub.categoryFolder || undefined,
+    channelFolder: sub.channelFolder || undefined,
+  });
   return {
     name: agent?.name || fallback?.name || sub.agentId,
     folder: agent?.folder || fallback?.folder || sub.agentId,
@@ -249,16 +258,16 @@ function buildRegisteredGroupFromSubscription(
     containerConfig: agent?.containerConfig || fallback?.containerConfig,
     requiresTrigger: sub.requiresTrigger,
     discordBotId: resolvedBotId,
-    discordGuildId: sub.discordGuildId || fallback?.discordGuildId,
-    serverFolder: agent?.serverFolder || fallback?.serverFolder,
+    discordGuildId,
+    serverFolder: layers.serverFolder,
     backend: agent?.backend || fallback?.backend || 'apple-container',
     agentRuntime:
       agent?.agentRuntime || fallback?.agentRuntime || runtimeDefault,
     description: agent?.description || fallback?.description,
     autoRespondToQuestions: fallback?.autoRespondToQuestions,
     autoRespondKeywords: fallback?.autoRespondKeywords,
-    channelFolder: sub.channelFolder || undefined,
-    categoryFolder: sub.categoryFolder || undefined,
+    channelFolder: layers.channelFolder,
+    categoryFolder: layers.categoryFolder,
     agentContextFolder: agent?.agentContextFolder || undefined,
   };
 }
@@ -426,6 +435,17 @@ function refreshRegisteredGroupsFromCanonicalState(): {
     const discordBotId =
       preferredSub?.discordBotId || route?.discordBotId || legacy?.discordBotId;
     const runtimeDefault = getDiscordRuntimeDefault(discordBotId);
+    const discordGuildId =
+      preferredSub?.discordGuildId ||
+      route?.discordGuildId ||
+      legacy?.discordGuildId;
+    const layers = resolveContextLayers({
+      channelJid: jid,
+      discordGuildId,
+      serverFolder: agent?.serverFolder || legacy?.serverFolder,
+      categoryFolder: preferredSub?.categoryFolder,
+      channelFolder: preferredSub?.channelFolder,
+    });
     nextGroups[jid] = {
       name: agent?.name || legacy?.name || agentId || jid,
       folder: agent?.folder || legacy?.folder || agentId || jid,
@@ -446,11 +466,8 @@ function refreshRegisteredGroupsFromCanonicalState(): {
         legacy?.requiresTrigger ??
         true,
       discordBotId,
-      discordGuildId:
-        preferredSub?.discordGuildId ||
-        route?.discordGuildId ||
-        legacy?.discordGuildId,
-      serverFolder: agent?.serverFolder || legacy?.serverFolder,
+      discordGuildId,
+      serverFolder: layers.serverFolder,
       backend: (agent?.backend ||
         legacy?.backend ||
         'apple-container') as BackendType,
@@ -459,8 +476,8 @@ function refreshRegisteredGroupsFromCanonicalState(): {
       description: agent?.description || legacy?.description,
       autoRespondToQuestions: legacy?.autoRespondToQuestions,
       autoRespondKeywords: legacy?.autoRespondKeywords,
-      channelFolder: preferredSub?.channelFolder,
-      categoryFolder: preferredSub?.categoryFolder,
+      channelFolder: layers.channelFolder,
+      categoryFolder: layers.categoryFolder,
       agentContextFolder: agent?.agentContextFolder,
     };
     synthesized++;


### PR DESCRIPTION
## Summary
- add a shared `resolveContextLayers` helper that derives server/category/channel folders from channel identity, with support for Discord (`dc:<channelId>`) and scoped Telegram (`tg:<botId>:<chatId>`)
- wire the helper into canonical group synthesis paths so Discord and Telegram both use the same 4-layer context resolution behavior
- ensure `/workspace/server` is always mounted when a `serverFolder` exists by creating the folder at mount time, preventing missing server context mounts
- add focused tests for Discord/Telegram derivation and override behavior in `src/context-layers.test.ts`

## Testing
- `bun run format:check`
- `bun test src/context-layers.test.ts src/channels/telegram.test.ts src/config.test.ts`
- `bun run build`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added folder path resolution that automatically derives server, channel, and category locations based on Discord guild and Telegram bot identifiers.

* **Bug Fixes**
  * Enhanced volume mount creation to ensure required server directories are always created and properly mounted.

* **Tests**
  * Added comprehensive test coverage for folder path resolution functionality, including Discord and Telegram support.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->