### PR TITLE
fix: restore remote logs in simtest

### DIFF
--- a/src/discovery/peer-client.ts
+++ b/src/discovery/peer-client.ts
@@ -15,7 +15,25 @@ import type {
 
 const DEFAULT_TIMEOUT_MS = 10_000;
 
-export class PeerClient {
+export interface PeerClientLike {
+  getAgents(): Promise<RemoteAgentSummary[]>;
+  getStats(): Promise<unknown>;
+  streamLogs(): Promise<Response>;
+  getContextLayers(params: Record<string, string>): Promise<unknown>;
+  listContextFiles(): Promise<ContextFileEntry[]>;
+  writeContextFile(
+    layerPath: string,
+    content: string,
+  ): Promise<{ ok: boolean }>;
+  getAgentAvatarImage?(
+    agentId: string,
+  ): Promise<{ data: ArrayBuffer; contentType: string } | null>;
+  getChatIcon?(
+    jid: string,
+  ): Promise<{ data: ArrayBuffer; contentType: string } | null>;
+}
+
+export class PeerClient implements PeerClientLike {
   private baseUrl: string;
   private instanceId: string;
   private sharedSecret: string | null;

--- a/src/discovery/routes.test.ts
+++ b/src/discovery/routes.test.ts
@@ -465,4 +465,56 @@ describe('checkPeerAuth — body hash verification', () => {
     expect(body).toContain('event: log');
     expect(body).toContain('remote log');
   });
+
+  it('uses an injected peer client override when provided', async () => {
+    const req = new Request(
+      'http://localhost/api/discovery/peers/peer-1/agents',
+      {
+        method: 'GET',
+      },
+    );
+
+    const ctx = makeContext({
+      trustStore: {
+        getPeer: () => ({
+          instanceId: 'peer-1',
+          status: 'trusted',
+          sharedSecret: 'secret',
+          host: '127.0.0.1',
+          port: 6001,
+        }),
+        updatePeerLastSeen: () => {},
+      } as any,
+      createPeerClient: () => ({
+        getAgents: async () => [
+          {
+            id: 'remote-1',
+            name: 'Remote Agent',
+            folder: 'remote-1',
+            backend: 'sprites',
+            agentRuntime: 'opencode',
+            channels: [],
+          },
+        ],
+        getStats: async () => ({}),
+        streamLogs: async () => new Response(''),
+        getContextLayers: async () => ({}),
+        listContextFiles: async () => [],
+        writeContextFile: async () => ({ ok: true }),
+      }),
+    });
+
+    const res = await handleDiscoveryRequest(req, new URL(req.url), ctx);
+    expect(res).not.toBeNull();
+    expect(await (res as Response).json()).toEqual([
+      {
+        id: 'remote-1',
+        name: 'Remote Agent',
+        folder: 'remote-1',
+        backend: 'sprites',
+        agentRuntime: 'opencode',
+        channels: [],
+      },
+    ]);
+  });
 });

--- a/src/discovery/routes.ts
+++ b/src/discovery/routes.ts
@@ -10,7 +10,11 @@ import { WEB_UI_PORT } from '../config.js';
 import { logger } from '../logger.js';
 import { listLocalContextFiles } from '../web/context-files.js';
 import type { WebStateProvider } from '../web/types.js';
-import { PeerClient, verifyPeerRequestSignature } from './peer-client.js';
+import {
+  PeerClient,
+  verifyPeerRequestSignature,
+  type PeerClientLike,
+} from './peer-client.js';
 import {
   encryptPairingSecret,
   generatePairingKeyPair,
@@ -26,6 +30,7 @@ import type {
   PairRequestBody,
   PeerView,
   RemotePeerAgents,
+  StoredPeer,
 } from './types.js';
 
 export interface DiscoveryRouteContext {
@@ -36,6 +41,10 @@ export interface DiscoveryRouteContext {
   discovery: DiscoveryHandle | null;
   state: WebStateProvider;
   runtime?: DiscoveryRuntimeController;
+  createPeerClient?: (
+    peer: Pick<StoredPeer, 'instanceId' | 'host' | 'port' | 'sharedSecret'>,
+    ctx: DiscoveryRouteContext,
+  ) => PeerClientLike | null;
   /** Callback to broadcast SSE events */
   broadcast?: (event: {
     type: string;
@@ -777,7 +786,7 @@ function handleRevokePeer(
 function getPeerClient(
   instanceId: string,
   ctx: DiscoveryRouteContext,
-): PeerClient | null {
+): PeerClientLike | null {
   if (ctx.runtime && !ctx.runtime.isRemoteAccessAllowed()) return null;
 
   const peer = ctx.trustStore.getPeer(instanceId);
@@ -791,6 +800,18 @@ function getPeerClient(
   if (!host || !port) return null;
 
   ctx.trustStore.updatePeerLastSeen(instanceId);
+  if (ctx.createPeerClient) {
+    return ctx.createPeerClient(
+      {
+        instanceId,
+        host,
+        port,
+        sharedSecret: peer.sharedSecret,
+      },
+      ctx,
+    );
+  }
+
   return new PeerClient(host, port, ctx.instanceId, peer.sharedSecret);
 }
 
@@ -821,6 +842,9 @@ async function handleProxyAgentAvatar(
 ): Promise<Response> {
   const client = getPeerClient(instanceId, ctx);
   if (!client) return json({ error: 'Peer not trusted or unreachable' }, 403);
+  if (!client.getAgentAvatarImage) {
+    return json({ error: 'Peer avatar proxy unavailable' }, 501);
+  }
 
   try {
     const result = await client.getAgentAvatarImage(agentId);
@@ -848,6 +872,9 @@ async function handleProxyChatIcon(
 ): Promise<Response> {
   const client = getPeerClient(instanceId, ctx);
   if (!client) return json({ error: 'Peer not trusted or unreachable' }, 403);
+  if (!client.getChatIcon) {
+    return json({ error: 'Peer chat icon proxy unavailable' }, 501);
+  }
 
   try {
     const result = await client.getChatIcon(jid);

--- a/src/simtest/admin-api.ts
+++ b/src/simtest/admin-api.ts
@@ -9,6 +9,7 @@ import type { IpcEventKind } from '../web/ipc-events.js';
 import type { WsEventType } from '../web/types.js';
 import type { WebServerHandle } from '../web/server.js';
 import { calculateNextRun } from '../schedule-utils.js';
+import type { SimDiscoveryEnvironment } from './discovery-sim.js';
 import type { FakeState } from './fake-state.js';
 
 export interface AdminApiConfig {
@@ -25,6 +26,7 @@ export function startAdminApi(
   config: AdminApiConfig,
   state: FakeState,
   webServer: WebServerHandle,
+  discovery?: SimDiscoveryEnvironment,
 ): AdminApiHandle {
   const hostname = config.hostname || '127.0.0.1';
 
@@ -56,6 +58,7 @@ export function startAdminApi(
           req,
           state,
           webServer,
+          discovery,
         );
         result.headers.set('Access-Control-Allow-Origin', '*');
         return result;
@@ -89,6 +92,7 @@ async function handleAdminRequest(
   req: Request,
   state: FakeState,
   webServer: WebServerHandle,
+  discovery?: SimDiscoveryEnvironment,
 ): Promise<Response> {
   const path = url.pathname;
 
@@ -120,6 +124,9 @@ async function handleAdminRequest(
           'Set queue stats { activeContainers?, idleContainers?, maxActive?, maxIdle? }',
         'POST /queue-details': 'Set queue details (array of GroupQueueDetail)',
         'POST /broadcast': 'Broadcast event to web UI { type, data }',
+        'GET /remote-peers': 'List simulated trusted remote peers',
+        'POST /remote-peers/:id/logs':
+          'Append remote peer log { level, msg, source?, time? }',
         'POST /scenario/:name':
           'Run predefined scenario (agent-overload, task-storm, error-cascade, idle-fleet, empty)',
       },
@@ -137,7 +144,36 @@ async function handleAdminRequest(
       ipcEvents: state.ipcEvents.length,
       queueStats: state.queueStats,
       queueDetails: state.queueDetails,
+      remotePeers: discovery?.listRemotePeers() ?? [],
     });
+  }
+
+  if (path === '/remote-peers' && method === 'GET') {
+    return json(discovery?.listRemotePeers() ?? []);
+  }
+
+  if (
+    path.startsWith('/remote-peers/') &&
+    path.endsWith('/logs') &&
+    method === 'POST'
+  ) {
+    if (!discovery)
+      return json({ error: 'Remote peer simulation unavailable' }, 404);
+    const instanceId = decodeURIComponent(
+      path.slice('/remote-peers/'.length, -'/logs'.length),
+    );
+    const body = (await req.json()) as Record<string, unknown>;
+    if (typeof body.level !== 'string' || typeof body.msg !== 'string') {
+      return json({ error: '"level" and "msg" are required' }, 400);
+    }
+    discovery.addRemoteLog(instanceId, {
+      level: body.level,
+      msg: body.msg,
+      source:
+        typeof body.source === 'string' ? body.source : `remote:${instanceId}`,
+      time: typeof body.time === 'string' ? body.time : undefined,
+    });
+    return json({ ok: true, instanceId }, 201);
   }
 
   // ---- Reset ----

--- a/src/simtest/discovery-sim.test.ts
+++ b/src/simtest/discovery-sim.test.ts
@@ -1,0 +1,43 @@
+import { describe, expect, it } from 'bun:test';
+
+import { handleDiscoveryRequest } from '../discovery/routes.js';
+import { createSimDiscoveryEnvironment } from './discovery-sim.js';
+import { FakeState } from './fake-state.js';
+
+describe('createSimDiscoveryEnvironment', () => {
+  it('exposes a trusted remote peer with agents and logs', async () => {
+    const env = createSimDiscoveryEnvironment(new FakeState());
+
+    const peers = env.listRemotePeers();
+    expect(peers).toHaveLength(1);
+    expect(peers[0]?.agents).toBeGreaterThan(0);
+
+    const agentsReq = new Request(
+      'http://localhost/api/discovery/peers/peer-remote-1/agents',
+    );
+    const agentsRes = await handleDiscoveryRequest(
+      agentsReq,
+      new URL(agentsReq.url),
+      env.context,
+    );
+    const agents = (await (agentsRes as Response).json()) as Array<{
+      id: string;
+    }>;
+
+    expect(Array.isArray(agents)).toBe(true);
+    expect(agents.some((agent) => agent.id === 'remote-builder')).toBe(true);
+
+    const logsReq = new Request(
+      'http://localhost/api/discovery/peers/peer-remote-1/logs',
+    );
+    const logsRes = await handleDiscoveryRequest(
+      logsReq,
+      new URL(logsReq.url),
+      env.context,
+    );
+    const body = await (logsRes as Response).text();
+
+    expect(body).toContain('event: log');
+    expect(body).toContain('Remote runner connected');
+  });
+});

--- a/src/simtest/discovery-sim.ts
+++ b/src/simtest/discovery-sim.ts
@@ -1,0 +1,488 @@
+import { createHash } from 'crypto';
+
+import type { DiscoveryRouteContext } from '../discovery/routes.js';
+import type { PeerClientLike } from '../discovery/peer-client.js';
+import type {
+  ContextFileEntry,
+  DiscoveredPeer,
+  PairRequest,
+  PeerView,
+  RemoteAgentSummary,
+  StoredPeer,
+} from '../discovery/types.js';
+import { buildAgentChannelData } from '../web/agent-channels.js';
+import type { NetworkPageState } from '../web/network.js';
+import { FakeState } from './fake-state.js';
+
+interface SimRemoteLogRecord {
+  time: string;
+  level: string;
+  msg: string;
+  source: string;
+}
+
+interface SimRemotePeer {
+  discovered: DiscoveredPeer;
+  stored: StoredPeer;
+  state: FakeState;
+  logs: SimRemoteLogRecord[];
+}
+
+class SimTrustStore {
+  private peers = new Map<string, StoredPeer>();
+  private pendingRequests: PairRequest[] = [];
+
+  constructor(peers: SimRemotePeer[]) {
+    for (const peer of peers) {
+      this.peers.set(peer.discovered.instanceId, { ...peer.stored });
+    }
+  }
+
+  getPeer(instanceId: string): StoredPeer | null {
+    return this.peers.get(instanceId) ?? null;
+  }
+
+  getAllPeers(): StoredPeer[] {
+    return Array.from(this.peers.values()).filter(
+      (peer) => peer.status !== 'revoked',
+    );
+  }
+
+  getPendingRequests(): PairRequest[] {
+    return [...this.pendingRequests];
+  }
+
+  isPeerTrusted(instanceId: string): boolean {
+    return this.peers.get(instanceId)?.status === 'trusted';
+  }
+
+  getPeerSecret(instanceId: string): string | null {
+    return this.peers.get(instanceId)?.sharedSecret ?? null;
+  }
+
+  updatePeerLastSeen(instanceId: string): void {
+    const peer = this.peers.get(instanceId);
+    if (!peer) return;
+    peer.lastSeen = new Date().toISOString();
+  }
+
+  revokePeer(instanceId: string): void {
+    const peer = this.peers.get(instanceId);
+    if (!peer) return;
+    peer.status = 'revoked';
+    peer.sharedSecret = null;
+  }
+
+  resetPeerToDiscovered(instanceId: string): void {
+    const peer = this.peers.get(instanceId);
+    if (!peer) return;
+    peer.status = 'discovered';
+  }
+
+  createPairRequest(
+    fromInstanceId: string,
+    fromName: string,
+    fromHost: string,
+    fromPort: number,
+    callbackToken: string,
+  ): PairRequest {
+    const request: PairRequest = {
+      id: `req-${Date.now()}`,
+      fromInstanceId,
+      fromName,
+      fromHost,
+      fromPort,
+      callbackToken,
+      status: 'pending',
+      sharedSecret: null,
+      createdAt: new Date().toISOString(),
+      resolvedAt: null,
+    };
+    this.pendingRequests.push(request);
+    return request;
+  }
+
+  approvePairRequest(requestId: string): {
+    sharedSecret: string;
+    request: PairRequest;
+  } {
+    const request = this.pendingRequests.find(
+      (entry) => entry.id === requestId,
+    );
+    if (!request) throw new Error('Request not found');
+    request.status = 'approved';
+    request.resolvedAt = new Date().toISOString();
+    const sharedSecret = `sim-secret-${request.fromInstanceId}`;
+    this.peers.set(request.fromInstanceId, {
+      instanceId: request.fromInstanceId,
+      name: request.fromName,
+      sharedSecret,
+      status: 'trusted',
+      host: request.fromHost,
+      port: request.fromPort,
+      approvedAt: request.resolvedAt,
+      lastSeen: request.resolvedAt,
+      createdAt: request.createdAt,
+    });
+    return { sharedSecret, request };
+  }
+
+  rejectPairRequest(requestId: string): void {
+    const request = this.pendingRequests.find(
+      (entry) => entry.id === requestId,
+    );
+    if (!request) throw new Error('Request not found');
+    request.status = 'rejected';
+    request.resolvedAt = new Date().toISOString();
+  }
+
+  markPeerPending(
+    instanceId: string,
+    name: string,
+    host: string | null,
+    port: number | null,
+  ): StoredPeer {
+    const now = new Date().toISOString();
+    const stored: StoredPeer = {
+      instanceId,
+      name,
+      sharedSecret: null,
+      status: 'pending',
+      host,
+      port,
+      approvedAt: null,
+      lastSeen: now,
+      createdAt: now,
+    };
+    this.peers.set(instanceId, stored);
+    return stored;
+  }
+
+  completePendingEncryptedPairing(): StoredPeer {
+    throw new Error('Encrypted pairing callbacks are not simulated');
+  }
+}
+
+class SimDiscoveryHandle {
+  constructor(private readonly peers: Map<string, DiscoveredPeer>) {}
+
+  getPeers(): Map<string, DiscoveredPeer> {
+    return new Map(this.peers);
+  }
+
+  setPeerOnline(instanceId: string, online: boolean): void {
+    const peer = this.peers.get(instanceId);
+    if (!peer) return;
+    if (online) {
+      this.peers.set(instanceId, peer);
+      return;
+    }
+    this.peers.delete(instanceId);
+  }
+
+  upsertPeer(peer: DiscoveredPeer): void {
+    this.peers.set(peer.instanceId, peer);
+  }
+
+  stop(): void {}
+}
+
+class SimRuntimeController {
+  private enabled = true;
+
+  getSnapshot() {
+    return {
+      enabled: this.enabled,
+      active: this.enabled,
+      currentNetwork: {
+        id: 'sim-lan',
+        label: 'Simulated LAN',
+      },
+      trustedNetworks: [],
+    };
+  }
+
+  setEnabled(enabled: boolean) {
+    this.enabled = enabled;
+    return this.getSnapshot();
+  }
+
+  trustCurrentNetwork() {
+    return this.getSnapshot();
+  }
+
+  untrustNetwork() {
+    return this.getSnapshot();
+  }
+
+  isRemoteAccessAllowed(): boolean {
+    return this.enabled;
+  }
+}
+
+class SimPeerClient implements PeerClientLike {
+  constructor(private readonly peer: SimRemotePeer) {}
+
+  async getAgents(): Promise<RemoteAgentSummary[]> {
+    return buildAgentChannelData(this.peer.state).map((agent) => ({
+      id: agent.id,
+      name: agent.name,
+      folder: agent.folder,
+      backend: agent.backend,
+      agentRuntime: agent.agentRuntime,
+      isAdmin: agent.isAdmin,
+      serverFolder: agent.serverFolder,
+      agentContextFolder: agent.agentContextFolder,
+      avatarUrl: agent.avatarUrl,
+      channels: agent.channels.map((channel) => ({
+        jid: channel.jid,
+        displayName: channel.displayName,
+        channelFolder: channel.channelFolder,
+        categoryFolder: channel.categoryFolder,
+      })),
+    }));
+  }
+
+  async getStats(): Promise<unknown> {
+    const tasks = this.peer.state.getTasks();
+    return {
+      agents: Object.keys(this.peer.state.getAgents()).length,
+      activeTasks: tasks.filter((task) => task.status === 'active').length,
+      pausedTasks: tasks.filter((task) => task.status === 'paused').length,
+      completedTasks: tasks.filter((task) => task.status === 'completed')
+        .length,
+      ...this.peer.state.getQueueStats(),
+    };
+  }
+
+  async streamLogs(): Promise<Response> {
+    const encoder = new TextEncoder();
+    const lines = this.peer.logs.slice(-50);
+    return new Response(
+      new ReadableStream({
+        start(controller) {
+          for (const record of lines) {
+            controller.enqueue(
+              encoder.encode(`event: log\ndata: ${JSON.stringify(record)}\n\n`),
+            );
+          }
+          controller.close();
+        },
+      }),
+      {
+        headers: { 'Content-Type': 'text/event-stream; charset=utf-8' },
+      },
+    );
+  }
+
+  async getContextLayers(params: Record<string, string>): Promise<unknown> {
+    const folder = params.folder || '';
+    return {
+      channel: {
+        path: folder || null,
+        content: folder ? this.peer.state.readContextFile(folder) : null,
+        exists: folder
+          ? this.peer.state.readContextFile(folder) !== null
+          : false,
+      },
+      agent: { path: null, content: null, exists: false },
+      category: { path: null, content: null, exists: false },
+      server: { path: null, content: null, exists: false },
+    };
+  }
+
+  async listContextFiles(): Promise<ContextFileEntry[]> {
+    return Object.entries(this.peer.state.contextFiles).map(
+      ([filePath, content]) => ({
+        path: filePath,
+        hash: sha256(content),
+        size: Buffer.byteLength(content, 'utf8'),
+        mtime: new Date().toISOString(),
+      }),
+    );
+  }
+
+  async writeContextFile(
+    layerPath: string,
+    content: string,
+  ): Promise<{ ok: boolean }> {
+    this.peer.state.writeContextFile(layerPath, content);
+    return { ok: true };
+  }
+}
+
+function sha256(content: string): string {
+  return createHash('sha256').update(content).digest('hex');
+}
+
+function buildPeerViews(
+  discovery: SimDiscoveryHandle,
+  trustStore: SimTrustStore,
+): PeerView[] {
+  const storedMap = new Map(
+    trustStore.getAllPeers().map((peer) => [peer.instanceId, peer]),
+  );
+  const peers: PeerView[] = [];
+
+  for (const [instanceId, discovered] of discovery.getPeers()) {
+    const stored = storedMap.get(instanceId);
+    peers.push({
+      instanceId,
+      name: discovered.name,
+      host: discovered.host,
+      port: discovered.port,
+      addresses: discovered.addresses,
+      status: stored?.status ?? 'discovered',
+      online: true,
+      approvedAt: stored?.approvedAt ?? null,
+      lastSeen: stored?.lastSeen ?? null,
+    });
+    storedMap.delete(instanceId);
+  }
+
+  for (const stored of storedMap.values()) {
+    peers.push({
+      instanceId: stored.instanceId,
+      name: stored.name,
+      host: stored.host ?? '',
+      port: stored.port ?? 0,
+      addresses: [],
+      status: stored.status,
+      online: false,
+      approvedAt: stored.approvedAt,
+      lastSeen: stored.lastSeen,
+    });
+  }
+
+  return peers;
+}
+
+function createDefaultRemotePeer(): SimRemotePeer {
+  const state = new FakeState();
+  state.addAgent({
+    id: 'remote-builder',
+    name: 'Remote Builder',
+    backend: 'docker',
+    agentRuntime: 'opencode',
+  });
+  state.addChat('sim:remote', '#remote');
+  state.addSubscription('sim:remote', 'remote-builder', {
+    isPrimary: true,
+    channelFolder: 'remote',
+  });
+
+  const now = new Date().toISOString();
+  return {
+    discovered: {
+      instanceId: 'peer-remote-1',
+      name: 'Remote OmniClaw',
+      host: 'remote-sim.local',
+      port: 3100,
+      addresses: ['192.168.1.80'],
+      version: 'simtest',
+      firstSeen: now,
+    },
+    stored: {
+      instanceId: 'peer-remote-1',
+      name: 'Remote OmniClaw',
+      sharedSecret: 'sim-remote-secret',
+      status: 'trusted',
+      host: 'remote-sim.local',
+      port: 3100,
+      approvedAt: now,
+      lastSeen: now,
+      createdAt: now,
+    },
+    state,
+    logs: [
+      {
+        time: now,
+        level: 'info',
+        msg: 'Remote runner connected to the fleet',
+        source: 'peer-remote-1',
+      },
+      {
+        time: now,
+        level: 'warn',
+        msg: 'Remote builder cache is warming up',
+        source: 'peer-remote-1',
+      },
+    ],
+  };
+}
+
+export interface SimDiscoveryEnvironment {
+  context: DiscoveryRouteContext;
+  getNetworkPageState(): NetworkPageState;
+  listRemotePeers(): Array<{
+    instanceId: string;
+    name: string;
+    online: boolean;
+    agents: number;
+    logs: number;
+  }>;
+  addRemoteLog(
+    instanceId: string,
+    record: Omit<SimRemoteLogRecord, 'time'> & { time?: string },
+  ): void;
+}
+
+export function createSimDiscoveryEnvironment(
+  state: FakeState,
+): SimDiscoveryEnvironment {
+  const remotePeer = createDefaultRemotePeer();
+  const peers = new Map([[remotePeer.discovered.instanceId, remotePeer]]);
+  const trustStore = new SimTrustStore([remotePeer]);
+  const discovery = new SimDiscoveryHandle(
+    new Map([[remotePeer.discovered.instanceId, remotePeer.discovered]]),
+  );
+  const runtime = new SimRuntimeController();
+
+  const context: DiscoveryRouteContext = {
+    instanceId: 'sim-local-instance',
+    instanceName: 'Sim Local OmniClaw',
+    version: 'simtest',
+    trustStore: trustStore as any,
+    discovery,
+    state,
+    runtime: runtime as any,
+    createPeerClient(peer) {
+      const remote = peers.get(peer.instanceId);
+      return remote ? new SimPeerClient(remote) : null;
+    },
+  };
+
+  return {
+    context,
+    getNetworkPageState() {
+      return {
+        instanceId: context.instanceId,
+        instanceName: context.instanceName,
+        discoveryAvailable: true,
+        discoveryEnabled: true,
+        runtime: runtime.getSnapshot(),
+        peers: buildPeerViews(discovery, trustStore),
+        pendingRequests: trustStore.getPendingRequests(),
+      };
+    },
+    listRemotePeers() {
+      return Array.from(peers.values()).map((peer) => ({
+        instanceId: peer.discovered.instanceId,
+        name: peer.discovered.name,
+        online: discovery.getPeers().has(peer.discovered.instanceId),
+        agents: Object.keys(peer.state.getAgents()).length,
+        logs: peer.logs.length,
+      }));
+    },
+    addRemoteLog(instanceId, record) {
+      const peer = peers.get(instanceId);
+      if (!peer) throw new Error(`Remote peer not found: ${instanceId}`);
+      peer.logs.push({
+        time: record.time ?? new Date().toISOString(),
+        level: record.level,
+        msg: record.msg,
+        source: record.source,
+      });
+    },
+  };
+}

--- a/src/simtest/index.ts
+++ b/src/simtest/index.ts
@@ -20,9 +20,11 @@
 
 import { parseArgs } from 'util';
 
+import { setDiscoveryContext } from '../web/routes.js';
 import { startWebServer } from '../web/server.js';
 import { FakeState } from './fake-state.js';
 import { startAdminApi } from './admin-api.js';
+import { createSimDiscoveryEnvironment } from './discovery-sim.js';
 
 const { values } = parseArgs({
   options: {
@@ -39,6 +41,7 @@ const hostname = values.hostname as string;
 
 // Create fake state with seed data
 const state = new FakeState();
+const discovery = createSimDiscoveryEnvironment(state);
 
 // Start the real web UI server (no auth in simtest mode)
 const webServer = startWebServer(
@@ -50,8 +53,16 @@ const webServer = startWebServer(
   state,
 );
 
+webServer.setNetworkPageState(discovery.getNetworkPageState);
+setDiscoveryContext(discovery.context, discovery.getNetworkPageState);
+
 // Start the admin API on a separate port
-const adminApi = startAdminApi({ port: adminPort, hostname }, state, webServer);
+const adminApi = startAdminApi(
+  { port: adminPort, hostname },
+  state,
+  webServer,
+  discovery,
+);
 
 console.log('');
 console.log('╔══════════════════════════════════════════════════════╗');
@@ -74,6 +85,8 @@ console.log('║    POST /scenario/:name    — Load a scenario        ║');
 console.log('║    POST /agents            — Add an agent           ║');
 console.log('║    POST /messages          — Inject a message       ║');
 console.log('║    POST /broadcast         — Push event to web UI   ║');
+console.log('║    GET  /remote-peers      — Remote sim snapshot    ║');
+console.log('║    POST /remote-peers/:id/logs — Inject remote log  ║');
 console.log('║                                                     ║');
 console.log('║  Scenarios: agent-overload, task-storm,             ║');
 console.log('║             error-cascade, idle-fleet, empty        ║');

--- a/src/web/network.test.ts
+++ b/src/web/network.test.ts
@@ -170,6 +170,7 @@ describe('renderPeerRows', () => {
     expect(html).toContain('<strong>Trusted &lt;Peer&gt;</strong>');
     expect(html).toContain('<span class="badge badge-admin">trusted</span>');
     expect(html).toContain('data-network-action="browse"');
+    expect(html).toContain('data-network-action="logs"');
     expect(html).toContain('data-network-action="sync"');
     expect(html).toContain('data-network-action="revoke"');
     expect(html).toContain('<span style="color:var(--green)">●</span>');

--- a/src/web/page-scripts.test.ts
+++ b/src/web/page-scripts.test.ts
@@ -63,3 +63,22 @@ describe('tasks page script', () => {
     );
   });
 });
+
+describe('network page script', () => {
+  it('keeps remote log controls wired after peer refreshes', () => {
+    const script = allPageScripts().network;
+
+    expect(script).toContain(
+      'if(action==="logs"){startRemoteLogs(id);return;}',
+    );
+    expect(script).toContain('data-network-action="logs"');
+    expect(script).toContain('function startRemoteLogs(instanceId){');
+    expect(script).toContain(
+      'new EventSource("/api/discovery/peers/"+encodeURIComponent(instanceId)+"/logs")',
+    );
+    expect(script).toContain('function stopRemoteLogs(silent){');
+    expect(script).toContain(
+      'window.__cleanup=function(){if(pollTimer)clearInterval(pollTimer);stopRemoteLogs(true);};',
+    );
+  });
+});

--- a/src/web/page-scripts.ts
+++ b/src/web/page-scripts.ts
@@ -1549,6 +1549,8 @@ function networkScript(): string {
   return `
 var pollTimer=null;
 var syncPeerId=null;
+var remoteLogsSource=null;
+var remoteLogsPeerId=null;
 var networkClicksBound=false;
 var networkRoot=document.getElementById("network-root");
 var discoveryAvailable=networkRoot&&networkRoot.getAttribute("data-discovery-available")==="true";
@@ -1644,6 +1646,7 @@ function networkAction(action,id){
     return;
   }
   if(action==="browse"){browseRemoteAgents(id);return;}
+  if(action==="logs"){startRemoteLogs(id);return;}
   if(action==="sync"){openSyncPanel(id);return;}
   if(action==="close-sync"){closeSyncPanel();return;}
   if(action==="push"){syncFile("push",id);return;}
@@ -1676,6 +1679,7 @@ function renderPeerActions(peer){
   var id=window.__esc(peer.instanceId||"");
   if(peer.status==="trusted"){
     return '<button class="btn btn-sm" data-network-action="browse" data-network-id="'+id+'">Browse</button> '
+      +'<button class="btn btn-sm" data-network-action="logs" data-network-id="'+id+'">Logs</button> '
       +'<button class="btn btn-sm btn-primary" data-network-action="sync" data-network-id="'+id+'">Sync</button> '
       +'<button class="btn btn-sm btn-danger" data-network-action="revoke" data-network-id="'+id+'">Revoke</button>';
   }
@@ -1760,6 +1764,59 @@ function browseRemoteAgents(instanceId){
     }).catch(function(e){
       container.innerHTML='<div class="card"><div style="padding:2rem;text-align:center;color:var(--red)">Error: '+window.__esc(e.message)+'</div></div>';
     });
+}
+
+function setRemoteLogsStatus(message,isError){
+  var status=document.getElementById("remote-logs-status");
+  if(!status)return;
+  status.textContent=message;
+  status.style.color=isError?"var(--red)":"var(--text-muted)";
+}
+
+function appendRemoteLog(record){
+  var output=document.getElementById("remote-logs-output");if(!output)return;
+  var line=document.createElement("div");
+  line.className="log-line";
+  var level=String(record&&record.level||"info").toUpperCase();
+  var time=String(record&&record.time||record&&record.timestamp||"");
+  var source=String(record&&record.source||"remote");
+  var msg=String(record&&record.msg||record&&record.message||"");
+  line.textContent=(time?"["+time+"] ":"")+level+" "+source+" - "+msg;
+  output.appendChild(line);
+  while(output.childNodes.length>200)output.removeChild(output.firstChild);
+  output.scrollTop=output.scrollHeight;
+}
+
+function stopRemoteLogs(silent){
+  if(remoteLogsSource){
+    remoteLogsSource.close();
+    remoteLogsSource=null;
+  }
+  remoteLogsPeerId=null;
+  if(!silent)setRemoteLogsStatus("Remote log stream stopped.",false);
+}
+
+function startRemoteLogs(instanceId){
+  if(!instanceId)return;
+  if(remoteLogsPeerId===instanceId&&remoteLogsSource)return;
+  stopRemoteLogs(true);
+  remoteLogsPeerId=instanceId;
+  var output=document.getElementById("remote-logs-output");if(output)output.innerHTML="";
+  setRemoteLogsStatus("Connecting to remote log stream...",false);
+  remoteLogsSource=new EventSource("/api/discovery/peers/"+encodeURIComponent(instanceId)+"/logs");
+  remoteLogsSource.addEventListener("log",function(event){
+    try {
+      var payload=JSON.parse(event.data);
+      appendRemoteLog(payload);
+      setRemoteLogsStatus("Streaming remote logs from "+instanceId+".",false);
+    } catch (_) {
+      appendRemoteLog({level:"info",source:instanceId,msg:event.data});
+    }
+  });
+  remoteLogsSource.onerror=function(){
+    setRemoteLogsStatus("Remote log stream unavailable for "+instanceId+".",true);
+    stopRemoteLogs(true);
+  };
 }
 
 function openSyncPanel(instanceId){


### PR DESCRIPTION
## Summary
- restore the missing remote log controls on the network page so trusted peers can actually start a log stream after the peers table refreshes
- add a peer-client override hook and a simtest discovery harness so local and remote agents can be exercised without real hardware
- cover the regression with page-script, discovery-route, and simtest-focused tests

## Verification
- `bun run typecheck`
- `bun test src/web/network.test.ts src/web/page-scripts.test.ts src/discovery/routes.test.ts src/simtest/discovery-sim.test.ts`
- launched `bun run src/simtest/index.ts --web-port 3105 --admin-port 3106` and verified `/remote-peers`, `/api/discovery/peers/peer-remote-1/agents`, and `/api/discovery/peers/peer-remote-1/logs`
