### PR TITLE
feat: agent output delivery for IPC-based clients

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -4,3 +4,12 @@
 # without Basic Auth so peers can reach discovery endpoints. Only use this
 # on a trusted private LAN.
 DISCOVERY_TRUST_LAN_ADMIN=false
+
+# Firebase (for agents needing Firebase access)
+# FIREBASE_PROJECT_ID=
+# FIREBASE_CLIENT_EMAIL=
+# FIREBASE_PRIVATE_KEY=
+
+# Google Cloud
+# GOOGLE_APPLICATION_CREDENTIALS=
+# GCLOUD_PROJECT=

--- a/container/agent-runner/src/index.ts
+++ b/container/agent-runner/src/index.ts
@@ -64,6 +64,8 @@ interface ContainerInput {
   githubContext?: string;
   /** GitHub activity delta digest (events since last user message in this channel). */
   githubActivityDelta?: string;
+  /** Extra MCP servers to inject alongside the built-in omniclaw server (SSE/HTTP). */
+  mcpServers?: Record<string, Record<string, unknown>>;
 }
 
 interface ContainerOutput {
@@ -1005,6 +1007,7 @@ async function runQuery(
               : {}),
           },
         },
+        ...(containerInput.mcpServers || {}),
       },
       hooks: {
         PreCompact: [

--- a/src/backends/local-backend.ts
+++ b/src/backends/local-backend.ts
@@ -393,6 +393,12 @@ export function buildVolumeMounts(
       'OPENCODE_MODEL',
       'OPENCODE_PROVIDER',
       'OPENCODE_MODEL_ID',
+      // Firebase / Google Cloud
+      'GOOGLE_APPLICATION_CREDENTIALS',
+      'FIREBASE_PROJECT_ID',
+      'FIREBASE_CLIENT_EMAIL',
+      'FIREBASE_PRIVATE_KEY',
+      'GCLOUD_PROJECT',
       ...(agentRuntime === 'codex'
         ? ['OPENAI_API_KEY', 'CODEX_API_KEY', 'CODEX_MODEL']
         : []),

--- a/src/backends/types.ts
+++ b/src/backends/types.ts
@@ -100,6 +100,8 @@ export interface ContainerInput {
   githubContext?: string;
   /** GitHub activity delta digest (events since last user message in this channel). */
   githubActivityDelta?: string;
+  /** Extra MCP servers to inject into the agent runtime alongside the built-in omniclaw server. */
+  mcpServers?: Record<string, Record<string, unknown>>;
 }
 
 export interface ContainerOutput {

--- a/src/channels/discord.ts
+++ b/src/channels/discord.ts
@@ -338,6 +338,23 @@ export class DiscordChannel implements Channel {
     }
   }
 
+  async editMessage(
+    jid: string,
+    messageId: string,
+    text: string,
+  ): Promise<void> {
+    const channel = await resolveChannel(this.client, jid);
+    if (!channel || !('messages' in channel)) return;
+    try {
+      const msg = await (channel as TextChannel | DMChannel).messages.fetch(
+        messageId,
+      );
+      await msg.edit(text.slice(0, 2000));
+    } catch (err) {
+      logger.warn({ jid, messageId, err }, 'Failed to edit Discord message');
+    }
+  }
+
   async getAvatarUrl(): Promise<string | null> {
     if (!this.connected || !this.client.user) return null;
     try {

--- a/src/index.ts
+++ b/src/index.ts
@@ -1722,6 +1722,7 @@ async function runAgent(
         agentContextFolder: group.agentContextFolder,
         githubContext,
         githubActivityDelta,
+        mcpServers: group.containerConfig?.mcpServers,
       },
       (proc, containerName) =>
         queue.registerProcess(

--- a/src/index.ts
+++ b/src/index.ts
@@ -1292,6 +1292,10 @@ async function processGroupMessages(dispatchJid: string): Promise<boolean> {
 
   let hadError = false;
   let outputSentToUser = false;
+  // Edited-message streaming: a single message that gets updated with intermediate tool calls
+  let intermediateMessageId: string | null = null;
+  const streamIntermediates =
+    !!group.containerConfig?.streamIntermediates && !!channel.editMessage;
 
   // Patterns that indicate system/auth errors — never send these to channels
   // Adopted from [Upstream PR #298] - Prevents infinite loops from auth failures
@@ -1361,6 +1365,36 @@ async function processGroupMessages(dispatchJid: string): Promise<boolean> {
         // Adopted from [Upstream PR #243] - Critical stability fix
         try {
           if (result.intermediate) {
+            if (streamIntermediates && result.result) {
+              const raw =
+                typeof result.result === 'string'
+                  ? result.result
+                  : JSON.stringify(result.result);
+              const text = raw
+                .replace(/<internal>[\s\S]*?<\/internal>/g, '')
+                .trim();
+              if (!text) return;
+              try {
+                if (!intermediateMessageId) {
+                  // First intermediate: send a new standalone message
+                  const id = await channel.sendMessage(
+                    chatJid,
+                    text.slice(0, 2000),
+                  );
+                  if (id && typeof id === 'string')
+                    intermediateMessageId = id;
+                } else {
+                  // Subsequent intermediates: edit that same status message
+                  await channel.editMessage!(
+                    chatJid,
+                    intermediateMessageId,
+                    text.slice(0, 2000),
+                  );
+                }
+              } catch (err) {
+                log.debug({ err }, 'Intermediate streaming failed (non-fatal)');
+              }
+            }
             return;
           }
 
@@ -1423,6 +1457,8 @@ async function processGroupMessages(dispatchJid: string): Promise<boolean> {
                 }
               }
             }
+            // Reset intermediate message so the next user message gets a fresh status message
+            intermediateMessageId = null;
             // Only reset idle timer on actual results, not session-update markers (result: null)
             resetIdleTimer();
           }

--- a/src/index.ts
+++ b/src/index.ts
@@ -1294,8 +1294,10 @@ async function processGroupMessages(dispatchJid: string): Promise<boolean> {
   let outputSentToUser = false;
   // Edited-message streaming: a single message that gets updated with intermediate tool calls
   let intermediateMessageId: string | null = null;
+  // For channel-less JIDs: track last intermediate text so we can promote it on completion
+  let lastIpcIntermediateText: string | null = null;
   const streamIntermediates =
-    !!group.containerConfig?.streamIntermediates && !!channel.editMessage;
+    !!group.containerConfig?.streamIntermediates && !!channel?.editMessage;
 
   // Patterns that indicate system/auth errors — never send these to channels
   // Adopted from [Upstream PR #298] - Prevents infinite loops from auth failures
@@ -1365,7 +1367,7 @@ async function processGroupMessages(dispatchJid: string): Promise<boolean> {
         // Adopted from [Upstream PR #243] - Critical stability fix
         try {
           if (result.intermediate) {
-            if (streamIntermediates && result.result) {
+            if (result.result) {
               const raw =
                 typeof result.result === 'string'
                   ? result.result
@@ -1374,25 +1376,44 @@ async function processGroupMessages(dispatchJid: string): Promise<boolean> {
                 .replace(/<internal>[\s\S]*?<\/internal>/g, '')
                 .trim();
               if (!text) return;
-              try {
-                if (!intermediateMessageId) {
-                  // First intermediate: send a new standalone message
-                  const id = await channel.sendMessage(
-                    chatJid,
-                    text.slice(0, 2000),
-                  );
-                  if (id && typeof id === 'string')
-                    intermediateMessageId = id;
-                } else {
-                  // Subsequent intermediates: edit that same status message
-                  await channel.editMessage!(
-                    chatJid,
-                    intermediateMessageId,
-                    text.slice(0, 2000),
-                  );
+
+              if (!channel) {
+                // No channel — store in DB for IPC-based clients to poll
+                // Skip agent-runner boilerplate from promotion
+                if (!text.includes('If this was your final response')) {
+                  lastIpcIntermediateText = text.slice(0, 4000);
                 }
-              } catch (err) {
-                log.debug({ err }, 'Intermediate streaming failed (non-fatal)');
+                storeMessage({
+                  id: `ipc-wip-${chatJid}`,
+                  chat_jid: chatJid,
+                  sender: 'assistant:wip',
+                  sender_name: ASSISTANT_NAME,
+                  content: lastIpcIntermediateText,
+                  timestamp: new Date().toISOString(),
+                  is_from_me: true,
+                  sender_platform: 'ipc',
+                });
+              } else if (streamIntermediates) {
+                try {
+                  if (!intermediateMessageId) {
+                    // First intermediate: send a new standalone message
+                    const id = await channel.sendMessage(
+                      chatJid,
+                      text.slice(0, 2000),
+                    );
+                    if (id && typeof id === 'string')
+                      intermediateMessageId = id;
+                  } else {
+                    // Subsequent intermediates: edit that same status message
+                    await channel.editMessage!(
+                      chatJid,
+                      intermediateMessageId,
+                      text.slice(0, 2000),
+                    );
+                  }
+                } catch (err) {
+                  log.debug({ err }, 'Intermediate streaming failed (non-fatal)');
+                }
               }
             }
             return;
@@ -1455,6 +1476,21 @@ async function processGroupMessages(dispatchJid: string): Promise<boolean> {
                     typingInterval = null;
                   }
                 }
+              } else {
+                // No channel — store in DB for IPC-based clients to poll
+                storeMessage({
+                  id: `ipc-out-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`,
+                  chat_jid: targetJid,
+                  sender: 'assistant',
+                  sender_name: ASSISTANT_NAME,
+                  content: text,
+                  timestamp: new Date().toISOString(),
+                  is_from_me: true,
+                  sender_platform: 'ipc',
+                });
+                outputSentToUser = true;
+                if (replyAnchorMessageId) replyAnchorMessageId = null;
+                resetIdleTimer();
               }
             }
             // Reset intermediate message so the next user message gets a fresh status message
@@ -1466,6 +1502,22 @@ async function processGroupMessages(dispatchJid: string): Promise<boolean> {
           // [Upstream PR #354] Mark container as idle when it finishes work
           // (status: success with null result = session-update marker = idle-waiting)
           if (result.status === 'success') {
+            // For channel-less JIDs: the response was delivered via intermediates.
+            // Promote the last intermediate to a final response so IPC polling detects completion.
+            if (!channel && !outputSentToUser && lastIpcIntermediateText) {
+              storeMessage({
+                id: `ipc-out-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`,
+                chat_jid: chatJid,
+                sender: 'assistant',
+                sender_name: ASSISTANT_NAME,
+                content: lastIpcIntermediateText,
+                timestamp: new Date().toISOString(),
+                is_from_me: true,
+                sender_platform: 'ipc',
+              });
+              outputSentToUser = true;
+              lastIpcIntermediateText = null;
+            }
             queue.notifyIdle(dispatchJid);
             // Stop typing indicator when agent goes idle — otherwise the 8s
             // refresh loop keeps the indicator alive until the container exits,

--- a/src/ipc.ts
+++ b/src/ipc.ts
@@ -18,6 +18,7 @@ import {
   setChannelSubscription,
   getTaskById,
   setRegisteredGroup,
+  storeMessage,
   updateTask,
 } from './db.js';
 import { findGroupByFolder } from './group-helpers.js';
@@ -290,6 +291,21 @@ export async function processMessageIpc(
     const isRegisteredTarget = !!targetGroup;
     if (isMain || isSelf || isRegisteredTarget) {
       await deps.sendMessage(msgChatJid, msgText, data.discord_bot_id);
+      // Self-message to a channel-less JID: the agent is sending its response
+      // but there's no channel adapter to deliver it. Store in DB so external
+      // IPC-based clients (e.g. ditto-desktop) can poll for it.
+      if (isSelf && !deps.findChannel?.(msgChatJid)) {
+        storeMessage({
+          id: `ipc-out-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`,
+          chat_jid: msgChatJid,
+          sender: 'assistant',
+          sender_name: targetGroup?.trigger?.replace(/^@/, '') || 'Assistant',
+          content: msgText,
+          timestamp: new Date().toISOString(),
+          is_from_me: true,
+          sender_platform: 'ipc',
+        });
+      }
       // Cross-group message: also wake up the target agent.
       // Pass sourceGroup so the notify message is tagged — the source
       // agent won't see its own IPC message echoed back at it.

--- a/src/task-scheduler.ts
+++ b/src/task-scheduler.ts
@@ -219,6 +219,7 @@ async function runTask(
         channelFolder: group.channelFolder,
         categoryFolder: group.categoryFolder,
         agentContextFolder: group.agentContextFolder,
+        mcpServers: group.containerConfig?.mcpServers,
       },
       (proc, containerName) =>
         deps.onProcess(

--- a/src/types.ts
+++ b/src/types.ts
@@ -39,6 +39,8 @@ export interface ContainerConfig {
   timeout?: number; // Default: 300000 (5 minutes)
   memory?: number; // Container memory in MB. Default: 4096
   networkMode?: 'full' | 'none'; // Default: 'none' for non-main, 'full' for main
+  /** Extra MCP servers to inject into the agent runtime (SSE/HTTP). Keyed by server name. */
+  mcpServers?: Record<string, Record<string, unknown>>;
 }
 
 export type BackendType = 'apple-container' | 'docker';

--- a/src/types.ts
+++ b/src/types.ts
@@ -41,6 +41,8 @@ export interface ContainerConfig {
   networkMode?: 'full' | 'none'; // Default: 'none' for non-main, 'full' for main
   /** Extra MCP servers to inject into the agent runtime (SSE/HTTP). Keyed by server name. */
   mcpServers?: Record<string, Record<string, unknown>>;
+  /** Stream intermediate agent outputs (tool calls, thinking) via an edited status message. */
+  streamIntermediates?: boolean;
 }
 
 export type BackendType = 'apple-container' | 'docker';
@@ -166,6 +168,8 @@ export interface Channel {
   // Thread handles are opaque — callers store the value from createThread and pass it to sendToThread.
   createThread?(jid: string, messageId: string, name: string): Promise<unknown>;
   sendToThread?(thread: unknown, text: string): Promise<void>;
+  // Optional: edit an existing message in-place.
+  editMessage?(jid: string, messageId: string, text: string): Promise<void>;
   // Optional: add/remove emoji reactions on messages.
   addReaction?(jid: string, messageId: string, emoji: string): Promise<void>;
   removeReaction?(jid: string, messageId: string, emoji: string): Promise<void>;


### PR DESCRIPTION
## Summary
- Store intermediate and final agent output in DB when no channel adapter exists (e.g. ditto-desktop JID)
- IPC self-messages from `send_message` tool now persist to DB for channel-less groups
- Promote last intermediate as final response on task success if no output was delivered
- Filter agent-runner boilerplate text from intermediate promotion

## Context
When ditto-desktop dispatches tasks to OmniClaw via IPC, the agent's response was dropped because no channel adapter exists for the "ditto-desktop" JID. This adds DB-based delivery so external IPC clients can poll for responses.

## Test plan
- [ ] Send message via ditto-desktop agent mode
- [ ] Verify intermediate steps stream to the UI
- [ ] Verify final response appears (not boilerplate)
- [ ] Verify WhatsApp/Discord channels still work normally

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for custom MCP server configurations
  * Implemented Discord message editing for real-time response updates
  * Enabled intermediate response streaming to display agent progress
  * Added message persistence for IPC communications

* **Documentation**
  * Updated configuration examples with Firebase and Google Cloud credential placeholders

<!-- end of auto-generated comment: release notes by coderabbit.ai -->