### PR TITLE
Fix OpenCode empty-response recovery

### DIFF
--- a/.claude/skills/debug/SKILL.md
+++ b/.claude/skills/debug/SKILL.md
@@ -165,6 +165,72 @@ This persists across reboots. The setup script (step 10) enables this automatica
 
 If an MCP server fails to start, the agent may exit. Check the container logs for MCP initialization errors.
 
+### 8. OpenCode Session Looks Healthy But Replies Are Empty
+
+Symptom pattern in `logs/omniclaw.log`:
+```text
+[opencode-runtime] Created new session: ...
+[opencode-runtime] Injected system context
+[opencode-runtime] Sending prompt ...
+[opencode-runtime] extractResponseText: 0 parts, types:
+[opencode-runtime] waitForAssistantText: 3 messages, last role: assistant, last parts: 0, types:
+```
+
+Important: if this happens on a brand new session, the root cause is not stale session resume alone.
+
+Known real-world case:
+- Remote Linux OpenCode agent worked normally
+- Local macOS OpenCode agent created fresh sessions but still returned empty assistant parts
+- The local base OpenCode auth store contained mixed providers (`anthropic` + `openai`)
+- The working remote auth store contained only `openai`
+
+What to check:
+```bash
+# Session persistence
+sqlite3 store/messages.db "SELECT group_folder, session_id, created_at FROM sessions WHERE group_folder LIKE 'ocpeyton-discord__dispatch__%';"
+
+# Base OpenCode auth/data
+python3 - <<'PY'
+from pathlib import Path
+import json
+p = Path('data/opencode-data/ocpeyton-discord')
+for name in ['auth.json','mcp-auth.json','opencode.db']:
+    fp = p / name
+    print(name, fp.exists())
+    if fp.exists() and name.endswith('.json'):
+        print(sorted(json.loads(fp.read_text()).keys()))
+PY
+```
+
+Recovery order:
+```bash
+# 1. Stop omniclaw so files are not recreated mid-delete
+launchctl bootout gui/$(id -u)/com.omniclaw          # macOS
+systemctl --user stop omniclaw                       # Linux
+
+# 2. Clear persisted dispatch sessions for the broken agent
+sqlite3 store/messages.db "DELETE FROM sessions WHERE group_folder LIKE 'ocpeyton-discord__dispatch__%';"
+
+# 3. Clear all dispatch OpenCode runtime stores for that agent
+find data/opencode-data -maxdepth 1 -type d -name 'ocpeyton-discord__dispatch__*' -print -exec rm -rf {} +
+
+# 4. Clear the agent's base OpenCode store if auth/provider state looks wrong
+rm -f data/opencode-data/ocpeyton-discord/auth.json \
+      data/opencode-data/ocpeyton-discord/mcp-auth.json \
+      data/opencode-data/ocpeyton-discord/opencode.db \
+      data/opencode-data/ocpeyton-discord/opencode.db-shm \
+      data/opencode-data/ocpeyton-discord/opencode.db-wal
+
+# 5. Start omniclaw again
+launchctl bootstrap gui/$(id -u) ~/Library/LaunchAgents/com.omniclaw.plist   # macOS
+systemctl --user start omniclaw                                              # Linux
+```
+
+Notes:
+- If the remote agent works and the local one does not, compare `auth.json` provider keys first.
+- Do not assume session corruption if the failure reproduces on a fresh session.
+- OpenCode reasoning should not be sent to users; only user-facing text parts should be forwarded.
+
 ## Service Management
 
 ```bash

--- a/.claude/skills/setup/SKILL.md
+++ b/.claude/skills/setup/SKILL.md
@@ -114,3 +114,49 @@ Without linger, systemd tears down all user services when the last session ends.
 ```
 
 Fix any failures per [guides/troubleshooting.md](guides/troubleshooting.md).
