### PR TITLE
fix(discord): detect image attachments without content type

### DIFF
--- a/pr-body.md
+++ b/pr-body.md
@@ -1,7 +1,10 @@
 ## Summary
-- let `CI` run via `workflow_dispatch` so automation can explicitly kick it off for bot-created branches
-- use a GitHub App token in the dependency-update workflows when available so auto-created PRs trigger normal `pull_request` checks
-- fall back to dispatching `ci.yml` manually when only the default `GITHUB_TOKEN` is available, and grant the workflows `actions: write` for that path
+- treat Discord attachments as images when their filename extension is image-like, even if Discord omits `contentType`
+- keep the existing content-type path first, then fall back to extension-based detection for common image formats
+- add regression coverage for missing-content-type image attachments in `src/channels/discord.test.ts`
 
 ## Testing
-- `for f in .github/workflows/*.yml; do yq eval '.' "$f" > /dev/null || exit 1; done`
+- `bun test src/channels/discord.test.ts`
+- `bun run typecheck`
+
+Follow-up hardening for the Discord image attachment path from #254.

--- a/src/channels/discord.test.ts
+++ b/src/channels/discord.test.ts
@@ -4,6 +4,7 @@ import {
   jidToChannelId,
   DiscordChannel,
   getAttachmentWorkspaceFolder,
+  isImageAttachment,
 } from './discord.js';
 import type { RegisteredGroup } from '../types.js';
 
@@ -73,6 +74,28 @@ describe('getAttachmentWorkspaceFolder', () => {
 
   it('falls back to agent folder when channelFolder is missing', () => {
     expect(getAttachmentWorkspaceFolder({ folder: 'rind' })).toBe('rind');
+  });
+});
+
+describe('isImageAttachment', () => {
+  it('detects image attachments from content type', () => {
+    expect(
+      isImageAttachment({ name: 'screenshot.bin', contentType: 'image/png' }),
+    ).toBe(true);
+  });
+
+  it('falls back to file extension when content type is missing', () => {
+    expect(isImageAttachment({ name: 'screenshot.PNG' })).toBe(true);
+    expect(isImageAttachment({ name: 'diagram.webp', contentType: null })).toBe(
+      true,
+    );
+  });
+
+  it('does not treat non-image files as images', () => {
+    expect(isImageAttachment({ name: 'notes.txt' })).toBe(false);
+    expect(
+      isImageAttachment({ name: 'clip.mp4', contentType: 'video/mp4' }),
+    ).toBe(false);
   });
 });
 

--- a/src/channels/discord.ts
+++ b/src/channels/discord.ts
@@ -48,6 +48,28 @@ export function getAttachmentWorkspaceFolder(
   return workspaceFolder;
 }
 
+const IMAGE_ATTACHMENT_EXTENSIONS = new Set([
+  '.png',
+  '.jpg',
+  '.jpeg',
+  '.gif',
+  '.webp',
+  '.bmp',
+  '.svg',
+  '.heic',
+  '.heif',
+  '.avif',
+]);
+
+export function isImageAttachment(attachment: {
+  contentType?: string | null;
+  name?: string | null;
+}): boolean {
+  if (attachment.contentType?.startsWith('image/')) return true;
+  const ext = path.extname(attachment.name || '').toLowerCase();
+  return IMAGE_ATTACHMENT_EXTENSIONS.has(ext);
+}
+
 function getAttachmentMediaDir(
   group: Pick<RegisteredGroup, 'folder' | 'channelFolder'>,
 ): string {
@@ -881,7 +903,7 @@ export class DiscordChannel implements Channel {
     if (message.attachments.size > 0) {
       const parts: string[] = [];
       for (const [, a] of message.attachments) {
-        if (a.contentType?.startsWith('image/')) {
+        if (isImageAttachment(a)) {
           try {
             const mediaDir = getAttachmentMediaDir(group);
             fs.mkdirSync(mediaDir, { recursive: true });


### PR DESCRIPTION
## Summary
- treat Discord attachments as images when their filename extension is image-like, even if Discord omits `contentType`
- keep the existing content-type path first, then fall back to extension-based detection for common image formats
- add regression coverage for missing-content-type image attachments in `src/channels/discord.test.ts`

## Testing
- `bun test src/channels/discord.test.ts`
- `bun run typecheck`

Follow-up hardening for the Discord image attachment path from #254.
