### PR TITLE
Allow local Web UI without auth when creds are unset

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -2080,10 +2080,14 @@ async function main(): Promise<void> {
       );
       process.exit(1);
     }
+    const webAuth =
+      WEB_UI_USER && WEB_UI_PASS
+        ? { username: WEB_UI_USER, password: WEB_UI_PASS }
+        : undefined;
     webServer = startWebServer(
       {
         port: WEB_UI_PORT,
-        auth: { username: WEB_UI_USER, password: WEB_UI_PASS },
+        auth: webAuth,
         hostname: WEB_UI_HOST,
         corsOrigin: WEB_UI_CORS_ORIGIN,
       },

--- a/src/web/server.test.ts
+++ b/src/web/server.test.ts
@@ -260,7 +260,7 @@ describe('startWebServer', () => {
   });
 });
 
-// ---- Basic auth (always enforced) ----
+// ---- Basic auth ----
 
 describe('basic auth', () => {
   it('rejects requests without credentials', async () => {
@@ -289,6 +289,15 @@ describe('basic auth', () => {
     handle = startWebServer(testConfig(), makeState());
     const res = await fetch(url('/api/agents'));
     expect(res.status).toBe(401);
+  });
+
+  it('skips auth when no credentials are configured', async () => {
+    handle = startWebServer(testConfig({ auth: undefined }), makeState());
+    const pageRes = await fetch(url('/'));
+    expect(pageRes.status).toBe(200);
+
+    const apiRes = await fetch(url('/api/agents'));
+    expect(apiRes.status).toBe(200);
   });
 });
 

--- a/src/web/server.ts
+++ b/src/web/server.ts
@@ -47,8 +47,8 @@ export function startWebServer(
         });
       }
 
-      // --- Basic auth for HTTP (always enforced) ---
-      if (!checkBasicAuth(req, auth)) {
+      // --- Basic auth for HTTP (optional on trusted local setups) ---
+      if (auth && !checkBasicAuth(req, auth)) {
         return new Response('Unauthorized', {
           status: 401,
           headers: { 'WWW-Authenticate': 'Basic realm="OmniClaw"' },

--- a/src/web/types.ts
+++ b/src/web/types.ts
@@ -69,8 +69,8 @@ export interface QueueStats {
 
 export interface WebServerConfig {
   port: number;
-  /** Basic auth credentials. Required — server refuses to start without them. */
-  auth: { username: string; password: string };
+  /** Basic auth credentials. If unset, HTTP auth is disabled. */
+  auth?: { username: string; password: string };
   /** Bind hostname. Defaults to '127.0.0.1' (loopback only). */
   hostname?: string;
   /** Allowed CORS origin. If unset, no CORS headers are sent. */


### PR DESCRIPTION
## Summary
- make Web UI basic auth optional when no credentials are configured
- keep refusing unauthenticated startup on public interfaces
- add a regression test covering unauthenticated local access

## Testing
- bun test src/web/server.test.ts *(fails in this environment before exercising the change: Bun reports EADDRINUSE when the suite tries to bind port 0)*