### PR TITLE
fix(ci): run checks for auto-created update PRs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,6 +3,7 @@ name: CI
 on:
   pull_request:
     branches: [main]
+  workflow_dispatch:
 
 jobs:
   format:

--- a/.github/workflows/update-claude-sdk.yml
+++ b/.github/workflows/update-claude-sdk.yml
@@ -10,12 +10,35 @@ jobs:
   update:
     runs-on: ubuntu-latest
     permissions:
+      actions: write
       contents: write
       pull-requests: write
 
     steps:
+      - name: Check for GitHub App secrets
+        id: check-secrets
+        run: |
+          if [ -z "$APP_ID" ]; then
+            echo "skip=true" >> "$GITHUB_OUTPUT"
+            echo "GitHub App secrets not configured, using default token"
+          else
+            echo "skip=false" >> "$GITHUB_OUTPUT"
+          fi
+        env:
+          APP_ID: ${{ secrets.APP_ID }}
+
+      - name: Create GitHub App token
+        if: steps.check-secrets.outputs.skip != 'true'
+        id: app-token
+        uses: actions/create-github-app-token@v1
+        with:
+          app-id: ${{ secrets.APP_ID }}
+          private-key: ${{ secrets.APP_PRIVATE_KEY }}
+
       - name: Checkout
         uses: actions/checkout@v4
+        with:
+          token: ${{ steps.app-token.outputs.token != '' && steps.app-token.outputs.token || github.token }}
 
       - name: Setup Bun
         uses: oven-sh/setup-bun@v2
@@ -58,7 +81,7 @@ jobs:
           PR=$(gh pr list --repo omniaura/omniclaw --base main --head update/claude-sdk-${{ steps.latest.outputs.version }} --json number --jq '.[0].number // ""')
           echo "pr=$PR" >> $GITHUB_OUTPUT
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ steps.app-token.outputs.token != '' && steps.app-token.outputs.token || github.token }}
 
       - name: Apply update
         if: steps.check.outputs.changed == 'true' && steps.existing_pr.outputs.pr == ''
@@ -94,4 +117,13 @@ jobs:
             --title "$TITLE" \
             --body-file "$BODY_FILE"
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ steps.app-token.outputs.token != '' && steps.app-token.outputs.token || github.token }}
+
+      - name: Trigger CI for update PR
+        if: steps.check.outputs.changed == 'true' && steps.existing_pr.outputs.pr == '' && steps.check-secrets.outputs.skip == 'true'
+        run: |
+          gh workflow run ci.yml \
+            --repo omniaura/omniclaw \
+            --ref "update/claude-sdk-${{ steps.latest.outputs.version }}"
+        env:
+          GH_TOKEN: ${{ github.token }}

--- a/.github/workflows/update-opencode.yml
+++ b/.github/workflows/update-opencode.yml
@@ -10,12 +10,35 @@ jobs:
   update:
     runs-on: ubuntu-latest
     permissions:
+      actions: write
       contents: write
       pull-requests: write
 
     steps:
+      - name: Check for GitHub App secrets
+        id: check-secrets
+        run: |
+          if [ -z "$APP_ID" ]; then
+            echo "skip=true" >> "$GITHUB_OUTPUT"
+            echo "GitHub App secrets not configured, using default token"
+          else
+            echo "skip=false" >> "$GITHUB_OUTPUT"
+          fi
+        env:
+          APP_ID: ${{ secrets.APP_ID }}
+
+      - name: Create GitHub App token
+        if: steps.check-secrets.outputs.skip != 'true'
+        id: app-token
+        uses: actions/create-github-app-token@v1
+        with:
+          app-id: ${{ secrets.APP_ID }}
+          private-key: ${{ secrets.APP_PRIVATE_KEY }}
+
       - name: Checkout
         uses: actions/checkout@v4
+        with:
+          token: ${{ steps.app-token.outputs.token != '' && steps.app-token.outputs.token || github.token }}
 
       - name: Setup Bun
         uses: oven-sh/setup-bun@v2
@@ -54,7 +77,7 @@ jobs:
           echo "sdk=$SDK" >> $GITHUB_OUTPUT
           echo "Latest CLI: $CLI, SDK: $SDK"
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ steps.app-token.outputs.token != '' && steps.app-token.outputs.token || github.token }}
 
       - name: Check if update needed
         id: check
@@ -101,7 +124,7 @@ jobs:
           PR=$(gh pr list --repo omniaura/omniclaw --base main --head update/opencode-${{ steps.check.outputs.branch_suffix }} --json number --jq '.[0].number // ""')
           echo "pr=$PR" >> $GITHUB_OUTPUT
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ steps.app-token.outputs.token != '' && steps.app-token.outputs.token || github.token }}
 
       - name: Apply updates
         if: steps.check.outputs.changed == 'true' && steps.existing_pr.outputs.pr == ''
@@ -154,4 +177,13 @@ jobs:
             --title "${{ steps.check.outputs.commit_title }}" \
             --body-file "$BODY_FILE"
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ steps.app-token.outputs.token != '' && steps.app-token.outputs.token || github.token }}
+
+      - name: Trigger CI for update PR
+        if: steps.check.outputs.changed == 'true' && steps.existing_pr.outputs.pr == '' && steps.check-secrets.outputs.skip == 'true'
+        run: |
+          gh workflow run ci.yml \
+            --repo omniaura/omniclaw \
+            --ref "update/opencode-${{ steps.check.outputs.branch_suffix }}"
+        env:
+          GH_TOKEN: ${{ github.token }}

--- a/pr-body.md
+++ b/pr-body.md
@@ -1,10 +1,7 @@
 ## Summary
+- let `CI` run via `workflow_dispatch` so automation can explicitly kick it off for bot-created branches
+- use a GitHub App token in the dependency-update workflows when available so auto-created PRs trigger normal `pull_request` checks
+- fall back to dispatching `ci.yml` manually when only the default `GITHUB_TOKEN` is available, and grant the workflows `actions: write` for that path
 
-- stop replaying stored discovery secrets when an already-trusted peer re-requests access
-- require pairing public keys for new discovery requests and encrypt all discovery secret delivery with per-request X25519 key agreement plus AES-GCM
-- add regression coverage for the trusted-peer re-pair flow and encrypted pairing completion
-
-## Validation
-
-- `bun run typecheck`
-- `bun test src/discovery/routes.test.ts src/discovery/pairing-crypto.test.ts`
+## Testing
+- `for f in .github/workflows/*.yml; do yq eval '.' "$f" > /dev/null || exit 1; done`


### PR DESCRIPTION
## Summary
- let `CI` run via `workflow_dispatch` so automation can explicitly kick it off for bot-created branches
- use a GitHub App token in the dependency-update workflows when available so auto-created PRs trigger normal `pull_request` checks
- fall back to dispatching `ci.yml` manually when only the default `GITHUB_TOKEN` is available, and grant the workflows `actions: write` for that path

## Testing
- `for f in .github/workflows/*.yml; do yq eval '.' "$f" > /dev/null || exit 1; done`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added manual trigger option to CI workflow, enabling explicit automation control for dependency updates.
  * Enhanced dependency-update workflows with GitHub App token support, improving CI automation for automatically-created pull requests.
  * Improved fallback mechanisms to ensure CI runs reliably with standard tokens when GitHub App authentication is unavailable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->