### PR TITLE
docs(slack): rewrite skill docs + fix telegram JID lookup

### DIFF
--- a/.claude/skills/slack/SKILL.md
+++ b/.claude/skills/slack/SKILL.md
@@ -1,98 +1,95 @@
 # Slack Integration Skill
 
-This skill provides Slack integration using a TypeScript/Bun script.
-
-## What This Skill Does
-
-- Read Slack threads and messages
-- Send messages to Slack channels
-- Post replies to threads
-- Fetch channel history
-- List all accessible channels
-- Standalone TypeScript implementation (no OmniClaw core modifications needed)
-
-## Usage
-
-All Slack operations are handled through `slack.ts` using Bun:
-
-```bash
-# Read messages from a channel
-bun run slack.ts read --channel C123456 --limit 10
-
-# Send a message to a channel
-bun run slack.ts send --channel C123456 --text "Hello from OmniClaw!"
-
-# Reply to a thread
-bun run slack.ts reply --channel C123456 --thread-ts 1234567890.123456 --text "Reply text"
-
-# Fetch thread messages
-bun run slack.ts thread --channel C123456 --thread-ts 1234567890.123456
-
-# List all channels
-bun run slack.ts list
-```
+OmniClaw has a built-in Slack channel (`src/channels/slack.ts`) that connects via Socket Mode. This skill handles setup and troubleshooting.
 
 ## Setup
 
-1. Create a Slack app at https://api.slack.com/apps
-2. Add the following Bot Token Scopes:
-   - `channels:history` - Read public channel messages
-   - `channels:read` - List public channels
-   - `chat:write` - Send messages
-   - `groups:history` - Read private channel messages
-   - `groups:read` - List private channels
-   - `im:history` - Read DM history
-   - `im:read` - List DMs
-   - `mpim:history` - Read group DM history
-   - `mpim:read` - List group DMs
+### 1. Create the Slack App
 
-3. Install the app to your workspace
-4. Copy the Bot User OAuth Token
-5. Set environment variable:
-   ```bash
-   export SLACK_BOT_TOKEN="xoxb-your-token-here"
-   ```
+Go to https://api.slack.com/apps -> **Create New App** -> **From a manifest** -> paste the contents of `slack-app-manifest.template.json` from this skill directory.
 
-## Dependencies
+Edit the `display_information.name` and `features.bot_user.display_name` fields before pasting if you want a custom bot name.
 
-Install dependencies using Bun:
+The manifest configures Socket Mode, all required scopes, and event subscriptions automatically.
+
+### 2. Generate Tokens
+
+After creating the app:
+
+1. **App-Level Token**: Go to **Basic Information** -> **App-Level Tokens** -> **Generate Token**. Give it a name (e.g. "socket"), add scope `connections:write`. Copy the `xapp-...` token.
+2. **Install to Workspace**: Go to **Install App** -> **Install to Workspace**. Copy the **Bot User OAuth Token** (`xoxb-...`).
+
+### 3. Set Environment Variables
+
+Add to `.env`:
+```
+SLACK_BOT_TOKEN=xoxb-your-token
+SLACK_APP_TOKEN=xapp-your-token
+```
+
+OmniClaw auto-connects Slack when both tokens are present.
+
+### 4. Subscribe an Agent to a Slack Channel
+
+Invite the bot to a Slack channel, then find the channel ID (right-click channel name -> **View channel details** -> ID at the bottom).
+
+```sql
+INSERT INTO channel_subscriptions (channel_jid, agent_id, trigger_pattern, requires_trigger, priority, is_primary, created_at)
+VALUES ('slack:CHANNEL_ID', 'YOUR_AGENT_ID', '@BotName', 0, 100, 1, datetime('now'));
+```
+
+Set `requires_trigger` to `1` if the agent should only respond when mentioned.
+
+### 5. Restart and Verify
 
 ```bash
-cd .claude/skills/slack
-bun install
+launchctl kickstart -k gui/$(id -u)/com.omniclaw  # macOS
+# or
+systemctl --user restart omniclaw                   # Linux
 ```
 
