### PR TITLE
feat(web): add task execution history API and sidebar UI

### DIFF
--- a/src/db.ts
+++ b/src/db.ts
@@ -1150,6 +1150,18 @@ export function logTaskRun(log: TaskRunLog): void {
   );
 }
 
+export function getTaskRunLogs(taskId: string, limit = 20): TaskRunLog[] {
+  return db
+    .query(
+      `SELECT task_id, run_at, duration_ms, status, result, error
+       FROM task_run_logs
+       WHERE task_id = ?
+       ORDER BY run_at DESC
+       LIMIT ?`,
+    )
+    .all(taskId, limit) as TaskRunLog[];
+}
+
 // --- Router state accessors ---
 
 export function getRouterState(key: string): string | undefined {

--- a/src/index.ts
+++ b/src/index.ts
@@ -90,6 +90,7 @@ import {
   updateAgentAvatar,
   createTrustStore,
   getOrCreateDiscoveryInstanceId,
+  getTaskRunLogs,
 } from './db.js';
 import { buildAgentToChannelsMapFromSubscriptions } from './channel-routes.js';
 import { resolveContextLayers } from './context-layers.js';
@@ -2254,6 +2255,7 @@ async function main(): Promise<void> {
     getQueueStats: () => queue.getStats(),
     getQueueDetails: () => queue.getDetailedStats(),
     getIpcEvents: (count) => ipcEvents.recent(count),
+    getTaskRunLogs: (taskId, limit) => getTaskRunLogs(taskId, limit),
     createTask: (task) => dbCreateTask(task),
     updateTask: (id, updates) => dbUpdateTask(id, updates),
     deleteTask: (id) => dbDeleteTask(id),

--- a/src/task-scheduler.test.ts
+++ b/src/task-scheduler.test.ts
@@ -8,6 +8,7 @@ import {
   getAllTasks,
   getDueTasks,
   getTaskById,
+  getTaskRunLogs,
   logTaskRun,
   updateTaskAfterRun,
 } from './db.js';
@@ -418,6 +419,107 @@ describe('DB task lifecycle', () => {
       // Should not throw (cascading delete of run logs)
       deleteTask('cleanup-task');
       expect(getTaskById('cleanup-task')).toBeNull();
+    });
+  });
+
+  describe('getTaskRunLogs', () => {
+    it('returns empty array for task with no runs', () => {
+      createTask({
+        id: 'no-runs',
+        group_folder: 'main',
+        chat_jid: 'g@g.us',
+        prompt: 'no runs yet',
+        schedule_type: 'cron',
+        schedule_value: '0 * * * *',
+        context_mode: 'isolated',
+        next_run: '2024-06-01T01:00:00.000Z',
+        status: 'active',
+        created_at: '2024-01-01T00:00:00.000Z',
+      });
+      expect(getTaskRunLogs('no-runs')).toEqual([]);
+    });
+
+    it('returns runs ordered by run_at descending', () => {
+      createTask({
+        id: 'multi-run',
+        group_folder: 'main',
+        chat_jid: 'g@g.us',
+        prompt: 'multiple runs',
+        schedule_type: 'cron',
+        schedule_value: '0 * * * *',
+        context_mode: 'isolated',
+        next_run: '2024-06-01T03:00:00.000Z',
+        status: 'active',
+        created_at: '2024-01-01T00:00:00.000Z',
+      });
+
+      logTaskRun({
+        task_id: 'multi-run',
+        run_at: '2024-06-01T00:00:00.000Z',
+        duration_ms: 1000,
+        status: 'success',
+        result: 'first',
+        error: null,
+      });
+      logTaskRun({
+        task_id: 'multi-run',
+        run_at: '2024-06-01T01:00:00.000Z',
+        duration_ms: 2000,
+        status: 'error',
+        result: null,
+        error: 'failed',
+      });
+      logTaskRun({
+        task_id: 'multi-run',
+        run_at: '2024-06-01T02:00:00.000Z',
+        duration_ms: 500,
+        status: 'success',
+        result: 'third',
+        error: null,
+      });
+
+      const runs = getTaskRunLogs('multi-run');
+      expect(runs).toHaveLength(3);
+      // Most recent first
+      expect(runs[0].run_at).toBe('2024-06-01T02:00:00.000Z');
+      expect(runs[0].result).toBe('third');
+      expect(runs[1].run_at).toBe('2024-06-01T01:00:00.000Z');
+      expect(runs[1].status).toBe('error');
+      expect(runs[2].run_at).toBe('2024-06-01T00:00:00.000Z');
+      expect(runs[2].result).toBe('first');
+    });
+
+    it('respects the limit parameter', () => {
+      createTask({
+        id: 'limited',
+        group_folder: 'main',
+        chat_jid: 'g@g.us',
+        prompt: 'limit test',
+        schedule_type: 'cron',
+        schedule_value: '0 * * * *',
+        context_mode: 'isolated',
+        next_run: null,
+        status: 'active',
+        created_at: '2024-01-01T00:00:00.000Z',
+      });
+
+      for (let i = 0; i < 5; i++) {
+        logTaskRun({
+          task_id: 'limited',
+          run_at: `2024-06-01T0${i}:00:00.000Z`,
+          duration_ms: 1000,
+          status: 'success',
+          result: `run-${i}`,
+          error: null,
+        });
+      }
+
+      expect(getTaskRunLogs('limited', 2)).toHaveLength(2);
+      expect(getTaskRunLogs('limited', 10)).toHaveLength(5);
+    });
+
+    it('returns empty array for nonexistent task', () => {
+      expect(getTaskRunLogs('does-not-exist')).toEqual([]);
     });
   });
 });

