### PR TITLE
Scope Discord channel roster to current channel and add role filtering

### DIFF
--- a/src/channels/discord.ts
+++ b/src/channels/discord.ts
@@ -12,6 +12,7 @@ import {
   DMChannel,
   ChannelType,
   ThreadAutoArchiveDuration,
+  PermissionFlagsBits,
   type ThreadChannel,
 } from 'discord.js';
 import { RESTEvents } from '@discordjs/rest';
@@ -410,6 +411,67 @@ export class DiscordChannel implements Channel {
       };
     } catch (err) {
       logger.warn({ guildId, err }, 'Failed to fetch guild roster');
+      return null;
+    }
+  }
+
+  /**
+   * Fetch members who can view a specific Discord channel.
+   * Used to keep model-side channel roster context scoped to the active channel.
+   */
+  async fetchChannelRoster(jid: string): Promise<
+    Array<{
+      id: string;
+      username: string;
+      displayName: string;
+      roles: string[];
+      isBot: boolean;
+    }> | null
+  > {
+    const channelId = jidToChannelId(jid);
+    if (!channelId) return null;
+
+    try {
+      const channel = await this.client.channels.fetch(channelId);
+      if (!channel || !('guild' in channel) || !('permissionsFor' in channel)) {
+        return null;
+      }
+
+      const guild = channel.guild;
+      const members = await guild.members.fetch();
+
+      const visible: Array<{
+        id: string;
+        username: string;
+        displayName: string;
+        roles: string[];
+        isBot: boolean;
+      }> = [];
+
+      for (const [, member] of members) {
+        const canView = channel
+          .permissionsFor(member)
+          ?.has(PermissionFlagsBits.ViewChannel);
+        if (!canView) continue;
+
+        visible.push({
+          id: member.id,
+          username: member.user.username,
+          displayName:
+            member.displayName ||
+            member.user.displayName ||
+            member.user.username,
+          roles: member.roles.cache
+            .filter((r) => r.name !== '@everyone')
+            .map((r) => r.name),
+          isBot: member.user.bot,
+        });
+      }
+
+      visible.sort((a, b) => a.displayName.localeCompare(b.displayName));
+      return visible;
+    } catch (err) {
+      logger.warn({ jid, err }, 'Failed to fetch Discord channel roster');
       return null;
     }
   }

