### PR TITLE
fix(security): verify peer-auth body hash against received bytes

### DIFF
--- a/src/discovery/routes.test.ts
+++ b/src/discovery/routes.test.ts
@@ -1,6 +1,8 @@
+import { createHash, createHmac, randomUUID } from 'crypto';
 import { afterEach, describe, expect, it, mock } from 'bun:test';
 
 import {
+  checkPeerAuth,
   handleDiscoveryRequest,
   type DiscoveryRouteContext,
 } from './routes.js';
@@ -96,5 +98,143 @@ describe('handleDiscoveryRequest', () => {
     expect((await (res as Response).json()) as { status: string }).toEqual({
       status: 'already_trusted',
     });
+  });
+});
+
+// ---- checkPeerAuth body hash verification ----
+
+const TEST_SECRET = 'test-shared-secret-32-bytes-long!';
+const TEST_INSTANCE = 'peer-instance-1';
+
+/** Build a signed request with valid peer auth headers. */
+function buildSignedRequest(
+  path: string,
+  method: string,
+  body: string,
+  secret: string = TEST_SECRET,
+  instanceId: string = TEST_INSTANCE,
+): Request {
+  const nonce = randomUUID();
+  const timestamp = Date.now().toString();
+  const bodyHash = createHash('sha256').update(body).digest('hex');
+  const signature = createHmac('sha256', secret)
+    .update([method, path, timestamp, nonce, bodyHash].join('\n'))
+    .digest('hex');
+
+  return new Request(`http://localhost${path}`, {
+    method,
+    headers: {
+      'Content-Type': 'application/json',
+      'X-OmniClaw-Instance': instanceId,
+      'X-OmniClaw-Timestamp': timestamp,
+      'X-OmniClaw-Nonce': nonce,
+      'X-OmniClaw-Body-SHA256': bodyHash,
+      'X-OmniClaw-Signature': signature,
+    },
+    body: body || undefined,
+  });
+}
+
+function makeTrustStore(secret: string | null = TEST_SECRET) {
+  return {
+    getPeerSecret: () => secret,
+    updatePeerLastSeen: () => {},
+  } as any;
+}
+
+describe('checkPeerAuth — body hash verification', () => {
+  it('accepts a request when computedBodyHash matches the header', () => {
+    const body = JSON.stringify({ path: 'test/CLAUDE.md', content: 'hello' });
+    const req = buildSignedRequest('/api/context/file', 'PUT', body);
+    const computedHash = createHash('sha256').update(body).digest('hex');
+
+    const result = checkPeerAuth(req, makeTrustStore(), computedHash);
+    expect(result).toBe(true);
+  });
+
+  it('rejects a request when the body was tampered after signing', () => {
+    const originalBody = JSON.stringify({
+      path: 'test/CLAUDE.md',
+      content: 'legitimate content',
+    });
+    const tamperedBody = JSON.stringify({
+      path: 'test/CLAUDE.md',
+      content: 'MALICIOUS INSTRUCTIONS',
+    });
+
+    // Sign headers with the original body
+    const req = buildSignedRequest('/api/context/file', 'PUT', originalBody);
+    // But compute the hash from the tampered body (simulating MITM)
+    const tamperedHash = createHash('sha256')
+      .update(tamperedBody)
+      .digest('hex');
+
+    const result = checkPeerAuth(req, makeTrustStore(), tamperedHash);
+    expect(result).toBe(false);
+  });
+
+  it('accepts a GET request with empty body hash', () => {
+    const req = buildSignedRequest('/api/agents', 'GET', '');
+    const computedHash = createHash('sha256').update('').digest('hex');
+
+    const result = checkPeerAuth(req, makeTrustStore(), computedHash);
+    expect(result).toBe(true);
+  });
+
+  it('still works without computedBodyHash (backward compatibility)', () => {
+    const body = JSON.stringify({ path: 'test/CLAUDE.md', content: 'hello' });
+    const req = buildSignedRequest('/api/context/file', 'PUT', body);
+
+    // No computedBodyHash — skips the body integrity check
+    const result = checkPeerAuth(req, makeTrustStore());
+    expect(result).toBe(true);
+  });
+
+  it('rejects when the shared secret is wrong', () => {
+    const body = JSON.stringify({ data: 'test' });
+    const req = buildSignedRequest('/api/context/file', 'PUT', body);
+    const computedHash = createHash('sha256').update(body).digest('hex');
+
+    const result = checkPeerAuth(
+      req,
+      makeTrustStore('wrong-secret-xxxxxxxxxx!'),
+      computedHash,
+    );
+    expect(result).toBe(false);
+  });
+
+  it('rejects when no peer secret is stored', () => {
+    const body = JSON.stringify({ data: 'test' });
+    const req = buildSignedRequest('/api/context/file', 'PUT', body);
+    const computedHash = createHash('sha256').update(body).digest('hex');
+
+    const result = checkPeerAuth(req, makeTrustStore(null), computedHash);
+    expect(result).toBe(false);
+  });
+
+  it('rejects when required auth headers are missing', () => {
+    const req = new Request('http://localhost/api/context/file', {
+      method: 'PUT',
+      headers: { 'Content-Type': 'application/json' },
+      body: '{}',
+    });
+    const computedHash = createHash('sha256').update('{}').digest('hex');
+
+    const result = checkPeerAuth(req, makeTrustStore(), computedHash);
+    expect(result).toBe(false);
+  });
+
+  it('rejects a replayed request with duplicate nonce', () => {
+    const body = JSON.stringify({ data: 'test' });
+    const req = buildSignedRequest('/api/context/file', 'PUT', body);
+    const computedHash = createHash('sha256').update(body).digest('hex');
+
+    // First call should succeed
+    const first = checkPeerAuth(req, makeTrustStore(), computedHash);
+    expect(first).toBe(true);
+
+    // Replaying the exact same request (same nonce) should fail
+    const replay = checkPeerAuth(req, makeTrustStore(), computedHash);
+    expect(replay).toBe(false);
   });
 });

