### PR TITLE
fix(discovery): pin pairing callbacks to requester address

### DIFF
--- a/src/discovery/routes.test.ts
+++ b/src/discovery/routes.test.ts
@@ -171,6 +171,54 @@ describe('handleDiscoveryRequest', () => {
     });
   });
 
+  it('normalizes IPv4-mapped IPv6 socket addresses before storing the callback host', async () => {
+    const createPairRequest = mock(() => ({
+      id: 'req-3',
+      fromInstanceId: 'remote-instance',
+      fromName: 'Remote',
+      fromHost: '10.0.0.22',
+      fromPort: 6001,
+      callbackToken: 'callback-token',
+      status: 'pending',
+      sharedSecret: null,
+      createdAt: new Date().toISOString(),
+      resolvedAt: null,
+    }));
+    const req = withSocketAddress(
+      new Request('http://localhost/api/discovery/pair', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          instanceId: 'remote-instance',
+          name: 'Remote',
+          host: '169.254.169.254',
+          port: 6001,
+          callbackToken: 'callback-token',
+          keyAgreementPublicKey: 'test-public-key',
+        }),
+      }),
+      '::ffff:10.0.0.22',
+    );
+
+    const ctx = makeContext({
+      trustStore: {
+        isPeerTrusted: () => false,
+        createPairRequest,
+      } as any,
+    });
+
+    const res = await handleDiscoveryRequest(req, new URL(req.url), ctx);
+    expect(res).not.toBeNull();
+    expect(createPairRequest).toHaveBeenCalledWith(
+      'remote-instance',
+      'Remote',
+      '10.0.0.22',
+      6001,
+      'callback-token',
+      'test-public-key',
+    );
+  });
+
   it('rejects pair requests when the requester address is unavailable', async () => {
     const req = new Request('http://localhost/api/discovery/pair', {
       method: 'POST',
@@ -198,32 +246,34 @@ describe('handleDiscoveryRequest', () => {
   });
 
   it('rejects pair requests with invalid callback ports', async () => {
-    const req = withSocketAddress(
-      new Request('http://localhost/api/discovery/pair', {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({
-          instanceId: 'remote-instance',
-          name: 'Remote',
-          host: '127.0.0.1',
-          port: 70000,
-          callbackToken: 'callback-token',
-          keyAgreementPublicKey: 'test-public-key',
+    for (const port of [70000, 0, -1]) {
+      const req = withSocketAddress(
+        new Request('http://localhost/api/discovery/pair', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({
+            instanceId: 'remote-instance',
+            name: 'Remote',
+            host: '127.0.0.1',
+            port,
+            callbackToken: 'callback-token',
+            keyAgreementPublicKey: 'test-public-key',
+          }),
         }),
-      }),
-      '10.0.0.22',
-    );
+        '10.0.0.22',
+      );
 
-    const res = await handleDiscoveryRequest(
-      req,
-      new URL(req.url),
-      makeContext(),
-    );
-    expect(res).not.toBeNull();
-    expect((await (res as Response).json()) as { error: string }).toEqual({
-      error: 'Invalid port',
-    });
-    expect((res as Response).status).toBe(400);
+      const res = await handleDiscoveryRequest(
+        req,
+        new URL(req.url),
+        makeContext(),
+      );
+      expect(res).not.toBeNull();
+      expect((await (res as Response).json()) as { error: string }).toEqual({
+        error: 'Invalid port',
+      });
+      expect((res as Response).status).toBe(400);
+    }
   });
 });
 

--- a/src/discovery/routes.ts
+++ b/src/discovery/routes.ts
@@ -83,7 +83,21 @@ function getClientIp(req: Request): string {
   // We avoid trusting X-Forwarded-For which is user-controllable.
   const socket = (req as unknown as { socket?: { remoteAddress?: string } })
     .socket;
-  return socket?.remoteAddress || 'unknown';
+  return normalizeSocketAddress(socket?.remoteAddress);
+}
+
+function normalizeSocketAddress(address?: string): string {
+  if (!address) return 'unknown';
+
+  const ipv4MappedPrefix = '::ffff:';
+  if (address.startsWith(ipv4MappedPrefix)) {
+    const ipv4 = address.slice(ipv4MappedPrefix.length);
+    if (/^\d{1,3}(?:\.\d{1,3}){3}$/.test(ipv4)) {
+      return ipv4;
+    }
+  }
+
+  return address;
 }
 
 function isValidPeerPort(port: unknown): port is number {


### PR DESCRIPTION
## Summary
- pin discovery pairing callbacks to the actual requester socket address instead of trusting the caller-supplied `host` field
- reject pairing requests when the peer address is unavailable or the callback port is outside the valid TCP range
- add regression coverage for socket-derived callback targets and malformed pairing metadata

## Testing
- `bun test src/discovery/routes.test.ts`
- `bun run typecheck`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced validation for peer pairing requests, including stricter port validation.
  * Improved network address detection and IPv6-to-IPv4 address normalization.

* **Tests**
  * Added comprehensive test coverage for address detection, normalization, and port validation scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->