### PR TITLE
test(github): cover webhook notification branches

### DIFF
--- a/src/github-webhooks.test.ts
+++ b/src/github-webhooks.test.ts
@@ -115,7 +115,8 @@ describe('github webhooks', () => {
         review: {
           state: 'APPROVED',
           body: 'Looks good to me.',
-          html_url: 'https://github.com/omniaura/omniclaw/pull/264#pullrequestreview-1',
+          html_url:
+            'https://github.com/omniaura/omniclaw/pull/264#pullrequestreview-1',
         },
       },
       config,
@@ -147,7 +148,8 @@ describe('github webhooks', () => {
         },
         comment: {
           body: longBody,
-          html_url: 'https://github.com/omniaura/omniclaw/issues/223#issuecomment-1',
+          html_url:
+            'https://github.com/omniaura/omniclaw/issues/223#issuecomment-1',
         },
       },
       config,


### PR DESCRIPTION
## Summary
- add deterministic tests for `buildGitHubWebhookNotification` review, issue comment, CI check suite, and ignored-event branches
- verify webhook summaries, URL fallbacks, truncation behavior, and missing-config handling for watched and unwatched repos
- raise the suite from 994 to 998 passing tests while keeping the full `bun test` run green

## Coverage Notes
- Covered: `src/github-webhooks.ts`
- Before: `994 pass`, `0 fail`, `Ran 994 tests across 53 files`
- After: `998 pass`, `0 fail`, `Ran 998 tests across 53 files`
- Remaining high-value gaps: `src/index.ts`, `src/ipc.ts`, `src/backends/local-backend.ts`, `src/web/routes.ts`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added comprehensive test coverage for webhook event handlers including PR reviews, issue comments with body truncation, CI check suite failures, and edge cases such as unsupported events and missing configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->