### PR TITLE
feat(discord): show roles in channel roster + per-agent role filters

### DIFF
--- a/src/db.ts
+++ b/src/db.ts
@@ -49,6 +49,7 @@ interface AgentRow {
   server_folder: string | null;
   created_at: string;
   agent_context_folder: string | null;
+  roster_role_filters: string | null;
 }
 
 /** Row type for channel_routes table SELECT * queries */
@@ -153,6 +154,9 @@ function mapRowToAgent(row: AgentRow): Agent {
     serverFolder: row.server_folder || undefined,
     createdAt: row.created_at,
     agentContextFolder: row.agent_context_folder || undefined,
+    rosterRoleFilters: row.roster_role_filters
+      ? row.roster_role_filters.split(',').map((r) => r.trim()).filter(Boolean)
+      : undefined,
   };
 }
 
@@ -440,6 +444,7 @@ export function createSchema(database: Database): void {
 
   // New context layer columns (agent/server/category/channel architecture)
   addColumnIfNotExists(database, 'agents', 'agent_context_folder', 'TEXT');
+  addColumnIfNotExists(database, 'agents', 'roster_role_filters', 'TEXT');
   addColumnIfNotExists(
     database,
     'channel_subscriptions',
@@ -1341,8 +1346,8 @@ export function getAllAgents(): Record<string, Agent> {
 export function setAgent(agent: Agent): void {
   db.query(
     `
-    INSERT OR REPLACE INTO agents (id, name, description, folder, backend, agent_runtime, container_config, is_admin, server_folder, created_at, agent_context_folder)
-    VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+    INSERT OR REPLACE INTO agents (id, name, description, folder, backend, agent_runtime, container_config, is_admin, server_folder, created_at, agent_context_folder, roster_role_filters)
+    VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
   `,
   ).run(
     agent.id,
@@ -1356,6 +1361,7 @@ export function setAgent(agent: Agent): void {
     agent.serverFolder || null,
     agent.createdAt,
     agent.agentContextFolder || null,
+    agent.rosterRoleFilters?.join(',') || null,
   );
 }
 

--- a/src/db.ts
+++ b/src/db.ts
@@ -138,6 +138,16 @@ function mapRowToRegisteredGroup(
 
 /** Map a database row to an Agent object */
 function mapRowToAgent(row: AgentRow): Agent {
+  const rosterRoleFilters =
+    row.roster_role_filters === null
+      ? undefined
+      : row.roster_role_filters === ''
+        ? []
+        : row.roster_role_filters
+            .split(',')
+            .map((r) => r.trim())
+            .filter(Boolean);
+
   return {
     id: row.id,
     name: row.name,
@@ -154,9 +164,7 @@ function mapRowToAgent(row: AgentRow): Agent {
     serverFolder: row.server_folder || undefined,
     createdAt: row.created_at,
     agentContextFolder: row.agent_context_folder || undefined,
-    rosterRoleFilters: row.roster_role_filters
-      ? row.roster_role_filters.split(',').map((r) => r.trim()).filter(Boolean)
-      : undefined,
+    rosterRoleFilters,
   };
 }
 
@@ -1361,7 +1369,9 @@ export function setAgent(agent: Agent): void {
     agent.serverFolder || null,
     agent.createdAt,
     agent.agentContextFolder || null,
-    agent.rosterRoleFilters?.join(',') || null,
+    agent.rosterRoleFilters === undefined
+      ? null
+      : agent.rosterRoleFilters.join(','),
   );
 }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -206,6 +206,15 @@ interface ChannelRosterOptions {
   agentFolder?: string;
 }
 
+function formatChannelRosterNames(members: ChannelRosterMemberView[]): string[] {
+  return members.map((member) => {
+    if (member.roles.length > 0) {
+      return `${member.displayName} [${member.roles.join(', ')}]`;
+    }
+    return member.displayName;
+  });
+}
+
 const channelRosterCache = new Map<
   string,
   {
@@ -847,13 +856,13 @@ async function getChannelRosterNames(
   const guildId = explicitGuildId || getChatGuildId(chatJid);
   const scope = options.scope || CHANNEL_ROSTER_SCOPE;
   const agentRoleFilters =
-    options.agentFolder
-      ? (getAgent(options.agentFolder)?.rosterRoleFilters ?? [])
-      : [];
+    options.agentFolder !== undefined
+      ? getAgent(options.agentFolder)?.rosterRoleFilters
+      : undefined;
   const roleFilters =
-    options.roleFilters && options.roleFilters.length > 0
+    options.roleFilters !== undefined
       ? options.roleFilters
-      : agentRoleFilters.length > 0
+      : agentRoleFilters !== undefined
         ? agentRoleFilters
         : CHANNEL_ROSTER_ROLE_FILTERS;
   const normalizedRoleFilters = roleFilters
@@ -870,7 +879,7 @@ async function getChannelRosterNames(
   ].join('::');
   const cached = channelRosterCache.get(cacheKey);
   if (cached && cached.expiresAt > Date.now()) {
-    return cached.members.map((m) => m.displayName);
+    return formatChannelRosterNames(cached.members);
   }
 
   let members: ChannelRosterMemberView[] = [];
@@ -961,10 +970,7 @@ async function getChannelRosterNames(
     expiresAt: Date.now() + CHANNEL_ROSTER_CACHE_TTL_MS,
   });
 
-  return filtered.map((m) => {
-    if (m.roles.length > 0) return `${m.displayName} [${m.roles.join(', ')}]`;
-    return m.displayName;
-  });
+  return formatChannelRosterNames(filtered);
 }
 
 /**

--- a/src/index.ts
+++ b/src/index.ts
@@ -62,6 +62,7 @@ import {
   storeGuildRoster,
   getNewMessages,
   getRouterState,
+  getAgent,
   getTaskById,
   createTask as dbCreateTask,
   updateTask as dbUpdateTask,
@@ -201,6 +202,8 @@ interface ChannelRosterOptions {
   scope?: 'channel' | 'guild';
   roleFilters?: string[];
   discordBotId?: string;
+  /** Agent folder (= agent ID) — used to load per-agent roster_role_filters from DB. */
+  agentFolder?: string;
 }
 
 const channelRosterCache = new Map<
@@ -843,10 +846,16 @@ async function getChannelRosterNames(
 ): Promise<string[]> {
   const guildId = explicitGuildId || getChatGuildId(chatJid);
   const scope = options.scope || CHANNEL_ROSTER_SCOPE;
+  const agentRoleFilters =
+    options.agentFolder
+      ? (getAgent(options.agentFolder)?.rosterRoleFilters ?? [])
+      : [];
   const roleFilters =
     options.roleFilters && options.roleFilters.length > 0
       ? options.roleFilters
-      : CHANNEL_ROSTER_ROLE_FILTERS;
+      : agentRoleFilters.length > 0
+        ? agentRoleFilters
+        : CHANNEL_ROSTER_ROLE_FILTERS;
   const normalizedRoleFilters = roleFilters
     .map((r) => r.trim().toLowerCase())
     .filter(Boolean);
@@ -952,7 +961,10 @@ async function getChannelRosterNames(
     expiresAt: Date.now() + CHANNEL_ROSTER_CACHE_TTL_MS,
   });
 
-  return filtered.map((m) => m.displayName);
+  return filtered.map((m) => {
+    if (m.roles.length > 0) return `${m.displayName} [${m.roles.join(', ')}]`;
+    return m.displayName;
+  });
 }
 
 /**
@@ -1049,9 +1061,10 @@ async function processGroupMessages(dispatchJid: string): Promise<boolean> {
       group.discordGuildId,
       {
         discordBotId: group.discordBotId,
+        agentFolder: group.folder,
       },
     ),
-    channelRosterHasRoleLabels: false,
+    channelRosterHasRoleLabels: true,
   });
 
   // Inject context about active background tasks
@@ -1746,9 +1759,10 @@ async function startMessageLoop(): Promise<void> {
                 group.discordGuildId,
                 {
                   discordBotId: group.discordBotId,
+                  agentFolder: group.folder,
                 },
               ),
-              channelRosterHasRoleLabels: false,
+              channelRosterHasRoleLabels: true,
             });
 
             if (await queue.sendMessage(chatJid, formatted)) {
@@ -1801,9 +1815,10 @@ async function startMessageLoop(): Promise<void> {
                 sub.discordGuildId,
                 {
                   discordBotId: sub.discordBotId,
+                  agentFolder: sub.agentId,
                 },
               ),
-              channelRosterHasRoleLabels: false,
+              channelRosterHasRoleLabels: true,
             });
 
             if (await queue.sendMessage(dispatchJid, formatted)) {

--- a/src/types.ts
+++ b/src/types.ts
@@ -202,6 +202,8 @@ export interface Agent {
   createdAt: string;
   /** Agent identity + global notes folder, mounted read-write at /workspace/agent/. */
   agentContextFolder?: string; // e.g., 'agents/peytonomi'
+  /** Roles required to appear in this agent's channel roster context. Empty = no filter. */
+  rosterRoleFilters?: string[];
 }
 
 /**


### PR DESCRIPTION
## Summary

- **Role labels in context**: `channel_roster` prompt attribute now includes role labels — e.g. `"Peyton [AGENTS, LLC], Clayton [AGENTS]"`. `channelRosterHasRoleLabels` flipped to `true` so agents know roles are available (previously they'd report "roles unavailable").
- **Per-agent role filters in DB**: New `roster_role_filters TEXT` column on the `agents` table (auto-migrated). Accepts a comma-separated list of role names. When set, only members with at least one matching role appear in the channel roster for that agent.
- **Priority chain**: explicit call-site filters → agent DB filters → `CHANNEL_ROSTER_ROLE_FILTERS` env var → no filter (show all visible members).

## Why

Agents couldn't distinguish humans from other agents by role, and there was no way to configure different roster audiences per agent without a global env var.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Agents can now have personalized roster role filters to control which members appear in their channel context.
  * Channel rosters now display role labels alongside member names when agent-specific filters are configured.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->