### PR TITLE
test: cover scheduler task execution edges

### DIFF
--- a/src/task-scheduler-runner.test.ts
+++ b/src/task-scheduler-runner.test.ts
@@ -84,15 +84,17 @@ describe('startSchedulerLoop task execution', () => {
       ['task-deleted', null],
     ]);
     const getDueTasksMock = mock(() => dueTasks);
-    const getTaskByIdMock = mock((taskId: string) => taskById.get(taskId) ?? null);
+    const getTaskByIdMock = mock(
+      (taskId: string) => taskById.get(taskId) ?? null,
+    );
     const advanceTaskNextRunMock = mock(() => {});
     const enqueueTaskMock = mock(() => {});
     const loggerMock = createLoggerMock();
     const originalSetTimeout = globalThis.setTimeout;
 
-    (globalThis as { setTimeout: typeof setTimeout }).setTimeout = (((
+    (globalThis as { setTimeout: typeof setTimeout }).setTimeout = ((
       _fn: Parameters<typeof setTimeout>[0],
-    ) => ({ id: 'poll' })) as unknown) as typeof setTimeout;
+    ) => ({ id: 'poll' })) as unknown as typeof setTimeout;
 
     try {
       const deps: SchedulerDependencies = {
@@ -205,13 +207,15 @@ describe('startSchedulerLoop task execution', () => {
     const timeoutCalls: number[] = [];
     const originalSetTimeout = globalThis.setTimeout;
 
-    (globalThis as { setTimeout: typeof setTimeout }).setTimeout = (((
+    (globalThis as { setTimeout: typeof setTimeout }).setTimeout = ((
       _fn: Parameters<typeof setTimeout>[0],
       ms?: number,
     ) => {
       timeoutCalls.push(ms ?? 0);
-      return { id: timeoutCalls.length } as unknown as ReturnType<typeof setTimeout>;
-    }) as unknown) as typeof setTimeout;
+      return { id: timeoutCalls.length } as unknown as ReturnType<
+        typeof setTimeout
+      >;
+    }) as unknown as typeof setTimeout;
 
     try {
       const deps: SchedulerDependencies = {


### PR DESCRIPTION
## Summary
- add deterministic scheduler execution tests for tasks that become paused or deleted between polling and enqueue
- cover isolated-task backend failures so scheduler error logging, next-run updates, and close-timer behavior stay stable under mocked runtime conditions

## Validation
- `bun test ./src/task-scheduler-runner.test.ts ./src/task-scheduler-loop.test.ts`
- `bun test`

## Test Count
- before: 1315 tests across 77 files
- after: 1317 tests across 78 files

## Files Covered
- `src/task-scheduler.ts` via new tests in `src/task-scheduler-runner.test.ts`

## Remaining Coverage Gaps
- `src/ipc.ts` still lacks direct watcher lifecycle tests
- `src/channels/slack.ts`, `src/channels/telegram.ts`, and `src/channels/discord.ts` still have major integration paths with partial unit coverage


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added comprehensive tests for the task scheduler runner: verifies the scheduling loop correctly processes due tasks (advances and enqueues only active tasks while ignoring paused/missing ones) and respects computed next-run times.
  * Adds test coverage for backend failure handling in isolated task runs, ensuring errors are recorded and no scheduling close-timers are scheduled.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->