### PR TITLE
fix(container): align Node with current LTS

### DIFF
--- a/.claude/skills/convert-to-docker/SKILL.md
+++ b/.claude/skills/convert-to-docker/SKILL.md
@@ -185,7 +185,7 @@ Update references in documentation files:
 ## Requirements
 
 - macOS or Linux
-- Node.js 20+
+- Node.js 22 LTS+ (22.12.0 or newer)
 - [Claude Code](https://claude.ai/download)
 - [Docker](https://docker.com/products/docker-desktop)
 ```

--- a/README.md
+++ b/README.md
@@ -109,7 +109,7 @@ Skills we'd love to see:
 ## Requirements
 
 - macOS or Linux
-- Node.js 20+
+- Node.js 22 LTS+ (22.12.0 or newer)
 - [Claude Code](https://claude.ai/download)
 - [Apple Container](https://github.com/apple/container) (macOS) or [Docker](https://docker.com/products/docker-desktop) (macOS/Linux)
 

--- a/README_zh.md
+++ b/README_zh.md
@@ -112,7 +112,7 @@ claude
 ## 系统要求
 
 - macOS 或 Linux
-- Node.js 20+
+- Node.js 22 LTS+（22.12.0 或更高版本）
 - [Claude Code](https://claude.ai/download)
 - [Apple Container](https://github.com/apple/container) (macOS) 或 [Docker](https://docker.com/products/docker-desktop) (macOS/Linux)
 

--- a/container/Dockerfile.base
+++ b/container/Dockerfile.base
@@ -3,12 +3,16 @@
 
 FROM oven/bun:slim
 
-# Install Node.js (agents expect node/npm/npx to be available alongside bun)
-# and essential system tools including Go and Rust (cargo/rustc)
+ARG NODE_MAJOR=22
+
+# Install Node.js LTS (agents expect node/npm/npx to be available alongside bun)
+# and essential system tools including Go and Rust (cargo/rustc).
+# Pin the major explicitly so agent sandboxes satisfy modern frontend toolchains
+# like Astro 6, which require Node 22+.
 RUN apt-get update && apt-get install -y --no-install-recommends \
-    nodejs \
-    npm \
+    ca-certificates \
     curl \
+    gnupg \
     git \
     wget \
     openssh-client \
@@ -17,6 +21,13 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     build-essential \
     cargo \
     rustc \
+    && mkdir -p /etc/apt/keyrings \
+    && curl -fsSL https://deb.nodesource.com/gpgkey/nodesource-repo.gpg.key \
+      | gpg --dearmor -o /etc/apt/keyrings/nodesource.gpg \
+    && echo "deb [signed-by=/etc/apt/keyrings/nodesource.gpg] https://deb.nodesource.com/node_${NODE_MAJOR}.x nodistro main" \
+      > /etc/apt/sources.list.d/nodesource.list \
+    && apt-get update && apt-get install -y --no-install-recommends \
+    nodejs \
     && rm -rf /var/lib/apt/lists/*
 
 # Install yq (YAML processor, like jq for YAML)

--- a/container/agent-runner/package.json
+++ b/container/agent-runner/package.json
@@ -4,6 +4,9 @@
   "type": "module",
   "description": "Container-side agent runner for OmniClaw",
   "main": "src/index.ts",
+  "engines": {
+    "node": ">=22.12.0"
+  },
   "scripts": {
     "start": "bun src/index.ts"
   },

--- a/package.json
+++ b/package.json
@@ -4,6 +4,9 @@
   "description": "OmniClaw - Personal Claude assistant from the Omni ecosystem.",
   "type": "module",
   "main": "src/index.ts",
+  "engines": {
+    "node": ">=22.12.0"
+  },
   "scripts": {
     "build": "bun build src/index.ts --outdir dist --target bun",
     "start": "bun src/index.ts",


### PR DESCRIPTION
## Summary
- pin the OmniClaw agent base image to Node 22 LTS instead of the distro `nodejs` package so agent sandboxes can build modern frontend projects like Astro 6
- declare `>=22.12.0` in both package manifests so local installs fail fast when the host Node runtime is too old
- update public docs and the Docker conversion skill to reflect the new Node baseline

## Testing
- `bun run typecheck`

## Notes
- I did not run a container rebuild in this environment, so the Dockerfile change is validated by inspection plus the updated runtime constraints rather than a full image build
