### PR TITLE
fix(ci): handle SDK-only OpenCode updates

### DIFF
--- a/.github/workflows/update-opencode.yml
+++ b/.github/workflows/update-opencode.yml
@@ -37,7 +37,8 @@ jobs:
           from pathlib import Path
 
           package = json.loads(Path('container/agent-runner/package.json').read_text())
-          print(package['dependencies']['@opencode-ai/sdk'].lstrip('^'))
+          version = package.get('dependencies', {}).get('@opencode-ai/sdk', '')
+          print(version.lstrip('^') if version else '')
           PY
           )
           echo "cli=$CLI" >> $GITHUB_OUTPUT
@@ -136,6 +137,7 @@ jobs:
           git push origin "$BRANCH"
 
           BODY_FILE=$(mktemp)
+          trap 'rm -f "$BODY_FILE"' EXIT
           printf '## OpenCode update\n\n' > "$BODY_FILE"
           if [ "${{ steps.check.outputs.cli_changed }}" == "true" ]; then
             printf -- '- **CLI**: `%s` → `%s` (Dockerfile `OPENCODE_VERSION`)\n' "${{ steps.current.outputs.cli }}" "${{ steps.latest.outputs.cli }}" >> "$BODY_FILE"


### PR DESCRIPTION
## Summary
- make the OpenCode updater tolerate repos that no longer track ARG OPENCODE_VERSION in container/Dockerfile
- derive branch names, commit titles, and existing-PR lookups from whichever component actually changed
- switch the workflow PR creation step to body-file generation instead of inline markdown interpolation

## Testing
- bunx prettier --check .github/workflows/update-opencode.yml
- executed the updated version-detection shell logic locally against the current repo layout


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Improved automated version-detection workflow with more reliable parsing and tracking for CLI and SDK.
  * Enhanced change detection to independently identify CLI and SDK updates and whether CLI is tracked.
  * Generates dynamic branch names, commit titles, and richer PR descriptions reflecting detected changes.
  * Emits additional metadata about tracked/changed status for transparency in the workflow.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->