### PR TITLE
fix(discord): log message ID on send, warn when no chunks sent

### DIFF
--- a/src/channels/discord.ts
+++ b/src/channels/discord.ts
@@ -276,10 +276,17 @@ export class DiscordChannel implements Channel {
         }
         lastMessageId = sent.id;
       }
-      logger.info(
-        { jid, length: normalizedText.length },
-        'Discord message sent',
-      );
+      if (lastMessageId) {
+        logger.info(
+          { jid, length: normalizedText.length, messageId: lastMessageId },
+          'Discord message sent',
+        );
+      } else {
+        logger.warn(
+          { jid, length: normalizedText.length },
+          'Discord sendMessage: no chunks were sent',
+        );
+      }
       this.ownedJids.add(jid);
       return lastMessageId;
     } catch (err) {


### PR DESCRIPTION
## Summary

- Adds `messageId` to the `'Discord message sent'` log entry so a delivered message can be looked up in Discord's audit log if it doesn't appear visually
- Guards the success log behind `lastMessageId` being truthy — previously the info log would fire even if `splitMessage` returned no chunks and nothing was actually sent

## Context

Investigated a case where a message appeared to silently fail (showed in agent-runner logs but not in Discord). The Discord API returned success, so this adds a traceable message ID to confirm delivery and surfaces the zero-chunk edge case as a warning.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Discord message sending reliability by adding detailed logging for chunked messages, including message IDs in success cases and warnings when message chunks fail to deliver.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->