### PR TITLE
feat(justfile): add update, update-js, update-container commands

### DIFF
--- a/Justfile
+++ b/Justfile
@@ -46,6 +46,21 @@ build-all:
     just build
     just build-container
 
+# Update everything: rebuild JS + container, then restart
+update:
+    just build-all
+    just restart
+
+# Update JS only: rebuild host, then restart (no container rebuild)
+update-js:
+    just build
+    just restart
+
+# Update container only: rebuild container image, then restart
+update-container:
+    just build-container
+    just restart
+
 # Tail OmniClaw logs (pretty-printed)
 tail:
     tail -f logs/omniclaw.log | ./scripts/log-fmt.sh


### PR DESCRIPTION
## Summary
- Adds `just update` (full rebuild + restart), `just update-js` (host JS only + restart), and `just update-container` (container image only + restart)
- Eliminates the common mistake of running `just restart` after pulling changes without rebuilding first

## Test plan
- [ ] `just update-js` rebuilds host and restarts
- [ ] `just update-container` rebuilds container image and restarts
- [ ] `just update` does both + restarts

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added three new update commands to streamline service maintenance and deployment workflows. Each command combines building specific components with service restart for quick updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->