### PR TITLE
security: strip Telegram bot tokens from avatar URLs

### DIFF
--- a/src/avatar-sync.ts
+++ b/src/avatar-sync.ts
@@ -1,6 +1,11 @@
+import fs from 'fs';
+import path from 'path';
+
+import { GROUPS_DIR } from './config.js';
 import { logger } from './logger.js';
 import { updateAgentAvatar } from './db.js';
 import type { Agent, Channel } from './types.js';
+import { containsTelegramToken } from './web/sanitize-avatar.js';
 
 type AvatarSource = 'discord' | 'telegram' | 'slack';
 type AvatarSubscription = {
@@ -173,9 +178,21 @@ export async function syncAvatars(
 
     try {
       const url = await candidate.channel.getAvatarUrl();
-      if (url && url !== agent.avatarUrl) {
-        updateAgentAvatar(agent.id, url, candidate.platform);
-        agent.avatarUrl = url;
+      if (!url) continue;
+
+      // For Telegram URLs that contain the bot token, download the image
+      // and store a local path. This prevents the token from leaking
+      // through API responses, DB backups, or peer sync.
+      let storedUrl = url;
+      if (containsTelegramToken(url)) {
+        const localPath = await downloadAvatarLocally(url, agent.folder);
+        if (!localPath) continue;
+        storedUrl = localPath;
+      }
+
+      if (storedUrl !== agent.avatarUrl) {
+        updateAgentAvatar(agent.id, storedUrl, candidate.platform);
+        agent.avatarUrl = storedUrl;
         agent.avatarSource = candidate.platform;
         logger.info(
           {
@@ -192,5 +209,38 @@ export async function syncAvatars(
         'Failed to sync avatar',
       );
     }
+  }
+}
+
+/**
+ * Download a remote avatar image and save it locally under the agent's
+ * group folder. Returns the local path suitable for storage in the DB
+ * (e.g., "/avatars/{folder}/avatar.png"), or null on failure.
+ */
+async function downloadAvatarLocally(
+  url: string,
+  agentFolder: string,
+): Promise<string | null> {
+  try {
+    const response = await fetch(url);
+    if (!response.ok) {
+      logger.warn(
+        { status: response.status, agentFolder },
+        'Failed to download avatar image',
+      );
+      return null;
+    }
+
+    const dir = path.join(GROUPS_DIR, agentFolder);
+    fs.mkdirSync(dir, { recursive: true });
+
+    const filePath = path.join(dir, 'avatar.png');
+    const bytes = Buffer.from(await response.arrayBuffer());
+    fs.writeFileSync(filePath, bytes);
+
+    return `/avatars/${agentFolder}/avatar.png`;
+  } catch (err) {
+    logger.warn({ err, agentFolder }, 'Failed to download avatar locally');
+    return null;
   }
 }

--- a/src/web/agent-channels.ts
+++ b/src/web/agent-channels.ts
@@ -1,6 +1,7 @@
 import type { WebStateProvider } from './types.js';
 import { escapeHtml } from './shared.js';
 import type { RemotePeerAgents } from '../discovery/types.js';
+import { sanitizeAvatarUrl } from './sanitize-avatar.js';
 
 export interface ChannelInfo {
   jid: string;
@@ -89,7 +90,7 @@ export function buildAgentChannelData(
       isAdmin: a.isAdmin,
       serverFolder: a.serverFolder,
       agentContextFolder: a.agentContextFolder,
-      avatarUrl: a.avatarUrl,
+      avatarUrl: sanitizeAvatarUrl(a.avatarUrl) ?? undefined,
       serverIconUrl,
       channels,
     };
@@ -105,7 +106,7 @@ export function buildAgentChannelData(
       isAdmin: !!agent.isAdmin,
       serverFolder: agent.serverFolder,
       agentContextFolder: agent.agentContextFolder,
-      avatarUrl: agent.avatarUrl,
+      avatarUrl: sanitizeAvatarUrl(agent.avatarUrl) ?? undefined,
       remoteInstanceId: peer.instanceId,
       remoteInstanceName: peer.instanceName,
       remoteHost: peer.host,

--- a/src/web/routes.ts
+++ b/src/web/routes.ts
@@ -6,6 +6,7 @@ import { assertPathWithin } from '../path-security.js';
 import type { ScheduledTask } from '../types.js';
 import type { WebStateProvider } from './types.js';
 import { serveCachedRemoteImage } from './image-cache.js';
+import { sanitizeAvatarUrl, containsTelegramToken } from './sanitize-avatar.js';
 import { renderAgentDetail, buildAgentDetailData } from './agent-detail.js';
 import { renderConversations } from './conversations.js';
 import {
@@ -737,7 +738,7 @@ function handleGetAgentAvatar(
   const agent = agents[agentId];
   if (!agent) return json({ error: 'Agent not found' }, 404);
   return json({
-    avatarUrl: agent.avatarUrl || null,
+    avatarUrl: sanitizeAvatarUrl(agent.avatarUrl),
     avatarSource: agent.avatarSource || null,
   });
 }
@@ -830,6 +831,14 @@ async function handleSetAgentAvatar(
   if (source && !VALID_AVATAR_SOURCES.has(source as string)) {
     return json(
       { error: '"source" must be discord | telegram | slack | custom' },
+      400,
+    );
+  }
+
+  // Reject URLs that contain embedded Telegram bot tokens.
+  if (url && containsTelegramToken(url as string)) {
+    return json(
+      { error: 'URL contains an embedded credential and cannot be stored' },
       400,
     );
   }

--- a/src/web/sanitize-avatar.test.ts
+++ b/src/web/sanitize-avatar.test.ts
@@ -1,0 +1,121 @@
+import { describe, expect, it } from 'bun:test';
+
+import {
+  containsTelegramToken,
+  extractTelegramFilePath,
+  buildTelegramFileUrl,
+  sanitizeAvatarUrl,
+} from './sanitize-avatar.js';
+
+describe('containsTelegramToken', () => {
+  it('returns true for Telegram file URLs with bot token', () => {
+    expect(
+      containsTelegramToken(
+        'https://api.telegram.org/file/bot123456:ABCDEF/photos/file_42.jpg',
+      ),
+    ).toBe(true);
+  });
+
+  it('returns true for varied token formats', () => {
+    expect(
+      containsTelegramToken(
+        'https://api.telegram.org/file/bot7890123456:AAFx_long-Token123/documents/file_99.pdf',
+      ),
+    ).toBe(true);
+  });
+
+  it('returns false for Discord CDN URLs', () => {
+    expect(
+      containsTelegramToken(
+        'https://cdn.discordapp.com/avatars/123/avatar.png',
+      ),
+    ).toBe(false);
+  });
+
+  it('returns false for local avatar paths', () => {
+    expect(containsTelegramToken('/avatars/my-agent/avatar.png')).toBe(false);
+  });
+
+  it('returns false for empty string', () => {
+    expect(containsTelegramToken('')).toBe(false);
+  });
+
+  it('is case-insensitive for domain', () => {
+    expect(
+      containsTelegramToken(
+        'HTTPS://API.TELEGRAM.ORG/file/bot123:ABC/photos/file.jpg',
+      ),
+    ).toBe(true);
+  });
+});
+
+describe('extractTelegramFilePath', () => {
+  it('extracts the file path from a Telegram URL', () => {
+    expect(
+      extractTelegramFilePath(
+        'https://api.telegram.org/file/bot123456:ABCDEF/photos/file_42.jpg',
+      ),
+    ).toBe('photos/file_42.jpg');
+  });
+
+  it('returns null for non-Telegram URLs', () => {
+    expect(
+      extractTelegramFilePath(
+        'https://cdn.discordapp.com/avatars/123/avatar.png',
+      ),
+    ).toBeNull();
+  });
+
+  it('handles nested file paths', () => {
+    expect(
+      extractTelegramFilePath(
+        'https://api.telegram.org/file/bot123:ABC/photos/profile/large.jpg',
+      ),
+    ).toBe('photos/profile/large.jpg');
+  });
+
+  it('returns null for empty string', () => {
+    expect(extractTelegramFilePath('')).toBeNull();
+  });
+});
+
+describe('buildTelegramFileUrl', () => {
+  it('reconstructs a full Telegram download URL', () => {
+    expect(buildTelegramFileUrl('photos/file_42.jpg', '123456:ABCDEF')).toBe(
+      'https://api.telegram.org/file/bot123456:ABCDEF/photos/file_42.jpg',
+    );
+  });
+});
+
+describe('sanitizeAvatarUrl', () => {
+  it('returns null for undefined', () => {
+    expect(sanitizeAvatarUrl(undefined)).toBeNull();
+  });
+
+  it('returns null for Telegram token-bearing URLs', () => {
+    expect(
+      sanitizeAvatarUrl(
+        'https://api.telegram.org/file/bot123456:ABCDEF/photos/file_42.jpg',
+      ),
+    ).toBeNull();
+  });
+
+  it('passes through Discord CDN URLs', () => {
+    const url = 'https://cdn.discordapp.com/avatars/123/avatar.png';
+    expect(sanitizeAvatarUrl(url)).toBe(url);
+  });
+
+  it('passes through local avatar paths', () => {
+    const url = '/avatars/my-agent/avatar.png';
+    expect(sanitizeAvatarUrl(url)).toBe(url);
+  });
+
+  it('passes through generic HTTPS URLs', () => {
+    const url = 'https://example.com/avatar.png';
+    expect(sanitizeAvatarUrl(url)).toBe(url);
+  });
+
+  it('returns null for empty string', () => {
+    expect(sanitizeAvatarUrl('')).toBeNull();
+  });
+});

--- a/src/web/sanitize-avatar.ts
+++ b/src/web/sanitize-avatar.ts
@@ -1,0 +1,52 @@
+/**
+ * Sanitize avatar URLs to prevent leaking Telegram bot tokens.
+ *
+ * Telegram file URLs embed the bot token in the path:
+ *   https://api.telegram.org/file/bot<TOKEN>/<file_path>
+ *
+ * This token is a bearer credential — anyone who obtains it can act as the bot.
+ * These URLs must never be stored in the DB or returned in API responses.
+ */
+
+const TG_FILE_URL_RE = /^https:\/\/api\.telegram\.org\/file\/bot[^/]+\/(.+)$/i;
+
+/**
+ * Returns true if the URL contains an embedded Telegram bot token.
+ */
+export function containsTelegramToken(url: string): boolean {
+  return TG_FILE_URL_RE.test(url);
+}
+
+/**
+ * Strip the Telegram bot token from a file URL, returning only the
+ * file path portion. Returns null if the URL is not a Telegram file URL.
+ *
+ * Input:  https://api.telegram.org/file/bot123:ABC/photos/file_42.jpg
+ * Output: photos/file_42.jpg
+ */
+export function extractTelegramFilePath(url: string): string | null {
+  const match = TG_FILE_URL_RE.exec(url);
+  return match ? match[1] : null;
+}
+
+/**
+ * Reconstruct a full Telegram download URL from a file path and bot token.
+ * Only used server-side for downloading — never exposed to clients.
+ */
+export function buildTelegramFileUrl(
+  filePath: string,
+  botToken: string,
+): string {
+  return `https://api.telegram.org/file/bot${botToken}/${filePath}`;
+}
+
+/**
+ * Sanitize an avatar URL for safe inclusion in API responses.
+ * Strips Telegram bot tokens, returning null for token-bearing URLs
+ * (callers should replace with a proxy URL like /api/agents/{id}/avatar/image).
+ */
+export function sanitizeAvatarUrl(url: string | undefined): string | null {
+  if (!url) return null;
+  if (containsTelegramToken(url)) return null;
+  return url;
+}


### PR DESCRIPTION
## Summary

Fixes a P0 credential disclosure issue: Telegram avatar URLs embed the bot token in the URL path (`https://api.telegram.org/file/bot<TOKEN>/...`). These token-bearing URLs were:

- Stored in the SQLite `agents.avatar_url` column
- Returned in `/api/agents` JSON responses
- Returned in `/api/agents/:id/avatar` JSON responses
- Embedded in dashboard HTML via `buildAgentChannelData()`
- Sent to trusted peers during discovery sync

### What changed

- **New `sanitize-avatar` module** — `containsTelegramToken()` detects token-bearing URLs, `sanitizeAvatarUrl()` strips them from API payloads
- **`avatar-sync.ts`** — Telegram images are now downloaded and saved locally as `/avatars/{folder}/avatar.png` during sync. The token-bearing URL is used once for the download and then discarded — never stored in the DB
- **`agent-channels.ts`** — `avatarUrl` in `/api/agents` responses runs through `sanitizeAvatarUrl()` as a safety net
- **`routes.ts`** — `/api/agents/:id/avatar` JSON endpoint sanitizes URLs; avatar update endpoint rejects token-bearing URLs with 400
- **17 unit tests** covering detection, extraction, reconstruction, and sanitization

### Not affected

Discord and Slack avatar URLs don't embed credentials — this fix is specific to Telegram's `file/bot<TOKEN>/...` URL format.

Closes #341

## Test plan

- [x] `bun run typecheck` passes
- [x] All 1217 tests pass (17 new)
- [x] `bun run format:check` passes
- [ ] Verify Telegram avatar sync downloads locally on a running instance
- [ ] Verify `/api/agents` no longer contains `api.telegram.org/file/bot` URLs
- [ ] Verify existing cached avatars continue to serve correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)
