### PR TITLE
test(web): expand utility coverage

### DIFF
--- a/src/resume-position-store.test.ts
+++ b/src/resume-position-store.test.ts
@@ -1,73 +1,174 @@
-import { describe, expect, it, mock } from 'bun:test';
+import { beforeEach, describe, expect, it, spyOn } from 'bun:test';
 
+import { _initTestDatabase } from './db.js';
+import { logger } from './logger.js';
 import {
   createResumePositionStore,
+  MemoryResumePositionStore,
   PersistentResumePositionStore,
+  type PersistentStateAdapter,
 } from './resume-position-store.js';
 
-describe('resume position store', () => {
-  it('keeps behavior inert when persistentTaskState is disabled', () => {
-    const existingState: Record<string, string> = {
-      main: 'cursor-1',
-    };
+describe('MemoryResumePositionStore', () => {
+  let store: MemoryResumePositionStore;
 
-    const store = createResumePositionStore({
-      persistentTaskState: false,
-      initialResumePositions: existingState,
+  beforeEach(() => {
+    store = new MemoryResumePositionStore({
+      alpha: '2026-03-01T00:00:00.000Z',
     });
-
-    expect(store.get('main')).toBe('cursor-1');
-
-    store.set('main', 'cursor-2');
-    expect(existingState.main).toBe('cursor-2');
   });
 
-  it('falls back to empty state when persisted resume positions are missing', () => {
-    const write = mock(() => {});
-    const store = new PersistentResumePositionStore({
+  it('reads and updates in-memory resume positions', () => {
+    expect(store.get('alpha')).toBe('2026-03-01T00:00:00.000Z');
+    expect(store.get('missing')).toBeUndefined();
+
+    store.set('beta', '2026-03-02T00:00:00.000Z');
+
+    expect(store.getAll()).toEqual({
+      alpha: '2026-03-01T00:00:00.000Z',
+      beta: '2026-03-02T00:00:00.000Z',
+    });
+  });
+
+  it('clears all tracked positions', () => {
+    store.set('beta', '2026-03-02T00:00:00.000Z');
+
+    store.clear();
+
+    expect(store.getAll()).toEqual({});
+  });
+});
+
+describe('PersistentResumePositionStore', () => {
+  it('loads only string resume positions from persisted state', () => {
+    const adapter: PersistentStateAdapter = {
+      read: <T>() =>
+        ({
+          alpha: '2026-03-01T00:00:00.000Z',
+          beta: 123,
+          gamma: null,
+        }) as T,
+      write: () => {},
+    };
+
+    const store = new PersistentResumePositionStore({ stateAdapter: adapter });
+
+    expect(store.getAll()).toEqual({
+      alpha: '2026-03-01T00:00:00.000Z',
+    });
+  });
+
+  it('falls back to an empty state when persisted data is not an object', () => {
+    const arrayStore = new PersistentResumePositionStore({
       stateAdapter: {
-        read: () => undefined,
-        write,
+        read: <T>() => ['bad'] as T,
+        write: () => {},
+      },
+    });
+    const nullStore = new PersistentResumePositionStore({
+      stateAdapter: {
+        read: <T>() => null as T,
+        write: () => {},
       },
     });
 
-    expect(store.getAll()).toEqual({});
-
-    store.set('group-a', 'cursor-a');
-    expect(write).toHaveBeenCalledTimes(1);
-    expect(store.get('group-a')).toBe('cursor-a');
+    expect(arrayStore.getAll()).toEqual({});
+    expect(nullStore.getAll()).toEqual({});
   });
 
-  it('falls back to empty state when persisted resume positions are unreadable', () => {
+  it('persists updates and clears through the adapter', () => {
+    const writes: Array<{ key: string; value: unknown }> = [];
+    const adapter: PersistentStateAdapter = {
+      read: <T>() => ({ alpha: '2026-03-01T00:00:00.000Z' }) as T,
+      write: (key, value) => {
+        writes.push({ key, value: structuredClone(value) });
+      },
+    };
+    const store = new PersistentResumePositionStore({ stateAdapter: adapter });
+
+    store.set('beta', '2026-03-02T00:00:00.000Z');
+    store.clear();
+
+    expect(writes).toEqual([
+      {
+        key: 'resume_positions',
+        value: {
+          alpha: '2026-03-01T00:00:00.000Z',
+          beta: '2026-03-02T00:00:00.000Z',
+        },
+      },
+      {
+        key: 'resume_positions',
+        value: {},
+      },
+    ]);
+  });
+
+  it('warns and continues when initial load fails', () => {
+    const warnSpy = spyOn(logger, 'warn');
     const store = new PersistentResumePositionStore({
       stateAdapter: {
         read: () => {
-          throw new Error('EACCES: permission denied');
+          throw new Error('boom');
         },
         write: () => {},
       },
     });
 
     expect(store.getAll()).toEqual({});
+    expect(warnSpy).toHaveBeenCalledTimes(1);
+    expect(warnSpy.mock.calls[0]?.[1]).toBe(
+      'Failed to load persisted resume positions',
+    );
 
-    store.set('group-b', 'cursor-b');
-    expect(store.get('group-b')).toBe('cursor-b');
+    warnSpy.mockRestore();
   });
 
-  it('drops corrupted persisted entries and keeps valid values', () => {
+  it('warns and keeps in-memory state when persisting fails', () => {
+    const warnSpy = spyOn(logger, 'warn');
     const store = new PersistentResumePositionStore({
       stateAdapter: {
-        read: <T>() =>
-          ({
-            valid: 'cursor-valid',
-            invalid: 42,
-          }) as T,
-        write: () => {},
+        read: <T>() => ({}) as T,
+        write: () => {
+          throw new Error('disk full');
+        },
       },
     });
 
-    expect(store.getAll()).toEqual({
-      valid: 'cursor-valid',
+    expect(() => {
+      store.set('alpha', '2026-03-03T00:00:00.000Z');
+    }).not.toThrow();
+    expect(store.get('alpha')).toBe('2026-03-03T00:00:00.000Z');
+    expect(warnSpy).toHaveBeenCalledTimes(1);
+    expect(warnSpy.mock.calls[0]?.[1]).toBe(
+      'Failed to persist resume positions',
+    );
+
+    warnSpy.mockRestore();
+  });
+});
+
+describe('createResumePositionStore', () => {
+  beforeEach(() => {
+    _initTestDatabase();
+  });
+
+  it('returns a memory-backed store when persistence is disabled', () => {
+    const store = createResumePositionStore({
+      persistentTaskState: false,
+      initialResumePositions: { alpha: '2026-03-01T00:00:00.000Z' },
     });
+
+    expect(store).toBeInstanceOf(MemoryResumePositionStore);
+    expect(store.get('alpha')).toBe('2026-03-01T00:00:00.000Z');
+  });
+
+  it('returns a persistent store when persistence is enabled', () => {
+    const store = createResumePositionStore({
+      persistentTaskState: true,
+      initialResumePositions: { alpha: 'ignored' },
+    });
+
+    expect(store).toBeInstanceOf(PersistentResumePositionStore);
   });
 });

--- a/src/slack-jid.test.ts
+++ b/src/slack-jid.test.ts
@@ -1,0 +1,27 @@
+import { describe, expect, it } from 'bun:test';
+
+import { parseScopedSlackJid } from './slack-jid.js';
+
+describe('parseScopedSlackJid', () => {
+  it('parses scoped Slack JIDs into bot and channel ids', () => {
+    expect(parseScopedSlackJid('slack:PRIMARY:C123456')).toEqual({
+      botId: 'PRIMARY',
+      channelId: 'C123456',
+    });
+  });
+
+  it('allows channel ids with separators after the second segment', () => {
+    expect(
+      parseScopedSlackJid('slack:OPS:thread-abc:1700000000.000100'),
+    ).toEqual({
+      botId: 'OPS',
+      channelId: 'thread-abc:1700000000.000100',
+    });
+  });
+
+  it('rejects unscoped or malformed JIDs', () => {
+    expect(parseScopedSlackJid('slack:C123456')).toBeNull();
+    expect(parseScopedSlackJid('discord:PRIMARY:C123456')).toBeNull();
+    expect(parseScopedSlackJid('slack:PRIMARY:channel with spaces')).toBeNull();
+  });
+});

--- a/src/web/agent-channels.test.ts
+++ b/src/web/agent-channels.test.ts
@@ -1,61 +1,101 @@
 import { describe, expect, it } from 'bun:test';
 
-import { buildAgentChannelData } from './agent-channels.js';
+import type { Agent, ChannelSubscription } from '../types.js';
+import { buildAgentChannelData, renderAgentGroups } from './agent-channels.js';
 import type { WebStateProvider } from './types.js';
 
-const state: WebStateProvider = {
-  getAgents: () => ({
-    local: {
-      id: 'local',
-      name: 'Local Agent',
-      folder: 'groups/local',
-      backend: 'docker',
-      agentRuntime: 'opencode',
-      isAdmin: false,
-      createdAt: '',
-    },
-  }),
-  getChannelSubscriptions: () => ({
-    'dc:1': [
-      {
-        channelJid: 'dc:1',
-        agentId: 'local',
-        trigger: '@omni',
-        requiresTrigger: true,
-        priority: 1,
-        isPrimary: true,
-        createdAt: '',
-        channelFolder: 'servers/acme/spec',
-        categoryFolder: 'servers/acme',
-      },
-    ],
-  }),
-  getTasks: () => [],
-  getTaskById: () => undefined,
-  getMessages: () => [],
-  getChats: () => [{ jid: 'dc:1', name: 'spec', last_message_time: '' }],
-  getQueueStats: () => ({
-    activeContainers: 0,
-    idleContainers: 0,
-    maxActive: 0,
-    maxIdle: 0,
-  }),
-  getQueueDetails: () => [],
-  getIpcEvents: () => [],
-  getTaskRunLogs: () => [],
-  createTask: () => {},
-  updateTask: () => {},
-  deleteTask: () => {},
-  calculateNextRun: () => null,
-  readContextFile: () => null,
-  writeContextFile: () => {},
-  updateAgentAvatar: () => {},
-  resolveChatImage: async () => null,
-  resolveDiscordGuildImage: async () => null,
-};
+function makeAgent(overrides: Partial<Agent> = {}): Agent {
+  return {
+    id: 'agent-1',
+    name: 'Agent One',
+    folder: 'agent-one',
+    backend: 'apple-container',
+    agentRuntime: 'claude-agent-sdk',
+    isAdmin: false,
+    createdAt: '2026-03-01T00:00:00.000Z',
+    ...overrides,
+  };
+}
+
+function makeSubscription(
+  overrides: Partial<ChannelSubscription> = {},
+): ChannelSubscription {
+  return {
+    channelJid: 'dc:123',
+    agentId: 'agent-1',
+    trigger: '@Omni',
+    requiresTrigger: true,
+    priority: 1,
+    isPrimary: true,
+    createdAt: '2026-03-01T00:00:00.000Z',
+    ...overrides,
+  };
+}
+
+function makeState(options?: {
+  agents?: Agent[];
+  subscriptions?: Record<string, ChannelSubscription[]>;
+  chats?: Array<{ jid: string; name: string; last_message_time: string }>;
+}): WebStateProvider {
+  const agents = options?.agents ?? [makeAgent()];
+  const agentMap = Object.fromEntries(agents.map((agent) => [agent.id, agent]));
+
+  return {
+    getAgents: () => agentMap,
+    getChannelSubscriptions: () => options?.subscriptions ?? {},
+    getTasks: () => [],
+    getTaskById: () => undefined,
+    getMessages: () => [],
+    getChats: () => options?.chats ?? [],
+    getQueueStats: () => ({
+      activeContainers: 0,
+      idleContainers: 0,
+      maxActive: 1,
+      maxIdle: 1,
+    }),
+    getQueueDetails: () => [],
+    getIpcEvents: () => [],
+    getTaskRunLogs: () => [],
+    createTask: () => {},
+    updateTask: () => {},
+    deleteTask: () => {},
+    calculateNextRun: () => null,
+    readContextFile: () => null,
+    writeContextFile: () => {},
+    updateAgentAvatar: () => {},
+    resolveChatImage: async () => null,
+    resolveDiscordGuildImage: async () => null,
+  };
+}
 
 describe('buildAgentChannelData', () => {
   it('includes remote peers in the unified agent list', () => {
+    const state = makeState({
+      agents: [
+        makeAgent({
+          id: 'local',
+          name: 'Local Agent',
+          folder: 'groups/local',
+          backend: 'docker',
+          agentRuntime: 'opencode',
+          createdAt: '',
+        }),
+      ],
+      subscriptions: {
+        'dc:1': [
+          makeSubscription({
+            channelJid: 'dc:1',
+            agentId: 'local',
+            trigger: '@omni',
+            channelFolder: 'servers/acme/spec',
+            categoryFolder: 'servers/acme',
+            createdAt: '',
+          }),
+        ],
+      },
+      chats: [{ jid: 'dc:1', name: 'spec', last_message_time: '' }],
+    });
+
     const result = buildAgentChannelData(state, [
       {
         instanceId: 'remote-1',
@@ -92,5 +132,173 @@ describe('buildAgentChannelData', () => {
       jid: 'dc:remote',
       displayName: 'remote-spec',
     });
+  });
+
+  it('enriches channels with chat names, fallback folders, and platform icons', () => {
+    const state = makeState({
+      agents: [
+        makeAgent({
+          id: 'agent-1',
+          agentContextFolder: 'agents/agent-one',
+          serverFolder: 'servers/alpha',
+          avatarUrl: '/avatars/agent-1.png',
+        }),
+      ],
+      subscriptions: {
+        'dc:123': [
+          makeSubscription({
+            channelJid: 'dc:123',
+            discordGuildId: 'guild-1',
+            discordBotId: 'bot-1',
+            channelFolder: 'servers/alpha/channels/general',
+          }),
+        ],
+        'tg:-1001': [
+          makeSubscription({
+            channelJid: 'tg:-1001',
+            channelFolder: 'servers/alpha/channels/alerts',
+            categoryFolder: 'servers/alpha',
+          }),
+        ],
+        'wa:999': [
+          makeSubscription({
+            channelJid: 'wa:999',
+            channelFolder: undefined,
+          }),
+        ],
+      },
+      chats: [
+        {
+          jid: 'dc:123',
+          name: 'General Chat',
+          last_message_time: '2026-03-01T00:00:00.000Z',
+        },
+      ],
+    });
+
+    const result = buildAgentChannelData(state);
+
+    expect(result).toHaveLength(1);
+    expect(result[0]).toMatchObject({
+      id: 'agent-1',
+      serverFolder: 'servers/alpha',
+      agentContextFolder: 'agents/agent-one',
+      avatarUrl: '/avatars/agent-1.png',
+      serverIconUrl: '/api/discord/guilds/guild-1/icon?botId=bot-1',
+    });
+    expect(result[0]?.channels).toEqual([
+      {
+        jid: 'dc:123',
+        displayName: 'General Chat',
+        channelFolder: 'servers/alpha/channels/general',
+        categoryFolder: undefined,
+        iconUrl: undefined,
+        discordGuildId: 'guild-1',
+        discordBotId: 'bot-1',
+      },
+      {
+        jid: 'tg:-1001',
+        displayName: '#alerts',
+        channelFolder: 'servers/alpha/channels/alerts',
+        categoryFolder: 'servers/alpha',
+        iconUrl: '/api/chats/tg%3A-1001/icon',
+        discordGuildId: undefined,
+        discordBotId: undefined,
+      },
+      {
+        jid: 'wa:999',
+        displayName: 'wa:999',
+        channelFolder: undefined,
+        categoryFolder: undefined,
+        iconUrl: undefined,
+        discordGuildId: undefined,
+        discordBotId: undefined,
+      },
+    ]);
+  });
+
+  it('only includes subscriptions for the matching agent', () => {
+    const state = makeState({
+      agents: [makeAgent({ id: 'agent-1' }), makeAgent({ id: 'agent-2' })],
+      subscriptions: {
+        'dc:123': [makeSubscription({ agentId: 'agent-2' })],
+      },
+    });
+
+    const result = buildAgentChannelData(state);
+
+    expect(result.find((agent) => agent.id === 'agent-1')?.channels).toEqual(
+      [],
+    );
+    expect(
+      result.find((agent) => agent.id === 'agent-2')?.channels,
+    ).toHaveLength(1);
+  });
+});
+
+describe('renderAgentGroups', () => {
+  it('renders backend/runtime badges and escaped channel content', () => {
+    const html = renderAgentGroups([
+      {
+        id: 'agent-1',
+        name: 'Agent <One>',
+        folder: 'agent-one',
+        backend: 'docker',
+        agentRuntime: 'opencode',
+        isAdmin: true,
+        channels: [
+          {
+            jid: 'dc:<123>',
+            displayName: 'General & Stuff',
+          },
+        ],
+      },
+    ]);
+
+    expect(html).toContain('badge-docker');
+    expect(html).toContain('badge-admin');
+    expect(html).toContain('opencode');
+    expect(html).toContain('Agent &lt;One&gt;');
+    expect(html).toContain('General &amp; Stuff');
+    expect(html).toContain('dc:&lt;123&gt;');
+    expect(html).not.toContain('Agent <One>');
+  });
+
+  it('adds context selection attributes only when requested', () => {
+    const agentData = [
+      {
+        id: 'agent-1',
+        name: 'Agent One',
+        folder: 'agent-one',
+        backend: 'apple-container',
+        agentRuntime: 'claude-agent-sdk',
+        isAdmin: false,
+        serverFolder: 'servers/root',
+        agentContextFolder: 'agents/agent-one',
+        channels: [
+          {
+            jid: 'dc:123',
+            displayName: 'General',
+            channelFolder: 'servers/root/general',
+            categoryFolder: 'servers/root',
+          },
+        ],
+      },
+    ];
+
+    const plainHtml = renderAgentGroups(agentData);
+    const contextHtml = renderAgentGroups(agentData, {
+      includeContextAttrs: true,
+    });
+
+    expect(plainHtml).not.toContain('data-select-channel');
+    expect(contextHtml).toContain('data-select-channel');
+    expect(contextHtml).toContain('data-folder="agent-one"');
+    expect(contextHtml).toContain('data-server-folder="servers/root"');
+    expect(contextHtml).toContain(
+      'data-agent-context-folder="agents/agent-one"',
+    );
+    expect(contextHtml).toContain('data-channel-folder="servers/root/general"');
+    expect(contextHtml).toContain('data-category-folder="servers/root"');
   });
 });

--- a/src/web/ipc-events.test.ts
+++ b/src/web/ipc-events.test.ts
@@ -1,75 +1,83 @@
-import { describe, expect, it } from 'bun:test';
+import { afterEach, describe, expect, it } from 'bun:test';
+
 import { IpcEventBuffer } from './ipc-events.js';
 
+const RealDate = Date;
+
+function installFixedDate(iso: string) {
+  const fixed = new RealDate(iso);
+
+  class FixedDate extends RealDate {
+    constructor(value?: string | number | Date) {
+      super(value ?? fixed.getTime());
+    }
+
+    static override now(): number {
+      return fixed.getTime();
+    }
+  }
+
+  globalThis.Date = FixedDate as unknown as DateConstructor;
+}
+
+afterEach(() => {
+  globalThis.Date = RealDate;
+});
+
 describe('IpcEventBuffer', () => {
-  it('pushes events and returns them via recent()', () => {
-    const buf = new IpcEventBuffer();
-    buf.push('message_sent', 'group-a', 'Sent to dc:123');
-    buf.push('task_created', 'group-b', 'Task created');
+  it('assigns incrementing ids and a deterministic timestamp', () => {
+    installFixedDate('2026-03-10T12:34:56.000Z');
+    const buffer = new IpcEventBuffer();
 
-    const events = buf.recent(10);
-    expect(events).toHaveLength(2);
-    // recent() returns newest first
-    expect(events[0].kind).toBe('task_created');
-    expect(events[1].kind).toBe('message_sent');
-  });
-
-  it('assigns incrementing IDs', () => {
-    const buf = new IpcEventBuffer();
-    const e1 = buf.push('message_sent', 'a', 'msg 1');
-    const e2 = buf.push('message_sent', 'a', 'msg 2');
-    expect(e2.id).toBe(e1.id + 1);
-  });
-
-  it('caps at maxEvents', () => {
-    const buf = new IpcEventBuffer(3);
-    buf.push('message_sent', 'a', '1');
-    buf.push('message_sent', 'a', '2');
-    buf.push('message_sent', 'a', '3');
-    buf.push('message_sent', 'a', '4');
-    expect(buf.size).toBe(3);
-    // Oldest event (id=1) should have been evicted
-    const events = buf.recent(10);
-    expect(events[2].summary).toBe('2');
-    expect(events[0].summary).toBe('4');
-  });
-
-  it('since() returns events after given ID', () => {
-    const buf = new IpcEventBuffer();
-    const e1 = buf.push('message_sent', 'a', '1');
-    buf.push('task_created', 'b', '2');
-    buf.push('task_edited', 'c', '3');
-
-    const after = buf.since(e1.id);
-    expect(after).toHaveLength(2);
-    expect(after[0].summary).toBe('2');
-    expect(after[1].summary).toBe('3');
-  });
-
-  it('stores details when provided', () => {
-    const buf = new IpcEventBuffer();
-    const ev = buf.push('task_created', 'a', 'Task created', {
-      taskId: 'task-123',
-      targetFolder: 'group-b',
+    const event = buffer.push('task_created', 'main', 'Created task', {
+      taskId: 'task-1',
     });
-    expect(ev.details).toEqual({
-      taskId: 'task-123',
-      targetFolder: 'group-b',
+
+    expect(event).toEqual({
+      id: 1,
+      kind: 'task_created',
+      timestamp: '2026-03-10T12:34:56.000Z',
+      sourceGroup: 'main',
+      summary: 'Created task',
+      details: { taskId: 'task-1' },
     });
   });
 
-  it('sets timestamp on events', () => {
-    const buf = new IpcEventBuffer();
-    const ev = buf.push('message_sent', 'a', 'test');
-    expect(ev.timestamp).toBeTruthy();
-    // Should be a valid ISO string
-    expect(new Date(ev.timestamp).toISOString()).toBe(ev.timestamp);
+  it('evicts the oldest events when the ring buffer reaches capacity', () => {
+    const buffer = new IpcEventBuffer(2);
+
+    buffer.push('message_sent', 'a', 'first');
+    buffer.push('message_sent', 'b', 'second');
+    buffer.push('task_cancelled', 'c', 'third');
+
+    expect(buffer.size).toBe(2);
+    expect(buffer.since(0).map((event) => event.summary)).toEqual([
+      'second',
+      'third',
+    ]);
   });
 
-  it('returns empty arrays when no events', () => {
-    const buf = new IpcEventBuffer();
-    expect(buf.recent()).toEqual([]);
-    expect(buf.since(0)).toEqual([]);
-    expect(buf.size).toBe(0);
+  it('returns recent events newest-first and respects the count', () => {
+    const buffer = new IpcEventBuffer();
+
+    buffer.push('message_sent', 'a', 'first');
+    buffer.push('message_blocked', 'b', 'second');
+    buffer.push('ipc_error', 'c', 'third');
+
+    expect(buffer.recent(2).map((event) => event.summary)).toEqual([
+      'third',
+      'second',
+    ]);
+  });
+
+  it('returns only events newer than the provided id', () => {
+    const buffer = new IpcEventBuffer();
+
+    buffer.push('message_sent', 'a', 'first');
+    buffer.push('task_edited', 'b', 'second');
+    buffer.push('task_error', 'c', 'third');
+
+    expect(buffer.since(1).map((event) => event.id)).toEqual([2, 3]);
+    expect(buffer.since(3)).toEqual([]);
   });
 });


### PR DESCRIPTION
## Summary
- Add focused coverage for `src/web/agent-channels.ts` and `src/slack-jid.ts`, including escaping, fallback naming, context attributes, and scoped Slack JID parsing.
- Expand deterministic utility coverage for `src/resume-position-store.ts` and `src/web/ipc-events.ts`, including sanitization, persistence failures, ring-buffer eviction, and fixed-time event timestamps.
- Raise the suite from 998 passing tests across 53 files to 1007 passing tests across 55 files, while documenting the next unpaired modules to target.

## Verification
- `bun test`

## Coverage Notes
- Files covered in this PR: `src/web/agent-channels.ts`, `src/slack-jid.ts`, deeper branch coverage for `src/resume-position-store.ts`, and deeper branch coverage for `src/web/ipc-events.ts`.
- Remaining paired-file coverage gaps still worth targeting: `src/backends/local-backend.ts`, `src/backends/local-backend.isolated.ts`, `src/discovery/peer-client.ts`, `src/discovery/trust-store.ts`, `src/ipc.ts`, `src/web/context-files.ts`, `src/web/context-viewer.ts`, `src/web/dashboard.ts`, `src/web/network.ts`, `src/web/page-scripts.ts`, `src/web/shared.ts`, and `src/whatsapp-auth.ts`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Expanded test coverage for resume position storage with in-memory and persistent state handling.
  * Added new test suite for Slack JID parsing validation.
  * Introduced comprehensive tests for agent-channel rendering logic, including channel enrichment and display features.
  * Enhanced event buffering tests with deterministic timing framework for improved reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->