### PR TITLE
fix(discovery): use Bun-safe bonjour import

### DIFF
--- a/src/discovery/mdns.ts
+++ b/src/discovery/mdns.ts
@@ -2,7 +2,7 @@
  * mDNS service advertisement and browsing for LAN peer discovery.
  * Uses bonjour-service (pure JS mDNS implementation).
  */
-import Bonjour from 'bonjour-service';
+import { Bonjour } from 'bonjour-service';
 
 import { logger } from '../logger.js';
 import type {


### PR DESCRIPTION
## Summary
- fix the `bonjour-service` import in the mDNS discovery module so Bun resolves the constructor correctly at runtime
- keep LAN discovery startup from crashing before service advertisement and browsing initialize

## Verification
- `bun run typecheck`
- `bun run build`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated internal code import style with no impact to functionality or user experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->