### PR TITLE
fix(discovery): allow trusted WiFi discovery without admin credentials

### DIFF
--- a/src/web/server.test.ts
+++ b/src/web/server.test.ts
@@ -393,16 +393,14 @@ describe('basic auth', () => {
     expect(apiRes.status).toBe(200);
   });
 
-  it('keeps discovery admin routes locked by default without credentials', async () => {
+  it('allows discovery admin routes from private network without credentials', async () => {
     setTestDiscoveryContext();
     handle = startWebServer(testConfig({ auth: undefined }), makeState());
 
+    // Test runs on localhost — private network requests are allowed without auth
     const res = await fetch(url('/api/discovery/requests'));
-    expect(res.status).toBe(403);
-    await expect(res.json()).resolves.toMatchObject({
-      error:
-        'Discovery admin routes require WEB_UI_USER/WEB_UI_PASS to be configured',
-    });
+    expect(res.status).toBe(200);
+    await expect(res.json()).resolves.toEqual([]);
   });
 
   it('allows discovery admin routes from loopback with trusted LAN mode enabled', async () => {

--- a/src/web/server.ts
+++ b/src/web/server.ts
@@ -124,14 +124,17 @@ export function startWebServer(
         req,
         url.pathname,
         bindHostname,
-        trustLanDiscoveryAdmin,
+        // When no auth is configured, implicitly trust private-network requests
+        // so WiFi-based discovery works out of the box without WEB_UI_USER/WEB_UI_PASS.
+        true, // no auth configured → implicitly trust private network
       )
     ) {
-      // Discovery admin routes MUST have auth — reject if credentials not configured
+      // Discovery admin routes from the public internet MUST have auth.
+      // Private-network requests (loopback, LAN) are allowed without credentials.
       return new Response(
         JSON.stringify({
           error:
-            'Discovery admin routes require WEB_UI_USER/WEB_UI_PASS to be configured',
+            'Discovery admin routes require authentication (set WEB_UI_USER/WEB_UI_PASS or access from a private network)',
         }),
         {
           status: 403,


### PR DESCRIPTION
## Summary
- When `WEB_UI_USER`/`WEB_UI_PASS` are not configured, discovery admin routes now implicitly trust private-network requests (loopback, LAN)
- This removes the requirement to set up admin credentials just to use WiFi-based trusted peer discovery locally
- Public internet requests to discovery admin routes still require authentication

## What changed
The auth guard for `/api/discovery/*` admin routes previously hard-rejected all requests when no credentials were configured, unless `DISCOVERY_TRUST_LAN_ADMIN=true` was explicitly set. Now, when `auth` is undefined (no credentials), the private-network check is automatically enabled — so loopback and RFC 1918 addresses pass through without needing extra env vars.

## Test plan
- [x] `bun test src/web/server.test.ts` — 70 pass, 0 fail
- [x] `bun run typecheck` — clean
- [x] `bun run format:check` — clean
