### PR TITLE
fix(security): block pre-approval share_request file transfer

### DIFF
--- a/src/ipc-processing.test.ts
+++ b/src/ipc-processing.test.ts
@@ -229,6 +229,49 @@ describe('processTaskIpc: share_request', () => {
 
     expect(sentMessages[0].text).toContain('← requested');
   });
+
+  it('includes shared and requested file lists for approval', async () => {
+    await processTaskIpc(
+      {
+        type: 'share_request',
+        description: 'Need files from teammate',
+        target_agent: 'third-group',
+        files: ['notes/context.md'],
+        request_files: ['data/snapshot.json'],
+      },
+      'other-group',
+      false,
+      deps,
+    );
+
+    expect(sentMessages).toHaveLength(1);
+    expect(sentMessages[0].text).toContain('Files shared');
+    expect(sentMessages[0].text).toContain('notes/context.md');
+    expect(sentMessages[0].text).toContain('Files requested');
+    expect(sentMessages[0].text).toContain('data/snapshot.json');
+    expect(sentMessages[0].text).toContain('React 👍 to approve');
+  });
+
+  it('drops traversal paths from share_request file lists', async () => {
+    await processTaskIpc(
+      {
+        type: 'share_request',
+        description: 'Need files',
+        target_agent: 'third-group',
+        files: ['safe.md', '../secrets.env'],
+        request_files: ['logs/out.txt', '../../etc/passwd'],
+      },
+      'other-group',
+      false,
+      deps,
+    );
+
+    expect(sentMessages).toHaveLength(1);
+    expect(sentMessages[0].text).toContain('safe.md');
+    expect(sentMessages[0].text).toContain('logs/out.txt');
+    expect(sentMessages[0].text).not.toContain('../secrets.env');
+    expect(sentMessages[0].text).not.toContain('../../etc/passwd');
+  });
 });
 
 // =============================================================================

--- a/src/ipc.ts
+++ b/src/ipc.ts
@@ -20,7 +20,6 @@ import {
   setRegisteredGroup,
   updateTask,
 } from './db.js';
-import { transferFiles } from './file-transfer.js';
 import { rejectTraversalSegments } from './path-security.js';
 import {
   findGroupByFolder,
@@ -856,9 +855,10 @@ export async function processTaskIpc(
       let sharedFiles: string[] = [];
       let requestedFiles: string[] = [];
 
-      // If files are specified with a target_agent, do the file transfer
-      if (data.target_agent && data.files && data.files.length > 0) {
-        // Validate all file paths before transfer (defense-in-depth)
+      // Validate file-share paths for display and approval context.
+      // IMPORTANT: Do not transfer files here. Transfers before approval can
+      // leak data cross-agent if the request is denied.
+      if (data.files && data.files.length > 0) {
         const validFiles: string[] = [];
         for (const file of data.files) {
           try {
@@ -871,38 +871,12 @@ export async function processTaskIpc(
             );
           }
         }
-
-        const targetGroupEntry = findGroupByFolder(
-          registeredGroups,
-          data.target_agent!,
-        );
-        if (targetGroupEntry && sourceGroupEntry && validFiles.length > 0) {
-          const result = await transferFiles({
-            sourceGroup: sourceGroupEntry[1],
-            targetGroup: targetGroupEntry[1],
-            files: validFiles,
-            direction: 'push',
-          });
-          logger.info(
-            {
-              sourceGroup,
-              targetAgent: data.target_agent,
-              transferred: result.transferred,
-              errors: result.errors,
-            },
-            'Share request file transfer completed',
-          );
-        }
         sharedFiles = validFiles;
       }
 
-      // If request_files are specified, pull files from target to source
-      if (
-        data.target_agent &&
-        data.request_files &&
-        data.request_files.length > 0
-      ) {
-        // Validate all requested file paths (defense-in-depth)
+      // Validate requested file paths for display and approval context.
+      // IMPORTANT: Do not pull files here for the same pre-approval reason.
+      if (data.request_files && data.request_files.length > 0) {
         const validRequestFiles: string[] = [];
         for (const file of data.request_files) {
           try {
@@ -914,31 +888,6 @@ export async function processTaskIpc(
               'Rejected share_request request_files path',
             );
           }
-        }
-
-        const targetGroupEntry = findGroupByFolder(
-          registeredGroups,
-          data.target_agent!,
-        );
-        if (
-          targetGroupEntry &&
-          sourceGroupEntry &&
-          validRequestFiles.length > 0
-        ) {
-          const result = await transferFiles({
-            sourceGroup: targetGroupEntry[1],
-            targetGroup: sourceGroupEntry[1],
-            files: validRequestFiles,
-            direction: 'push',
-          });
-          logger.info(
-            {
-              sourceGroup,
-              targetAgent: data.target_agent,
-              transferred: result.transferred,
-            },
-            'Share request file pull completed',
-          );
         }
         requestedFiles = validRequestFiles;
       }


### PR DESCRIPTION
## Summary
- Blocks pre-approval file movement in `share_request` to prevent cross-agent data exfiltration when a request is denied.
- Keeps path validation and includes sanitized `files` / `request_files` in the approval prompt so reviewers still see exactly what was requested.
- Adds IPC tests that cover file list rendering and traversal-path filtering in `share_request` messages.

## Security
- Fixes #217
- Severity: P0 / High

## Testing
- `bun test src/ipc-processing.test.ts`
- `bun run typecheck` *(currently fails due unrelated local untracked test files: `src/task-scheduler-controls.test.ts` importing non-existent exports)*


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * File transfers now require explicit approval before initiating the exchange.
  * Unsafe file path patterns are sanitized in shared and requested file lists for improved security.

* **Tests**
  * Added comprehensive test coverage for the file transfer approval workflow and path validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->