### PR TITLE
feat(web): IPC Inspector — real-time queue and event visibility

### DIFF
--- a/src/group-queue.ts
+++ b/src/group-queue.ts
@@ -29,6 +29,28 @@ const BASE_RETRY_MS = 5000;
 
 export type Lane = 'message' | 'task';
 
+export interface GroupQueueDetail {
+  folderKey: string;
+  messageLane: {
+    active: boolean;
+    idle: boolean;
+    pendingCount: number;
+    containerName: string | null;
+  };
+  taskLane: {
+    active: boolean;
+    pendingCount: number;
+    containerName: string | null;
+    activeTask: {
+      taskId: string;
+      promptPreview: string;
+      startedAt: number;
+      runningMs: number;
+    } | null;
+  };
+  retryCount: number;
+}
+
 interface ActiveTaskInfo {
   taskId: string;
   promptPreview: string;
@@ -722,6 +744,37 @@ export class GroupQueue {
       maxActive: MAX_ACTIVE_CONTAINERS,
       maxIdle: MAX_IDLE_CONTAINERS,
     };
+  }
+
+  /** Return per-group queue state for the IPC inspector. */
+  getDetailedStats(): GroupQueueDetail[] {
+    const details: GroupQueueDetail[] = [];
+    for (const [folderKey, state] of this.groups) {
+      details.push({
+        folderKey,
+        messageLane: {
+          active: state.messageActive,
+          idle: state.idleWaiting,
+          pendingCount: state.pendingMessageJids.length,
+          containerName: state.messageContainerName,
+        },
+        taskLane: {
+          active: state.taskActive,
+          pendingCount: state.pendingTasks.length,
+          containerName: state.taskContainerName,
+          activeTask: state.activeTaskInfo
+            ? {
+                taskId: state.activeTaskInfo.taskId,
+                promptPreview: state.activeTaskInfo.promptPreview,
+                startedAt: state.activeTaskInfo.startedAt,
+                runningMs: Date.now() - state.activeTaskInfo.startedAt,
+              }
+            : null,
+        },
+        retryCount: state.retryCount,
+      });
+    }
+    return details;
   }
 
   async shutdown(_gracePeriodMs: number): Promise<void> {

--- a/src/index.ts
+++ b/src/index.ts
@@ -112,6 +112,7 @@ import {
   startWebServer,
   startLogStream,
   IpcEventBuffer,
+  type IpcEventKind,
   type WebServerHandle,
 } from './web/index.js';
 import { Effect } from 'effect';
@@ -2524,13 +2525,8 @@ async function main(): Promise<void> {
         agentFolder: agents[s.agentId]?.folder ?? s.agentId,
       }));
     },
