### PR TITLE
fix(container): ignore comments in mounted env files

### DIFF
--- a/container/entrypoint.sh
+++ b/container/entrypoint.sh
@@ -8,7 +8,14 @@ if ! id -un &>/dev/null 2>&1; then
 fi
 
 # Source environment variables from mounted env file
-[ -f /workspace/env-dir/env ] && export $(cat /workspace/env-dir/env | xargs)
+if [ -f /workspace/env-dir/env ]; then
+  while IFS= read -r line || [ -n "$line" ]; do
+    [[ "$line" =~ ^[[:space:]]*$ ]] && continue
+    [[ "$line" =~ ^[[:space:]]*# ]] && continue
+    [[ "$line" =~ ^[A-Za-z_][A-Za-z0-9_]*= ]] || continue
+    export "$line"
+  done < /workspace/env-dir/env
+fi
 
 # Cap JS heap to prevent OOM
 export NODE_OPTIONS="--max-old-space-size=2048"

--- a/src/backends/local-backend.test.ts
+++ b/src/backends/local-backend.test.ts
@@ -371,6 +371,45 @@ describe('LocalBackend', () => {
       }
     });
 
+    it('strips comments and blank lines from exported env mounts', () => {
+      const fixture = createFixture();
+      try {
+        fs.writeFileSync(
+          path.join(fixture.tempProjectRoot, '.env'),
+          [
+            '# top-level comment',
+            'CLAUDE_MODEL=claude-opus-4-6',
+            '  # Bot identity map',
+            '',
+            'OPENCODE_MODEL=openai/gpt-5.4',
+            '',
+            'UNRELATED_SECRET=blocked',
+          ].join('\n') + '\n',
+        );
+
+        buildVolumeMounts(
+          { folder: fixture.groupFolder, name: 'Claude Test' } as any,
+          false,
+          false,
+          fixture.altRuntimeFolder,
+          'claude-agent-sdk',
+          undefined,
+          fixture.pathOverrides,
+        );
+
+        const claudeEnv = fs.readFileSync(
+          path.join(fixture.altEnvDir, 'env'),
+          'utf-8',
+        );
+        expect(claudeEnv).toContain('CLAUDE_MODEL=claude-opus-4-6');
+        expect(claudeEnv).toContain('OPENCODE_MODEL=openai/gpt-5.4');
+        expect(claudeEnv).not.toContain('# Bot identity map');
+        expect(claudeEnv).not.toContain('UNRELATED_SECRET=blocked');
+      } finally {
+        fixture.cleanup();
+      }
+    });
+
     it('refreshes the cached agent-runner source when the source tree changes', () => {
       const fixture = createFixture();
       try {

--- a/src/backends/local-backend.ts
+++ b/src/backends/local-backend.ts
@@ -500,7 +500,12 @@ function extractAllowedEnvBlocks(
       continue;
     }
 
-    if (currentKey) currentLines.push(line);
+    if (!currentKey) continue;
+
+    const trimmed = line.trim();
+    if (trimmed === '' || trimmed.startsWith('#')) continue;
+
+    currentLines.push(line);
   }
 
   flush();


### PR DESCRIPTION
## Summary
- ignore blank lines and comments when extracting allowed env vars into runtime-scoped container env files
- harden the container entrypoint env loader so malformed or commented lines are skipped instead of crashing startup
- add regression coverage for `.env` comments appearing between allowed variables

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved environment variable processing to properly handle comments and blank lines in configuration files, preventing unintended variables from being exported.

* **Tests**
  * Added verification tests for environment variable filtering behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->