### PR TITLE
feat(web): add System Health page and /api/health endpoint

### DIFF
--- a/src/web/index.ts
+++ b/src/web/index.ts
@@ -4,6 +4,8 @@ export { startLogStream } from './log-stream.js';
 export { renderConversations } from './conversations.js';
 export { renderContextViewer } from './context-viewer.js';
 export { renderIpcInspector } from './ipc-inspector.js';
+export { renderSystem, buildHealthData } from './system.js';
+export type { HealthData } from './system.js';
 export { IpcEventBuffer } from './ipc-events.js';
 export type { IpcEvent, IpcEventKind } from './ipc-events.js';
 export type {

--- a/src/web/page-scripts.ts
+++ b/src/web/page-scripts.ts
@@ -13,6 +13,7 @@ export function allPageScripts(): Record<string, string> {
     context: contextScript(),
     ipc: ipcScript(),
     network: networkScript(),
+    system: systemScript(),
   };
 }
 
@@ -1145,4 +1146,37 @@ refreshRequests();
 pollTimer=setInterval(function(){refreshPeers();refreshRequests();},${DISCOVERY_POLL_INTERVAL});
 window.__cleanup=function(){if(pollTimer)clearInterval(pollTimer);};
 `;
+}
+
+function systemScript(): string {
+  return [
+    '(function(){',
+    'function fmtUptime(s){',
+    '  var d=Math.floor(s/86400),h=Math.floor(s%86400/3600),m=Math.floor(s%3600/60),sec=s%60;',
+    '  var parts=[];if(d>0)parts.push(d+"d");if(h>0)parts.push(h+"h");if(m>0)parts.push(m+"m");parts.push(sec+"s");',
+    '  return parts.join(" ");',
+    '}',
+    '',
+    'var pollTimer=setInterval(function(){',
+    '  fetch("/api/health").then(function(r){return r.json();}).then(function(h){',
+    '    var el;',
+    '    el=document.getElementById("sys-uptime");if(el)el.textContent=fmtUptime(h.uptime_seconds);',
+    '    el=document.getElementById("sys-rss");if(el)el.textContent=h.memory.rss_mb+" MB";',
+    '    el=document.getElementById("sys-heap-used");if(el)el.textContent=h.memory.heap_used_mb+" MB";',
+    '    el=document.getElementById("sys-heap-total");if(el)el.textContent=h.memory.heap_total_mb+" MB";',
+    '    el=document.getElementById("sys-sse");if(el)el.textContent=String(h.sse_clients);',
+    '    el=document.getElementById("sys-agents-total");if(el)el.textContent=String(h.agents.total);',
+    '    el=document.getElementById("sys-containers-active");if(el)el.textContent=h.containers.active+"/"+h.containers.max_active;',
+    '    el=document.getElementById("sys-containers-idle");if(el)el.textContent=h.containers.idle+"/"+h.containers.max_idle;',
+    '    el=document.getElementById("sys-tasks-active");if(el)el.textContent=String(h.tasks.active);',
+    '    el=document.getElementById("sys-tasks-paused");if(el)el.textContent=String(h.tasks.paused);',
+    '    el=document.getElementById("sys-tasks-completed");if(el)el.textContent=String(h.tasks.completed);',
+    '    el=document.getElementById("sys-tasks-total");if(el)el.textContent=String(h.tasks.total);',
+    '    el=document.getElementById("health-status");if(el)el.textContent=h.status;',
+    '  }).catch(function(){});',
+    '},5000);',
+    '',
+    'window.__cleanup=function(){clearInterval(pollTimer);};',
+    '})();',
+  ].join('\n');
 }

--- a/src/web/routes.ts
+++ b/src/web/routes.ts
@@ -20,6 +20,7 @@ import {
   renderNetworkContent,
   type NetworkPageState,
 } from './network.js';
+import { buildHealthData, renderSystem } from './system.js';
 
 /** Optional discovery context — set by the orchestrator when discovery is enabled. */
 let discoveryContext: DiscoveryRouteContext | null = null;
@@ -41,6 +42,7 @@ export function setDiscoveryContext(
 export function handleRequest(
   req: Request,
   state: WebStateProvider,
+  sseClientCount?: number,
 ): Response | Promise<Response> {
   const url = new URL(req.url);
   const { pathname } = url;
@@ -67,6 +69,8 @@ export function handleRequest(
   }
 
   // --- API routes ---
+  if (pathname === '/api/health')
+    return json(buildHealthData(state, sseClientCount ?? 0));
   if (pathname === '/api/agents') return handleGetAgents(state);
 
   // Tasks — CRUD
@@ -129,6 +133,12 @@ export function handleRequest(
   // --- IPC Inspector ---
   if (pathname === '/ipc')
     return new Response(renderIpcInspector(state), {
+      headers: { 'Content-Type': 'text/html; charset=utf-8' },
+    });
+
+  // --- System Health ---
+  if (pathname === '/system')
+    return new Response(renderSystem(state, sseClientCount ?? 0), {
       headers: { 'Content-Type': 'text/html; charset=utf-8' },
     });
 

--- a/src/web/server.ts
+++ b/src/web/server.ts
@@ -17,6 +17,7 @@ import {
 } from './network.js';
 import { checkPeerAuth } from '../discovery/routes.js';
 import type { TrustStore } from '../discovery/trust-store.js';
+import { renderSystemContent } from './system.js';
 
 const MAX_SSE_CLIENTS = 100;
 const MAX_LOG_LINES = 500;
@@ -196,6 +197,11 @@ export function startWebServer(
                 },
               ),
           },
+          system: {
+            path: '/system',
+            title: 'System',
+            render: () => renderSystemContent(state, sseClients.size),
+          },
         };
 
         const page = pageRenderers[pageName];
@@ -233,7 +239,7 @@ export function startWebServer(
         });
       }
 
-      const result = handleRequest(req, state);
+      const result = handleRequest(req, state, sseClients.size);
       // handleRequest may return a Promise (for POST/PATCH with body parsing)
       const addCors = (response: Response) => {
         if (corsOrigin && url.pathname.startsWith('/api/')) {

--- a/src/web/shared.ts
+++ b/src/web/shared.ts
@@ -10,6 +10,7 @@ const NAV_ITEMS = [
   { href: '/context', label: 'Context', page: 'context' },
   { href: '/ipc', label: 'IPC', page: 'ipc' },
   { href: '/network', label: 'Network', page: 'network' },
+  { href: '/system', label: 'System', page: 'system' },
 ];
 
 export function escapeHtml(str: string): string {
@@ -435,8 +436,24 @@ function shellCSS(): string {
     `tr.event-warn td.event-summary{color:var(--yellow)}`,
     `.ipc-empty{padding:2rem;text-align:center;color:var(--text-dim);font-size:12px}`,
 
+    // --- System Health Page ---
+    `.system-page{padding:1.5rem;overflow:auto;flex:1}`,
+    `.system-header{display:flex;align-items:center;gap:.75rem;margin-bottom:1.5rem}`,
+    `.system-header h2{font-size:14px;font-weight:600;color:var(--text-bright);letter-spacing:.03em}`,
+    `.health-badge{font-size:10px;font-weight:600;padding:2px 8px;border-radius:3px;color:var(--green);background:rgba(52,211,153,.1);letter-spacing:.03em}`,
+    `.system-grid{display:grid;grid-template-columns:repeat(auto-fill,minmax(280px,1fr));gap:1rem}`,
+    `.metric-card{background:var(--surface);border:1px solid var(--border);border-radius:6px;padding:1rem;display:flex;flex-direction:column;gap:.5rem}`,
+    `.metric-card-title{font-size:11px;font-weight:600;color:var(--accent);text-transform:lowercase;letter-spacing:.05em;padding-bottom:.5rem;border-bottom:1px solid var(--border)}`,
+    `.metric-row{display:flex;justify-content:space-between;align-items:center;padding:3px 0}`,
+    `.metric-label{font-size:11px;color:var(--text-dim)}`,
+    `.metric-value{font-size:12px;color:var(--text-bright);font-weight:500;font-variant-numeric:tabular-nums}`,
+    `.metric-sub{font-size:10px;color:var(--text-dim);margin-top:.5rem;padding-top:.5rem;border-top:1px solid var(--border);letter-spacing:.03em}`,
+    `.breakdown-item{display:flex;justify-content:space-between;align-items:center;padding:2px 0 2px .5rem}`,
+    `.breakdown-key{font-size:11px;color:var(--text)}`,
+    `.breakdown-val{font-size:11px;color:var(--text-bright);font-weight:500;font-variant-numeric:tabular-nums}`,
+
     // --- Responsive ---
-    `@media(max-width:900px){.stats-grid{grid-template-columns:repeat(2,1fr)}.tables-grid{grid-template-columns:1fr}}`,
+    `@media(max-width:900px){.stats-grid{grid-template-columns:repeat(2,1fr)}.tables-grid{grid-template-columns:1fr}.system-grid{grid-template-columns:1fr}}`,
     `@media(max-width:600px){.stats-grid{grid-template-columns:1fr}}`,
   ].join('\n');
 }

--- a/src/web/system.test.ts
+++ b/src/web/system.test.ts
@@ -1,0 +1,267 @@
+import { describe, expect, it } from 'bun:test';
+
+import { handleRequest } from './routes.js';
+import { buildHealthData, renderSystemContent } from './system.js';
+import type { HealthData } from './system.js';
+import type { WebStateProvider } from './types.js';
+import type { Agent } from '../types.js';
+
+function makeAgent(overrides: Partial<Agent> = {}): Agent {
+  return {
+    id: 'test-agent',
+    name: 'Test Agent',
+    folder: 'test-agent',
+    backend: 'apple-container',
+    agentRuntime: 'claude-agent-sdk',
+    isAdmin: false,
+    createdAt: '2026-01-01T00:00:00.000Z',
+    ...overrides,
+  };
+}
+
+function makeState(agents: Agent[] = [makeAgent()]): WebStateProvider {
+  const agentMap: Record<string, Agent> = {};
+  for (const a of agents) agentMap[a.id] = a;
+  return {
+    getAgents: () => agentMap,
+    getChannelSubscriptions: () => ({}),
+    getTasks: () => [
+      {
+        id: 't1',
+        group_folder: 'g1',
+        chat_jid: 'j1',
+        prompt: 'test',
+        schedule_type: 'cron' as const,
+        schedule_value: '0 * * * *',
+        context_mode: 'isolated' as const,
+        next_run: null,
+        last_run: null,
+        last_result: null,
+        status: 'active' as const,
+        created_at: '2026-01-01T00:00:00.000Z',
+      },
+      {
+        id: 't2',
+        group_folder: 'g1',
+        chat_jid: 'j1',
+        prompt: 'paused task',
+        schedule_type: 'interval' as const,
+        schedule_value: '60000',
+        context_mode: 'isolated' as const,
+        next_run: null,
+        last_run: null,
+        last_result: null,
+        status: 'paused' as const,
+        created_at: '2026-01-01T00:00:00.000Z',
+      },
+      {
+        id: 't3',
+        group_folder: 'g1',
+        chat_jid: 'j1',
+        prompt: 'done',
+        schedule_type: 'once' as const,
+        schedule_value: '2026-01-01T00:00:00',
+        context_mode: 'group' as const,
+        next_run: null,
+        last_run: '2026-01-01T00:00:00.000Z',
+        last_result: 'ok',
+        status: 'completed' as const,
+        created_at: '2026-01-01T00:00:00.000Z',
+      },
+    ],
+    getTaskById: () => undefined,
+    getMessages: () => [],
+    getChats: () => [],
+    getQueueStats: () => ({
+      activeContainers: 3,
+      idleContainers: 1,
+      maxActive: 8,
+      maxIdle: 4,
+    }),
+    getQueueDetails: () => [],
+    getIpcEvents: () => [],
+    createTask: () => {},
+    updateTask: () => {},
+    deleteTask: () => {},
+    calculateNextRun: () => null,
+    readContextFile: () => null,
+    writeContextFile: () => {},
+    updateAgentAvatar: () => {},
+  };
+}
+
+describe('buildHealthData', () => {
+  it('returns correct structure with status healthy', () => {
+    const health = buildHealthData(makeState(), 5);
+    expect(health.status).toBe('healthy');
+    expect(health.sse_clients).toBe(5);
+    expect(typeof health.uptime_seconds).toBe('number');
+    expect(health.uptime_seconds).toBeGreaterThanOrEqual(0);
+  });
+
+  it('counts agents by backend and runtime', () => {
+    const agents = [
+      makeAgent({
+        id: 'a1',
+        backend: 'apple-container',
+        agentRuntime: 'claude-agent-sdk',
+      }),
+      makeAgent({ id: 'a2', backend: 'docker', agentRuntime: 'opencode' }),
+      makeAgent({
+        id: 'a3',
+        backend: 'apple-container',
+        agentRuntime: 'claude-agent-sdk',
+      }),
+    ];
+    const health = buildHealthData(makeState(agents), 0);
+    expect(health.agents.total).toBe(3);
+    expect(health.agents.by_backend).toEqual({
+      'apple-container': 2,
+      docker: 1,
+    });
+    expect(health.agents.by_runtime).toEqual({
+      'claude-agent-sdk': 2,
+      opencode: 1,
+    });
+  });
+
+  it('counts tasks by status', () => {
+    const health = buildHealthData(makeState(), 0);
+    expect(health.tasks.active).toBe(1);
+    expect(health.tasks.paused).toBe(1);
+    expect(health.tasks.completed).toBe(1);
+    expect(health.tasks.total).toBe(3);
+  });
+
+  it('reports container stats correctly', () => {
+    const health = buildHealthData(makeState(), 0);
+    expect(health.containers.active).toBe(2); // 3 active - 1 idle
+    expect(health.containers.idle).toBe(1);
+    expect(health.containers.max_active).toBe(8);
+    expect(health.containers.max_idle).toBe(4);
+  });
+
+  it('reports memory in MB', () => {
+    const health = buildHealthData(makeState(), 0);
+    expect(health.memory.rss_mb).toBeGreaterThan(0);
+    expect(health.memory.heap_used_mb).toBeGreaterThan(0);
+    expect(health.memory.heap_total_mb).toBeGreaterThan(0);
+  });
+
+  it('reports runtime info', () => {
+    const health = buildHealthData(makeState(), 0);
+    expect(health.runtime.platform).toBe(process.platform);
+    expect(health.runtime.arch).toBe(process.arch);
+    expect(typeof health.runtime.bun).toBe('string');
+  });
+
+  it('includes started_at timestamp', () => {
+    const health = buildHealthData(makeState(), 0);
+    expect(health.started_at).toBeTruthy();
+    // Should be a valid ISO string
+    expect(new Date(health.started_at).toISOString()).toBe(health.started_at);
+  });
+
+  it('handles zero agents', () => {
+    const health = buildHealthData(makeState([]), 0);
+    expect(health.agents.total).toBe(0);
+    expect(health.agents.by_backend).toEqual({});
+    expect(health.agents.by_runtime).toEqual({});
+  });
+});
+
+describe('GET /api/health route', () => {
+  it('returns 200 with health data', async () => {
+    const res = await handleRequest(
+      new Request('http://localhost/api/health'),
+      makeState(),
+      3,
+    );
+    expect(res.status).toBe(200);
+    expect(res.headers.get('content-type')).toBe('application/json');
+    const data = (await res.json()) as HealthData;
+    expect(data.status).toBe('healthy');
+    expect(data.sse_clients).toBe(3);
+    expect(data.agents.total).toBe(1);
+    expect(data.tasks.total).toBe(3);
+  });
+
+  it('defaults sseClientCount to 0 when not provided', async () => {
+    const res = await handleRequest(
+      new Request('http://localhost/api/health'),
+      makeState(),
+    );
+    const data = (await res.json()) as HealthData;
+    expect(data.sse_clients).toBe(0);
+  });
+});
+
+describe('GET /system page', () => {
+  it('returns HTML with system health content', async () => {
+    const res = await handleRequest(
+      new Request('http://localhost/system'),
+      makeState(),
+      2,
+    );
+    expect(res.status).toBe(200);
+    expect(res.headers.get('content-type')).toBe('text/html; charset=utf-8');
+    const html = await res.text();
+    expect(html).toContain('system health');
+    expect(html).toContain('OmniClaw');
+    expect(html).toContain('sys-uptime');
+    expect(html).toContain('sys-rss');
+  });
+});
+
+describe('renderSystemContent', () => {
+  it('renders metric cards for all sections', () => {
+    const html = renderSystemContent(makeState(), 0);
+    expect(html).toContain('system health');
+    expect(html).toContain('server');
+    expect(html).toContain('runtime');
+    expect(html).toContain('memory');
+    expect(html).toContain('containers');
+    expect(html).toContain('agents');
+    expect(html).toContain('tasks');
+  });
+
+  it('renders breakdown lists for agent backends', () => {
+    const agents = [
+      makeAgent({ id: 'a1', backend: 'apple-container' }),
+      makeAgent({ id: 'a2', backend: 'docker' }),
+    ];
+    const html = renderSystemContent(makeState(agents), 0);
+    expect(html).toContain('apple-container');
+    expect(html).toContain('docker');
+  });
+
+  it('includes stable IDs for live updates', () => {
+    const html = renderSystemContent(makeState(), 0);
+    expect(html).toContain('id="sys-uptime"');
+    expect(html).toContain('id="sys-rss"');
+    expect(html).toContain('id="sys-heap-used"');
+    expect(html).toContain('id="sys-sse"');
+    expect(html).toContain('id="sys-agents-total"');
+    expect(html).toContain('id="sys-containers-active"');
+    expect(html).toContain('id="sys-tasks-active"');
+    expect(html).toContain('id="health-status"');
+  });
+
+  it('escapes HTML in values', () => {
+    const html = renderSystemContent(
+      makeState([
+        makeAgent({
+          id: 'agent<script>&"',
+          name: 'Agent <unsafe> & "quoted"',
+          backend: 'docker<&>' as Agent['backend'],
+          agentRuntime: 'opencode"<&' as Agent['agentRuntime'],
+        }),
+      ]),
+      0,
+    );
+
+    expect(html).not.toContain('<script');
+    expect(html).toContain('docker&lt;&amp;&gt;');
+    expect(html).toContain('opencode&quot;&lt;&amp;');
+  });
+});

--- a/src/web/system.ts
+++ b/src/web/system.ts
@@ -1,0 +1,265 @@
+import fs from 'fs';
+
+import type { WebStateProvider } from './types.js';
+import { renderShell, escapeHtml } from './shared.js';
+import { allPageScripts } from './page-scripts.js';
+
+export interface HealthData {
+  status: 'healthy';
+  version: string;
+  uptime_seconds: number;
+  memory: {
+    rss_mb: number;
+    heap_used_mb: number;
+    heap_total_mb: number;
+  };
+  runtime: {
+    bun: string;
+    platform: string;
+    arch: string;
+  };
+  agents: {
+    total: number;
+    by_backend: Record<string, number>;
+    by_runtime: Record<string, number>;
+  };
+  containers: {
+    active: number;
+    idle: number;
+    max_active: number;
+    max_idle: number;
+  };
+  tasks: {
+    active: number;
+    paused: number;
+    completed: number;
+    total: number;
+  };
+  sse_clients: number;
+  started_at: string;
+}
+
+const startedAt = new Date().toISOString();
+const APP_VERSION = getAppVersion();
+
+function getAppVersion(): string {
+  if (process.env.npm_package_version) {
+    return process.env.npm_package_version;
+  }
+
+  try {
+    const packageJson = JSON.parse(
+      fs.readFileSync(new URL('../../package.json', import.meta.url), 'utf-8'),
+    ) as { version?: string };
+    return packageJson.version || 'unknown';
+  } catch {
+    return 'unknown';
+  }
+}
+
+export function buildHealthData(
+  state: WebStateProvider,
+  sseClientCount: number,
+): HealthData {
+  const agents = Object.values(state.getAgents());
+  const tasks = state.getTasks();
+  const stats = state.getQueueStats();
+  const mem = process.memoryUsage();
+
+  const byBackend: Record<string, number> = {};
+  const byRuntime: Record<string, number> = {};
+  for (const agent of agents) {
+    byBackend[agent.backend] = (byBackend[agent.backend] || 0) + 1;
+    byRuntime[agent.agentRuntime] = (byRuntime[agent.agentRuntime] || 0) + 1;
+  }
+
+  let activeTasks = 0,
+    pausedTasks = 0,
+    completedTasks = 0;
+  for (const t of tasks) {
+    if (t.status === 'active') activeTasks++;
+    else if (t.status === 'paused') pausedTasks++;
+    else if (t.status === 'completed') completedTasks++;
+  }
+
+  return {
+    status: 'healthy',
+    version: APP_VERSION,
+    uptime_seconds: Math.floor(process.uptime()),
+    memory: {
+      rss_mb: Math.round((mem.rss / 1024 / 1024) * 10) / 10,
+      heap_used_mb: Math.round((mem.heapUsed / 1024 / 1024) * 10) / 10,
+      heap_total_mb: Math.round((mem.heapTotal / 1024 / 1024) * 10) / 10,
+    },
+    runtime: {
+      bun: typeof Bun !== 'undefined' ? Bun.version : process.version,
+      platform: process.platform,
+      arch: process.arch,
+    },
+    agents: {
+      total: agents.length,
+      by_backend: byBackend,
+      by_runtime: byRuntime,
+    },
+    containers: {
+      active: Math.max(0, stats.activeContainers - stats.idleContainers),
+      idle: stats.idleContainers,
+      max_active: stats.maxActive,
+      max_idle: stats.maxIdle,
+    },
+    tasks: {
+      active: activeTasks,
+      paused: pausedTasks,
+      completed: completedTasks,
+      total: tasks.length,
+    },
+    sse_clients: sseClientCount,
+    started_at: startedAt,
+  };
+}
+
+function formatUptime(seconds: number): string {
+  const d = Math.floor(seconds / 86400);
+  const h = Math.floor((seconds % 86400) / 3600);
+  const m = Math.floor((seconds % 3600) / 60);
+  const s = seconds % 60;
+  const parts: string[] = [];
+  if (d > 0) parts.push(`${d}d`);
+  if (h > 0) parts.push(`${h}h`);
+  if (m > 0) parts.push(`${m}m`);
+  parts.push(`${s}s`);
+  return parts.join(' ');
+}
+
+function metricRow(label: string, value: string, id?: string): string {
+  const idAttr = id ? ` id="${escapeHtml(id)}"` : '';
+  return (
+    `<div class="metric-row">` +
+    `<span class="metric-label">${escapeHtml(label)}</span>` +
+    `<span class="metric-value"${idAttr}>${escapeHtml(value)}</span>` +
+    `</div>`
+  );
+}
+
+function metricCard(title: string, rows: string): string {
+  return (
+    `<div class="metric-card">` +
+    `<div class="metric-card-title">${escapeHtml(title)}</div>` +
+    `${rows}` +
+    `</div>`
+  );
+}
+
+function breakdownList(obj: Record<string, number>): string {
+  return Object.entries(obj)
+    .sort((a, b) => b[1] - a[1])
+    .map(
+      ([key, count]) =>
+        `<div class="breakdown-item">` +
+        `<span class="breakdown-key">${escapeHtml(key)}</span>` +
+        `<span class="breakdown-val">${count}</span>` +
+        `</div>`,
+    )
+    .join('');
+}
+
+/** Render the system page content (no shell wrapper). */
+export function renderSystemContent(
+  state: WebStateProvider,
+  sseClientCount: number,
+): string {
+  const health = buildHealthData(state, sseClientCount);
+
+  return (
+    `<div class="system-page" data-init="window.__initPage && window.__initPage('system')">` +
+    `<div class="system-header">` +
+    `<h2>system health</h2>` +
+    `<span class="health-badge" id="health-status">${escapeHtml(health.status)}</span>` +
+    `</div>` +
+    `<div class="system-grid" id="system-metrics">` +
+    // Server info
+    metricCard(
+      'server',
+      metricRow('version', health.version, 'sys-version') +
+        metricRow('uptime', formatUptime(health.uptime_seconds), 'sys-uptime') +
+        metricRow(
+          'started',
+          new Date(health.started_at).toLocaleString(),
+          'sys-started',
+        ) +
+        metricRow('sse clients', String(health.sse_clients), 'sys-sse'),
+    ) +
+    // Runtime
+    metricCard(
+      'runtime',
+      metricRow('bun', health.runtime.bun, 'sys-bun') +
+        metricRow('platform', health.runtime.platform, 'sys-platform') +
+        metricRow('arch', health.runtime.arch, 'sys-arch'),
+    ) +
+    // Memory
+    metricCard(
+      'memory',
+      metricRow('rss', `${health.memory.rss_mb} MB`, 'sys-rss') +
+        metricRow(
+          'heap used',
+          `${health.memory.heap_used_mb} MB`,
+          'sys-heap-used',
+        ) +
+        metricRow(
+          'heap total',
+          `${health.memory.heap_total_mb} MB`,
+          'sys-heap-total',
+        ),
+    ) +
+    // Containers
+    metricCard(
+      'containers',
+      metricRow(
+        'active',
+        `${health.containers.active}/${health.containers.max_active}`,
+        'sys-containers-active',
+      ) +
+        metricRow(
+          'idle',
+          `${health.containers.idle}/${health.containers.max_idle}`,
+          'sys-containers-idle',
+        ),
+    ) +
+    // Agents
+    metricCard(
+      'agents',
+      metricRow('total', String(health.agents.total), 'sys-agents-total') +
+        `<div class="metric-sub">by backend</div>` +
+        breakdownList(health.agents.by_backend) +
+        `<div class="metric-sub">by runtime</div>` +
+        breakdownList(health.agents.by_runtime),
+    ) +
+    // Tasks
+    metricCard(
+      'tasks',
+      metricRow('active', String(health.tasks.active), 'sys-tasks-active') +
+        metricRow('paused', String(health.tasks.paused), 'sys-tasks-paused') +
+        metricRow(
+          'completed',
+          String(health.tasks.completed),
+          'sys-tasks-completed',
+        ) +
+        metricRow('total', String(health.tasks.total), 'sys-tasks-total'),
+    ) +
+    `</div>` +
+    `</div>`
+  );
+}
+
+/** Full system page with SPA shell. */
+export function renderSystem(
+  state: WebStateProvider,
+  sseClientCount: number,
+): string {
+  return renderShell(
+    '/system',
+    'System',
+    renderSystemContent(state, sseClientCount),
+    allPageScripts(),
+  );
+}


### PR DESCRIPTION
## Summary

Adds a **System Health** page and `GET /api/health` JSON endpoint to the web dashboard, providing operational monitoring capabilities.

### What's included

- **`GET /api/health`** — JSON endpoint returning system health data:
  - Server uptime, version, started_at timestamp
  - Memory usage (RSS, heap used/total) in MB
  - Runtime info (Bun version, platform, arch)
  - Agent count with breakdown by backend and runtime
  - Container stats (active/idle vs max limits)
  - Task counts by status (active/paused/completed)
  - SSE client count

- **System page** (`/system`) — new nav entry in the dashboard with metric cards:
  - Six cards: Server, Runtime, Memory, Containers, Agents, Tasks
  - Agent breakdown lists (by backend type and by runtime)
  - Auto-refreshing metrics via 5-second `/api/health` polling
  - Consistent dark theme styling with the rest of the dashboard

- **SPA navigation** — system page is registered in the shell nav and `/api/page/system` endpoint

- **15 tests** (57 assertions) covering:
  - `buildHealthData()` — agent counting, task counting, container stats, memory, runtime, edge cases
  - `GET /api/health` route — response format, SSE client count forwarding
  - `GET /system` page — HTML rendering
  - `renderSystemContent()` — metric card rendering, stable IDs for live updates

### Files changed (7 files, +566 LOC)

| File | Change |
|------|--------|
| `src/web/system.ts` | New — health data builder + system page renderer |
| `src/web/system.test.ts` | New — 15 tests |
| `src/web/routes.ts` | Add `/api/health` + `/system` routes |
| `src/web/server.ts` | Add system page to SPA navigation, pass SSE count |
| `src/web/shared.ts` | Add "System" nav item + system page CSS |
| `src/web/page-scripts.ts` | Add system page auto-refresh script |
| `src/web/index.ts` | Export system module |

## Test plan

- [ ] `bun test` — all 985 tests pass (including 15 new)
- [ ] `bun run typecheck` — clean
- [ ] Navigate to `/system` in the dashboard and verify metric cards render
- [ ] Check `/api/health` returns valid JSON with all expected fields
- [ ] Verify 5-second auto-refresh updates metrics in the browser

Closes part of #157

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added System health dashboard displaying server metrics including memory usage, uptime, and runtime information.
  * Added system health monitoring with agent status breakdown and container metrics.
  * Added task status overview and SSE client tracking on the system page.
  * New System navigation item for accessing the health dashboard.
  * Added health check API endpoint for monitoring.

* **Tests**
  * Added comprehensive test coverage for system health features and API endpoints.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->