-    onIpcEvent: (kind, sourceGroup, summary, details) => {
-      const event = ipcEvents.push(
-        kind as Parameters<typeof ipcEvents.push>[0],
-        sourceGroup,
-        summary,
-        details,
-      );
+    onIpcEvent: (kind: IpcEventKind, sourceGroup, summary, details) => {
+      const event = ipcEvents.push(kind, sourceGroup, summary, details);
       webServer?.broadcast({
         type: 'ipc_event',
         data: event,

--- a/src/index.ts
+++ b/src/index.ts
@@ -111,6 +111,7 @@ import { redactSensitiveData } from './security/redaction.js';
 import {
   startWebServer,
   startLogStream,
+  IpcEventBuffer,
   type WebServerHandle,
 } from './web/index.js';
 import { Effect } from 'effect';
@@ -184,6 +185,7 @@ const MAX_CONSECUTIVE_ERRORS = 3;
 let whatsapp: WhatsAppChannel | null = null;
 let channels: Channel[] = [];
 const queue = new GroupQueue();
+const ipcEvents = new IpcEventBuffer();
 let githubWebhookServer: { stop: () => void } | null = null;
 
 const MAX_CHANNEL_AGENT_FANOUT = parseInt(
@@ -206,7 +208,9 @@ interface ChannelRosterOptions {
   agentFolder?: string;
 }
 
-function formatChannelRosterNames(members: ChannelRosterMemberView[]): string[] {
+function formatChannelRosterNames(
+  members: ChannelRosterMemberView[],
+): string[] {
   return members.map((member) => {
     if (member.roles.length > 0) {
       return `${member.displayName} [${member.roles.join(', ')}]`;
@@ -868,7 +872,10 @@ async function getChannelRosterNames(
   const normalizedRoleFilters = roleFilters
     .map((r) => r.trim().toLowerCase())
     .filter(Boolean);
-  const preferredBotId = getPreferredChannelBotId(chatJid, options.discordBotId);
+  const preferredBotId = getPreferredChannelBotId(
+    chatJid,
+    options.discordBotId,
+  );
 
   const cacheKey = [
     guildId || '__no_guild__',
@@ -899,10 +906,7 @@ async function getChannelRosterNames(
   }
 
   if (guildId && scope === 'channel' && chatJid.startsWith('dc:')) {
-    const discord = findChannelForJid(
-      chatJid,
-      preferredBotId,
-    );
+    const discord = findChannelForJid(chatJid, preferredBotId);
     if (discord instanceof DiscordChannel) {
       const visibleMembers = await discord.fetchChannelRoster(chatJid);
       if (visibleMembers && visibleMembers.length > 0) {
@@ -2080,6 +2084,8 @@ async function main(): Promise<void> {
         },
         getChats: () => getAllChats(),
         getQueueStats: () => queue.getStats(),
+        getQueueDetails: () => queue.getDetailedStats(),
+        getIpcEvents: (count) => ipcEvents.recent(count),
         createTask: (task) => dbCreateTask(task),
         updateTask: (id, updates) => dbUpdateTask(id, updates),
         deleteTask: (id) => dbDeleteTask(id),
@@ -2517,6 +2523,19 @@ async function main(): Promise<void> {
         agentId: s.agentId,
         agentFolder: agents[s.agentId]?.folder ?? s.agentId,
       }));
+    },
+    onIpcEvent: (kind, sourceGroup, summary, details) => {
+      const event = ipcEvents.push(
+        kind as Parameters<typeof ipcEvents.push>[0],
+        sourceGroup,
+        summary,
+        details,
+      );
+      webServer?.broadcast({
+        type: 'ipc_event',
+        data: event,
+        timestamp: event.timestamp,
+      });
     },
   });
 }

--- a/src/ipc.ts
+++ b/src/ipc.ts
@@ -34,6 +34,7 @@ import {
   IpcTaskPayload,
   RegisteredGroup,
 } from './types.js';
+import type { IpcEventKind } from './web/ipc-events.js';
 
 export interface IpcDeps {
   sendMessage: (
@@ -70,7 +71,7 @@ export interface IpcDeps {
   ) => Array<{ agentId: string; agentFolder: string }>;
   /** Called when an IPC event occurs (for the web UI inspector). */
   onIpcEvent?: (
-    kind: string,
+    kind: IpcEventKind,
     sourceGroup: string,
     summary: string,
     details?: Record<string, unknown>,
@@ -108,6 +109,23 @@ function resolveOwnerGroupFolder(
     return null; // Owner unknown or digest malformed
   }
   return owner;
+}
+
+function safeEmitIpcEvent(
+  deps: IpcDeps,
+  ...args: Parameters<NonNullable<IpcDeps['onIpcEvent']>>
+): void {
+  if (!deps.onIpcEvent) return;
+  queueMicrotask(() => {
+    try {
+      deps.onIpcEvent?.(...args);
+    } catch (err) {
+      logger.warn(
+        { err, kind: args[0], sourceGroup: args[1] },
+        'IPC event observer failed',
+      );
+    }
+  });
 }
 
 /** Result of processing an IPC message. */
@@ -251,7 +269,8 @@ export async function processMessageIpc(
         { chatJid: data.chatJid, sourceGroup },
         'IPC message suppressed (internal-only)',
       );
-      deps.onIpcEvent?.(
+      safeEmitIpcEvent(
+        deps,
         'message_suppressed',
         sourceGroup,
         'Message suppressed (internal-only)',
@@ -278,7 +297,8 @@ export async function processMessageIpc(
         deps.notifyGroup(msgChatJid, msgText, sourceGroup);
       }
       logger.info({ chatJid: data.chatJid, sourceGroup }, 'IPC message sent');
-      deps.onIpcEvent?.(
+      safeEmitIpcEvent(
+        deps,
         'message_sent',
         sourceGroup,
         `Message sent to ${msgChatJid}`,
@@ -290,7 +310,8 @@ export async function processMessageIpc(
         { chatJid: data.chatJid, sourceGroup },
         'Unauthorized IPC message attempt blocked (target not registered)',
       );
-      deps.onIpcEvent?.(
+      safeEmitIpcEvent(
+        deps,
         'message_blocked',
         sourceGroup,
         `Blocked: target ${msgChatJid} not registered`,
@@ -518,7 +539,8 @@ export async function processTaskIpc(
     if (isMainGroup || task.group_folder === srcGroup) {
       deleteTask(taskId);
       logger.info({ taskId, sourceGroup: srcGroup }, 'Task cancelled via IPC');
-      deps.onIpcEvent?.(
+      safeEmitIpcEvent(
+        deps,
         'task_cancelled',
         srcGroup,
         `Task ${taskId} cancelled`,
@@ -596,7 +618,8 @@ export async function processTaskIpc(
           { taskId, sourceGroup, targetFolder, contextMode },
           'Task created via IPC',
         );
-        deps.onIpcEvent?.(
+        safeEmitIpcEvent(
+          deps,
           'task_created',
           sourceGroup,
           `Task ${taskId} created for ${targetFolder}`,
@@ -680,7 +703,8 @@ export async function processTaskIpc(
         { taskId: data.taskId, sourceGroup, updates: Object.keys(updates) },
         'Task edited via IPC',
       );
-      deps.onIpcEvent?.(
+      safeEmitIpcEvent(
+        deps,
         'task_edited',
         sourceGroup,
         `Task ${data.taskId} updated: ${Object.keys(updates).join(', ')}`,
@@ -758,7 +782,8 @@ export async function processTaskIpc(
         }
 
         deps.registerGroup(data.jid, groupToRegister);
-        deps.onIpcEvent?.(
+        safeEmitIpcEvent(
+          deps,
           'group_registered',
           sourceGroup,
           `Group registered: ${data.name} (${data.folder})`,

--- a/src/ipc.ts
+++ b/src/ipc.ts
@@ -20,9 +20,7 @@ import {
   setRegisteredGroup,
   updateTask,
 } from './db.js';
-import {
-  findGroupByFolder,
-} from './group-helpers.js';
+import { findGroupByFolder } from './group-helpers.js';
 import {
   listIpcJsonFiles,
   quarantineIpcFile,
@@ -70,6 +68,13 @@ export interface IpcDeps {
   getSubscriptions?: (
     jid: string,
   ) => Array<{ agentId: string; agentFolder: string }>;
+  /** Called when an IPC event occurs (for the web UI inspector). */
+  onIpcEvent?: (
+    kind: string,
+    sourceGroup: string,
+    summary: string,
+    details?: Record<string, unknown>,
+  ) => void;
 }
 
 /**
@@ -246,6 +251,12 @@ export async function processMessageIpc(
         { chatJid: data.chatJid, sourceGroup },
         'IPC message suppressed (internal-only)',
       );
+      deps.onIpcEvent?.(
+        'message_suppressed',
+        sourceGroup,
+        'Message suppressed (internal-only)',
+        { chatJid: data.chatJid },
+      );
       return { action: 'suppressed', reason: 'internal-only' };
     }
     // Authorization: any registered agent can message any other registered agent
@@ -267,11 +278,23 @@ export async function processMessageIpc(
         deps.notifyGroup(msgChatJid, msgText, sourceGroup);
       }
       logger.info({ chatJid: data.chatJid, sourceGroup }, 'IPC message sent');
+      deps.onIpcEvent?.(
+        'message_sent',
+        sourceGroup,
+        `Message sent to ${msgChatJid}`,
+        { chatJid: msgChatJid },
+      );
       return { action: 'handled' };
     } else {
       logger.warn(
         { chatJid: data.chatJid, sourceGroup },
         'Unauthorized IPC message attempt blocked (target not registered)',
+      );
+      deps.onIpcEvent?.(
+        'message_blocked',
+        sourceGroup,
+        `Blocked: target ${msgChatJid} not registered`,
+        { chatJid: msgChatJid },
       );
       return { action: 'blocked', reason: 'target not registered' };
     }
@@ -495,6 +518,12 @@ export async function processTaskIpc(
     if (isMainGroup || task.group_folder === srcGroup) {
       deleteTask(taskId);
       logger.info({ taskId, sourceGroup: srcGroup }, 'Task cancelled via IPC');
+      deps.onIpcEvent?.(
+        'task_cancelled',
+        srcGroup,
+        `Task ${taskId} cancelled`,
+        { taskId },
+      );
       refreshTasksSnapshot();
     } else {
       logger.warn(
@@ -566,6 +595,12 @@ export async function processTaskIpc(
         logger.info(
           { taskId, sourceGroup, targetFolder, contextMode },
           'Task created via IPC',
+        );
+        deps.onIpcEvent?.(
+          'task_created',
+          sourceGroup,
+          `Task ${taskId} created for ${targetFolder}`,
+          { taskId, targetFolder },
         );
         refreshTasksSnapshot();
       }
@@ -645,6 +680,12 @@ export async function processTaskIpc(
         { taskId: data.taskId, sourceGroup, updates: Object.keys(updates) },
         'Task edited via IPC',
       );
+      deps.onIpcEvent?.(
+        'task_edited',
+        sourceGroup,
+        `Task ${data.taskId} updated: ${Object.keys(updates).join(', ')}`,
+        { taskId: data.taskId, fields: Object.keys(updates) },
+      );
       refreshTasksSnapshot();
       break;
     }
@@ -717,6 +758,12 @@ export async function processTaskIpc(
         }
 
         deps.registerGroup(data.jid, groupToRegister);
+        deps.onIpcEvent?.(
+          'group_registered',
+          sourceGroup,
+          `Group registered: ${data.name} (${data.folder})`,
+          { jid: data.jid, name: data.name, folder: data.folder },
+        );
       } else {
         logger.warn(
           { data },

--- a/src/web/conversations.test.ts
+++ b/src/web/conversations.test.ts
@@ -112,6 +112,8 @@ function makeState(
     },
     getChats: () => testChats,
     getQueueStats: () => defaultStats,
+    getQueueDetails: () => [],
+    getIpcEvents: () => [],
     createTask: () => {},
     updateTask: () => {},
     deleteTask: () => {},

--- a/src/web/conversations.ts
+++ b/src/web/conversations.ts
@@ -219,6 +219,7 @@ export function renderConversations(state: WebStateProvider): string {
   <nav>
     <a href="/">Dashboard</a>
     <a href="/conversations" class="active">Conversations</a>
+    <a href="/ipc">IPC</a>
   </nav>
 </header>
 <div class="layout">

--- a/src/web/dashboard.ts
+++ b/src/web/dashboard.ts
@@ -315,6 +315,7 @@ export function renderDashboard(state: WebStateProvider): string {
   <nav style="display:flex;gap:0.5rem;margin-left:1rem">
     <a href="/" style="color:var(--accent);text-decoration:none;font-size:0.8rem;padding:0.25rem 0.5rem;border-radius:4px;background:var(--surface)">Dashboard</a>
     <a href="/conversations" style="color:var(--text-dim);text-decoration:none;font-size:0.8rem;padding:0.25rem 0.5rem;border-radius:4px" onmouseover="this.style.color='var(--text)';this.style.background='var(--surface)'" onmouseout="this.style.color='var(--text-dim)';this.style.background='transparent'">Conversations</a>
+    <a href="/ipc" style="color:var(--text-dim);text-decoration:none;font-size:0.8rem;padding:0.25rem 0.5rem;border-radius:4px" onmouseover="this.style.color='var(--text)';this.style.background='var(--surface)'" onmouseout="this.style.color='var(--text-dim)';this.style.background='transparent'">IPC</a>
   </nav>
   <span id="ws-status" class="ws-status disconnected">disconnected</span>
 </header>

--- a/src/web/index.ts
+++ b/src/web/index.ts
@@ -2,6 +2,9 @@ export { startWebServer } from './server.js';
 export type { WebServerHandle } from './server.js';
 export { startLogStream } from './log-stream.js';
 export { renderConversations } from './conversations.js';
+export { renderIpcInspector } from './ipc-inspector.js';
+export { IpcEventBuffer } from './ipc-events.js';
+export type { IpcEvent, IpcEventKind } from './ipc-events.js';
 export type {
   WebServerConfig,
   WebStateProvider,

--- a/src/web/ipc-events.test.ts
+++ b/src/web/ipc-events.test.ts
@@ -1,0 +1,75 @@
+import { describe, expect, it } from 'bun:test';
+import { IpcEventBuffer } from './ipc-events.js';
+
+describe('IpcEventBuffer', () => {
+  it('pushes events and returns them via recent()', () => {
+    const buf = new IpcEventBuffer();
+    buf.push('message_sent', 'group-a', 'Sent to dc:123');
+    buf.push('task_created', 'group-b', 'Task created');
+
+    const events = buf.recent(10);
+    expect(events).toHaveLength(2);
+    // recent() returns newest first
+    expect(events[0].kind).toBe('task_created');
+    expect(events[1].kind).toBe('message_sent');
+  });
+
+  it('assigns incrementing IDs', () => {
+    const buf = new IpcEventBuffer();
+    const e1 = buf.push('message_sent', 'a', 'msg 1');
+    const e2 = buf.push('message_sent', 'a', 'msg 2');
+    expect(e2.id).toBe(e1.id + 1);
+  });
+
+  it('caps at maxEvents', () => {
+    const buf = new IpcEventBuffer(3);
+    buf.push('message_sent', 'a', '1');
+    buf.push('message_sent', 'a', '2');
+    buf.push('message_sent', 'a', '3');
+    buf.push('message_sent', 'a', '4');
+    expect(buf.size).toBe(3);
+    // Oldest event (id=1) should have been evicted
+    const events = buf.recent(10);
+    expect(events[2].summary).toBe('2');
+    expect(events[0].summary).toBe('4');
+  });
+
+  it('since() returns events after given ID', () => {
+    const buf = new IpcEventBuffer();
+    const e1 = buf.push('message_sent', 'a', '1');
+    buf.push('task_created', 'b', '2');
+    buf.push('task_edited', 'c', '3');
+
+    const after = buf.since(e1.id);
+    expect(after).toHaveLength(2);
+    expect(after[0].summary).toBe('2');
+    expect(after[1].summary).toBe('3');
+  });
+
+  it('stores details when provided', () => {
+    const buf = new IpcEventBuffer();
+    const ev = buf.push('task_created', 'a', 'Task created', {
+      taskId: 'task-123',
+      targetFolder: 'group-b',
+    });
+    expect(ev.details).toEqual({
+      taskId: 'task-123',
+      targetFolder: 'group-b',
+    });
+  });
+
+  it('sets timestamp on events', () => {
+    const buf = new IpcEventBuffer();
+    const ev = buf.push('message_sent', 'a', 'test');
+    expect(ev.timestamp).toBeTruthy();
+    // Should be a valid ISO string
+    expect(new Date(ev.timestamp).toISOString()).toBe(ev.timestamp);
+  });
+
+  it('returns empty arrays when no events', () => {
+    const buf = new IpcEventBuffer();
+    expect(buf.recent()).toEqual([]);
+    expect(buf.since(0)).toEqual([]);
+    expect(buf.size).toBe(0);
+  });
+});

--- a/src/web/ipc-events.ts
+++ b/src/web/ipc-events.ts
@@ -1,0 +1,72 @@
+/**
+ * In-memory ring buffer for recent IPC events.
+ * Captures message, task, and error events for the IPC inspector.
+ */
+
+export type IpcEventKind =
+  | 'message_sent'
+  | 'message_blocked'
+  | 'message_suppressed'
+  | 'task_created'
+  | 'task_edited'
+  | 'task_cancelled'
+  | 'task_error'
+  | 'group_registered'
+  | 'ipc_error';
+
+export interface IpcEvent {
+  id: number;
+  kind: IpcEventKind;
+  timestamp: string;
+  sourceGroup: string;
+  summary: string;
+  details?: Record<string, unknown>;
+}
+
+const DEFAULT_MAX_EVENTS = 200;
+
+export class IpcEventBuffer {
+  private events: IpcEvent[] = [];
+  private nextId = 1;
+  private maxEvents: number;
+
+  constructor(maxEvents = DEFAULT_MAX_EVENTS) {
+    this.maxEvents = maxEvents;
+  }
+
+  push(
+    kind: IpcEventKind,
+    sourceGroup: string,
+    summary: string,
+    details?: Record<string, unknown>,
+  ): IpcEvent {
+    const event: IpcEvent = {
+      id: this.nextId++,
+      kind,
+      timestamp: new Date().toISOString(),
+      sourceGroup,
+      summary,
+      details,
+    };
+    this.events.push(event);
+    if (this.events.length > this.maxEvents) {
+      this.events.shift();
+    }
+    return event;
+  }
+
+  /** Return the most recent N events, newest first. */
+  recent(count = 50): IpcEvent[] {
+    return this.events.slice(-count).reverse();
+  }
+
+  /** Return events newer than the given ID. */
+  since(afterId: number): IpcEvent[] {
+    return this.events.filter((e) => e.id > afterId);
+  }
+
+  /** Current count of buffered events. */
+  get size(): number {
+    return this.events.length;
+  }
+}

--- a/src/web/ipc-inspector.test.ts
+++ b/src/web/ipc-inspector.test.ts
@@ -182,18 +182,18 @@ describe('IPC Inspector API routes', () => {
     handle = startWebServer({ port: randomPort() }, makeState());
     const res = await fetch(`http://localhost:${handle.port}/api/ipc/queue`);
     expect(res.status).toBe(200);
-    const data = await res.json();
+    const data = (await res.json()) as GroupQueueDetail[];
     expect(data).toHaveLength(2);
     expect(data[0].folderKey).toBe('agent-alpha');
     expect(data[1].folderKey).toBe('agent-beta');
-    expect(data[0].taskLane.activeTask.taskId).toBe('task-123');
+    expect(data[0].taskLane.activeTask?.taskId).toBe('task-123');
   });
 
   it('GET /api/ipc/events returns recent events', async () => {
     handle = startWebServer({ port: randomPort() }, makeState());
     const res = await fetch(`http://localhost:${handle.port}/api/ipc/events`);
     expect(res.status).toBe(200);
-    const data = await res.json();
+    const data = (await res.json()) as IpcEvent[];
     expect(data).toHaveLength(2);
     expect(data[0].kind).toBe('task_created');
   });

--- a/src/web/ipc-inspector.test.ts
+++ b/src/web/ipc-inspector.test.ts
@@ -1,0 +1,236 @@
+import { describe, expect, it, afterEach } from 'bun:test';
+import type { ChannelSubscription } from '../types.js';
+import type { WebStateProvider, QueueStats } from './types.js';
+import type { GroupQueueDetail } from '../group-queue.js';
+import type { IpcEvent } from './ipc-events.js';
+import { startWebServer, type WebServerHandle } from './server.js';
+import { renderIpcInspector } from './ipc-inspector.js';
+
+// ---- Helpers ----
+
+function randomPort(): number {
+  return 30000 + Math.floor(Math.random() * 20000);
+}
+
+const defaultStats: QueueStats = {
+  activeContainers: 2,
+  idleContainers: 1,
+  maxActive: 5,
+  maxIdle: 3,
+};
+
+const sampleQueueDetails: GroupQueueDetail[] = [
+  {
+    folderKey: 'agent-alpha',
+    messageLane: {
+      active: true,
+      idle: false,
+      pendingCount: 2,
+      containerName: 'ctr-alpha-msg',
+    },
+    taskLane: {
+      active: true,
+      pendingCount: 1,
+      containerName: 'ctr-alpha-task',
+      activeTask: {
+        taskId: 'task-123',
+        promptPreview: 'Do something important',
+        startedAt: Date.now() - 30000,
+        runningMs: 30000,
+      },
+    },
+    retryCount: 0,
+  },
+  {
+    folderKey: 'agent-beta',
+    messageLane: {
+      active: true,
+      idle: true,
+      pendingCount: 0,
+      containerName: 'ctr-beta-msg',
+    },
+    taskLane: {
+      active: false,
+      pendingCount: 0,
+      containerName: null,
+      activeTask: null,
+    },
+    retryCount: 2,
+  },
+];
+
+const sampleEvents: IpcEvent[] = [
+  {
+    id: 2,
+    kind: 'task_created',
+    timestamp: '2026-03-06T12:00:01.000Z',
+    sourceGroup: 'agent-alpha',
+    summary: 'Task task-123 created for agent-beta',
+    details: { taskId: 'task-123' },
+  },
+  {
+    id: 1,
+    kind: 'message_sent',
+    timestamp: '2026-03-06T12:00:00.000Z',
+    sourceGroup: 'agent-beta',
+    summary: 'Message sent to dc:456',
+  },
+];
+
+function makeState(
+  overrides: Partial<WebStateProvider> = {},
+): WebStateProvider {
+  return {
+    getAgents: () => ({}),
+    getChannelSubscriptions: () => ({}),
+    getTasks: () => [],
+    getTaskById: () => undefined,
+    getMessages: () => [],
+    getChats: () => [],
+    getQueueStats: () => defaultStats,
+    getQueueDetails: () => sampleQueueDetails,
+    getIpcEvents: () => sampleEvents,
+    createTask: () => {},
+    updateTask: () => {},
+    deleteTask: () => {},
+    calculateNextRun: () => '2026-03-03T09:00:00.000Z',
+    ...overrides,
+  };
+}
+
+// ---- Tests ----
+
+describe('renderIpcInspector', () => {
+  it('renders HTML with queue details and events', () => {
+    const html = renderIpcInspector(makeState());
+    expect(html).toContain('IPC Inspector');
+    expect(html).toContain('agent-alpha');
+    expect(html).toContain('agent-beta');
+    expect(html).toContain('task-123');
+    expect(html).toContain('Message sent to dc:456');
+  });
+
+  it('shows correct stats', () => {
+    const html = renderIpcInspector(makeState());
+    // Processing = active - idle = 2 - 1 = 1
+    expect(html).toContain('1/5');
+    // Idle
+    expect(html).toContain('1/3');
+    // Groups tracked
+    expect(html).toContain('>2<');
+  });
+
+  it('shows empty state when no groups', () => {
+    const html = renderIpcInspector(makeState({ getQueueDetails: () => [] }));
+    expect(html).toContain('No groups currently tracked');
+  });
+
+  it('shows empty state when no events', () => {
+    const html = renderIpcInspector(makeState({ getIpcEvents: () => [] }));
+    expect(html).toContain('No IPC events recorded');
+  });
+
+  it('renders lane badges correctly', () => {
+    const html = renderIpcInspector(makeState());
+    // agent-alpha has active message lane
+    expect(html).toContain('lane-active');
+    // agent-beta has idle message lane
+    expect(html).toContain('lane-idle');
+  });
+
+  it('shows retry count when > 0', () => {
+    const html = renderIpcInspector(makeState());
+    expect(html).toContain('retry-count');
+  });
+
+  it('escapes HTML in group names', () => {
+    const xssDetail: GroupQueueDetail = {
+      folderKey: '<script>alert(1)</script>',
+      messageLane: {
+        active: false,
+        idle: false,
+        pendingCount: 0,
+        containerName: null,
+      },
+      taskLane: {
+        active: false,
+        pendingCount: 0,
+        containerName: null,
+        activeTask: null,
+      },
+      retryCount: 0,
+    };
+    const html = renderIpcInspector(
+      makeState({ getQueueDetails: () => [xssDetail] }),
+    );
+    expect(html).not.toContain('<script>alert(1)</script>');
+    expect(html).toContain('&lt;script&gt;');
+  });
+});
+
+describe('IPC Inspector API routes', () => {
+  let handle: WebServerHandle | undefined;
+
+  afterEach(async () => {
+    if (handle) {
+      await handle.stop();
+      handle = undefined;
+    }
+  });
+
+  it('GET /api/ipc/queue returns queue details', async () => {
+    handle = startWebServer({ port: randomPort() }, makeState());
+    const res = await fetch(`http://localhost:${handle.port}/api/ipc/queue`);
+    expect(res.status).toBe(200);
+    const data = await res.json();
+    expect(data).toHaveLength(2);
+    expect(data[0].folderKey).toBe('agent-alpha');
+    expect(data[1].folderKey).toBe('agent-beta');
+    expect(data[0].taskLane.activeTask.taskId).toBe('task-123');
+  });
+
+  it('GET /api/ipc/events returns recent events', async () => {
+    handle = startWebServer({ port: randomPort() }, makeState());
+    const res = await fetch(`http://localhost:${handle.port}/api/ipc/events`);
+    expect(res.status).toBe(200);
+    const data = await res.json();
+    expect(data).toHaveLength(2);
+    expect(data[0].kind).toBe('task_created');
+  });
+
+  it('GET /api/ipc/events respects count param', async () => {
+    handle = startWebServer({ port: randomPort() }, makeState());
+    const res = await fetch(
+      `http://localhost:${handle.port}/api/ipc/events?count=1`,
+    );
+    expect(res.status).toBe(200);
+    const data = await res.json();
+    // The state mock returns the full array — count is passed to getIpcEvents
+    // Our mock ignores the count param, so this just verifies the route works
+    expect(Array.isArray(data)).toBe(true);
+  });
+
+  it('GET /ipc returns HTML page', async () => {
+    handle = startWebServer({ port: randomPort() }, makeState());
+    const res = await fetch(`http://localhost:${handle.port}/ipc`);
+    expect(res.status).toBe(200);
+    expect(res.headers.get('content-type')).toContain('text/html');
+    const html = await res.text();
+    expect(html).toContain('IPC Inspector');
+    expect(html).toContain('agent-alpha');
+  });
+
+  it('nav links include IPC on dashboard', async () => {
+    handle = startWebServer({ port: randomPort() }, makeState());
+    const res = await fetch(`http://localhost:${handle.port}/`);
+    const html = await res.text();
+    expect(html).toContain('href="/ipc"');
+  });
+
+  it('nav links include IPC on conversations', async () => {
+    handle = startWebServer({ port: randomPort() }, makeState());
+    const res = await fetch(`http://localhost:${handle.port}/conversations`);
+    const html = await res.text();
+    expect(html).toContain('href="/ipc"');
+  });
+});

--- a/src/web/ipc-inspector.ts
+++ b/src/web/ipc-inspector.ts
@@ -1,0 +1,401 @@
+import type { WebStateProvider } from './types.js';
+
+function escapeHtml(str: string): string {
+  return str
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;');
+}
+
+/**
+ * Render the IPC Inspector page.
+ * Shows per-group queue state and recent IPC event timeline.
+ */
+export function renderIpcInspector(state: WebStateProvider): string {
+  const stats = state.getQueueStats();
+  const queueDetails = state.getQueueDetails();
+  const events = state.getIpcEvents(50);
+
+  // Build group rows
+  const groupRows = queueDetails
+    .map((g) => {
+      const msgStatus = g.messageLane.idle
+        ? 'idle'
+        : g.messageLane.active
+          ? 'active'
+          : 'off';
+      const taskStatus = g.taskLane.active ? 'active' : 'off';
+      const taskInfo = g.taskLane.activeTask
+        ? `${escapeHtml(g.taskLane.activeTask.taskId)} (${formatDuration(g.taskLane.activeTask.runningMs)})`
+        : '—';
+      return `<tr>
+        <td class="folder-key">${escapeHtml(g.folderKey)}</td>
+        <td><span class="lane-badge lane-${msgStatus}">${msgStatus}</span></td>
+        <td>${g.messageLane.pendingCount}</td>
+        <td><span class="lane-badge lane-${taskStatus}">${taskStatus}</span></td>
+        <td>${g.taskLane.pendingCount}</td>
+        <td class="task-info">${taskInfo}</td>
+        <td>${g.retryCount > 0 ? `<span class="retry-count">${g.retryCount}</span>` : '—'}</td>
+      </tr>`;
+    })
+    .join('\n');
+
+  // Build event rows
+  const eventRows = events
+    .map((e) => {
+      const kindClass =
+        e.kind.includes('error') || e.kind.includes('blocked')
+          ? 'event-error'
+          : e.kind.includes('suppressed')
+            ? 'event-warn'
+            : 'event-ok';
+      const time = new Date(e.timestamp).toLocaleTimeString('en-US', {
+        hour12: false,
+        hour: '2-digit',
+        minute: '2-digit',
+        second: '2-digit',
+      });
+      return `<tr class="${kindClass}">
+        <td class="event-time">${time}</td>
+        <td><span class="event-kind-badge">${escapeHtml(e.kind)}</span></td>
+        <td class="event-source">${escapeHtml(e.sourceGroup)}</td>
+        <td class="event-summary">${escapeHtml(e.summary)}</td>
+      </tr>`;
+    })
+    .join('\n');
+
+  return `<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>OmniClaw — IPC Inspector</title>
+<style>
+  :root {
+    --bg: #0f1117;
+    --surface: #1a1d27;
+    --border: #2a2d3a;
+    --text: #e1e4ed;
+    --text-dim: #8b8fa3;
+    --accent: #6366f1;
+    --green: #22c55e;
+    --yellow: #eab308;
+    --red: #ef4444;
+    --blue: #60a5fa;
+  }
+  * { margin: 0; padding: 0; box-sizing: border-box; }
+  body {
+    font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, monospace;
+    background: var(--bg);
+    color: var(--text);
+    line-height: 1.5;
+  }
+  header {
+    padding: 1rem 2rem;
+    border-bottom: 1px solid var(--border);
+    display: flex;
+    align-items: center;
+    gap: 1rem;
+  }
+  header h1 { font-size: 1.25rem; font-weight: 600; }
+  header nav { display: flex; gap: 0.5rem; margin-left: 1rem; }
+  header nav a {
+    color: var(--text-dim);
+    text-decoration: none;
+    font-size: 0.8rem;
+    padding: 0.25rem 0.5rem;
+    border-radius: 4px;
+    transition: all 0.15s;
+  }
+  header nav a:hover { color: var(--text); background: var(--surface); }
+  header nav a.active { color: var(--accent); background: var(--surface); }
+  header .ws-status {
+    margin-left: auto;
+    font-size: 0.75rem;
+    padding: 0.25rem 0.5rem;
+    border-radius: 4px;
+    background: var(--surface);
+  }
+  header .ws-status.connected { color: var(--green); }
+  header .ws-status.disconnected { color: var(--red); }
+  main { padding: 1.5rem 2rem; }
+
+  /* Stats grid */
+  .stats-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(140px, 1fr));
+    gap: 1rem;
+    margin-bottom: 2rem;
+  }
+  .stat-card {
+    background: var(--surface);
+    border: 1px solid var(--border);
+    border-radius: 8px;
+    padding: 1rem;
+  }
+  .stat-card .label { font-size: 0.75rem; color: var(--text-dim); text-transform: uppercase; letter-spacing: 0.05em; }
+  .stat-card .value { font-size: 1.5rem; font-weight: 700; margin-top: 0.25rem; }
+
+  /* Sections */
+  section { margin-bottom: 2rem; }
+  section h2 { font-size: 1rem; font-weight: 600; margin-bottom: 0.75rem; color: var(--text-dim); text-transform: uppercase; letter-spacing: 0.05em; }
+
+  /* Tables */
+  table {
+    width: 100%;
+    border-collapse: collapse;
+    background: var(--surface);
+    border: 1px solid var(--border);
+    border-radius: 8px;
+    overflow: hidden;
+    font-size: 0.85rem;
+  }
+  th {
+    text-align: left;
+    padding: 0.5rem 0.75rem;
+    font-size: 0.7rem;
+    text-transform: uppercase;
+    letter-spacing: 0.05em;
+    color: var(--text-dim);
+    border-bottom: 1px solid var(--border);
+    background: var(--bg);
+  }
+  td {
+    padding: 0.5rem 0.75rem;
+    border-bottom: 1px solid var(--border);
+    vertical-align: top;
+  }
+  tr:last-child td { border-bottom: none; }
+
+  /* Lane badges */
+  .lane-badge {
+    display: inline-block;
+    font-size: 0.7rem;
+    font-weight: 600;
+    padding: 0.1rem 0.4rem;
+    border-radius: 3px;
+    text-transform: uppercase;
+  }
+  .lane-active { color: var(--green); background: rgba(34,197,94,0.12); }
+  .lane-idle { color: var(--yellow); background: rgba(234,179,8,0.12); }
+  .lane-off { color: var(--text-dim); background: rgba(139,143,163,0.08); }
+
+  .folder-key { font-family: 'SF Mono', 'Cascadia Code', monospace; font-size: 0.8rem; }
+  .task-info { font-family: 'SF Mono', 'Cascadia Code', monospace; font-size: 0.75rem; color: var(--text-dim); max-width: 300px; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+  .retry-count { color: var(--yellow); font-weight: 600; }
+
+  /* Event timeline */
+  .event-time { font-family: 'SF Mono', 'Cascadia Code', monospace; font-size: 0.75rem; color: var(--text-dim); white-space: nowrap; }
+  .event-source { font-family: 'SF Mono', 'Cascadia Code', monospace; font-size: 0.75rem; color: var(--blue); }
+  .event-summary { font-size: 0.8rem; max-width: 500px; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+  .event-kind-badge {
+    display: inline-block;
+    font-size: 0.65rem;
+    font-weight: 600;
+    padding: 0.1rem 0.35rem;
+    border-radius: 3px;
+    white-space: nowrap;
+  }
+  tr.event-ok .event-kind-badge { color: var(--green); background: rgba(34,197,94,0.12); }
+  tr.event-warn .event-kind-badge { color: var(--yellow); background: rgba(234,179,8,0.12); }
+  tr.event-error .event-kind-badge { color: var(--red); background: rgba(239,68,68,0.12); }
+  tr.event-error td { color: var(--red); }
+  tr.event-warn td.event-summary { color: var(--yellow); }
+
+  .empty-state {
+    padding: 2rem;
+    text-align: center;
+    color: var(--text-dim);
+    font-size: 0.85rem;
+  }
+</style>
+</head>
+<body>
+<header>
+  <h1>OmniClaw</h1>
+  <nav>
+    <a href="/">Dashboard</a>
+    <a href="/conversations">Conversations</a>
+    <a href="/ipc" class="active">IPC</a>
+  </nav>
+  <span id="ws-status" class="ws-status disconnected">disconnected</span>
+</header>
+<main>
+  <div class="stats-grid">
+    <div class="stat-card"><div class="label">Processing</div><div class="value" id="stat-processing">${Math.max(0, stats.activeContainers - stats.idleContainers)}/${stats.maxActive}</div></div>
+    <div class="stat-card"><div class="label">Idle</div><div class="value" id="stat-idle">${stats.idleContainers}/${stats.maxIdle}</div></div>
+    <div class="stat-card"><div class="label">Groups Tracked</div><div class="value" id="stat-groups">${queueDetails.length}</div></div>
+    <div class="stat-card"><div class="label">Recent Events</div><div class="value" id="stat-events">${events.length}</div></div>
+  </div>
+
+  <section>
+    <h2>Group Queue State</h2>
+    ${
+      queueDetails.length > 0
+        ? `<table id="queue-table">
+      <thead><tr>
+        <th>Group</th>
+        <th>Messages</th>
+        <th>Msg Queue</th>
+        <th>Tasks</th>
+        <th>Task Queue</th>
+        <th>Running Task</th>
+        <th>Retries</th>
+      </tr></thead>
+      <tbody id="queue-body">${groupRows}</tbody>
+    </table>`
+        : '<div class="empty-state">No groups currently tracked in the queue.</div>'
+    }
+  </section>
+
+  <section>
+    <h2>IPC Event Timeline</h2>
+    ${
+      events.length > 0
+        ? `<table id="events-table">
+      <thead><tr>
+        <th>Time</th>
+        <th>Kind</th>
+        <th>Source</th>
+        <th>Summary</th>
+      </tr></thead>
+      <tbody id="events-body">${eventRows}</tbody>
+    </table>`
+        : '<div class="empty-state">No IPC events recorded yet. Events will appear here as the orchestrator processes IPC messages and tasks.</div>'
+    }
+  </section>
+</main>
+
+<script>
+(function() {
+  const wsStatus = document.getElementById('ws-status');
+  let ws;
+  let reconnectTimer;
+
+  function connect() {
+    const proto = location.protocol === 'https:' ? 'wss:' : 'ws:';
+    ws = new WebSocket(proto + '//' + location.host + '/ws');
+
+    ws.onopen = function() {
+      wsStatus.textContent = 'connected';
+      wsStatus.className = 'ws-status connected';
+      ws.send(JSON.stringify({ subscribe: ['stats', 'ipc'] }));
+    };
+
+    ws.onclose = function() {
+      wsStatus.textContent = 'disconnected';
+      wsStatus.className = 'ws-status disconnected';
+      reconnectTimer = setTimeout(connect, 3000);
+    };
+
+    ws.onerror = function() {
+      ws.close();
+    };
+
+    ws.onmessage = function(evt) {
+      try {
+        const msg = JSON.parse(evt.data);
+        if (msg.type === 'stats' && msg.data) {
+          const s = msg.data;
+          const processing = Math.max(0, (s.activeContainers || 0) - (s.idleContainers || 0));
+          document.getElementById('stat-processing').textContent = processing + '/' + (s.maxActive || 0);
+          document.getElementById('stat-idle').textContent = (s.idleContainers || 0) + '/' + (s.maxIdle || 0);
+        }
+        if (msg.type === 'ipc_event' && msg.data) {
+          addEventRow(msg.data);
+        }
+      } catch(e) { /* ignore parse errors */ }
+    };
+  }
+
+  function addEventRow(e) {
+    const tbody = document.getElementById('events-body');
+    if (!tbody) {
+      // Table might not exist yet (was empty-state), reload
+      location.reload();
+      return;
+    }
+    const kindClass = (e.kind || '').includes('error') || (e.kind || '').includes('blocked')
+      ? 'event-error'
+      : (e.kind || '').includes('suppressed')
+        ? 'event-warn'
+        : 'event-ok';
+    const time = new Date(e.timestamp).toLocaleTimeString('en-US', {
+      hour12: false, hour: '2-digit', minute: '2-digit', second: '2-digit'
+    });
+    const tr = document.createElement('tr');
+    tr.className = kindClass;
+    tr.innerHTML =
+      '<td class="event-time">' + esc(time) + '</td>' +
+      '<td><span class="event-kind-badge">' + esc(e.kind || '') + '</span></td>' +
+      '<td class="event-source">' + esc(e.sourceGroup || '') + '</td>' +
+      '<td class="event-summary">' + esc(e.summary || '') + '</td>';
+    tbody.insertBefore(tr, tbody.firstChild);
+
+    // Cap at 100 rows in the DOM
+    while (tbody.children.length > 100) {
+      tbody.removeChild(tbody.lastChild);
+    }
+
+    // Update event count
+    const evCount = document.getElementById('stat-events');
+    if (evCount) evCount.textContent = String(tbody.children.length);
+  }
+
+  function esc(s) {
+    const d = document.createElement('div');
+    d.textContent = s;
+    return d.innerHTML;
+  }
+
+  // Auto-refresh queue table every 5 seconds
+  setInterval(function() {
+    fetch('/api/ipc/queue')
+      .then(function(r) { return r.json(); })
+      .then(function(details) {
+        const tbody = document.getElementById('queue-body');
+        if (!tbody) return;
+        document.getElementById('stat-groups').textContent = String(details.length);
+        if (details.length === 0) {
+          tbody.innerHTML = '';
+          return;
+        }
+        tbody.innerHTML = details.map(function(g) {
+          const msgStatus = g.messageLane.idle ? 'idle' : g.messageLane.active ? 'active' : 'off';
+          const taskStatus = g.taskLane.active ? 'active' : 'off';
+          const taskInfo = g.taskLane.activeTask
+            ? esc(g.taskLane.activeTask.taskId) + ' (' + formatMs(g.taskLane.activeTask.runningMs) + ')'
+            : '\\u2014';
+          return '<tr>' +
+            '<td class="folder-key">' + esc(g.folderKey) + '</td>' +
+            '<td><span class="lane-badge lane-' + msgStatus + '">' + msgStatus + '</span></td>' +
+            '<td>' + g.messageLane.pendingCount + '</td>' +
+            '<td><span class="lane-badge lane-' + taskStatus + '">' + taskStatus + '</span></td>' +
+            '<td>' + g.taskLane.pendingCount + '</td>' +
+            '<td class="task-info">' + taskInfo + '</td>' +
+            '<td>' + (g.retryCount > 0 ? '<span class="retry-count">' + g.retryCount + '</span>' : '\\u2014') + '</td>' +
+            '</tr>';
+        }).join('');
+      })
+      .catch(function() { /* ignore */ });
+  }, 5000);
+
+  function formatMs(ms) {
+    if (ms < 1000) return ms + 'ms';
+    if (ms < 60000) return (ms / 1000).toFixed(1) + 's';
+    return (ms / 60000).toFixed(1) + 'm';
+  }
+
+  connect();
+})();
+</script>
+</body>
+</html>`;
+}
+
+function formatDuration(ms: number): string {
+  if (ms < 1000) return `${ms}ms`;
+  if (ms < 60000) return `${(ms / 1000).toFixed(1)}s`;
+  return `${(ms / 60000).toFixed(1)}m`;
+}

--- a/src/web/ipc-inspector.ts
+++ b/src/web/ipc-inspector.ts
@@ -280,7 +280,7 @@ export function renderIpcInspector(state: WebStateProvider): string {
     ws.onopen = function() {
       wsStatus.textContent = 'connected';
       wsStatus.className = 'ws-status connected';
-      ws.send(JSON.stringify({ subscribe: ['stats', 'ipc'] }));
+      ws.send(JSON.stringify({ subscribe: ['stats', 'ipc_event'] }));
     };
 
     ws.onclose = function() {

--- a/src/web/routes.ts
+++ b/src/web/routes.ts
@@ -2,6 +2,7 @@ import type { ScheduledTask } from '../types.js';
 import type { WebStateProvider } from './types.js';
 import { renderConversations } from './conversations.js';
 import { renderDashboard } from './dashboard.js';
+import { renderIpcInspector } from './ipc-inspector.js';
 
 /**
  * Handle an authenticated HTTP request and return a Response.
@@ -43,6 +44,10 @@ export function handleRequest(
     return handleGetMessages(url, state);
   if (pathname === '/api/stats') return handleGetStats(state);
 
+  // IPC inspector API
+  if (pathname === '/api/ipc/queue') return handleGetQueueDetails(state);
+  if (pathname === '/api/ipc/events') return handleGetIpcEvents(url, state);
+
   // --- Dashboard ---
   if (pathname === '/' || pathname === '/index.html')
     return new Response(renderDashboard(state), {
@@ -52,6 +57,12 @@ export function handleRequest(
   // --- Conversations viewer ---
   if (pathname === '/conversations')
     return new Response(renderConversations(state), {
+      headers: { 'Content-Type': 'text/html; charset=utf-8' },
+    });
+
+  // --- IPC Inspector ---
+  if (pathname === '/ipc')
+    return new Response(renderIpcInspector(state), {
       headers: { 'Content-Type': 'text/html; charset=utf-8' },
     });
 
@@ -373,6 +384,18 @@ function handleGetStats(state: WebStateProvider): Response {
     completedTasks,
     ...stats,
   });
+}
+
+function handleGetQueueDetails(state: WebStateProvider): Response {
+  return json(state.getQueueDetails());
+}
+
+function handleGetIpcEvents(url: URL, state: WebStateProvider): Response {
+  const countParam = url.searchParams.get('count');
+  const count = countParam
+    ? Math.min(Math.max(1, parseInt(countParam, 10) || 50), 200)
+    : 50;
+  return json(state.getIpcEvents(count));
 }
 
 // ---- Helpers ----

--- a/src/web/server.test.ts
+++ b/src/web/server.test.ts
@@ -130,6 +130,8 @@ function makeState(
       },
     ],
     getQueueStats: () => defaultStats,
+    getQueueDetails: () => [],
+    getIpcEvents: () => [],
     createTask: (task) => store.create(task),
     updateTask: (id, updates) => store.update(id, updates),
     deleteTask: (id) => store.delete(id),

--- a/src/web/types.ts
+++ b/src/web/types.ts
@@ -1,4 +1,6 @@
 import type { Agent, ChannelSubscription, ScheduledTask } from '../types.js';
+import type { GroupQueueDetail } from '../group-queue.js';
+import type { IpcEvent } from './ipc-events.js';
 
 /**
  * State provider interface — the web server reads orchestrator state
@@ -28,6 +30,10 @@ export interface WebStateProvider {
   }>;
   /** Live queue stats from GroupQueue. */
   getQueueStats(): QueueStats;
+  /** Per-group queue details for the IPC inspector. */
+  getQueueDetails(): GroupQueueDetail[];
+  /** Recent IPC events from the event buffer. */
+  getIpcEvents(count?: number): IpcEvent[];
 
   // ---- Task mutations ----
   createTask(task: Omit<ScheduledTask, 'last_run' | 'last_result'>): void;
@@ -67,7 +73,7 @@ export interface WsData {
   subscriptions: Set<string>;
 }
 
-export type WsEventType = 'agent_status' | 'task_update' | 'log';
+export type WsEventType = 'agent_status' | 'task_update' | 'log' | 'ipc_event';
 
 export interface WsEvent {
   type: WsEventType;


### PR DESCRIPTION
## Summary
- Add new `/ipc` page to the web dashboard for real-time IPC and queue visibility
- Per-group queue state table: message/task lane status, pending counts, running tasks, retry counts
- IPC event timeline: ring buffer (200 events) tracking messages, tasks, group registrations
- WebSocket push for live event updates + 5s auto-refresh for queue table
- REST API: `GET /api/ipc/queue` and `GET /api/ipc/events`

### Files Changed
- **New:** `src/web/ipc-events.ts` — In-memory ring buffer for IPC events
- **New:** `src/web/ipc-inspector.ts` — IPC Inspector HTML page (queue table + event timeline)
- **New:** `src/web/ipc-events.test.ts` — 7 tests for event buffer
- **New:** `src/web/ipc-inspector.test.ts` — 13 tests for page rendering + API routes
- `src/group-queue.ts` — Add `getDetailedStats()` + `GroupQueueDetail` type
- `src/ipc.ts` — Add `onIpcEvent` callback to `IpcDeps`, emit events from message/task processing
- `src/web/types.ts` — Add `getQueueDetails()`, `getIpcEvents()` to WebStateProvider
- `src/web/routes.ts` — Add `/ipc`, `/api/ipc/queue`, `/api/ipc/events` routes
- `src/web/index.ts` — Export new modules
- `src/web/dashboard.ts`, `src/web/conversations.ts` — Add IPC nav link
- `src/index.ts` — Wire up `IpcEventBuffer` + `onIpcEvent` + broadcast to WebSocket
- `src/web/server.test.ts`, `src/web/conversations.test.ts` — Add stubs for new provider methods

## Test plan
- [x] `tsc --noEmit` passes (0 errors)
- [x] `bun test` passes (945 tests, 0 failures — 20 new tests added)
- [x] `prettier --check` passes
- [ ] Manual: Navigate to `/ipc`, verify queue table and event timeline render
- [ ] Manual: Trigger IPC messages, verify events appear in real-time via WebSocket
- [ ] Manual: Verify nav links on Dashboard and Conversations pages

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * IPC Inspector: new web page for real-time monitoring of IPC events and queue state, with nav links added.
  * Per-group queue details: shows message/task lanes, container info, active tasks and retry counts.
  * Live event timeline: interactive, auto-updating feed of recent IPC events with severity styling.

* **API**
  * New endpoints and WebSocket events to fetch queue details and recent IPC events.

* **Tests**
  * Added comprehensive tests covering the inspector UI, event buffering, and API routes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->