### PR TITLE
fix(routing): preserve hot-mode follow-ups

### DIFF
--- a/src/attentive-routing.test.ts
+++ b/src/attentive-routing.test.ts
@@ -1,0 +1,74 @@
+import { describe, expect, it } from 'bun:test';
+
+import {
+  hasAttentiveEligibleMessage,
+  isAttentiveEligibleMessage,
+} from './attentive-routing.js';
+
+describe('isAttentiveEligibleMessage', () => {
+  it('accepts user-authored chat messages', () => {
+    expect(
+      isAttentiveEligibleMessage({
+        sender: 'discord:123',
+        sender_name: 'Alice',
+        sender_platform: 'discord',
+      }),
+    ).toBe(true);
+  });
+
+  it('rejects agent-authored IPC echoes', () => {
+    expect(
+      isAttentiveEligibleMessage({
+        sender: 'agent:groups/test-agent',
+        sender_name: 'Test Agent',
+        sender_platform: 'ipc',
+      }),
+    ).toBe(false);
+  });
+
+  it('rejects synthetic system messages', () => {
+    expect(
+      isAttentiveEligibleMessage({
+        sender: 'system',
+        sender_name: 'System',
+        sender_platform: 'system',
+      }),
+    ).toBe(false);
+  });
+});
+
+describe('hasAttentiveEligibleMessage', () => {
+  it('keeps attentive mode alive through internal-only traffic', () => {
+    expect(
+      hasAttentiveEligibleMessage([
+        {
+          sender: 'agent:groups/test-agent',
+          sender_name: 'Test Agent',
+          sender_platform: 'ipc',
+        },
+        {
+          sender: 'system',
+          sender_name: 'GitHub Webhook',
+          sender_platform: 'system',
+        },
+      ]),
+    ).toBe(false);
+  });
+
+  it('considers the batch eligible when a human follow-up is present', () => {
+    expect(
+      hasAttentiveEligibleMessage([
+        {
+          sender: 'agent:groups/test-agent',
+          sender_name: 'Test Agent',
+          sender_platform: 'ipc',
+        },
+        {
+          sender: 'discord:456',
+          sender_name: 'Bob',
+          sender_platform: 'discord',
+        },
+      ]),
+    ).toBe(true);
+  });
+});

--- a/src/attentive-routing.ts
+++ b/src/attentive-routing.ts
@@ -1,0 +1,21 @@
+import type { NewMessage } from './types.js';
+
+type AttentiveMessage = Pick<
+  NewMessage,
+  'sender' | 'sender_name' | 'sender_platform'
+>;
+
+export function isAttentiveEligibleMessage(message: AttentiveMessage): boolean {
+  if (message.sender.startsWith('agent:')) return false;
+  if (message.sender === 'system') return false;
+  if (message.sender_platform === 'system') return false;
+  if (message.sender_platform === 'ipc') return false;
+  if (message.sender_name === 'System') return false;
+  return true;
+}
+
+export function hasAttentiveEligibleMessage(
+  messages: readonly AttentiveMessage[],
+): boolean {
+  return messages.some(isAttentiveEligibleMessage);
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -3,6 +3,7 @@ import path from 'path';
 import { createHash } from 'crypto';
 
 import { syncAvatars } from './avatar-sync.js';
+import { hasAttentiveEligibleMessage } from './attentive-routing.js';
 
 import {
   ASSISTANT_NAME,
@@ -1870,10 +1871,16 @@ async function startMessageLoop(): Promise<void> {
           const { selected: triggerSelected, selectedByTrigger } =
             selectSubscriptionsForMessage(chatJid, groupMessages);
           let selectedSubs = triggerSelected;
+          const hasEligibleAttentiveMessage =
+            hasAttentiveEligibleMessage(groupMessages);
 
           // Attentive follow-up: if agents were selected by explicit trigger/mention,
           // mark them attentive so the next human message is routed without a trigger.
-          if (selectedByTrigger && selectedSubs.length > 0) {
+          if (
+            selectedByTrigger &&
+            selectedSubs.length > 0 &&
+            hasEligibleAttentiveMessage
+          ) {
             if (!attentiveAgents[chatJid]) attentiveAgents[chatJid] = new Set();
             for (const s of selectedSubs) {
               attentiveAgents[chatJid].add(s.agentId);
@@ -1883,7 +1890,7 @@ async function startMessageLoop(): Promise<void> {
           // If no trigger match (or only fallback agents selected), check if
           // any agents are attentive from a recent mention — route the
           // follow-up message to them.
-          if (!selectedByTrigger) {
+          if (!selectedByTrigger && hasEligibleAttentiveMessage) {
             const attentive = attentiveAgents[chatJid];
             if (attentive && attentive.size > 0) {
               const subs = getSubscriptionsForChannelInMemory(chatJid);


### PR DESCRIPTION
## Summary
- preserve one-message hot mode when internal IPC or system messages land between a mention and the user's follow-up
- gate attentive-state arming and consumption on user-authored messages only
- add focused tests for the new attentive routing helper

## Testing
- `bun test src/attentive-routing.test.ts`
- `bun run typecheck`
- `bun run format:check`
