### PR TITLE
test: cover simtest state and admin API

### DIFF
--- a/src/ipc-watcher.test.ts
+++ b/src/ipc-watcher.test.ts
@@ -23,17 +23,30 @@ const flushMicrotasks = async () => {
 
 describe('startIpcWatcher', () => {
   const originalSetTimeout = globalThis.setTimeout;
+  let staleRuntimeFolder: string | undefined;
+  let rogueErrorDir: string | undefined;
 
   afterEach(() => {
     globalThis.setTimeout = originalSetTimeout;
+    if (staleRuntimeFolder) {
+      fs.rmSync(path.join(IPC_BASE_DIR, staleRuntimeFolder), {
+        recursive: true,
+        force: true,
+      });
+      staleRuntimeFolder = undefined;
+    }
+    if (rogueErrorDir) {
+      fs.rmSync(rogueErrorDir, { recursive: true, force: true });
+      rogueErrorDir = undefined;
+    }
   });
 
   it('maps runtime folders to owners, cleans stale dispatch dirs, and quarantines rogue sources', async () => {
     const id = `${Date.now()}-${Math.random().toString(16).slice(2, 10)}`;
     const ownerFolder = `runtime-owner-${id}`;
-    const staleRuntimeFolder = `${ownerFolder}${DISPATCH_RUNTIME_SEP}0123456789abcdef`;
+    staleRuntimeFolder = `${ownerFolder}${DISPATCH_RUNTIME_SEP}0123456789abcdef`;
     const rogueFolder = `rogue-source-${id}`;
-    const rogueErrorDir = path.join(IPC_BASE_DIR, 'errors', rogueFolder);
+    rogueErrorDir = path.join(IPC_BASE_DIR, 'errors', rogueFolder);
 
     fs.rmSync(path.join(IPC_BASE_DIR, staleRuntimeFolder), {
       recursive: true,
@@ -94,7 +107,11 @@ describe('startIpcWatcher', () => {
     const events: Array<{ kind: string; sourceGroup: string }> = [];
     const scheduledDelays: number[] = [];
 
-    globalThis.setTimeout = ((fn: TimerHandler, delay?: number) => {
+    globalThis.setTimeout = ((
+      _fn: Parameters<typeof setTimeout>[0],
+      delay?: number,
+      ..._args: unknown[]
+    ) => {
       scheduledDelays.push(delay ?? 0);
       return 1 as unknown as ReturnType<typeof setTimeout>;
     }) as typeof setTimeout;
@@ -142,7 +159,5 @@ describe('startIpcWatcher', () => {
     );
     expect(fs.existsSync(rogueErrorDir)).toBe(true);
     expect(scheduledDelays).toEqual([IPC_POLL_INTERVAL]);
-
-    fs.rmSync(rogueErrorDir, { recursive: true, force: true });
   });
 });

--- a/src/simtest/admin-api.test.ts
+++ b/src/simtest/admin-api.test.ts
@@ -42,7 +42,10 @@ describe('startAdminApi', () => {
     return `http://127.0.0.1:${handle!.port}${path}`;
   }
 
-  async function requestJson(path: string, init?: RequestInit): Promise<Response> {
+  async function requestJson(
+    path: string,
+    init?: RequestInit,
+  ): Promise<Response> {
     return fetch(baseUrl(path), init);
   }
 
@@ -206,6 +209,14 @@ describe('startAdminApi', () => {
     const discovery = createSimDiscoveryEnvironment(state);
     handle = startAdminApi({ port: 0 }, state, webServer, discovery);
 
+    const peersBeforeLog = await requestJson('/remote-peers');
+    const peerBefore = (
+      (await peersBeforeLog.json()) as Array<{
+        instanceId: string;
+        logs: number;
+      }>
+    ).find((peer) => peer.instanceId === 'peer-remote-1');
+
     const logResponse = await requestJson('/remote-peers/peer-remote-1/logs', {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
@@ -218,10 +229,10 @@ describe('startAdminApi', () => {
       instanceId: string;
       logs: number;
     }>;
-    expect(peerSummaries[0]).toMatchObject({
-      instanceId: 'peer-remote-1',
-      logs: 3,
-    });
+    const updatedPeer = peerSummaries.find(
+      (peer) => peer.instanceId === 'peer-remote-1',
+    );
+    expect(updatedPeer?.logs).toBe((peerBefore?.logs ?? 0) + 1);
 
     const scenarioResponse = await requestJson('/scenario/task-storm', {
       method: 'POST',

--- a/src/simtest/fake-state.test.ts
+++ b/src/simtest/fake-state.test.ts
@@ -10,7 +10,10 @@ describe('FakeState', () => {
   });
 
   it('filters chat messages by timestamp and limit', () => {
-    const allGeneral = state.getMessages('sim:general', '1970-01-01T00:00:00.000Z');
+    const allGeneral = state.getMessages(
+      'sim:general',
+      '1970-01-01T00:00:00.000Z',
+    );
 
     expect(allGeneral.map((message) => message.id)).toEqual([
       'msg-1',
@@ -49,9 +52,9 @@ describe('FakeState', () => {
     expect(matches).toHaveLength(4);
     expect(matches[0]?.chat_jid).toBe('sim:general');
     expect(matches[1]?.chat_jid).toBe('sim:code-review');
-    expect(matches.slice(2).every((message) => message.chat_jid === 'sim:general')).toBe(
-      true,
-    );
+    expect(
+      matches.slice(2).every((message) => message.chat_jid === 'sim:general'),
+    ).toBe(true);
 
     const filtered = state.searchMessages('pr #315', 'sim:general', 1);
     expect(filtered).toHaveLength(1);
@@ -109,9 +112,9 @@ describe('FakeState', () => {
       next_run: null,
     });
 
-    expect(() => state.updateTask('missing-task', { status: 'paused' })).toThrow(
-      'Task not found: missing-task',
-    );
+    expect(() =>
+      state.updateTask('missing-task', { status: 'paused' }),
+    ).toThrow('Task not found: missing-task');
 
     state.deleteTask('task-new');
     expect(state.getTaskById('task-new')).toBeUndefined();
@@ -128,8 +131,10 @@ describe('FakeState', () => {
     expect(state.getChannelSubscriptions()['sim:temp']).toBeUndefined();
     expect(
       state
-        .getChannelSubscriptions()['sim:general']
-        ?.some((subscription) => subscription.agentId === 'research-bot'),
+        .getChannelSubscriptions()
+        [
+          'sim:general'
+        ]?.some((subscription) => subscription.agentId === 'research-bot'),
     ).toBe(false);
     expect(state.removeAgent('research-bot')).toBe(false);
   });
@@ -160,11 +165,18 @@ describe('FakeState', () => {
     expect(state.ipcEvents.at(-1)?.summary).toBe('event-204');
 
     const latest = state.getIpcEvents(2);
-    expect(latest.map((event) => event.summary)).toEqual(['event-204', 'event-203']);
+    expect(latest.map((event) => event.summary)).toEqual([
+      'event-204',
+      'event-203',
+    ]);
   });
 
   it('updates avatars, task logs, and reset restores seeded state', () => {
-    state.updateAgentAvatar('main', 'https://example.com/avatar.png', 'discord');
+    state.updateAgentAvatar(
+      'main',
+      'https://example.com/avatar.png',
+      'discord',
+    );
     expect(state.getAgents().main).toMatchObject({
       avatarUrl: 'https://example.com/avatar.png',
       avatarSource: 'discord',

--- a/src/telegram-avatar.test.ts
+++ b/src/telegram-avatar.test.ts
@@ -25,7 +25,9 @@ describe('telegram avatar helpers', () => {
   it('rejects malformed file descriptors', () => {
     expect(parseTelegramFileDescriptor('not-telegram')).toBeNull();
     expect(parseTelegramFileDescriptor('tg-file:no-separator')).toBeNull();
-    expect(parseTelegramFileDescriptor('tg-file:%E0%A4%A:avatar.png')).toBeNull();
+    expect(
+      parseTelegramFileDescriptor('tg-file:%E0%A4%A:avatar.png'),
+    ).toBeNull();
     expect(parseTelegramFileDescriptor('tg-file:bot-id:')).toBeNull();
   });
 
@@ -42,9 +44,19 @@ describe('telegram avatar helpers', () => {
   });
 
   it('rejects malformed Telegram API file urls', () => {
-    expect(parseTelegramApiFileUrl('https://example.com/avatar.png')).toBeNull();
-    expect(parseTelegramApiFileUrl('https://api.telegram.org/file/bot/photos/avatar.png')).toBeNull();
-    expect(parseTelegramApiFileUrl('https://api.telegram.org/file/bot:token/photos/avatar.png')).toBeNull();
+    expect(
+      parseTelegramApiFileUrl('https://example.com/avatar.png'),
+    ).toBeNull();
+    expect(
+      parseTelegramApiFileUrl(
+        'https://api.telegram.org/file/bot/photos/avatar.png',
+      ),
+    ).toBeNull();
+    expect(
+      parseTelegramApiFileUrl(
+        'https://api.telegram.org/file/bot:token/photos/avatar.png',
+      ),
+    ).toBeNull();
   });
 
   it('sanitizes Telegram avatar urls only for Telegram sources', () => {
@@ -54,18 +66,22 @@ describe('telegram avatar helpers', () => {
       buildTelegramFileDescriptor('123456', 'photos/avatar.png'),
     );
     expect(sanitizeTelegramAvatarUrl(url, 'discord')).toBe(url);
+    expect(sanitizeTelegramAvatarUrl(url, 'slack')).toBe(url);
     expect(sanitizeTelegramAvatarUrl(undefined, 'telegram')).toBeUndefined();
   });
 
   it('redacts Telegram bot tokens from matching urls', () => {
-    const url = buildTelegramApiFileUrl('123456:super-secret', 'photos/avatar.png');
+    const url = buildTelegramApiFileUrl(
+      '123456:super-secret',
+      'photos/avatar.png',
+    );
 
     expect(redactTelegramBotTokenFromUrl(url)).toBe(
       buildTelegramFileDescriptor('123456', 'photos/avatar.png'),
     );
-    expect(redactTelegramBotTokenFromUrl('https://example.com/avatar.png')).toBe(
-      'https://example.com/avatar.png',
-    );
+    expect(
+      redactTelegramBotTokenFromUrl('https://example.com/avatar.png'),
+    ).toBe('https://example.com/avatar.png');
     expect(redactTelegramBotTokenFromUrl(undefined)).toBeUndefined();
   });
 });


### PR DESCRIPTION
## Summary
- add deterministic coverage for `FakeState` task, message, IPC, avatar, and reset mutations used by the simtest web harness
- add admin API request tests for task lifecycle, IPC validation, remote peer logs, scenarios, CORS preflight, and invalid JSON handling
- add supporting coverage for `src/ipc.ts` ownership/quarantine behavior and Telegram avatar helper parsing/sanitization
- resolve CI blockers by replacing the Bun-incompatible `TimerHandler` mock type, tightening a peer-log assertion to use a delta, and formatting the changed tests

## Testing
- `bun test src/ipc-watcher.test.ts src/simtest/admin-api.test.ts src/simtest/fake-state.test.ts src/telegram-avatar.test.ts`
- `bunx tsc --noEmit`
- `bunx prettier --check "src/ipc-watcher.test.ts" "src/simtest/admin-api.test.ts" "src/simtest/fake-state.test.ts" "src/telegram-avatar.test.ts"`

## Coverage Notes
- Files covered in this PR: `src/simtest/fake-state.ts`, `src/simtest/admin-api.ts`, `src/ipc.ts`, `src/telegram-avatar.ts`
- Remaining notable gaps: `src/index.ts`, `src/whatsapp-auth.ts`
