### PR TITLE
fix: conservative fallback routing for multi-agent channels

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1803,13 +1803,19 @@ function selectSubscriptionsForMessage(
     selected = hasAllAgents ? [...subs] : matched;
     selectedByTrigger = true;
   } else {
+    // No explicit trigger/mention — be conservative to avoid waking all agents.
+    // Pick at most ONE fallback agent: the highest-priority primary that doesn't
+    // require a trigger (or is admin).  This prevents every subscribed agent from
+    // typing when a user sends an untriggered message in a multi-agent channel.
     const primaries = subs.filter((s) => s.isPrimary);
-    selected = primaries.length > 0 ? primaries : [subs[0]];
-    selected = selected.filter((s) => {
+    const candidates = primaries.length > 0 ? primaries : [subs[0]];
+    const eligible = candidates.filter((s) => {
       const agent = agents[s.agentId];
       const isMain = agent?.isAdmin === true;
       return isMain || s.requiresTrigger === false;
     });
+    // Limit to a single fallback agent — attentive state handles follow-ups
+    selected = eligible.length > 0 ? [eligible[0]] : [];
   }
 
   if (selected.length === 0) {
@@ -1891,13 +1897,10 @@ async function startMessageLoop(): Promise<void> {
                 attentive.has(s.agentId),
               );
               if (attentiveSubs.length > 0) {
-                // Merge attentive agents into selection (alongside any fallback agents)
-                const existing = new Set(selectedSubs.map((s) => s.agentId));
-                for (const s of attentiveSubs) {
-                  if (!existing.has(s.agentId)) {
-                    selectedSubs = [...selectedSubs, s];
-                  }
-                }
+                // Replace fallback selection with attentive agents — the user is
+                // continuing a conversation with specific agent(s), so only those
+                // should respond, not the generic fallback agent too.
+                selectedSubs = attentiveSubs;
                 // Consume attentive state — one follow-up per mention
                 for (const s of attentiveSubs) {
                   attentive.delete(s.agentId);


### PR DESCRIPTION
## Summary

Fixes the issue where all agents in a multi-agent channel wake up and start typing when a user sends a message without an @mention — even when they were only talking to one specific agent.

**Root cause**: The fallback path in `selectSubscriptionsForMessage` selected *all* primary agents that don't require a trigger. In channels with multiple subscribed agents, this meant every agent got dispatched.

**Changes**:
- **Conservative fallback**: Limit the no-trigger fallback to a single agent (the highest-priority eligible primary) instead of all eligible primaries
- **Attentive replacement**: When the user is continuing a conversation with a recently-mentioned agent, route *only* to that agent — don't merge the fallback agent into the selection

**Before**: `@OCPeyton hello` → OCPeyton responds → next message without @mention → all agents start typing
**After**: `@OCPeyton hello` → OCPeyton responds → next message without @mention → only OCPeyton responds (via attentive state)

## Test plan

- [x] All 1175 existing tests pass
- [x] `tsc --noEmit` clean
- [ ] Manual test: @mention one agent, send follow-up without mention — only that agent should respond
- [ ] Manual test: send message with no prior conversation — only primary agent should respond
- [ ] Manual test: `@allagents` still fans out to all agents

🤖 Generated with [Claude Code](https://claude.com/claude-code)