--- a/src/discovery/routes.ts
+++ b/src/discovery/routes.ts
@@ -877,8 +877,16 @@ function getLocalAddress(): string {
 /**
  * Check if an incoming API request is from a trusted peer.
  * Used by the web server to authenticate peer-to-peer API calls.
+ *
+ * @param computedBodyHash - SHA-256 hex digest computed from the actual
+ *   received request body. When provided, it is compared against the
+ *   caller-supplied X-OmniClaw-Body-SHA256 header to detect body tampering.
  */
-export function checkPeerAuth(req: Request, trustStore: TrustStore): boolean {
+export function checkPeerAuth(
+  req: Request,
+  trustStore: TrustStore,
+  computedBodyHash?: string,
+): boolean {
   const instanceId = req.headers.get('X-OmniClaw-Instance');
   const timestamp = req.headers.get('X-OmniClaw-Timestamp');
   const nonce = req.headers.get('X-OmniClaw-Nonce');
@@ -886,6 +894,14 @@ export function checkPeerAuth(req: Request, trustStore: TrustStore): boolean {
   const signature = req.headers.get('X-OmniClaw-Signature');
 
   if (!instanceId || !timestamp || !nonce || !bodyHash || !signature) {
+    return false;
+  }
+
+  // Verify that the received body matches the claimed hash before checking
+  // the HMAC signature. Without this, an on-path attacker could tamper with
+  // the body while the signed headers (including the original hash) remain
+  // valid.
+  if (computedBodyHash !== undefined && computedBodyHash !== bodyHash) {
     return false;
   }
 

--- a/src/web/server.ts
+++ b/src/web/server.ts
@@ -1,3 +1,5 @@
+import { createHash } from 'crypto';
+
 import { ServerSentEventGenerator } from '@starfederation/datastar-sdk/web';
 
 import { logger } from '../logger.js';
@@ -48,7 +50,7 @@ export function startWebServer(
     hostname: hostname || '127.0.0.1',
     development: false,
 
-    fetch(req) {
+    async fetch(req) {
       const url = new URL(req.url);
       if (url.pathname === '/ws') {
         return new Response('WebSocket is deprecated for the web dashboard', {
@@ -61,7 +63,17 @@ export function startWebServer(
       const isPeerRequest =
         isPeerRoute(url.pathname) && req.headers.has('X-OmniClaw-Instance');
       if (isPeerRequest && trustStore) {
-        if (!checkPeerAuth(req, trustStore)) {
+        // Read the raw body and compute its SHA-256 so checkPeerAuth can
+        // verify the claimed X-OmniClaw-Body-SHA256 header matches the
+        // bytes actually received. This prevents body-tampering attacks
+        // where an on-path attacker modifies the body while keeping the
+        // signed headers intact.
+        const cloned = req.clone();
+        const rawBody = await cloned.text();
+        const computedBodyHash = createHash('sha256')
+          .update(rawBody)
+          .digest('hex');
+        if (!checkPeerAuth(req, trustStore, computedBodyHash)) {
           return new Response('Unauthorized peer', {
             status: 403,
             headers: corsOrigin ? makeCorsHeaders(corsOrigin) : {},


### PR DESCRIPTION
## Summary

Fixes a P1 security bug where `checkPeerAuth()` trusted the caller-supplied `X-OmniClaw-Body-SHA256` header without recomputing the digest from the actual request body. An on-path attacker on a trusted LAN could tamper with authenticated peer write requests (e.g. `PUT /api/context/file`) while keeping the signed headers intact, effectively poisoning agent context files with malicious instructions.

### Changes

- **`src/discovery/routes.ts`** — `checkPeerAuth()` now accepts an optional `computedBodyHash` parameter. When provided, it compares the server-computed SHA-256 against the header-claimed hash before verifying the HMAC signature.
- **`src/web/server.ts`** — The peer auth path now clones the request, reads the raw body, and computes SHA-256 before calling `checkPeerAuth()`. The original request body remains intact for downstream handlers.
- **`src/discovery/routes.test.ts`** — 8 regression tests covering: valid body hash, tampered body detection, empty-body GET requests, backward compatibility (no hash), wrong secret, missing secret, missing headers, and nonce replay.

### Root cause

`PeerClient.authenticatedFetch()` computed a body hash locally and placed it in `X-OmniClaw-Body-SHA256`, which was signed via HMAC. But `checkPeerAuth()` only verified the HMAC using the header-provided hash — it never recomputed the hash from the received body. This meant authentication proved sender identity but not body integrity.

## Test plan

- [x] `bun test src/discovery/routes.test.ts` — 9 tests pass (1 existing + 8 new)
- [x] `bun test src/web/server.test.ts` — 61 tests pass (no regressions)
- [x] `npx tsc --noEmit` — clean typecheck
- [x] Prettier formatting verified

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Enhanced peer authentication with request body verification to detect and reject tampered requests.
  * Added support for validating request integrity during peer-to-peer communication.

* **Tests**
  * Added comprehensive test suite covering peer authentication scenarios, including body tampering detection, nonce validation, and secret key verification.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->