### PR TITLE
ui: remove parenthetical labels from web UI

### DIFF
--- a/src/web/logs.test.ts
+++ b/src/web/logs.test.ts
@@ -75,7 +75,7 @@ describe('renderLogsContent', () => {
   it('renders search input', () => {
     const html = renderLogsContent(makeState());
     expect(html).toContain('logs-search-input');
-    expect(html).toContain('regex supported');
+    expect(html).toContain('Search logs');
   });
 
   it('renders level filter buttons', () => {

--- a/src/web/logs.ts
+++ b/src/web/logs.ts
@@ -32,7 +32,7 @@ export function renderLogsContent(state: WebStateProvider): string {
     `<div class="logs-toolbar-center">` +
     // Search input
     `<div class="logs-search">` +
-    `<input type="text" id="logs-search-input" placeholder="Search logs (regex supported)…" spellcheck="false" autocomplete="off">` +
+    `<input type="text" id="logs-search-input" placeholder="Search logs…" spellcheck="false" autocomplete="off">` +
     `<label class="logs-search-option"><input type="checkbox" id="logs-regex-toggle"> regex</label>` +
     `</div>` +
     `</div>` +

--- a/src/web/server.ts
+++ b/src/web/server.ts
@@ -274,7 +274,7 @@ export function startWebServer(
           logger.debug({ sseClients: sseClients.size }, 'SSE client connected');
 
           stream.patchElements(
-            renderStatusBadge('connected (datastar)', 'connected'),
+            renderStatusBadge('connected', 'connected'),
           );
           patchSnapshot(nextClient, state);
         },


### PR DESCRIPTION
## Summary

• Removes "connected (datastar)" → "connected" in SSE status badge
• Removes "Search logs (regex supported)…" → "Search logs…" in logs page placeholder
• Updates test assertion to match

## Test plan

• [x] `bun test src/web/logs.test.ts src/web/server.test.ts` — 88 pass, 0 fail

🤖 Generated with [Claude Code](https://claude.com/claude-code)