--- a/src/config.ts
+++ b/src/config.ts
@@ -156,6 +156,10 @@ export const CHANNEL_ROSTER_SCOPE = parseChannelRosterScope(
 export const CHANNEL_ROSTER_ROLE_FILTERS = parseEnvList(
   process.env.CHANNEL_ROSTER_ROLE_FILTERS,
 ).map((role) => role.toLowerCase());
+export const CHANNEL_ROSTER_CACHE_TTL_MS = parseInt(
+  process.env.CHANNEL_ROSTER_CACHE_TTL_MS || '300000',
+  10,
+);
 /** Max containers actively processing messages or tasks. */
 export const MAX_ACTIVE_CONTAINERS = Math.max(
   1,

--- a/src/config.ts
+++ b/src/config.ts
@@ -140,6 +140,22 @@ export const ROSTER_REFRESH_INTERVAL = parseInt(
   process.env.ROSTER_REFRESH_INTERVAL || '900000',
   10,
 ); // 15min default — how often to refresh Discord guild rosters
+
+export type ChannelRosterScope = 'channel' | 'guild';
+
+function parseChannelRosterScope(
+  value: string | undefined,
+): ChannelRosterScope {
+  return value?.toLowerCase() === 'guild' ? 'guild' : 'channel';
+}
+
+export const CHANNEL_ROSTER_SCOPE = parseChannelRosterScope(
+  process.env.CHANNEL_ROSTER_SCOPE,
+);
+
+export const CHANNEL_ROSTER_ROLE_FILTERS = parseEnvList(
+  process.env.CHANNEL_ROSTER_ROLE_FILTERS,
+).map((role) => role.toLowerCase());
 /** Max containers actively processing messages or tasks. */
 export const MAX_ACTIVE_CONTAINERS = Math.max(
   1,

--- a/src/formatting.test.ts
+++ b/src/formatting.test.ts
@@ -75,6 +75,14 @@ describe('formatMessages', () => {
     expect(result).toContain('excerpt_participants="Alice"');
   });
 
+  it('marks channel roster role labels as unavailable when requested', () => {
+    const result = formatMessages([makeMsg()], {
+      channelRosterNames: ['Alice', 'BotOne'],
+      channelRosterHasRoleLabels: false,
+    });
+    expect(result).toContain('channel_roster_roles="unavailable"');
+  });
+
   it('formats multiple messages with participants roster', () => {
     const msgs = [
       makeMsg({

--- a/src/index.ts
+++ b/src/index.ts
@@ -5,6 +5,8 @@ import { createHash } from 'crypto';
 import {
   ASSISTANT_NAME,
   buildTriggerPattern,
+  CHANNEL_ROSTER_ROLE_FILTERS,
+  CHANNEL_ROSTER_SCOPE,
   DATA_DIR,
   DISPATCH_RUNTIME_SEP,
   DISCORD_BOTS,
@@ -188,6 +190,27 @@ const MAX_CHANNEL_AGENT_FANOUT = parseInt(
   10,
 );
 const DISPATCH_KEY_SEP = '::agent::';
+const CHANNEL_ROSTER_CACHE_TTL_MS = 5 * 60 * 1000;
+
+interface ChannelRosterMemberView {
+  userId: string;
+  displayName: string;
+  roles: string[];
+}
+
+interface ChannelRosterOptions {
+  scope?: 'channel' | 'guild';
+  roleFilters?: string[];
+  discordBotId?: string;
+}
+
+const channelRosterCache = new Map<
+  string,
+  {
+    expiresAt: number;
+    members: ChannelRosterMemberView[];
+  }
+>();
 
 function makeDispatchKey(channelJid: string, agentId: string): string {
   return `${channelJid}${DISPATCH_KEY_SEP}${agentId}`;
@@ -815,26 +838,90 @@ async function refreshGuildRosters(
   }
 }
 
-function getChannelRosterNames(
+async function getChannelRosterNames(
   chatJid: string,
   explicitGuildId?: string,
-): string[] {
+  options: ChannelRosterOptions = {},
+): Promise<string[]> {
   const guildId = explicitGuildId || getChatGuildId(chatJid);
   if (!guildId) return [];
 
-  const members = getGuildRoster(guildId);
-  if (members.length === 0) return [];
+  const scope = options.scope || CHANNEL_ROSTER_SCOPE;
+  const roleFilters =
+    options.roleFilters && options.roleFilters.length > 0
+      ? options.roleFilters
+      : CHANNEL_ROSTER_ROLE_FILTERS;
+  const normalizedRoleFilters = roleFilters
+    .map((r) => r.trim().toLowerCase())
+    .filter(Boolean);
 
+  const cacheKey = [
+    guildId,
+    chatJid,
+    scope,
+    options.discordBotId || '',
+    normalizedRoleFilters.join(','),
+  ].join('::');
+  const cached = channelRosterCache.get(cacheKey);
+  if (cached && cached.expiresAt > Date.now()) {
+    return cached.members.map((m) => m.displayName);
+  }
+
+  let members: ChannelRosterMemberView[] = [];
+
+  if (scope === 'channel' && chatJid.startsWith('dc:')) {
+    const discord = findChannelForJid(
+      chatJid,
+      getPreferredChannelBotId(chatJid, options.discordBotId),
+    );
+    if (discord instanceof DiscordChannel) {
+      const visibleMembers = await discord.fetchChannelRoster(chatJid);
+      if (visibleMembers && visibleMembers.length > 0) {
+        members = visibleMembers.map((m) => ({
+          userId: m.id,
+          displayName: (m.displayName || m.username || '').trim(),
+          roles: m.roles || [],
+        }));
+      }
+    }
+  }
+
+  if (members.length === 0) {
+    members = getGuildRoster(guildId).map((member) => ({
+      userId: member.userId,
+      displayName: (member.displayName || member.username || '').trim(),
+      roles: member.roles || [],
+    }));
+  }
+
+  const roleFilterSet = new Set(normalizedRoleFilters);
   const seen = new Set<string>();
-  const names: string[] = [];
+  const filtered: ChannelRosterMemberView[] = [];
+
   for (const member of members) {
+    if (!member.displayName) continue;
     if (seen.has(member.userId)) continue;
     seen.add(member.userId);
-    const display = (member.displayName || member.username || '').trim();
-    if (!display) continue;
-    names.push(display);
+
+    if (roleFilterSet.size > 0) {
+      const normalizedMemberRoles = (member.roles || []).map((r) =>
+        r.toLowerCase(),
+      );
+      const hasMatchingRole = normalizedMemberRoles.some((role) =>
+        roleFilterSet.has(role),
+      );
+      if (!hasMatchingRole) continue;
+    }
+
+    filtered.push(member);
   }
-  return names;
+
+  channelRosterCache.set(cacheKey, {
+    members: filtered,
+    expiresAt: Date.now() + CHANNEL_ROSTER_CACHE_TTL_MS,
+  });
+
+  return filtered.map((m) => m.displayName);
 }
 
 /**
@@ -926,7 +1013,14 @@ async function processGroupMessages(dispatchJid: string): Promise<boolean> {
   });
 
   let prompt = formatMessages(missedMessages, {
-    channelRosterNames: getChannelRosterNames(chatJid, group.discordGuildId),
+    channelRosterNames: await getChannelRosterNames(
+      chatJid,
+      group.discordGuildId,
+      {
+        discordBotId: group.discordBotId,
+      },
+    ),
+    channelRosterHasRoleLabels: false,
   });
 
   // Inject context about active background tasks
@@ -1616,10 +1710,14 @@ async function startMessageLoop(): Promise<void> {
             if (allPending.length === 0) continue;
             const messagesToSend = allPending;
             const formatted = formatMessages(messagesToSend, {
-              channelRosterNames: getChannelRosterNames(
+              channelRosterNames: await getChannelRosterNames(
                 chatJid,
                 group.discordGuildId,
+                {
+                  discordBotId: group.discordBotId,
+                },
               ),
+              channelRosterHasRoleLabels: false,
             });
 
             if (await queue.sendMessage(chatJid, formatted)) {
@@ -1667,10 +1765,14 @@ async function startMessageLoop(): Promise<void> {
             if (filteredPending.length === 0) continue;
             const messagesToSend = filteredPending;
             const formatted = formatMessages(messagesToSend, {
-              channelRosterNames: getChannelRosterNames(
+              channelRosterNames: await getChannelRosterNames(
                 chatJid,
                 sub.discordGuildId,
+                {
+                  discordBotId: sub.discordBotId,
+                },
               ),
+              channelRosterHasRoleLabels: false,
             });
 
             if (await queue.sendMessage(dispatchJid, formatted)) {

--- a/src/index.ts
+++ b/src/index.ts
@@ -5,6 +5,7 @@ import { createHash } from 'crypto';
 import {
   ASSISTANT_NAME,
   buildTriggerPattern,
+  CHANNEL_ROSTER_CACHE_TTL_MS,
   CHANNEL_ROSTER_ROLE_FILTERS,
   CHANNEL_ROSTER_SCOPE,
   DATA_DIR,
@@ -190,7 +191,6 @@ const MAX_CHANNEL_AGENT_FANOUT = parseInt(
   10,
 );
 const DISPATCH_KEY_SEP = '::agent::';
-const CHANNEL_ROSTER_CACHE_TTL_MS = 5 * 60 * 1000;
 
 interface ChannelRosterMemberView {
   userId: string;
@@ -844,8 +844,6 @@ async function getChannelRosterNames(
   options: ChannelRosterOptions = {},
 ): Promise<string[]> {
   const guildId = explicitGuildId || getChatGuildId(chatJid);
-  if (!guildId) return [];
-
   const scope = options.scope || CHANNEL_ROSTER_SCOPE;
   const roleFilters =
     options.roleFilters && options.roleFilters.length > 0
@@ -854,12 +852,13 @@ async function getChannelRosterNames(
   const normalizedRoleFilters = roleFilters
     .map((r) => r.trim().toLowerCase())
     .filter(Boolean);
+  const preferredBotId = getPreferredChannelBotId(chatJid, options.discordBotId);
 
   const cacheKey = [
-    guildId,
+    guildId || '__no_guild__',
     chatJid,
     scope,
-    options.discordBotId || '',
+    preferredBotId || '',
     normalizedRoleFilters.join(','),
   ].join('::');
   const cached = channelRosterCache.get(cacheKey);
@@ -869,10 +868,24 @@ async function getChannelRosterNames(
 
   let members: ChannelRosterMemberView[] = [];
 
-  if (scope === 'channel' && chatJid.startsWith('dc:')) {
+  if (!guildId) {
+    const discord = findChannelForJid(chatJid, preferredBotId);
+    if (discord instanceof DiscordChannel) {
+      const visibleMembers = await discord.fetchChannelRoster(chatJid);
+      if (visibleMembers && visibleMembers.length > 0) {
+        members = visibleMembers.map((m) => ({
+          userId: m.id,
+          displayName: (m.displayName || m.username || '').trim(),
+          roles: m.roles || [],
+        }));
+      }
+    }
+  }
+
+  if (guildId && scope === 'channel' && chatJid.startsWith('dc:')) {
     const discord = findChannelForJid(
       chatJid,
-      getPreferredChannelBotId(chatJid, options.discordBotId),
+      preferredBotId,
     );
     if (discord instanceof DiscordChannel) {
       const visibleMembers = await discord.fetchChannelRoster(chatJid);
@@ -886,7 +899,27 @@ async function getChannelRosterNames(
     }
   }
 
-  if (members.length === 0) {
+  if (guildId && members.length === 0) {
+    const preferredDiscord = findChannelForJid(chatJid, preferredBotId);
+    if (preferredDiscord instanceof DiscordChannel) {
+      const preferredRoster = await preferredDiscord.fetchGuildRoster(guildId);
+      if (preferredRoster) {
+        const preferredMembers = [
+          ...preferredRoster.humans,
+          ...preferredRoster.bots,
+        ].map((member) => ({
+          userId: member.id,
+          displayName: (member.displayName || member.username || '').trim(),
+          roles: member.roles || [],
+        }));
+        if (preferredMembers.length > 0) {
+          members = preferredMembers;
+        }
+      }
+    }
+  }
+
+  if (guildId && members.length === 0) {
     members = getGuildRoster(guildId).map((member) => ({
       userId: member.userId,
       displayName: (member.displayName || member.username || '').trim(),

--- a/src/router.ts
+++ b/src/router.ts
@@ -13,6 +13,7 @@ export function escapeXml(s: string): string {
 
 export interface FormatMessagesOptions {
   channelRosterNames?: string[];
+  channelRosterHasRoleLabels?: boolean;
 }
 
 export function formatMessages(
@@ -73,6 +74,9 @@ export function formatMessages(
     attrs.push(
       `channel_roster="${uniqueRosterNames.map(escapeXml).join(', ')}"`,
     );
+    if (options.channelRosterHasRoleLabels === false) {
+      attrs.push('channel_roster_roles="unavailable"');
+    }
   }
 
   const header =


### PR DESCRIPTION
## Summary
- Default `channel_roster` context to members visible in the current Discord channel instead of the full guild roster, with a guild-level fallback when channel membership cannot be fetched.
- Add configurable role-based filtering (`CHANNEL_ROSTER_ROLE_FILTERS`) and scope control (`CHANNEL_ROSTER_SCOPE=channel|guild`) so roster context can be limited to specific labels (for example `LLC` and `AGENT`).
- Make role-label limitations explicit in prompt context by adding `channel_roster_roles=\"unavailable\"` when only names are provided, so agents do not assume per-user role labels are available.

## Validation
- `bun test src/formatting.test.ts src/channels/discord.test.ts src/config.test.ts`
- `bun run build`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Channel member roster with scope and role-based filtering, per-bot context awareness, and caching for faster lookups.
  * New configuration options to control roster scope, role filters, and roster cache TTL.
  * Message header now indicates when roster role labels are unavailable.

* **Tests**
  * Added coverage for roster role label availability scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->