-Dependencies (in `package.json`):
-- `@slack/web-api` - Official Slack Web API client for TypeScript
-
-## Integration with OmniClaw
-
-This skill can be invoked from OmniClaw agents to:
-- Monitor Slack channels for mentions
-- Post agent responses back to Slack
-- Enable cross-platform communication (WhatsApp ↔ Slack)
-
-Example OmniClaw integration:
-```typescript
-import { $ } from 'bun';
-
-// Call from OmniClaw agent
-const result = await $`bun run .claude/skills/slack/slack.ts send --channel ${channelId} --text ${message}`.json();
-console.log(result); // { ok: true, ts: "1234567890.123456", channel: "C123456" }
+Check logs for `Slack bot connected`:
+```bash
+grep -i slack logs/omniclaw.log | tail -5
 ```
 
-## Architecture
+## Standalone CLI Tool
 
-Unlike the PR #5 approach (full TypeScript integration), this skill:
-- ✅ No modifications to OmniClaw core codebase
-- ✅ Standalone Bun/TypeScript script
-- ✅ Simple CLI interface for easy testing
-- ✅ Can be invoked from any OmniClaw agent or skill
-- ✅ Same language as OmniClaw (TypeScript) - easier to maintain
-- ✅ Uses Bun's fast runtime and built-in utilities
+This skill also includes a standalone script for quick Slack operations outside the orchestrator:
+
+```bash
+cd .claude/skills/slack && bun install
+
+# List channels
+bun run slack.ts list
+
+# Read messages
+bun run slack.ts read --channel C123456 --limit 10
+
+# Send a message
+bun run slack.ts send --channel C123456 --text "Hello!"
+
+# Reply to a thread
+bun run slack.ts reply --channel C123456 --thread-ts 1234567890.123456 --text "Reply"
+
+# Fetch thread
+bun run slack.ts thread --channel C123456 --thread-ts 1234567890.123456
+```
+
+Requires `SLACK_BOT_TOKEN` env var.
+
+## Troubleshooting
+
+| Issue | Fix |
+|-------|-----|
+| "Failed to connect Slack bot" | Check both `SLACK_BOT_TOKEN` and `SLACK_APP_TOKEN` are set |
+| Bot doesn't respond in channel | Verify the bot is invited to the channel and a `channel_subscriptions` row exists |
+| "Message from unregistered Slack channel" in logs | Add a subscription for that channel JID |
+| Socket disconnects | Slack reconnects automatically; check network if persistent |
 
 ## Files
 
 - `SKILL.md` - This documentation
-- `slack.ts` - Main TypeScript script for Slack operations
+- `slack.ts` - Standalone CLI script for Slack operations
 - `package.json` - Dependencies (@slack/web-api)
+- `slack-app-manifest.template.json` - Slack app manifest template

--- a/.claude/skills/slack/slack-app-manifest.template.json
+++ b/.claude/skills/slack/slack-app-manifest.template.json
@@ -1,0 +1,45 @@
+{
+  "display_information": {
+    "name": "OmniClaw",
+    "description": "OmniClaw AI assistant",
+    "background_color": "#1a1a2e"
+  },
+  "features": {
+    "bot_user": {
+      "display_name": "OmniClaw",
+      "always_online": true
+    }
+  },
+  "oauth_config": {
+    "scopes": {
+      "bot": [
+        "channels:history",
+        "channels:read",
+        "chat:write",
+        "groups:history",
+        "groups:read",
+        "im:history",
+        "im:read",
+        "mpim:history",
+        "mpim:read",
+        "reactions:read",
+        "reactions:write",
+        "users:read"
+      ]
+    }
+  },
+  "settings": {
+    "event_subscriptions": {
+      "bot_events": [
+        "message.channels",
+        "message.groups",
+        "message.im",
+        "message.mpim",
+        "reaction_added"
+      ]
+    },
+    "socket_mode_enabled": true,
+    "org_deploy_enabled": false,
+    "token_rotation_enabled": false
+  }
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -268,7 +268,11 @@ function getRuntimeGroupFolder(
 function getSubscriptionsForChannelInMemory(
   channelJid: string,
 ): ChannelSubscription[] {
-  return channelSubscriptions[channelJid] || [];
+  const exact = channelSubscriptions[channelJid];
+  if (exact && exact.length > 0) return exact;
+  const legacyJid = toLegacyTelegramJid(channelJid);
+  if (legacyJid) return channelSubscriptions[legacyJid] || [];
+  return [];
 }
 
 function buildRegisteredGroupFromSubscription(


### PR DESCRIPTION
## Summary
- Rewrites Slack SKILL.md to document the built-in Socket Mode channel (setup via app manifest, token generation, channel subscriptions, troubleshooting)
- Adds `slack-app-manifest.template.json` to the skill directory for easy Slack app creation
- Fixes Telegram subscription lookup to fall back to legacy (unscoped) JID when scoped JID has no subscriptions, preventing missed messages after the JID format migration

## Test plan
- [ ] Verify Slack skill docs render correctly and instructions are accurate
- [ ] Confirm Telegram messages still route correctly for both scoped and legacy JID formats

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Documentation**
  * Comprehensive Slack setup workflow with detailed environment configuration and token generation instructions
  * Added troubleshooting guide addressing common Slack connection and subscription issues

* **New Features**
  * Slack app manifest template to streamline bot deployment and configuration
  * Improved subscription retrieval with enhanced legacy system compatibility

<!-- end of auto-generated comment: release notes by coderabbit.ai -->