+
+---
+
+## OpenCode auth reset
+
+Use this when a local OpenCode agent creates fresh sessions but still returns empty assistant outputs, especially after auth/provider drift.
+
+Common symptom:
+```text
+[opencode-runtime] Created new session: ...
+[opencode-runtime] Injected system context
+[opencode-runtime] extractResponseText: 0 parts, types:
+```
+
+Known cause:
+- base OpenCode auth store for the agent contains mixed providers or stale auth state
+- fresh dispatch sessions inherit that bad base state
+
+Safe reset sequence for a local agent such as `ocpeyton-discord`:
+```bash
+# Stop service first
+launchctl bootout gui/$(id -u)/com.omniclaw          # macOS
+systemctl --user stop omniclaw                       # Linux
+
+# Clear persisted dispatch sessions
+sqlite3 store/messages.db "DELETE FROM sessions WHERE group_folder LIKE 'ocpeyton-discord__dispatch__%';"
+
+# Clear dispatch runtime stores
+find data/opencode-data -maxdepth 1 -type d -name 'ocpeyton-discord__dispatch__*' -exec rm -rf {} +
+
+# Clear base auth/database so agent rebuilds from fresh login
+rm -f data/opencode-data/ocpeyton-discord/auth.json \
+      data/opencode-data/ocpeyton-discord/mcp-auth.json \
+      data/opencode-data/ocpeyton-discord/opencode.db \
+      data/opencode-data/ocpeyton-discord/opencode.db-shm \
+      data/opencode-data/ocpeyton-discord/opencode.db-wal
+
+# Start service again
+launchctl bootstrap gui/$(id -u) ~/Library/LaunchAgents/com.omniclaw.plist   # macOS
+systemctl --user start omniclaw                                              # Linux
+```
+
+After restart:
+- re-auth if needed
+- send a simple test message to the agent
+- confirm the next run no longer logs `extractResponseText: 0 parts`

--- a/container/agent-runner/src/__tests__/opencode-runtime.test.ts
+++ b/container/agent-runner/src/__tests__/opencode-runtime.test.ts
@@ -3,6 +3,7 @@ import fs from 'fs';
 import path from 'path';
 
 import {
+  classifyPromptResponse,
   extractResponseText,
   extractTextFromParts,
 } from '../opencode-runtime.js';
@@ -20,14 +21,12 @@ describe('extractTextFromParts', () => {
     expect(extractTextFromParts(parts)).toBe('Hello\nWorld');
   });
 
-  it('extracts reasoning parts', () => {
+  it('ignores reasoning parts', () => {
     const parts = [
       { type: 'reasoning', text: 'Let me think...' },
       { type: 'text', text: 'The answer is 42.' },
     ];
-    expect(extractTextFromParts(parts)).toBe(
-      'Let me think...\nThe answer is 42.',
-    );
+    expect(extractTextFromParts(parts)).toBe('The answer is 42.');
   });
 
   it('ignores tool parts (no tool output in user-facing response)', () => {
@@ -86,6 +85,29 @@ describe('extractResponseText', () => {
       },
     };
     expect(extractResponseText(result as any)).toBe('response');
+  });
+});
+
+describe('classifyPromptResponse', () => {
+  it('retries fresh session when a resumed session returns no text', () => {
+    expect(classifyPromptResponse(null, true)).toEqual({
+      retryFreshSession: true,
+      finalText: null,
+    });
+  });
+
+  it('falls back to a synthetic reply for fresh empty responses', () => {
+    expect(classifyPromptResponse(null, false)).toEqual({
+      retryFreshSession: false,
+      finalText: 'I processed your message but did not generate a text response.',
+    });
+  });
+
+  it('passes through real text responses', () => {
+    expect(classifyPromptResponse('hello', true)).toEqual({
+      retryFreshSession: false,
+      finalText: 'hello',
+    });
   });
 });
 

--- a/container/agent-runner/src/opencode-runtime.ts
+++ b/container/agent-runner/src/opencode-runtime.ts
@@ -13,7 +13,6 @@ import {
   createOpencode,
   OpencodeClient,
   type Part,
-  type ReasoningPart,
   type SessionMessagesResponse,
   type TextPart,
 } from '@opencode-ai/sdk';
@@ -267,10 +266,7 @@ type OpenCodePromptResult = Awaited<
 /** @internal exported for testing */
 export function extractTextFromParts(parts: Array<Part>): string | null {
   const texts = parts
-    .filter(
-      (p): p is TextPart | ReasoningPart =>
-        p.type === 'text' || p.type === 'reasoning',
-    )
+    .filter((p): p is TextPart => p.type === 'text')
     .map((p) => p.text);
   return texts.length > 0 ? texts.join('\n') : null;
 }
@@ -280,7 +276,16 @@ export function extractResponseText(
   result: OpenCodePromptResult | null,
 ): string | null {
   const parts = result?.data?.parts;
-  if (!parts) return null;
+  if (!parts) {
+    const rawData = result?.data;
+    console.error(
+      `[opencode-runtime] extractResponseText: no parts in result. data keys: ${rawData ? Object.keys(rawData).join(',') : 'null'}, raw: ${JSON.stringify(rawData)?.slice(0, 500) ?? 'null'}`,
+    );
+    return null;
+  }
+  console.error(
+    `[opencode-runtime] extractResponseText: ${parts.length} parts, types: ${parts.map((p) => p.type).join(',')}`,
+  );
   return extractTextFromParts(parts);
 }
 
