### PR TITLE
Fix: Handle 529 overloaded errors with retry notifications

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -184,6 +184,14 @@ export const SESSION_MAX_AGE = parseInt(
   process.env.SESSION_MAX_AGE || '14400000',
   10,
 ); // 4 hours — rotate sessions to prevent unbounded context growth
+// Guild IDs where verbose retry notifications are shown (comma-separated).
+// Other servers get silent retries with a message only on final failure.
+export const ADMIN_GUILD_IDS = new Set(
+  (process.env.ADMIN_GUILD_IDS || '940321040482074702')
+    .split(',')
+    .map((s) => s.trim())
+    .filter(Boolean),
+);
 export const ROSTER_REFRESH_INTERVAL = parseInt(
   process.env.ROSTER_REFRESH_INTERVAL || '900000',
   10,

--- a/src/index.ts
+++ b/src/index.ts
@@ -36,6 +36,7 @@ import {
   DISCOVERY_ENABLED,
   DISCOVERY_TRUST_LAN_ADMIN,
   INSTANCE_NAME,
+  ADMIN_GUILD_IDS,
 } from './config.js';
 import { DiscordChannel } from './channels/discord.js';
 import { SlackChannel } from './channels/slack.js';
@@ -1250,6 +1251,7 @@ async function processGroupMessages(dispatchJid: string): Promise<boolean> {
   }
 
   let hadError = false;
+  let hadOverloadedError = false;
   let outputSentToUser = false;
 
   // Patterns that indicate system/auth errors — never send these to channels
@@ -1261,6 +1263,10 @@ async function processGroupMessages(dispatchJid: string): Promise<boolean> {
     /Invalid (?:API key|bearer token)/,
     /rate_limit_error/,
   ];
+  // 529 overloaded errors get special treatment: retry with optional notification
+  const overloadedPattern = /overloaded_error|API Error: 529\b/i;
+  const isAdminChannel =
+    isMainGroup || ADMIN_GUILD_IDS.has(group.discordGuildId || '');
 
   // Thread streaming via shared helper
   // Synthetic IDs (synth-*, react-*, notify-*) aren't real channel message IDs
@@ -1337,8 +1343,26 @@ async function processGroupMessages(dispatchJid: string): Promise<boolean> {
 
             // Suppress system/auth errors — log them but don't send to channels
             // This prevents infinite loops when auth fails (error echoed back → triggers agent → fails again)
+            const isOverloaded = overloadedPattern.test(text);
             const isSystemError = systemErrorPatterns.some((p) => p.test(text));
-            if (isSystemError) {
+            if (isOverloaded) {
+              // 529 overloaded — track separately for retry messaging
+              log.warn('API overloaded (529), will retry');
+              hadError = true;
+              hadOverloadedError = true;
+              // In admin channels, notify the user that we're retrying
+              const errorCount = (consecutiveErrors[dispatchJid] || 0) + 1;
+              if (isAdminChannel && channel && errorCount < MAX_CONSECUTIVE_ERRORS) {
+                const retryMsg = `API is overloaded, retrying... (attempt ${errorCount}/${MAX_CONSECUTIVE_ERRORS})`;
+                const formatted = formatOutbound(channel, retryMsg, getAgentName(group));
+                if (formatted) {
+                  channel.sendMessage(chatJid, formatted, replyAnchorMessageId || undefined).catch((err) => {
+                    log.debug({ err }, 'Failed to send overloaded retry notice');
+                  });
+                  if (replyAnchorMessageId) replyAnchorMessageId = null;
+                }
+              }
+            } else if (isSystemError) {
               const redactedText = redactSensitiveData(text.slice(0, 300));
               log.error(
                 `Suppressed system error (not sent to user): ${redactedText}`,
@@ -1443,8 +1467,9 @@ async function processGroupMessages(dispatchJid: string): Promise<boolean> {
 
       // Notify the user so the message isn't silently dropped (fixes #94)
       if (channel) {
-        const errorMsg =
-          "Sorry, I hit a server error a few times and couldn't process your message. Please try again.";
+        const errorMsg = hadOverloadedError
+          ? "The AI API is currently overloaded. I'll respond once it's back. Please try again shortly."
+          : "Sorry, I hit a server error a few times and couldn't process your message. Please try again.";
         const formatted = formatOutbound(
           channel,
           errorMsg,


### PR DESCRIPTION
## Summary
- Agents were appearing "frozen" because 529 overloaded API errors were being silently suppressed by the `systemErrorPatterns` regex (`/^API Error: \d{3}\b/`)
- Logs showed 43 zero-cost container runs and frequent 529 errors across all agents
- Users received no feedback whatsoever — the error was swallowed and the agent just looked dead

## Changes
- **Detect 529/overloaded errors separately** from auth errors — new `overloadedPattern` regex
- **Admin channels** (BotServer guild + WhatsApp main): send a retry notification like "API is overloaded, retrying... (attempt 1/3)" so you know what's happening
- **Other Discord servers**: silent retries (no spam), but on final failure after 3 attempts, send "The AI API is currently overloaded" message
- **New config**: `ADMIN_GUILD_IDS` env var (defaults to BotServer `940321040482074702`)

## Test plan
- [ ] Verify type-check passes (`tsc --noEmit` — confirmed clean)
- [ ] Test with a 529 error in BotServer — should see retry notifications
- [ ] Test with a 529 error in another Discord server — should be silent until final failure
- [ ] Verify auth errors (401, 403) still get suppressed as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added admin guild ID configuration capability to support targeted admin notifications and request retry handling coordination.
  * Implemented enhanced API overload handling with specialized error messaging and intelligent admin channel notifications when service retries occur.

* **Bug Fixes**
  * Improved error message differentiation between API overloads and other server errors for clearer user feedback.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->