### PR TITLE
fix(telegram): broken reactions with scoped JIDs + token leak in error logs

### DIFF
--- a/src/channels/telegram.test.ts
+++ b/src/channels/telegram.test.ts
@@ -4,6 +4,7 @@ import {
   isTelegramReactionEmoji,
   VALID_TELEGRAM_REACTIONS,
   TelegramChannel,
+  safeErrorMessage,
 } from './telegram.js';
 
 // --- isTelegramReactionEmoji ---
@@ -215,5 +216,42 @@ describe('TelegramChannel bot identity', () => {
     });
 
     expect(channel.botId).toBe('telegram-bot');
+  });
+});
+
+// --- safeErrorMessage (token redaction) ---
+
+describe('safeErrorMessage', () => {
+  it('redacts Telegram bot API URLs from Error messages', () => {
+    const err = new Error(
+      'Request failed: https://api.telegram.org/bot123456:ABCdefGHIjklMNOpqrSTUvwxYZ/sendMessage 403 Forbidden',
+    );
+    const msg = safeErrorMessage(err);
+    expect(msg).not.toContain('123456:ABCdefGHIjklMNOpqrSTUvwxYZ');
+    expect(msg).toContain('https://api.telegram.org/bot[REDACTED]');
+    expect(msg).toContain('403 Forbidden');
+  });
+
+  it('redacts multiple bot URLs in a single message', () => {
+    const err = new Error(
+      'Tried https://api.telegram.org/bot111:aaa/getMe then https://api.telegram.org/bot222:bbb/sendMessage',
+    );
+    const msg = safeErrorMessage(err);
+    expect(msg).not.toContain('111:aaa');
+    expect(msg).not.toContain('222:bbb');
+    expect(msg).toContain('https://api.telegram.org/bot[REDACTED]');
+  });
+
+  it('handles non-Error values (strings)', () => {
+    const msg = safeErrorMessage(
+      'network error at https://api.telegram.org/bot999:xyz/getUpdates',
+    );
+    expect(msg).not.toContain('999:xyz');
+    expect(msg).toContain('https://api.telegram.org/bot[REDACTED]');
+  });
+
+  it('passes through safe messages unchanged', () => {
+    const err = new Error('Connection timed out');
+    expect(safeErrorMessage(err)).toBe('Connection timed out');
   });
 });

--- a/src/channels/telegram.ts
+++ b/src/channels/telegram.ts
@@ -11,6 +11,23 @@ import {
 } from '../types.js';
 import { splitMessage } from './utils.js';
 
+// Grammy HTTP errors can contain the full bot API URL (https://api.telegram.org/bot<TOKEN>/...)
+// which leaks the bot token into structured logs. Extract only the safe message.
+const TELEGRAM_BOT_URL_RE = /https?:\/\/api\.telegram\.org\/bot[^\s/]+/gi;
+
+export function safeErrorMessage(err: unknown): string {
+  if (err instanceof Error) {
+    return err.message.replace(
+      TELEGRAM_BOT_URL_RE,
+      'https://api.telegram.org/bot[REDACTED]',
+    );
+  }
+  return String(err).replace(
+    TELEGRAM_BOT_URL_RE,
+    'https://api.telegram.org/bot[REDACTED]',
+  );
+}
+
 type TelegramReactionEmoji =
   import('@grammyjs/types').ReactionTypeEmoji['emoji'];
 export const VALID_TELEGRAM_REACTIONS: readonly TelegramReactionEmoji[] = [
@@ -367,7 +384,10 @@ export class TelegramChannel implements Channel {
       }
       logger.info({ jid, length: text.length }, 'Telegram message sent');
     } catch (err) {
-      logger.error({ jid, err }, 'Failed to send Telegram message');
+      logger.error(
+        { jid, err: safeErrorMessage(err) },
+        'Failed to send Telegram message',
+      );
     }
   }
 
