### PR TITLE
fix(security): validate external MCP server config

### DIFF
--- a/container/agent-runner/src/__tests__/mcp-config.test.ts
+++ b/container/agent-runner/src/__tests__/mcp-config.test.ts
@@ -14,7 +14,11 @@ describe('external MCP config security', () => {
     });
 
     expect(buildAllowedTools(normalized)).toEqual(
-      expect.arrayContaining(['mcp__omniclaw__*', 'mcp__gmail__*', 'mcp__calendar__*']),
+      expect.arrayContaining([
+        'mcp__omniclaw__*',
+        'mcp__gmail__*',
+        'mcp__calendar__*',
+      ]),
     );
   });
 

--- a/container/agent-runner/src/index.ts
+++ b/container/agent-runner/src/index.ts
@@ -156,7 +156,9 @@ export function validateExternalMcpCommand(
 ): string {
   const trimmed = command.trim();
   if (!trimmed) {
-    throw new Error(`External MCP server '${serverName}' must define a command`);
+    throw new Error(
+      `External MCP server '${serverName}' must define a command`,
+    );
   }
   if (trimmed.includes('\0')) {
     throw new Error(
@@ -184,7 +186,10 @@ export function validateExternalMcpCommand(
     : path.resolve('/workspace/group', trimmed);
   const isAllowed = ALLOWED_EXTERNAL_MCP_COMMAND_ROOTS.some((root) => {
     const resolvedRoot = path.resolve(root);
-    return resolved === resolvedRoot || resolved.startsWith(`${resolvedRoot}${path.sep}`);
+    return (
+      resolved === resolvedRoot ||
+      resolved.startsWith(`${resolvedRoot}${path.sep}`)
+    );
   });
   if (!isAllowed) {
     throw new Error(
@@ -210,7 +215,9 @@ export function normalizeExternalMcpServers(
       );
     }
     if (!isPlainObject(rawConfig)) {
-      throw new Error(`External MCP server '${serverName}' config must be an object`);
+      throw new Error(
+        `External MCP server '${serverName}' config must be an object`,
+      );
     }
 
     const type = rawConfig.type;
@@ -1150,7 +1157,9 @@ async function runQuery(
   }
 
   startHeartbeat();
-  const externalMcpServers = normalizeExternalMcpServers(containerInput.mcpServers);
+  const externalMcpServers = normalizeExternalMcpServers(
+    containerInput.mcpServers,
+  );
 
   for await (const message of query({
     prompt: stream,


### PR DESCRIPTION
## Summary
- validate external MCP server names and config shapes before passing them into the agent SDK
- reject reserved `omniclaw` collisions and block stdio command paths that escape mounted workspaces
- extend `allowedTools` for accepted external MCP servers and add focused regression tests

## Testing
- `bun test ./src/__tests__/mcp-config.test.ts` (in `container/agent-runner/`)
- `bun test ./src/__tests__/security-hooks.test.ts` (in `container/agent-runner/`)
- `bunx tsc --noEmit -p container/agent-runner/tsconfig.json`

Closes #378.
