### PR TITLE
fix(web): cache remote peer fetches per request

### DIFF
--- a/src/web/routes.test.ts
+++ b/src/web/routes.test.ts
@@ -10,7 +10,11 @@ import type {
   ScheduledTask,
   TaskRunLog,
 } from '../types.js';
-import { handleRequest, resetDiscoveryContextForTests } from './routes.js';
+import {
+  createRemotePeerResolver,
+  handleRequest,
+  resetDiscoveryContextForTests,
+} from './routes.js';
 import type { WebStateProvider } from './types.js';
 
 function makeAgent(overrides: Partial<Agent> = {}): Agent {
@@ -163,6 +167,35 @@ afterEach(() => {
   globalThis.Date = originalDateCtor;
   Math.random = originalRandom;
   resetDiscoveryContextForTests();
+});
+
+describe('createRemotePeerResolver', () => {
+  it('memoizes the fetcher result for a single request flow', async () => {
+    let callCount = 0;
+    const expected = [
+      {
+        instanceId: 'peer-1',
+        instanceName: 'orangepi5',
+        online: true,
+        host: '10.0.0.12',
+        port: 7777,
+        agents: [],
+      },
+    ];
+    const resolveRemotePeers = createRemotePeerResolver(async () => {
+      callCount += 1;
+      return expected;
+    });
+
+    const [first, second] = await Promise.all([
+      resolveRemotePeers(),
+      resolveRemotePeers(),
+    ]);
+
+    expect(callCount).toBe(1);
+    expect(first).toBe(expected);
+    expect(second).toBe(expected);
+  });
 });
 
 describe('handleRequest avatar image proxy', () => {

--- a/src/web/routes.ts
+++ b/src/web/routes.ts
@@ -19,6 +19,7 @@ import {
   handleDiscoveryRequest,
   type DiscoveryRouteContext,
 } from '../discovery/routes.js';
+import type { RemotePeerAgents } from '../discovery/types.js';
 import { listLocalContextFiles } from './context-files.js';
 import {
   renderNetworkPage,
@@ -56,6 +57,16 @@ export function getRemotePeers() {
     : Promise.resolve([]);
 }
 
+export function createRemotePeerResolver(
+  fetcher: () => Promise<RemotePeerAgents[]> = getRemotePeers,
+): () => Promise<RemotePeerAgents[]> {
+  let cached: Promise<RemotePeerAgents[]> | null = null;
+  return () => {
+    cached ??= fetcher();
+    return cached;
+  };
+}
+
 export function resetDiscoveryContextForTests(): void {
   discoveryContext = null;
   networkPageState = null;
@@ -73,6 +84,7 @@ export function handleRequest(
   const url = new URL(req.url);
   const { pathname } = url;
   const method = req.method;
+  const resolveRemotePeers = createRemotePeerResolver();
 
   // --- Discovery API routes ---
   if (pathname.startsWith('/api/discovery/') && discoveryContext) {
@@ -170,12 +182,12 @@ export function handleRequest(
       pathname.slice('/api/agents/'.length, -'/detail'.length),
     );
     if (!agentId) return json({ error: 'Missing agent ID' }, 400);
-    return handleGetAgentDetail(agentId, state);
+    return handleGetAgentDetail(agentId, state, resolveRemotePeers);
   }
 
   // --- Dashboard ---
   if (pathname === '/' || pathname === '/index.html')
-    return handleDashboardPage(state);
+    return handleDashboardPage(state, resolveRemotePeers);
 
   // --- Conversations viewer ---
   if (pathname === '/conversations')
@@ -184,7 +196,8 @@ export function handleRequest(
     });
 
   // --- Context viewer ---
-  if (pathname === '/context') return handleContextPage(state);
+  if (pathname === '/context')
+    return handleContextPage(state, resolveRemotePeers);
 
   // --- IPC Inspector ---
   if (pathname === '/ipc')
@@ -193,7 +206,8 @@ export function handleRequest(
     });
 
   // --- Agents list ---
-  if (pathname === '/agents-list') return handleAgentsListPage(state);
+  if (pathname === '/agents-list')
+    return handleAgentsListPage(state, resolveRemotePeers);
 
   // --- Task Manager ---
   if (pathname === '/tasks')
@@ -222,7 +236,7 @@ export function handleRequest(
   // --- Agent Detail ---
   if (pathname === '/agents') {
     const agentId = url.searchParams.get('id') || '';
-    return handleAgentDetailPage(agentId, state);
+    return handleAgentDetailPage(agentId, state, resolveRemotePeers);
   }
 
   // --- Agent avatar endpoints ---
@@ -279,10 +293,11 @@ export function handleRequest(
   return json({ error: 'Not found' }, 404);
 }
 
-async function handleDashboardPage(state: WebStateProvider): Promise<Response> {
-  const remotePeers = discoveryContext
-    ? await fetchTrustedRemoteAgents(discoveryContext)
-    : [];
+async function handleDashboardPage(
+  state: WebStateProvider,
+  resolveRemotePeers: () => Promise<RemotePeerAgents[]>,
+): Promise<Response> {
+  const remotePeers = await resolveRemotePeers();
   return new Response(renderDashboardWithRemote(state, remotePeers), {
     headers: { 'Content-Type': 'text/html; charset=utf-8' },
   });
@@ -290,10 +305,9 @@ async function handleDashboardPage(state: WebStateProvider): Promise<Response> {
 
 async function handleAgentsListPage(
   state: WebStateProvider,
+  resolveRemotePeers: () => Promise<RemotePeerAgents[]>,
 ): Promise<Response> {
-  const remotePeers = discoveryContext
-    ? await fetchTrustedRemoteAgents(discoveryContext)
-    : [];
+  const remotePeers = await resolveRemotePeers();
   return new Response(renderAgentsPageWithRemote(state, remotePeers), {
     headers: { 'Content-Type': 'text/html; charset=utf-8' },
   });
@@ -302,10 +316,9 @@ async function handleAgentsListPage(
 async function handleAgentDetailPage(
   agentId: string,
   state: WebStateProvider,
+  resolveRemotePeers: () => Promise<RemotePeerAgents[]>,
 ): Promise<Response> {
-  const remotePeers = discoveryContext
-    ? await fetchTrustedRemoteAgents(discoveryContext)
-    : [];
+  const remotePeers = await resolveRemotePeers();
   return new Response(renderAgentDetail(agentId, state, remotePeers), {
     headers: { 'Content-Type': 'text/html; charset=utf-8' },
   });
@@ -314,19 +327,19 @@ async function handleAgentDetailPage(
 async function handleGetAgentDetail(
   agentId: string,
   state: WebStateProvider,
+  resolveRemotePeers: () => Promise<RemotePeerAgents[]>,
 ): Promise<Response> {
-  const remotePeers = discoveryContext
-    ? await fetchTrustedRemoteAgents(discoveryContext)
-    : [];
+  const remotePeers = await resolveRemotePeers();
   const data = buildAgentDetailData(agentId, state, remotePeers);
   if (!data) return json({ error: 'Agent not found' }, 404);
   return json(data);
 }
 
-async function handleContextPage(state: WebStateProvider): Promise<Response> {
-  const remotePeers = discoveryContext
-    ? await fetchTrustedRemoteAgents(discoveryContext)
-    : [];
+async function handleContextPage(
+  state: WebStateProvider,
+  resolveRemotePeers: () => Promise<RemotePeerAgents[]>,
+): Promise<Response> {
+  const remotePeers = await resolveRemotePeers();
   return new Response(renderContextViewerWithRemote(state, remotePeers), {
     headers: { 'Content-Type': 'text/html; charset=utf-8' },
   });

--- a/src/web/server.ts
+++ b/src/web/server.ts
@@ -3,7 +3,11 @@ import { createHash } from 'crypto';
 import { ServerSentEventGenerator } from '@starfederation/datastar-sdk/web';
 
 import { logger } from '../logger.js';
-import { handleRequest, getRemotePeers } from './routes.js';
+import {
+  handleRequest,
+  getRemotePeers,
+  createRemotePeerResolver,
+} from './routes.js';
 import type { ScheduledTask } from '../types.js';
 import { escapeHtml, renderPagePatch } from './shared.js';
 import type { WebServerConfig, WebStateProvider, WsEvent } from './types.js';
@@ -82,6 +86,7 @@ export function startWebServer(
       : null;
   const fetchHandler = async (req: Request) => {
     const url = new URL(req.url);
+    const resolveRemotePeers = createRemotePeerResolver(getRemotePeers);
     if (url.pathname === '/ws') {
       return new Response('WebSocket is deprecated for the web dashboard', {
         status: 410,
@@ -303,13 +308,13 @@ export function startWebServer(
           path: '/',
           title: 'Dashboard',
           render: async () =>
-            renderDashboardContent(state, await getRemotePeers()),
+            renderDashboardContent(state, await resolveRemotePeers()),
         },
         agents: {
           path: '/agents-list',
           title: 'Agents',
           render: async () =>
-            renderAgentsContent(state, await getRemotePeers()),
+            renderAgentsContent(state, await resolveRemotePeers()),
         },
         conversations: {
           path: '/conversations',
@@ -320,7 +325,7 @@ export function startWebServer(
           path: '/context',
           title: 'Context',
           render: async () =>
-            renderContextViewerContent(state, await getRemotePeers()),
+            renderContextViewerContent(state, await resolveRemotePeers()),
         },
         ipc: {
           path: '/ipc',
@@ -376,7 +381,7 @@ export function startWebServer(
         const data = buildAgentDetailData(
           agentId,
           state,
-          await getRemotePeers(),
+          await resolveRemotePeers(),
         );
         const title = data ? data.name : 'Agent Not Found';
         const qs = agentId ? `?id=${encodeURIComponent(agentId)}` : '';


### PR DESCRIPTION
## Summary
- memoize trusted remote peer lookups for each web request so route handlers and SPA page renders reuse the same discovery result
- thread the request-scoped resolver through the HTML and JSON handlers that consume remote peer data
- add a focused test covering the resolver's memoization behavior

## Testing
- `bun test src/web/routes.test.ts src/web/server.test.ts src/web/agent-detail.test.ts`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Implemented efficient caching for remote peer data lookups, reducing redundant network requests across agent dashboard, agents list, agent detail, and context pages.

* **Tests**
  * Added test coverage for memoization behavior to ensure caching operates correctly under concurrent requests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->