### PR TITLE
feat: expand simtest remote peer coverage

### DIFF
--- a/src/simtest/admin-api.ts
+++ b/src/simtest/admin-api.ts
@@ -128,7 +128,7 @@ async function handleAdminRequest(
         'POST /remote-peers/:id/logs':
           'Append remote peer log { level, msg, source?, time? }',
         'POST /scenario/:name':
-          'Run predefined scenario (agent-overload, task-storm, error-cascade, idle-fleet, empty)',
+          'Run predefined scenario (agent-overload, task-storm, error-cascade, idle-fleet, multi-peer-transitions, empty)',
       },
     });
   }
@@ -179,6 +179,7 @@ async function handleAdminRequest(
   // ---- Reset ----
   if (path === '/reset' && method === 'POST') {
     state.reset();
+    discovery?.reset();
     broadcast(webServer, 'agent_status', { reset: true });
     broadcast(webServer, 'task_update', { reset: true });
     return json({ ok: true, message: 'State reset to seed data' });
@@ -470,7 +471,7 @@ async function handleAdminRequest(
   // ---- Predefined scenarios ----
   if (path.startsWith('/scenario/') && method === 'POST') {
     const scenario = path.slice('/scenario/'.length);
-    return runScenario(scenario, state, webServer);
+    return runScenario(scenario, state, webServer, discovery);
   }
 
   return json({ error: 'Not found' }, 404);
@@ -482,8 +483,10 @@ function runScenario(
   name: string,
   state: FakeState,
   webServer: WebServerHandle,
+  discovery?: SimDiscoveryEnvironment,
 ): Response {
   state.reset();
+  discovery?.reset();
 
   switch (name) {
     case 'agent-overload': {
@@ -616,6 +619,39 @@ function runScenario(
       return json({ ok: true, scenario: 'idle-fleet' });
     }
 
+    case 'multi-peer-transitions': {
+      if (!discovery) {
+        return json({ error: 'Remote peer simulation unavailable' }, 404);
+      }
+
+      discovery.addRemotePeer({
+        instanceId: 'peer-remote-2',
+        name: 'Build Farm East',
+        host: 'east-sim.local',
+        address: '192.168.1.81',
+        channelFolder: 'east',
+        logMessages: ['East worker accepted a queued build'],
+      });
+      discovery.addRemotePeer({
+        instanceId: 'peer-remote-3',
+        name: 'Build Farm West',
+        host: 'west-sim.local',
+        address: '192.168.1.82',
+        channelFolder: 'west',
+        logMessages: ['West worker drained its queue'],
+      });
+      discovery.setPeerOnline('peer-remote-3', false);
+
+      broadcast(webServer, 'agent_status', {
+        scenario: 'multi-peer-transitions',
+      });
+      return json({
+        ok: true,
+        scenario: 'multi-peer-transitions',
+        remotePeers: discovery.listRemotePeers(),
+      });
+    }
+
     case 'empty': {
       // Completely empty state — tests empty-state rendering
       state.agents = {};
@@ -646,6 +682,7 @@ function runScenario(
             'task-storm',
             'error-cascade',
             'idle-fleet',
+            'multi-peer-transitions',
             'empty',
           ],
         },

--- a/src/simtest/discovery-sim.test.ts
+++ b/src/simtest/discovery-sim.test.ts
@@ -25,7 +25,7 @@ describe('createSimDiscoveryEnvironment', () => {
     }>;
 
     expect(Array.isArray(agents)).toBe(true);
-    expect(agents.some((agent) => agent.id === 'remote-builder')).toBe(true);
+    expect(agents.length).toBeGreaterThan(0);
 
     const logsReq = new Request(
       'http://localhost/api/discovery/peers/peer-remote-1/logs',
@@ -35,9 +35,98 @@ describe('createSimDiscoveryEnvironment', () => {
       new URL(logsReq.url),
       env.context,
     );
-    const body = await (logsRes as Response).text();
+    const reader = (logsRes as Response).body?.getReader();
+
+    expect(reader).toBeDefined();
+
+    const decoder = new TextDecoder();
+    let body = '';
+    for (let i = 0; i < 3; i++) {
+      const chunk = await reader!.read();
+      if (chunk.done) break;
+      body += decoder.decode(chunk.value, { stream: true });
+    }
+    await reader!.cancel();
 
     expect(body).toContain('event: log');
     expect(body).toContain('Remote runner connected');
+  });
+
+  it('supports multi-peer snapshots and offline peers', () => {
+    const env = createSimDiscoveryEnvironment(new FakeState());
+
+    env.addRemotePeer({
+      instanceId: 'peer-remote-2',
+      name: 'Build Farm East',
+      host: 'east-sim.local',
+      address: '192.168.1.81',
+      channelFolder: 'east',
+    });
+    env.addRemotePeer({
+      instanceId: 'peer-remote-3',
+      name: 'Build Farm West',
+      host: 'west-sim.local',
+      address: '192.168.1.82',
+      channelFolder: 'west',
+    });
+    env.setPeerOnline('peer-remote-3', false);
+
+    const peers = env.listRemotePeers();
+    expect(peers).toHaveLength(3);
+    expect(
+      peers.find((peer) => peer.instanceId === 'peer-remote-2')?.online,
+    ).toBe(true);
+    expect(
+      peers.find((peer) => peer.instanceId === 'peer-remote-3')?.online,
+    ).toBe(false);
+
+    const pageState = env.getNetworkPageState();
+    expect(pageState.peers).toHaveLength(3);
+    expect(
+      pageState.peers.find((peer) => peer.instanceId === 'peer-remote-3')
+        ?.online,
+    ).toBe(false);
+  });
+
+  it('streams new remote log entries without closing the stream', async () => {
+    const env = createSimDiscoveryEnvironment(new FakeState());
+    const logsReq = new Request(
+      'http://localhost/api/discovery/peers/peer-remote-1/logs',
+    );
+    const logsRes = (await handleDiscoveryRequest(
+      logsReq,
+      new URL(logsReq.url),
+      env.context,
+    )) as Response;
+    const reader = logsRes.body?.getReader();
+
+    expect(reader).toBeDefined();
+
+    const decoder = new TextDecoder();
+    let output = '';
+
+    for (let i = 0; i < 3; i++) {
+      const chunk = await reader!.read();
+      if (chunk.done) break;
+      output += decoder.decode(chunk.value, { stream: true });
+    }
+
+    env.addRemoteLog('peer-remote-1', {
+      level: 'error',
+      msg: 'Remote log arrived after stream start',
+      source: 'peer-remote-1',
+    });
+
+    for (let i = 0; i < 2; i++) {
+      const chunk = await reader!.read();
+      if (chunk.done) break;
+      output += decoder.decode(chunk.value, { stream: true });
+      if (output.includes('Remote log arrived after stream start')) break;
+    }
+
+    expect(output).toContain('Remote runner connected');
+    expect(output).toContain('Remote log arrived after stream start');
+
+    await reader!.cancel();
   });
 });

--- a/src/simtest/discovery-sim.ts
+++ b/src/simtest/discovery-sim.ts
@@ -26,6 +26,28 @@ interface SimRemotePeer {
   stored: StoredPeer;
   state: FakeState;
   logs: SimRemoteLogRecord[];
+  logListeners: Set<(record: SimRemoteLogRecord) => void>;
+  online: boolean;
+}
+
+interface CreateRemotePeerParams {
+  instanceId: string;
+  name: string;
+  host: string;
+  address: string;
+  channelFolder: string;
+  online?: boolean;
+  status?: StoredPeer['status'];
+  logMessages?: string[];
+}
+
+interface SimRemotePeerSummary {
+  instanceId: string;
+  name: string;
+  online: boolean;
+  status: StoredPeer['status'];
+  agents: number;
+  logs: number;
 }
 
 class SimTrustStore {
@@ -33,6 +55,11 @@ class SimTrustStore {
   private pendingRequests: PairRequest[] = [];
 
   constructor(peers: SimRemotePeer[]) {
+    this.replacePeers(peers);
+  }
+
+  replacePeers(peers: SimRemotePeer[]): void {
+    this.peers.clear();
     for (const peer of peers) {
       this.peers.set(peer.discovered.instanceId, { ...peer.stored });
     }
@@ -170,6 +197,13 @@ class SimDiscoveryHandle {
     return new Map(this.peers);
   }
 
+  reset(peers: DiscoveredPeer[]): void {
+    this.peers.clear();
+    for (const peer of peers) {
+      this.peers.set(peer.instanceId, peer);
+    }
+  }
+
   setPeerOnline(instanceId: string, online: boolean): void {
     const peer = this.peers.get(instanceId);
     if (!peer) return;
@@ -257,16 +291,48 @@ class SimPeerClient implements PeerClientLike {
 
   async streamLogs(): Promise<Response> {
     const encoder = new TextEncoder();
-    const lines = this.peer.logs.slice(-50);
+    const peer = this.peer;
+    let cleanup: (() => void) | null = null;
+
     return new Response(
       new ReadableStream({
         start(controller) {
-          for (const record of lines) {
+          let closed = false;
+
+          const send = (record: SimRemoteLogRecord) => {
+            if (closed) return;
             controller.enqueue(
               encoder.encode(`event: log\ndata: ${JSON.stringify(record)}\n\n`),
             );
+          };
+
+          for (const record of peer.logs.slice(-50)) {
+            send(record);
           }
-          controller.close();
+
+          const onLog = (record: SimRemoteLogRecord) => {
+            send(record);
+          };
+
+          peer.logListeners.add(onLog);
+          controller.enqueue(encoder.encode(': connected\n\n'));
+
+          const heartbeat = setInterval(() => {
+            if (closed) return;
+            controller.enqueue(encoder.encode(': keepalive\n\n'));
+          }, 15000);
+
+          cleanup = () => {
+            if (closed) return;
+            closed = true;
+            clearInterval(heartbeat);
+            peer.logListeners.delete(onLog);
+          };
+
+          return cleanup;
+        },
+        cancel() {
+          cleanup?.();
         },
       }),
       {
@@ -315,6 +381,86 @@ function sha256(content: string): string {
   return createHash('sha256').update(content).digest('hex');
 }
 
+function createRemoteState(name: string, channelFolder: string): FakeState {
+  const state = new FakeState();
+  const agentId = name.toLowerCase().replace(/[^a-z0-9]+/g, '-');
+  state.addAgent({
+    id: agentId,
+    name,
+    backend: 'docker',
+    agentRuntime: 'opencode',
+  });
+  state.addChat(`sim:${channelFolder}`, `#${channelFolder}`);
+  state.addSubscription(`sim:${channelFolder}`, agentId, {
+    isPrimary: true,
+    channelFolder,
+  });
+  return state;
+}
+
+function createRemotePeer(params: CreateRemotePeerParams): SimRemotePeer {
+  const now = new Date().toISOString();
+  const state = createRemoteState(
+    `${params.name} Builder`,
+    params.channelFolder,
+  );
+  const status = params.status ?? 'trusted';
+
+  return {
+    discovered: {
+      instanceId: params.instanceId,
+      name: params.name,
+      host: params.host,
+      port: 3100,
+      addresses: [params.address],
+      version: 'simtest',
+      firstSeen: now,
+    },
+    stored: {
+      instanceId: params.instanceId,
+      name: params.name,
+      sharedSecret:
+        status === 'trusted' ? `sim-secret-${params.instanceId}` : null,
+      status,
+      host: params.host,
+      port: 3100,
+      approvedAt: status === 'trusted' ? now : null,
+      lastSeen: now,
+      createdAt: now,
+    },
+    state,
+    logs: (
+      params.logMessages ?? [
+        `${params.name} connected to the fleet`,
+        `${params.name} cache is warming up`,
+      ]
+    ).map((msg, index) => ({
+      time: new Date(Date.now() + index).toISOString(),
+      level: index === 0 ? 'info' : 'warn',
+      msg,
+      source: params.instanceId,
+    })),
+    logListeners: new Set(),
+    online: params.online ?? true,
+  };
+}
+
+function createDefaultRemotePeers(): SimRemotePeer[] {
+  return [
+    createRemotePeer({
+      instanceId: 'peer-remote-1',
+      name: 'Remote OmniClaw',
+      host: 'remote-sim.local',
+      address: '192.168.1.80',
+      channelFolder: 'remote',
+      logMessages: [
+        'Remote runner connected to the fleet',
+        'Remote builder cache is warming up',
+      ],
+    }),
+  ];
+}
+
 function buildPeerViews(
   discovery: SimDiscoveryHandle,
   trustStore: SimTrustStore,
@@ -357,86 +503,46 @@ function buildPeerViews(
   return peers;
 }
 
-function createDefaultRemotePeer(): SimRemotePeer {
-  const state = new FakeState();
-  state.addAgent({
-    id: 'remote-builder',
-    name: 'Remote Builder',
-    backend: 'docker',
-    agentRuntime: 'opencode',
-  });
-  state.addChat('sim:remote', '#remote');
-  state.addSubscription('sim:remote', 'remote-builder', {
-    isPrimary: true,
-    channelFolder: 'remote',
-  });
-
-  const now = new Date().toISOString();
-  return {
-    discovered: {
-      instanceId: 'peer-remote-1',
-      name: 'Remote OmniClaw',
-      host: 'remote-sim.local',
-      port: 3100,
-      addresses: ['192.168.1.80'],
-      version: 'simtest',
-      firstSeen: now,
-    },
-    stored: {
-      instanceId: 'peer-remote-1',
-      name: 'Remote OmniClaw',
-      sharedSecret: 'sim-remote-secret',
-      status: 'trusted',
-      host: 'remote-sim.local',
-      port: 3100,
-      approvedAt: now,
-      lastSeen: now,
-      createdAt: now,
-    },
-    state,
-    logs: [
-      {
-        time: now,
-        level: 'info',
-        msg: 'Remote runner connected to the fleet',
-        source: 'peer-remote-1',
-      },
-      {
-        time: now,
-        level: 'warn',
-        msg: 'Remote builder cache is warming up',
-        source: 'peer-remote-1',
-      },
-    ],
-  };
-}
-
 export interface SimDiscoveryEnvironment {
   context: DiscoveryRouteContext;
   getNetworkPageState(): NetworkPageState;
-  listRemotePeers(): Array<{
-    instanceId: string;
-    name: string;
-    online: boolean;
-    agents: number;
-    logs: number;
-  }>;
+  listRemotePeers(): SimRemotePeerSummary[];
   addRemoteLog(
     instanceId: string,
     record: Omit<SimRemoteLogRecord, 'time'> & { time?: string },
   ): void;
+  reset(): void;
+  addRemotePeer(params: CreateRemotePeerParams): void;
+  setPeerOnline(instanceId: string, online: boolean): void;
 }
 
 export function createSimDiscoveryEnvironment(
   state: FakeState,
 ): SimDiscoveryEnvironment {
-  const remotePeer = createDefaultRemotePeer();
-  const peers = new Map([[remotePeer.discovered.instanceId, remotePeer]]);
-  const trustStore = new SimTrustStore([remotePeer]);
-  const discovery = new SimDiscoveryHandle(
-    new Map([[remotePeer.discovered.instanceId, remotePeer.discovered]]),
-  );
+  const peers = new Map<string, SimRemotePeer>();
+  const trustStore = new SimTrustStore([]);
+  const discovery = new SimDiscoveryHandle(new Map());
   const runtime = new SimRuntimeController();
+
+  const syncStores = () => {
+    const currentPeers = Array.from(peers.values());
+    trustStore.replacePeers(currentPeers);
+    discovery.reset(
+      currentPeers
+        .filter((peer) => peer.stored.status !== 'revoked' && peer.online)
+        .map((peer) => peer.discovered),
+    );
+  };
+
+  const reset = () => {
+    peers.clear();
+    for (const peer of createDefaultRemotePeers()) {
+      peers.set(peer.discovered.instanceId, peer);
+    }
+    syncStores();
+  };
+
+  reset();
 
   const context: DiscoveryRouteContext = {
     instanceId: 'sim-local-instance',
@@ -469,7 +575,8 @@ export function createSimDiscoveryEnvironment(
       return Array.from(peers.values()).map((peer) => ({
         instanceId: peer.discovered.instanceId,
         name: peer.discovered.name,
-        online: discovery.getPeers().has(peer.discovered.instanceId),
+        online: peer.online,
+        status: peer.stored.status,
         agents: Object.keys(peer.state.getAgents()).length,
         logs: peer.logs.length,
       }));
@@ -477,12 +584,31 @@ export function createSimDiscoveryEnvironment(
     addRemoteLog(instanceId, record) {
       const peer = peers.get(instanceId);
       if (!peer) throw new Error(`Remote peer not found: ${instanceId}`);
-      peer.logs.push({
+      const entry = {
         time: record.time ?? new Date().toISOString(),
         level: record.level,
         msg: record.msg,
         source: record.source,
-      });
+      };
+      peer.logs.push(entry);
+      for (const listener of peer.logListeners) {
+        listener(entry);
+      }
+    },
+    reset,
+    addRemotePeer(params) {
+      const peer = createRemotePeer(params);
+      peers.set(peer.discovered.instanceId, peer);
+      syncStores();
+      if (params.online === false) {
+        discovery.setPeerOnline(peer.discovered.instanceId, false);
+      }
+    },
+    setPeerOnline(instanceId, online) {
+      const peer = peers.get(instanceId);
+      if (!peer) throw new Error(`Remote peer not found: ${instanceId}`);
+      peer.online = online;
+      syncStores();
     },
   };
 }

--- a/src/simtest/index.ts
+++ b/src/simtest/index.ts
@@ -89,7 +89,8 @@ console.log('║    GET  /remote-peers      — Remote sim snapshot    ║');
 console.log('║    POST /remote-peers/:id/logs — Inject remote log  ║');
 console.log('║                                                     ║');
 console.log('║  Scenarios: agent-overload, task-storm,             ║');
-console.log('║             error-cascade, idle-fleet, empty        ║');
+console.log('║             error-cascade, idle-fleet,              ║');
+console.log('║             multi-peer-transitions, empty           ║');
 console.log('╚══════════════════════════════════════════════════════╝');
 console.log('');
 


### PR DESCRIPTION
## Summary
- add a dedicated `multi-peer-transitions` simtest scenario so the web UI can exercise trusted peers, additional remotes, and offline transitions from one admin call
- upgrade the remote log simulator from replay-only to a live SSE stream that stays open for newly injected log lines
- extend simtest coverage so remote peer snapshots and continuous log streaming are regression-tested

## Verification
- `bun run typecheck`
- `bun test src/simtest/discovery-sim.test.ts src/discovery/routes.test.ts src/web/page-scripts.test.ts src/web/network.test.ts`
- launched `bun run src/simtest/index.ts --web-port 3115 --admin-port 3116` and verified `POST /scenario/multi-peer-transitions` plus `GET /remote-peers`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `multi-peer-transitions` scenario for testing multi-peer network behavior and state transitions.
  * Implemented live log streaming for remote peers with continuous updates instead of snapshots.
  * Added dynamic control for remote peer online/offline status.

* **Tests**
  * Added tests for multi-peer scenarios with peer status tracking and network state verification.
  * Added tests for continuous remote log streaming and live log delivery.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->