### PR TITLE
chore: remove Phase 0 sender_name_fallback_to_id instrumentation

### DIFF
--- a/src/channels/discord.ts
+++ b/src/channels/discord.ts
@@ -67,7 +67,6 @@ function updateUserRegistry(
     const now = new Date().toISOString();
     for (const { id, name, platform } of mentions) {
       const key = name.toLowerCase().trim();
-      // Phase 0 instrumentation: detect display name key collisions
       const existing = registry[key];
       if (existing && existing.id !== id) {
         logger.warn(
@@ -419,15 +418,13 @@ export class DiscordChannel implements Channel {
    * Fetch members who can view a specific Discord channel.
    * Used to keep model-side channel roster context scoped to the active channel.
    */
-  async fetchChannelRoster(jid: string): Promise<
-    Array<{
-      id: string;
-      username: string;
-      displayName: string;
-      roles: string[];
-      isBot: boolean;
-    }> | null
-  > {
+  async fetchChannelRoster(jid: string): Promise<Array<{
+    id: string;
+    username: string;
+    displayName: string;
+    roles: string[];
+    isBot: boolean;
+  }> | null> {
     const channelId = jidToChannelId(jid);
     if (!channelId) return null;
 
@@ -797,7 +794,6 @@ export class DiscordChannel implements Channel {
     const sender = `discord:${senderUserId}`;
     const msgId = message.id;
 
-    // Phase 0 instrumentation: detect sender identity anomalies
     if (!senderName) {
       logger.warn(
         {
@@ -807,17 +803,6 @@ export class DiscordChannel implements Channel {
           sender,
         },
         'Discord message has empty sender_name',
-      );
-    } else if (senderName === sender) {
-      logger.warn(
-        {
-          op: 'senderIdentity',
-          counter: 'sender_name_fallback_to_id',
-          platform: 'discord',
-          sender,
-          sender_name: senderName,
-        },
-        'Discord sender_name matches sender ID (fallback produced ID-as-name)',
       );
     }
 

--- a/src/channels/slack.ts
+++ b/src/channels/slack.ts
@@ -317,7 +317,6 @@ export class SlackChannel implements Channel {
       'Unknown user',
     );
 
-    // Phase 0 instrumentation: detect sender identity anomalies
     if (!senderName) {
       logger.warn(
         {
@@ -327,17 +326,6 @@ export class SlackChannel implements Channel {
           sender: senderUserId,
         },
         'Slack message has empty sender_name',
-      );
-    } else if (senderName === senderUserId) {
-      logger.warn(
-        {
-          op: 'senderIdentity',
-          counter: 'sender_name_fallback_to_id',
-          platform: 'slack',
-          sender: senderUserId,
-          sender_name: senderName,
-        },
-        'Slack sender_name matches sender ID (API lookup failed, user ID used as name)',
       );
     }
 

--- a/src/channels/telegram.ts
+++ b/src/channels/telegram.ts
@@ -159,7 +159,6 @@ export class TelegramChannel implements Channel {
         ctx.from?.first_name || ctx.from?.username || 'Unknown';
       const msgId = ctx.message.message_id.toString();
 
-      // Phase 0 instrumentation: detect sender identity anomalies
       if (!senderName || senderName === 'Unknown') {
         logger.warn(
           {
@@ -169,17 +168,6 @@ export class TelegramChannel implements Channel {
             sender,
           },
           'Telegram message has empty/unknown sender_name',
-        );
-      } else if (senderName === sender) {
-        logger.warn(
-          {
-            op: 'senderIdentity',
-            counter: 'sender_name_fallback_to_id',
-            platform: 'telegram',
-            sender,
-            sender_name: senderName,
-          },
-          'Telegram sender_name matches sender ID (numeric ID used as name)',
         );
       }
 

--- a/src/channels/whatsapp.ts
+++ b/src/channels/whatsapp.ts
@@ -353,7 +353,6 @@ export class WhatsAppChannel implements Channel {
             const sender = rawSender ? `whatsapp:${rawSender}` : '';
             const senderName = msg.pushName?.trim() || '';
 
-            // Phase 0 instrumentation: detect sender identity anomalies
             if (!senderName) {
               logger.warn(
                 {
@@ -363,20 +362,6 @@ export class WhatsAppChannel implements Channel {
                   sender,
                 },
                 'WhatsApp message has empty sender_name',
-              );
-            } else if (
-              senderName === sender ||
-              senderName === sender.split('@')[0]
-            ) {
-              logger.warn(
-                {
-                  op: 'senderIdentity',
-                  counter: 'sender_name_fallback_to_id',
-                  platform: 'whatsapp',
-                  sender,
-                  sender_name: senderName,
-                },
-                'WhatsApp sender_name matches sender ID (pushName absent, phone number used as name)',
               );
             }
 

--- a/src/router.ts
+++ b/src/router.ts
@@ -28,7 +28,7 @@ export function formatMessages(
   // Build a participant roster so that conversation compaction/summarization
   // preserves correct sender attribution (see Issue #13).
   // Deduplicate by immutable sender ID to prevent roster inflation when
-  // a user changes their display name mid-conversation (R2 in Phase 0 audit).
+  // a user changes their display name mid-conversation.
   const seen = new Set<string>();
   const senders: string[] = [];
   for (const m of messages) {
@@ -38,25 +38,6 @@ export function formatMessages(
     if (seen.has(key)) continue;
     seen.add(key);
     senders.push(m.sender_name);
-  }
-
-  // Phase 0 counter: detect roster inflation from mutable name dedup
-  const nameOnlyCount = new Set(
-    messages
-      .map((m) => m.sender_name)
-      .filter((name) => name && name !== 'System'),
-  ).size;
-  if (nameOnlyCount > senders.length) {
-    logger.info(
-      {
-        op: 'senderIdentity',
-        counter: 'participant_roster_inflation',
-        expected_count: senders.length,
-        actual_count: nameOnlyCount,
-        chat_jid: messages[0]?.chat_jid,
-      },
-      'Participant roster inflated: unique sender_name count exceeds unique sender count',
-    );
   }
 
   const attrs: string[] = [];


### PR DESCRIPTION
## Summary

Removes dead Phase 0 sender identity instrumentation that is no longer needed after the canonicalization logic in PR #208.

### Removed
- `sender_name_fallback_to_id` counter from WhatsApp, Telegram, Slack, Discord adapters (-4 blocks)
- `participant_roster_inflation` counter from router.ts (-18 lines)
- `Phase 0 instrumentation` comments from discord.ts registry collision block

### Kept
- `sender_name_empty` warnings — still useful for detecting messages with missing sender display names
- `sender_missing` error in db.ts — real error condition, not instrumentation
- `user_registry_collision` warning in discord.ts — still useful for detecting name collisions

Net: -81 lines of dead code across 5 files.

Closes #213

## Testing
```
bun test src/router.test.ts src/channels/discord.test.ts src/channels/whatsapp.test.ts src/channels/telegram.test.ts src/channels/slack.test.ts
bun run build
bun run format:check
```