@@ -377,7 +397,8 @@ export class TelegramChannel implements Channel {
     emoji: string,
   ): Promise<void> {
     if (!this.bot) return;
-    const numericChatId = jid.replace(/^tg:/, '');
+    const numericChatId = this.extractNumericChatId(jid);
+    if (!numericChatId) return;
     const numericMsgId = parseInt(messageId, 10);
     if (isNaN(numericMsgId)) return;
     if (!isTelegramReactionEmoji(emoji)) {
@@ -393,7 +414,7 @@ export class TelegramChannel implements Channel {
       ]);
     } catch (err) {
       logger.warn(
-        { jid, messageId, emoji, err },
+        { jid, messageId, emoji, err: safeErrorMessage(err) },
         'Failed to add Telegram reaction',
       );
     }
@@ -408,14 +429,15 @@ export class TelegramChannel implements Channel {
     _emoji: string,
   ): Promise<void> {
     if (!this.bot) return;
-    const numericChatId = jid.replace(/^tg:/, '');
+    const numericChatId = this.extractNumericChatId(jid);
+    if (!numericChatId) return;
     const numericMsgId = parseInt(messageId, 10);
     if (isNaN(numericMsgId)) return;
     try {
       await this.bot.api.setMessageReaction(numericChatId, numericMsgId, []);
     } catch (err) {
       logger.warn(
-        { jid, messageId, err },
+        { jid, messageId, err: safeErrorMessage(err) },
         'Failed to remove Telegram reaction',
       );
     }
@@ -446,7 +468,10 @@ export class TelegramChannel implements Channel {
       if (!numericId) return;
       await this.bot.api.sendChatAction(numericId, 'typing');
     } catch (err) {
-      logger.debug({ jid, err }, 'Failed to send Telegram typing indicator');
+      logger.debug(
+        { jid, err: safeErrorMessage(err) },
+        'Failed to send Telegram typing indicator',
+      );
     }
   }
 

--- a/src/config.test.ts
+++ b/src/config.test.ts
@@ -168,6 +168,14 @@ describe('buildTelegramBotTokensFromEnv', () => {
 
     expect(tokens).toEqual(['token-a', 'token-b']);
   });
+
+  it('deduplicates identical tokens', () => {
+    const tokens = buildTelegramBotTokensFromEnv({
+      TELEGRAM_BOT_TOKENS: 'token-a,token-b,token-a',
+    });
+
+    expect(tokens).toEqual(['token-a', 'token-b']);
+  });
 });
 
 // --- buildTriggerPattern ---

--- a/src/config.ts
+++ b/src/config.ts
@@ -73,7 +73,7 @@ export function buildTelegramBotTokensFromEnv(
   const configured = parseEnvList(env.TELEGRAM_BOT_TOKENS).filter(
     (token) => token.length > 0,
   );
-  if (configured.length > 0) return configured;
+  if (configured.length > 0) return [...new Set(configured)];
 
   const legacyToken = (env.TELEGRAM_BOT_TOKEN || '').trim();
   return legacyToken ? [legacyToken] : [];


### PR DESCRIPTION
## Summary

Hotfix for P0 security issues found during PR #233 review.

### 1. Broken reactions with scoped JIDs (P0 — functional)
`addReaction` and `removeReaction` still used `jid.replace(/^tg:/, '')` which produces `botId:chatId` for the new scoped JID format (`tg:123456:789` → `123456:789`). Every reaction API call fails in multi-bot mode. Fixed to use `extractNumericChatId()` consistent with `sendMessage`/`setTyping`.

### 2. Token leakage in error logs (P0 — security)
Grammy HTTP errors contain the full API URL including the bot token (`https://api.telegram.org/bot<TOKEN>/method`). All catch blocks in telegram.ts now use a new `safeErrorMessage()` helper that redacts bot API URLs before logging.

### 3. Token deduplication (P1 — reliability)
`buildTelegramBotTokensFromEnv` now deduplicates via `[...new Set()]` to prevent duplicate Grammy polling instances (which cause race conditions and 409 Conflict errors from Telegram).

## Testing
```
bun test src/channels/telegram.test.ts src/config.test.ts src/security/redaction.test.ts
bun run build
bun run format:check
```

All 88 tests pass, build succeeds, formatting clean.

## New test coverage
- `safeErrorMessage` — 4 tests: URL redaction (single/multi), non-Error values, passthrough for safe messages
- Token dedup — 1 test: verifies duplicates are removed
