### PR TITLE
security: harden discovery module (audit fixes)

### DIFF
--- a/src/discovery/peer-client.ts
+++ b/src/discovery/peer-client.ts
@@ -2,7 +2,7 @@
  * HTTP client for communicating with remote OmniClaw instances.
  * Uses native fetch() with signed peer authentication headers.
  */
-import { createHash, createHmac, randomUUID } from 'crypto';
+import { createHash, createHmac, randomUUID, timingSafeEqual } from 'crypto';
 
 import type {
   ContextFileEntry,
@@ -188,5 +188,6 @@ export function verifyPeerRequestSignature(params: {
     params.nonce,
     params.bodyHash,
   );
-  return expected === params.signature;
+  if (expected.length !== params.signature.length) return false;
+  return timingSafeEqual(Buffer.from(expected), Buffer.from(params.signature));
 }

--- a/src/discovery/routes.ts
+++ b/src/discovery/routes.ts
@@ -43,23 +43,43 @@ export interface DiscoveryRouteContext {
 const PEER_AUTH_MAX_SKEW_MS = 30_000;
 const seenPeerNonces = new Map<string, number>();
 
-// Rate limiting for /api/discovery/pair
+// Rate limiting for pairing endpoints
 const pairRateLimiter = new Map<string, { count: number; resetAt: number }>();
 const PAIR_RATE_LIMIT = 10;
 const PAIR_RATE_WINDOW_MS = 60_000;
+const RATE_LIMITER_MAX_ENTRIES = 10_000;
 
-function checkPairRateLimit(ip: string): boolean {
+function checkRateLimit(
+  ip: string,
+  limiter: Map<string, { count: number; resetAt: number }> = pairRateLimiter,
+): boolean {
   const now = Date.now();
-  const entry = pairRateLimiter.get(ip);
+  const entry = limiter.get(ip);
+
+  // Periodically prune expired entries to prevent unbounded growth
+  if (limiter.size > RATE_LIMITER_MAX_ENTRIES) {
+    for (const [key, val] of limiter.entries()) {
+      if (val.resetAt <= now) limiter.delete(key);
+    }
+  }
 
   if (!entry || now > entry.resetAt) {
-    pairRateLimiter.set(ip, { count: 1, resetAt: now + PAIR_RATE_WINDOW_MS });
+    limiter.set(ip, { count: 1, resetAt: now + PAIR_RATE_WINDOW_MS });
     return true;
   }
 
   if (entry.count >= PAIR_RATE_LIMIT) return false;
   entry.count++;
   return true;
+}
+
+/** Extract the real client IP from the request (socket address, not headers). */
+function getClientIp(req: Request): string {
+  // Bun exposes the socket address via the non-standard .socket property.
+  // We avoid trusting X-Forwarded-For which is user-controllable.
+  const socket = (req as unknown as { socket?: { remoteAddress?: string } })
+    .socket;
+  return socket?.remoteAddress || 'unknown';
 }
 
 /**
@@ -254,10 +274,9 @@ async function handlePairRequest(
   req: Request,
   ctx: DiscoveryRouteContext,
 ): Promise<Response> {
-  // Rate limit
-  const ip =
-    req.headers.get('x-forwarded-for')?.split(',')[0]?.trim() || 'unknown';
-  if (!checkPairRateLimit(ip)) {
+  // Rate limit using socket IP (not user-controllable headers)
+  const ip = getClientIp(req);
+  if (!checkRateLimit(ip)) {
     return json({ error: 'Rate limit exceeded' }, 429);
   }
 
@@ -317,10 +336,21 @@ async function handlePairRequest(
   });
 }
 
+const completePairingRateLimiter = new Map<
+  string,
+  { count: number; resetAt: number }
+>();
+
 async function handleCompletePairing(
   req: Request,
   ctx: DiscoveryRouteContext,
 ): Promise<Response> {
+  // Rate limit complete-pairing to prevent brute-force on callback tokens
+  const ip = getClientIp(req);
+  if (!checkRateLimit(ip, completePairingRateLimiter)) {
+    return json({ error: 'Rate limit exceeded' }, 429);
+  }
+
   let body: {
     instanceId: string;
     name: string;
@@ -644,6 +674,10 @@ async function handleProxyContextWrite(
     return json({ error: 'Missing path or content' }, 400);
   }
 
+  if (!isPathSafe(body.path)) {
+    return json({ error: 'Invalid path' }, 400);
+  }
+
   try {
     const result = await client.writeContextFile(body.path, body.content);
     return json(result);
@@ -732,6 +766,10 @@ async function handleContextPush(
     return json({ error: 'Missing path' }, 400);
   }
 
+  if (!isPathSafe(body.path)) {
+    return json({ error: 'Invalid path' }, 400);
+  }
+
   // Read local content
   const layerPath = toLayerPath(body.path);
   const content = ctx.state.readContextFile(layerPath);
@@ -770,6 +808,10 @@ async function handleContextPull(
 
   if (!body.path || typeof body.path !== 'string') {
     return json({ error: 'Missing path' }, 400);
+  }
+
+  if (!isPathSafe(body.path)) {
+    return json({ error: 'Invalid path' }, 400);
   }
 
   try {
@@ -857,6 +899,8 @@ export function checkPeerAuth(req: Request, trustStore: TrustStore): boolean {
   for (const [key, expiresAt] of seenPeerNonces.entries()) {
     if (expiresAt <= now) seenPeerNonces.delete(key);
   }
+  // Cap nonce cache size to prevent memory exhaustion
+  if (seenPeerNonces.size > RATE_LIMITER_MAX_ENTRIES) return false;
   const nonceKey = `${instanceId}:${nonce}`;
   if (seenPeerNonces.has(nonceKey)) return false;
 
@@ -885,6 +929,14 @@ export function checkPeerAuth(req: Request, trustStore: TrustStore): boolean {
 function toLayerPath(contextFilePath: string): string {
   const layerPath = path.dirname(contextFilePath);
   return layerPath === '.' ? '' : layerPath;
+}
+
+/** Reject paths containing traversal sequences or absolute paths. */
+function isPathSafe(p: string): boolean {
+  if (!p || p.startsWith('/') || p.startsWith('\\')) return false;
+  // Split on both Unix and Windows separators
+  const segments = p.split(/[/\\]/);
+  return !segments.some((s) => s === '..' || s === '.');
 }
 
 async function sendPairingSecretToPeer(

--- a/src/web/server.ts
+++ b/src/web/server.ts
@@ -69,11 +69,27 @@ export function startWebServer(
         }
         // Peer is authenticated — skip Basic Auth, fall through to routing
       } else if (auth && !checkBasicAuth(req, auth)) {
-        // --- Basic auth for HTTP (optional on trusted local setups) ---
+        // --- Basic auth for HTTP ---
         return new Response('Unauthorized', {
           status: 401,
           headers: { 'WWW-Authenticate': 'Basic realm="OmniClaw"' },
         });
+      } else if (
+        !auth &&
+        url.pathname.startsWith('/api/discovery/') &&
+        !isUnauthDiscoveryRoute(url.pathname)
+      ) {
+        // Discovery admin routes MUST have auth — reject if credentials not configured
+        return new Response(
+          JSON.stringify({
+            error:
+              'Discovery admin routes require WEB_UI_USER/WEB_UI_PASS to be configured',
+          }),
+          {
+            status: 403,
+            headers: { 'Content-Type': 'application/json' },
+          },
+        );
       }
 
       // --- SSE stream ---
@@ -414,6 +430,15 @@ function isPeerRoute(pathname: string): boolean {
     pathname === '/api/context/files' ||
     pathname === '/api/context/layers' ||
     pathname === '/api/context/file'
+  );
+}
+
+/** Discovery routes that intentionally allow unauthenticated access. */
+function isUnauthDiscoveryRoute(pathname: string): boolean {
+  return (
+    pathname === '/api/discovery/info' ||
+    pathname === '/api/discovery/pair' ||
+    pathname === '/api/discovery/complete-pairing'
   );
 }
 


### PR DESCRIPTION
## Summary

Addresses critical and high-severity findings from the security audit of the LAN discovery module (issue #284). Full audit posted as a comment on #284 with 16 findings.

This PR fixes the 6 most urgent items:

• *Critical* — Discovery admin routes (approve/reject pairing, revoke peers, proxy writes) were unprotected when `WEB_UI_USER`/`WEB_UI_PASS` env vars were not set. Now returns 403 for admin discovery routes without auth config.

• *High* — Rate limiting used `X-Forwarded-For` header (user-controllable). Now uses socket remote address.

• *High* — `/api/discovery/complete-pairing` had no rate limiting. Added rate limiter matching the `/pair` endpoint.

• *High* — Path traversal on context push/pull/proxy-write — `../` sequences in `path` field could escape the groups directory. Added `isPathSafe()` validation.

• *Medium* — HMAC signature verification used `===` (timing-unsafe). Now uses `crypto.timingSafeEqual`.

• *Medium* — Nonce replay cache and rate limiter maps grew unboundedly. Added max-entries cap (10K) with pruning.

## Test plan

- [x] `tsc --noEmit` passes (0 errors)
- [x] All 62 discovery + server tests pass (326 assertions)
- [ ] Manual: verify admin discovery routes return 403 without auth env vars
- [ ] Manual: verify path traversal attempts return 400

Closes #284

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Security Enhancements**
  * Strengthened peer signature verification against timing attacks
  * Enhanced rate limiting with IP-based detection and periodic cleanup to prevent abuse
  * Added path traversal attack prevention for file operations
  * Improved peer authentication nonce management with expiration and caching controls

* **New Features**
  * Discovery admin endpoints now require HTTP basic authentication via WEB_UI_USER/WEB_UI_PASS configuration

<!-- end of auto-generated comment: release notes by coderabbit.ai -->