@@ -309,12 +314,26 @@ async function waitForAssistantText(
   timeoutMs: number = 60000,
 ): Promise<string | null> {
   const start = Date.now();
+  let pollCount = 0;
   while (Date.now() - start < timeoutMs) {
     try {
       const messagesResponse = await client.session.messages({
         path: { id: sessionId },
       });
       const messages = getMessagesFromPayload(messagesResponse.data);
+      if (pollCount === 0) {
+        // Log first poll details
+        const lastMsg = messages[messages.length - 1];
+        log(
+          `waitForAssistantText: ${messages.length} messages, last role: ${lastMsg?.info?.role}, last parts: ${lastMsg?.parts?.length}, types: ${lastMsg?.parts?.map((p: Part) => p.type).join(',')}`,
+        );
+        if (lastMsg?.parts) {
+          for (const p of lastMsg.parts) {
+            log(`  part type=${p.type} keys=${Object.keys(p).join(',')}`);
+          }
+        }
+      }
+      pollCount++;
       const text = extractLatestAssistantFromSessionMessages(messages);
       if (text) return text;
     } catch (err) {
@@ -325,6 +344,82 @@ async function waitForAssistantText(
     await new Promise((r) => setTimeout(r, 500));
   }
   return null;
+}
+
+/** @internal exported for testing */
+export function classifyPromptResponse(
+  responseText: string | null,
+  isResumedSession: boolean,
+): {
+  retryFreshSession: boolean;
+  finalText: string | null;
+} {
+  if (responseText) {
+    return { retryFreshSession: false, finalText: responseText };
+  }
+
+  if (isResumedSession) {
+    return { retryFreshSession: true, finalText: null };
+  }
+
+  return {
+    retryFreshSession: false,
+    finalText: 'I processed your message but did not generate a text response.',
+  };
+}
+
+async function createSession(
+  client: OpencodeClient,
+  existingSessionId?: string,
+): Promise<{ sessionId: string; isResumedSession: boolean }> {
+  if (existingSessionId) {
+    try {
+      const existing = await client.session.get({
+        path: { id: existingSessionId },
+      });
+      const resolvedId = existing.data?.id || existingSessionId;
+      if (!resolvedId) {
+        throw new Error('Session exists but returned empty ID');
+      }
+      log(`Resumed session: ${resolvedId}`);
+      return { sessionId: resolvedId, isResumedSession: true };
+    } catch {
+      const fresh = await createSession(client);
+      log(`Previous session not found, created new: ${fresh.sessionId}`);
+      return fresh;
+    }
+  }
+
+  const newSession = await client.session.create({ body: {} });
+  if (!newSession.data?.id) {
+    throw new Error('Session created but returned no ID');
+  }
+  return { sessionId: newSession.data.id, isResumedSession: false };
+}
+
+async function injectSystemContext(
+  client: OpencodeClient,
+  sessionId: string,
+  containerInput: ContainerInput,
+  forcedModel?: { providerID: string; modelID: string },
+): Promise<void> {
+  const systemContext = buildSystemContext(containerInput);
+  if (!systemContext) return;
+  try {
+    await client.session.prompt({
+      path: { id: sessionId },
+      body: {
+        noReply: true,
+        parts: [{ type: 'text', text: systemContext }],
+        ...(forcedModel ? { model: forcedModel } : {}),
+      },
+    });
+    log('Injected system context');
+  } catch (err) {
+    log(
+      `Failed to inject system context (continuing): ${err instanceof Error ? err.message : String(err)}`,
+    );
+  }
 }
 
 // ---------------------------------------------------------------------------
@@ -345,6 +440,7 @@ async function runOpenCodePrompt(
   sessionId: string;
   closedDuringPrompt: boolean;
   promptSucceeded: boolean;
+  emptyResponse: boolean;
 }> {
   let closedDuringPrompt = false;
 
@@ -430,8 +526,13 @@ async function runOpenCodePrompt(
       responseText = await waitForAssistantText(client, sessionId);
     }
     if (!responseText) {
-      responseText =
-        'I processed your message but did not generate a text response.';
+      log('Prompt completed without assistant text');
+      return {
+        sessionId,
+        closedDuringPrompt,
+        promptSucceeded: true,
+        emptyResponse: true,
+      };
     }
     log(`Prompt completed, response: ${responseText.slice(0, 200)}...`);
 
@@ -447,12 +548,22 @@ async function runOpenCodePrompt(
     if (currentChatJid) output.chatJid = currentChatJid;
     writeOutput(output);
 
-    return { sessionId, closedDuringPrompt, promptSucceeded: true };
+    return {
+      sessionId,
+      closedDuringPrompt,
+      promptSucceeded: true,
+      emptyResponse: false,
+    };
   } catch (err) {
     ipcPolling = false;
 
     if (closedDuringPrompt) {
-      return { sessionId, closedDuringPrompt: true, promptSucceeded: false };
+      return {
+        sessionId,
+        closedDuringPrompt: true,
+        promptSucceeded: false,
+        emptyResponse: false,
+      };
     }
 
     const errorMessage = err instanceof Error ? err.message : String(err);
@@ -464,7 +575,12 @@ async function runOpenCodePrompt(
       error: `OpenCode prompt error: ${errorMessage}`,
     });
 
-    return { sessionId, closedDuringPrompt: false, promptSucceeded: false };
+    return {
+      sessionId,
+      closedDuringPrompt: false,
+      promptSucceeded: false,
+      emptyResponse: false,
+    };
   }
 }
 
@@ -641,32 +757,10 @@ export async function runOpenCodeRuntime(
   let sessionId: string;
   let isResumedSession = false;
   try {
-    if (containerInput.sessionId) {
-      try {
-        const existing = await client.session.get({
-          path: { id: containerInput.sessionId },
-        });
-        const resolvedId = existing.data?.id || containerInput.sessionId;
-        if (!resolvedId) {
-          throw new Error('Session exists but returned empty ID');
-        }
-        sessionId = resolvedId;
-        isResumedSession = true;
-        log(`Resumed session: ${sessionId}`);
-      } catch {
-        const newSession = await client.session.create({ body: {} });
-        if (!newSession.data?.id) {
-          throw new Error('Session created but returned no ID');
-        }
-        sessionId = newSession.data.id;
-        log(`Previous session not found, created new: ${sessionId}`);
-      }
-    } else {
-      const newSession = await client.session.create({ body: {} });
-      if (!newSession.data?.id) {
-        throw new Error('Session created but returned no ID');
-      }
-      sessionId = newSession.data.id;
+    const created = await createSession(client, containerInput.sessionId);
+    sessionId = created.sessionId;
+    isResumedSession = created.isResumedSession;
+    if (!isResumedSession) {
       log(`Created new session: ${sessionId}`);
     }
   } catch (err) {
@@ -685,24 +779,7 @@ export async function runOpenCodeRuntime(
   // Only inject on NEW sessions — resumed sessions already have context
   // from the original setup prompt. Re-injecting would duplicate CLAUDE.md.
   if (!isResumedSession) {
-    const systemContext = buildSystemContext(containerInput);
-    if (systemContext) {
-      try {
-        await client.session.prompt({
-          path: { id: sessionId },
-          body: {
-            noReply: true,
-            parts: [{ type: 'text', text: systemContext }],
-            ...(forcedModel ? { model: forcedModel } : {}),
-          },
-        });
-        log('Injected system context');
-      } catch (err) {
-        log(
-          `Failed to inject system context (continuing): ${err instanceof Error ? err.message : String(err)}`,
-        );
-      }
-    }
+    await injectSystemContext(client, sessionId, containerInput, forcedModel);
   } else {
     log('Skipping system context injection (resumed session)');
   }
@@ -742,6 +819,27 @@ export async function runOpenCodeRuntime(
       if (!result.promptSucceeded) {
         log('Prompt failed, exiting runtime loop');
         break;
+      }
+      if (result.emptyResponse) {
+        const responsePlan = classifyPromptResponse(null, isResumedSession);
+        if (responsePlan.retryFreshSession) {
+          log(
+            'Resumed session produced no assistant text; recreating fresh session and retrying prompt once',
+          );
+          const freshSession = await createSession(client);
+          sessionId = freshSession.sessionId;
+          isResumedSession = false;
+          log(`Created replacement session: ${sessionId}`);
+          await injectSystemContext(client, sessionId, containerInput, forcedModel);
+          continue;
+        }
+
+        writeOutput({
+          status: 'success',
+          result: responsePlan.finalText,
+          newSessionId: sessionId,
+          ...(currentChatJid ? { chatJid: currentChatJid } : {}),
+        });
       }
 
       // Emit session update so host can track it


### PR DESCRIPTION
## Summary
- recover from empty OpenCode responses by recreating stale resumed sessions
- stop forwarding OpenCode reasoning parts to users and keep only user-facing text
- document the mixed-provider auth/session reset edge case in setup/debug skills

## Testing
- bun test ./container/agent-runner/src/__tests__/opencode-runtime.test.ts

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added troubleshooting guidance for diagnosing empty OpenCode responses and performing safe authentication resets.

* **Bug Fixes**
  * Improved handling of empty responses from OpenCode sessions with automatic recovery through fresh session creation.
  * Enhanced error logging and diagnostics for better debugging visibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->