--- a/src/web/agent-channels.test.ts
+++ b/src/web/agent-channels.test.ts
@@ -42,6 +42,7 @@ const state: WebStateProvider = {
   }),
   getQueueDetails: () => [],
   getIpcEvents: () => [],
+  getTaskRunLogs: () => [],
   createTask: () => {},
   updateTask: () => {},
   deleteTask: () => {},
@@ -49,6 +50,8 @@ const state: WebStateProvider = {
   readContextFile: () => null,
   writeContextFile: () => {},
   updateAgentAvatar: () => {},
+  resolveChatImage: async () => null,
+  resolveDiscordGuildImage: async () => null,
 };
 
 describe('buildAgentChannelData', () => {

--- a/src/web/conversations.test.ts
+++ b/src/web/conversations.test.ts
@@ -114,6 +114,7 @@ function makeState(
     getQueueStats: () => defaultStats,
     getQueueDetails: () => [],
     getIpcEvents: () => [],
+    getTaskRunLogs: () => [],
     createTask: () => {},
     updateTask: () => {},
     deleteTask: () => {},

--- a/src/web/ipc-inspector.test.ts
+++ b/src/web/ipc-inspector.test.ts
@@ -90,6 +90,7 @@ function makeState(
     getQueueStats: () => defaultStats,
     getQueueDetails: () => sampleQueueDetails,
     getIpcEvents: () => sampleEvents,
+    getTaskRunLogs: () => [],
     createTask: () => {},
     updateTask: () => {},
     deleteTask: () => {},

--- a/src/web/routes.test.ts
+++ b/src/web/routes.test.ts
@@ -3,7 +3,12 @@ import fs from 'fs';
 import path from 'path';
 
 import { DATA_DIR } from '../config.js';
-import type { Agent, ChannelSubscription, ScheduledTask } from '../types.js';
+import type {
+  Agent,
+  ChannelSubscription,
+  ScheduledTask,
+  TaskRunLog,
+} from '../types.js';
 import { handleRequest } from './routes.js';
 import type { WebStateProvider } from './types.js';
 
@@ -96,6 +101,7 @@ function makeState(
     deleteTask: (id) => {
       tasks.delete(id);
     },
+    getTaskRunLogs: () => [],
     calculateNextRun: () => '2026-03-06T09:00:00.000Z',
     readContextFile: () => null,
     writeContextFile: () => {},
@@ -462,6 +468,134 @@ describe('web routes unit tests', () => {
       makeState(),
     );
 
+    expect(res.status).toBe(405);
+  });
+});
+
+describe('handleRequest task run logs', () => {
+  const sampleRuns: TaskRunLog[] = [
+    {
+      task_id: 'task-001',
+      run_at: '2026-03-10T12:00:00.000Z',
+      duration_ms: 5000,
+      status: 'success',
+      result: 'Completed successfully',
+      error: null,
+    },
+    {
+      task_id: 'task-001',
+      run_at: '2026-03-10T11:00:00.000Z',
+      duration_ms: 2000,
+      status: 'error',
+      result: null,
+      error: 'Something went wrong',
+    },
+  ];
+
+  it('returns 404 for unknown task', async () => {
+    const res = await handleRequest(
+      new Request('http://localhost/api/tasks/nonexistent/runs'),
+      makeState(makeAgent()),
+    );
+    expect(res.status).toBe(404);
+    const body = (await res.json()) as { error: string };
+    expect(body.error).toBe('Task not found');
+  });
+
+  it('returns run logs for existing task', async () => {
+    const state: WebStateProvider = {
+      ...makeState(makeAgent()),
+      getTaskById: (id) =>
+        id === 'task-001'
+          ? {
+              id: 'task-001',
+              group_folder: 'test',
+              chat_jid: 'dc:123',
+              prompt: 'do stuff',
+              schedule_type: 'cron',
+              schedule_value: '0 * * * *',
+              context_mode: 'isolated',
+              next_run: '2026-03-10T13:00:00.000Z',
+              last_run: '2026-03-10T12:00:00.000Z',
+              last_result: 'Completed successfully',
+              status: 'active',
+              created_at: '2026-03-01T00:00:00.000Z',
+            }
+          : undefined,
+      getTaskRunLogs: (taskId, limit) => {
+        if (taskId !== 'task-001') return [];
+        return sampleRuns.slice(0, limit ?? 20);
+      },
+    };
+
+    const res = await handleRequest(
+      new Request('http://localhost/api/tasks/task-001/runs'),
+      state,
+    );
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as TaskRunLog[];
+    expect(body).toHaveLength(2);
+    expect(body[0].status).toBe('success');
+    expect(body[1].status).toBe('error');
+  });
+
+  it('respects limit query param', async () => {
+    const state: WebStateProvider = {
+      ...makeState(makeAgent()),
+      getTaskById: (id) =>
+        id === 'task-001'
+          ? {
+              id: 'task-001',
+              group_folder: 'test',
+              chat_jid: 'dc:123',
+              prompt: 'do stuff',
+              schedule_type: 'cron',
+              schedule_value: '0 * * * *',
+              context_mode: 'isolated',
+              next_run: null,
+              last_run: null,
+              last_result: null,
+              status: 'active',
+              created_at: '2026-03-01T00:00:00.000Z',
+            }
+          : undefined,
+      getTaskRunLogs: (_taskId, limit) => sampleRuns.slice(0, limit ?? 20),
+    };
+
+    const res = await handleRequest(
+      new Request('http://localhost/api/tasks/task-001/runs?limit=1'),
+      state,
+    );
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as TaskRunLog[];
+    expect(body).toHaveLength(1);
+  });
+
+  it('rejects non-GET methods', async () => {
+    const state: WebStateProvider = {
+      ...makeState(makeAgent()),
+      getTaskById: () => ({
+        id: 'task-001',
+        group_folder: 'test',
+        chat_jid: 'dc:123',
+        prompt: 'do stuff',
+        schedule_type: 'cron' as const,
+        schedule_value: '0 * * * *',
+        context_mode: 'isolated' as const,
+        next_run: null,
+        last_run: null,
+        last_result: null,
+        status: 'active' as const,
+        created_at: '2026-03-01T00:00:00.000Z',
+      }),
+    };
+
+    const res = await handleRequest(
+      new Request('http://localhost/api/tasks/task-001/runs', {
+        method: 'POST',
+      }),
+      state,
+    );
     expect(res.status).toBe(405);
   });
 });

--- a/src/web/routes.ts
+++ b/src/web/routes.ts
@@ -98,9 +98,24 @@ export function handleRequest(
     return json({ error: 'Method not allowed' }, 405);
   }
   if (pathname.startsWith('/api/tasks/')) {
+    const rest = pathname.slice('/api/tasks/'.length);
+
+    // Task run logs: /api/tasks/{id}/runs
+    if (rest.endsWith('/runs')) {
+      let taskId: string;
+      try {
+        taskId = decodeURIComponent(rest.slice(0, -'/runs'.length));
+      } catch {
+        return json({ error: 'Invalid task ID encoding' }, 400);
+      }
+      if (!taskId) return json({ error: 'Missing task ID' }, 400);
+      if (method === 'GET') return handleGetTaskRuns(taskId, req, state);
+      return json({ error: 'Method not allowed' }, 405);
+    }
+
     let taskId: string;
     try {
-      taskId = decodeURIComponent(pathname.slice('/api/tasks/'.length));
+      taskId = decodeURIComponent(rest);
     } catch {
       return json({ error: 'Invalid task ID encoding' }, 400);
     }
@@ -250,6 +265,24 @@ function handleGetSingleTask(
   const task = state.getTaskById(taskId);
   if (!task) return json({ error: 'Task not found' }, 404);
   return json(task);
+}
+
+function handleGetTaskRuns(
+  taskId: string,
+  req: Request,
+  state: WebStateProvider,
+): Response {
+  const task = state.getTaskById(taskId);
+  if (!task) return json({ error: 'Task not found' }, 404);
+
+  const url = new URL(req.url);
+  const limitParam = url.searchParams.get('limit');
+  const limit = limitParam
+    ? Math.min(Math.max(1, parseInt(limitParam, 10) || 20), 100)
+    : 20;
+
+  const runs = state.getTaskRunLogs(taskId, limit);
+  return json(runs);
 }
 
 async function handleCreateTask(

--- a/src/web/server.test.ts
+++ b/src/web/server.test.ts
@@ -133,6 +133,7 @@ function makeState(
     getQueueStats: () => defaultStats,
     getQueueDetails: () => [],
     getIpcEvents: () => [],
+    getTaskRunLogs: () => [],
     createTask: (task) => store.create(task),
     updateTask: (id, updates) => store.update(id, updates),
     deleteTask: (id) => store.delete(id),

--- a/src/web/server.ts
+++ b/src/web/server.ts
@@ -641,16 +641,25 @@ function renderTaskRows(tasks: ScheduledTask[]): string {
       const agentShort = task.group_folder.split('-')[0] || task.group_folder;
       const promptShort =
         task.prompt.slice(0, 40) + (task.prompt.length > 40 ? '…' : '');
+      const lastRunInfo = task.last_run
+        ? `<span class="task-last-run" title="Last run: ${escapeHtml(task.last_run)}">${escapeHtml(task.last_result ?? '—')}</span>`
+        : '';
       return (
         `<div class="task-card" data-task-id="${escapeHtml(task.id)}">` +
         `<div class="task-top"><span class="badge ${statusClass}">${escapeHtml(task.status)}</span>` +
         `<span class="task-agent">${escapeHtml(agentShort)}</span>` +
         `<span class="task-sched">${escapeHtml(task.schedule_value)}</span></div>` +
         `<div class="task-prompt" title="${escapeHtml(task.prompt)}">${escapeHtml(promptShort)}</div>` +
+        (lastRunInfo
+          ? `<div class="task-last-run-row">${lastRunInfo}</div>`
+          : '') +
         `<div class="task-actions">` +
         `<button class="btn btn-sm btn-toggle" data-action="toggle" data-status="${toggleStatus}">${toggleLabel}</button>` +
+        `<button class="btn btn-sm" data-action="runs">Runs</button>` +
         `<button class="btn btn-sm btn-danger" data-action="delete">Del</button>` +
-        `</div></div>`
+        `</div>` +
+        `<div class="task-runs" style="display:none"></div>` +
+        `</div>`
       );
     })
     .join('\n');

--- a/src/web/shared.ts
+++ b/src/web/shared.ts
@@ -277,8 +277,19 @@ function shellCSS(): string {
     `.task-agent{font-weight:600;font-size:10px;color:var(--text)}`,
     `.task-sched{margin-left:auto;font-size:9px;color:var(--text-dim);font-variant-numeric:tabular-nums}`,
     `.task-prompt{font-size:10px;color:var(--text-dim);margin-bottom:4px;overflow:hidden;text-overflow:ellipsis;white-space:nowrap}`,
+    `.task-last-run-row{font-size:9px;color:var(--text-dim);margin-bottom:3px;overflow:hidden;text-overflow:ellipsis;white-space:nowrap}`,
     `.task-actions{display:flex;gap:4px}`,
     `.task-actions .btn{padding:1px 6px;font-size:9px}`,
+    `.task-runs{margin-top:6px;border-top:1px solid var(--border);padding-top:4px}`,
+    `.task-runs-loading,.task-runs-empty{font-size:10px;color:var(--text-dim);padding:4px 0}`,
+    `.task-run-row{display:grid;grid-template-columns:1fr auto auto;gap:4px;padding:3px 0;font-size:10px;border-bottom:1px solid var(--border)}`,
+    `.task-run-row:last-child{border-bottom:none}`,
+    `.run-ts{color:var(--text-dim);font-variant-numeric:tabular-nums}`,
+    `.run-dur{color:var(--text-dim);font-variant-numeric:tabular-nums;text-align:right}`,
+    `.run-status{font-weight:600;text-align:right}`,
+    `.run-success .run-status{color:var(--green,#4ade80)}`,
+    `.run-error .run-status{color:var(--red,#f87171)}`,
+    `.run-detail{grid-column:1/-1;font-size:9px;color:var(--text-dim);overflow:hidden;text-overflow:ellipsis;white-space:nowrap}`,
     `.agent-groups-wrap{border:1px solid var(--border);border-radius:4px;overflow:auto;flex:1}`,
     `.tables-grid{display:grid;grid-template-columns:1fr 1fr;gap:10px;flex:1;min-height:0;overflow:hidden}`,
     // Topology
@@ -770,6 +781,58 @@ function shellScript(pageScripts: Record<string, string>): string {
   );
   parts.push(
     '    .catch(function(err){window.__toast(err.message||"Failed","error");btn.disabled=false;});',
+  );
+  parts.push('  }');
+  // ---- Task run history toggle ----
+  parts.push('  if(action==="runs"){');
+  parts.push(
+    '    var runsEl=card.querySelector(".task-runs");if(!runsEl)return;',
+  );
+  parts.push(
+    '    if(runsEl.style.display!=="none"){runsEl.style.display="none";return;}',
+  );
+  parts.push(
+    '    runsEl.innerHTML="<div class=\\"task-runs-loading\\">Loading…</div>";',
+  );
+  parts.push('    runsEl.style.display="";');
+  parts.push(
+    '    fetch("/api/tasks/"+encodeURIComponent(taskId)+"/runs?limit=10")',
+  );
+  parts.push(
+    '    .then(function(r){if(!r.ok)throw new Error("Failed");return r.json();})',
+  );
+  parts.push('    .then(function(runs){');
+  parts.push(
+    '      if(!runs.length){runsEl.innerHTML="<div class=\\"task-runs-empty\\">No runs yet</div>";return;}',
+  );
+  parts.push('      runsEl.innerHTML=runs.map(function(r){');
+  parts.push('        var d=new Date(r.run_at);var ts=d.toLocaleString();');
+  parts.push(
+    '        var dur=r.duration_ms<1000?r.duration_ms+"ms":(r.duration_ms/1000).toFixed(1)+"s";',
+  );
+  parts.push('        var cls=r.status==="success"?"run-success":"run-error";');
+  parts.push(
+    '        var detail=r.status==="success"?(r.result||"ok"):("Error: "+(r.error||"unknown"));',
+  );
+  parts.push('        if(detail.length>60)detail=detail.slice(0,57)+"…";');
+  parts.push('        return "<div class=\\"task-run-row \\"+cls+"\\">"');
+  parts.push(
+    '          +"<span class=\\"run-ts\\">"+window.__esc(ts)+"</span>"',
+  );
+  parts.push(
+    '          +"<span class=\\"run-dur\\">"+window.__esc(dur)+"</span>"',
+  );
+  parts.push(
+    '          +"<span class=\\"run-status\\">"+window.__esc(r.status)+"</span>"',
+  );
+  parts.push(
+    '          +"<div class=\\"run-detail\\" title=\\""+window.__esc(r.result||r.error||"")+"\\">"+window.__esc(detail)+"</div>"',
+  );
+  parts.push('          +"</div>";');
+  parts.push('      }).join("");');
+  parts.push('    })');
+  parts.push(
+    '    .catch(function(){runsEl.innerHTML="<div class=\\"task-runs-empty\\">Failed to load runs</div>";});',
   );
   parts.push('  }');
   parts.push('});');

--- a/src/web/system.test.ts
+++ b/src/web/system.test.ts
@@ -80,6 +80,7 @@ function makeState(agents: Agent[] = [makeAgent()]): WebStateProvider {
     }),
     getQueueDetails: () => [],
     getIpcEvents: () => [],
+    getTaskRunLogs: () => [],
     createTask: () => {},
     updateTask: () => {},
     deleteTask: () => {},

--- a/src/web/types.ts
+++ b/src/web/types.ts
@@ -1,4 +1,9 @@
-import type { Agent, ChannelSubscription, ScheduledTask } from '../types.js';
+import type {
+  Agent,
+  ChannelSubscription,
+  ScheduledTask,
+  TaskRunLog,
+} from '../types.js';
 import type { GroupQueueDetail } from '../group-queue.js';
 import type { IpcEvent } from './ipc-events.js';
 
@@ -34,6 +39,8 @@ export interface WebStateProvider {
   getQueueDetails(): GroupQueueDetail[];
   /** Recent IPC events from the event buffer. */
   getIpcEvents(count?: number): IpcEvent[];
+  /** Execution history for a specific task. */
+  getTaskRunLogs(taskId: string, limit?: number): TaskRunLog[];
 
   // ---- Task mutations ----
   createTask(task: Omit<ScheduledTask, 'last_run' | 'last_result'>): void;


### PR DESCRIPTION
## Summary

Expose the existing `task_run_logs` table through the Web UI. The task scheduler already writes run logs on every execution, but until now there was no way to read or display them.

• **DB**: Add `getTaskRunLogs(taskId, limit)` query — returns runs ordered by `run_at DESC`
• **API**: Add `GET /api/tasks/{id}/runs?limit=N` endpoint (default 20, max 100) — returns 404 if task not found
• **UI**: Add "Runs" toggle button to sidebar task cards — click to expand/collapse execution history panel
• **UI**: Show `last_result` inline on task cards when available
• **CSS**: Run history rows with timestamp, duration, status badge, result detail — color-coded green/red for success/error

### Files changed (12)
- `src/db.ts` — new `getTaskRunLogs()` function
- `src/web/types.ts` — extend `WebStateProvider` interface
- `src/index.ts` — wire up `getTaskRunLogs` in orchestrator state
- `src/web/routes.ts` — new `/api/tasks/{id}/runs` route
- `src/web/server.ts` — "Runs" button + last_run info in task card HTML
- `src/web/shared.ts` — JS handler for runs toggle + CSS styles
- 6 test files updated with `getTaskRunLogs` mock + 8 new test cases

## Test plan

- [x] `bun run typecheck` passes
- [x] All 128 web tests pass (0 fail)
- [x] All 45 task scheduler tests pass (0 fail), including 4 new `getTaskRunLogs` tests
- [ ] Manual: open dashboard, click "Runs" on a task card with execution history
- [ ] Manual: verify run history shows timestamp, duration, status, and result preview
- [ ] Manual: verify "No runs yet" shown for tasks that haven't executed

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added task run history feature with a new "Runs" button to view execution logs for each task
  * Run history displays timestamp, duration, status, and result details per run
  * New API endpoint for retrieving task run logs with configurable limits

* **Tests**
  * Added comprehensive test coverage for task run log retrieval and UI functionality

<!-- end of auto-generated comment: release notes by coderabbit.ai -->