### PR TITLE
Optimize agent container build context

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,3 +1,0 @@
-*
-!container/
-!container/**

--- a/container/.dockerignore
+++ b/container/.dockerignore
@@ -1,0 +1,6 @@
+*
+!Dockerfile
+!Dockerfile.base
+!entrypoint.sh
+!agent-runner/
+!agent-runner/**

--- a/container/Dockerfile
+++ b/container/Dockerfile
@@ -5,18 +5,18 @@ ARG BASE_IMAGE=omniclaw-agent-base:latest
 FROM ${BASE_IMAGE}
 
 # Copy package files first for better caching
-COPY container/agent-runner/package.json container/agent-runner/bun.lock* ./
+COPY agent-runner/package.json agent-runner/bun.lock* ./
 
 # Install dependencies
 RUN bun install
 
 # Copy source code
-COPY container/agent-runner/ ./
+COPY agent-runner/ ./
 
 # Copy entrypoint script
 # Sources env, configures git, pre-installs cross-platform deps for host mounts,
 # buffers stdin, then runs agent-runner
-COPY container/entrypoint.sh /app/entrypoint.sh
+COPY entrypoint.sh /app/entrypoint.sh
 RUN chmod +x /app/entrypoint.sh
 
 # Switch to non-root user (required for --dangerously-skip-permissions)

--- a/container/build.sh
+++ b/container/build.sh
@@ -4,8 +4,7 @@
 set -e
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-PROJECT_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
-cd "$PROJECT_ROOT"
+cd "$SCRIPT_DIR"
 
 BASE_IMAGE_NAME="omniclaw-agent-base"
 IMAGE_NAME="omniclaw-agent"
@@ -14,15 +13,15 @@ TAG="${1:-latest}"
 echo "Building OmniClaw agent base image..."
 echo "Image: ${BASE_IMAGE_NAME}:${TAG}"
 
-# Build with Apple Container (context = project root, trimmed by .dockerignore)
-container build -t "${BASE_IMAGE_NAME}:${TAG}" -f container/Dockerfile.base .
+# Build with Apple Container (context = container/)
+container build -t "${BASE_IMAGE_NAME}:${TAG}" -f Dockerfile.base .
 
 echo ""
 echo "Building OmniClaw agent container image..."
 echo "Image: ${IMAGE_NAME}:${TAG}"
 container build -t "${IMAGE_NAME}:${TAG}" \
     --build-arg "BASE_IMAGE=${BASE_IMAGE_NAME}:${TAG}" \
-    -f container/Dockerfile .
+    -f Dockerfile .
 
 echo ""
 echo "Build complete!"

--- a/docs/CONTAINER-DEV-TOOL-PACKS.md
+++ b/docs/CONTAINER-DEV-TOOL-PACKS.md
@@ -15,6 +15,7 @@ Issue #191 starts by adding Rust (`cargo`/`rustc`) to the base image and defines
 - Rust (`cargo` and `rustc`) is now included in base image for immediate productivity.
 - Browser tooling stays in the shared base image for now because it is broadly useful across agents.
 - Container startup remains deterministic (no runtime language bootstrap required for Go/Rust workflows).
+- Container builds should use `container/` as the build context directly rather than relying on repo-root ignore rules.
 
 ## Design goals
 


### PR DESCRIPTION
## Summary
- split the heavy shared toolchain/browser image into `container/Dockerfile.base` and keep `container/Dockerfile` as a thin app layer
- switch Apple Container builds to use `container/` as the actual build context instead of repo root
- add `container/.dockerignore` so only the Dockerfiles, `entrypoint.sh`, and `agent-runner/` are transferred
- document the next step toward specialized agents with per-agent model choice and canonical dev tool packs

## Why
A recent Apple Container build spent most of its wall time loading `.dockerignore` and transferring build context rather than executing layers.

Before the context-path fix:
- `load .dockerignore`: ~201s
- `load build context`: ~199s
- context transferred: ~210 MB

After switching to `container/` as the build context:
- base image `load .dockerignore`: `0.8s`
- app image `load .dockerignore`: `0.7s`
- app image `load build context`: `5.9s`
- app image context transferred: ~210 MB, but no longer via repo-root traversal

The actual app-layer work was already fast; the bottleneck was Apple Container treating repo root as context. Using `container/` directly removes the ~200-second `.dockerignore` stall and cuts context loading from ~199s to ~6s.

## Notes
- Browser tooling stays in the shared base image for now because it is broadly useful across agents.
- Specialized per-agent tool packs and model selection are documented as the follow-up direction, not implemented here.
- The follow-up architectural direction is per-agent `llm model` selection plus per-agent canonical dev tool packs, with repo-shipped Dockerfile templates for custom variants.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Simplified Docker container build process with a new dedicated base image approach for improved optimization and reusability across agent variants.
  * Updated build script to implement separate base image compilation step.

* **Documentation**
  * Updated container development tool packs documentation to reflect shared base image strategy, including planned phases for agent-level model and tool pack selection.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->