### PR TITLE
fix(ci): backstop auto-update PR workflow runs

### DIFF
--- a/.github/workflows/update-claude-sdk.yml
+++ b/.github/workflows/update-claude-sdk.yml
@@ -92,6 +92,7 @@ jobs:
           cd ../..
 
       - name: Commit and open PR
+        id: create_pr
         if: steps.check.outputs.changed == 'true' && steps.existing_pr.outputs.pr == ''
         run: |
           BRANCH="update/claude-sdk-${{ steps.latest.outputs.version }}"
@@ -103,6 +104,8 @@ jobs:
           git add container/agent-runner/package.json container/agent-runner/bun.lock
           git commit -m "$TITLE"
           git push origin "$BRANCH"
+          echo "branch=$BRANCH" >> "$GITHUB_OUTPUT"
+          echo "head_sha=$(git rev-parse HEAD)" >> "$GITHUB_OUTPUT"
 
           BODY_FILE=$(mktemp)
           trap 'rm -f "$BODY_FILE"' EXIT
@@ -119,11 +122,27 @@ jobs:
         env:
           GH_TOKEN: ${{ steps.app-token.outputs.token != '' && steps.app-token.outputs.token || github.token }}
 
-      - name: Trigger CI for update PR
-        if: steps.check.outputs.changed == 'true' && steps.existing_pr.outputs.pr == '' && steps.check-secrets.outputs.skip == 'true'
+      - name: Ensure CI is queued for update PR
+        if: steps.check.outputs.changed == 'true' && steps.existing_pr.outputs.pr == ''
         run: |
-          gh workflow run ci.yml \
+          BRANCH="${{ steps.create_pr.outputs.branch }}"
+          HEAD_SHA="${{ steps.create_pr.outputs.head_sha }}"
+          sleep 15
+
+          EXISTING_RUN=$(gh run list \
             --repo omniaura/omniclaw \
-            --ref "update/claude-sdk-${{ steps.latest.outputs.version }}"
+            --workflow ci.yml \
+            --branch "$BRANCH" \
+            --json headSha,event,status \
+            --jq 'map(select(.headSha == "'"$HEAD_SHA"'" and (.event == "pull_request" or .event == "workflow_dispatch" or .event == "pull_request_target"))) | length')
+
+          if [ "$EXISTING_RUN" -eq 0 ]; then
+            echo "No CI run detected for $BRANCH@$HEAD_SHA; dispatching workflow manually"
+            gh workflow run ci.yml \
+              --repo omniaura/omniclaw \
+              --ref "$BRANCH"
+          else
+            echo "CI already queued for $BRANCH@$HEAD_SHA"
+          fi
         env:
-          GH_TOKEN: ${{ github.token }}
+          GH_TOKEN: ${{ steps.app-token.outputs.token != '' && steps.app-token.outputs.token || github.token }}

--- a/.github/workflows/update-opencode.yml
+++ b/.github/workflows/update-opencode.yml
@@ -140,6 +140,7 @@ jobs:
           fi
 
       - name: Commit and open PR
+        id: create_pr
         if: steps.check.outputs.changed == 'true' && steps.existing_pr.outputs.pr == ''
         run: |
           BRANCH="update/opencode-${{ steps.check.outputs.branch_suffix }}"
@@ -158,6 +159,8 @@ jobs:
           git add $CHANGED_FILES
           git commit -m "${{ steps.check.outputs.commit_title }}"
           git push origin "$BRANCH"
+          echo "branch=$BRANCH" >> "$GITHUB_OUTPUT"
+          echo "head_sha=$(git rev-parse HEAD)" >> "$GITHUB_OUTPUT"
 
           BODY_FILE=$(mktemp)
           trap 'rm -f "$BODY_FILE"' EXIT
@@ -179,11 +182,27 @@ jobs:
         env:
           GH_TOKEN: ${{ steps.app-token.outputs.token != '' && steps.app-token.outputs.token || github.token }}
 
-      - name: Trigger CI for update PR
-        if: steps.check.outputs.changed == 'true' && steps.existing_pr.outputs.pr == '' && steps.check-secrets.outputs.skip == 'true'
+      - name: Ensure CI is queued for update PR
+        if: steps.check.outputs.changed == 'true' && steps.existing_pr.outputs.pr == ''
         run: |
-          gh workflow run ci.yml \
+          BRANCH="${{ steps.create_pr.outputs.branch }}"
+          HEAD_SHA="${{ steps.create_pr.outputs.head_sha }}"
+          sleep 15
+
+          EXISTING_RUN=$(gh run list \
             --repo omniaura/omniclaw \
-            --ref "update/opencode-${{ steps.check.outputs.branch_suffix }}"
+            --workflow ci.yml \
+            --branch "$BRANCH" \
+            --json headSha,event,status \
+            --jq 'map(select(.headSha == "'"$HEAD_SHA"'" and (.event == "pull_request" or .event == "workflow_dispatch" or .event == "pull_request_target"))) | length')
+
+          if [ "$EXISTING_RUN" -eq 0 ]; then
+            echo "No CI run detected for $BRANCH@$HEAD_SHA; dispatching workflow manually"
+            gh workflow run ci.yml \
+              --repo omniaura/omniclaw \
+              --ref "$BRANCH"
+          else
+            echo "CI already queued for $BRANCH@$HEAD_SHA"
+          fi
         env:
-          GH_TOKEN: ${{ github.token }}
+          GH_TOKEN: ${{ steps.app-token.outputs.token != '' && steps.app-token.outputs.token || github.token }}


### PR DESCRIPTION
## Summary

- make the OpenCode and Claude SDK auto-update workflows verify that CI was actually queued for the newly created update branch
- fall back to `gh workflow run ci.yml --ref <branch>` when the PR creation path does not emit a `pull_request` run for that head SHA

## Why

Auto-created dependency PRs sometimes land with no CI runs at all. That leaves routine update PRs stuck until somebody manually pushes the branch. This change keeps the GitHub App path intact, but adds an explicit backstop so update PRs still get CI even when GitHub suppresses downstream workflow execution.

## Testing

- `bunx prettier --check ".github/workflows/update-opencode.yml" ".github/workflows/update-claude-sdk.yml"`

## Manual GitHub setup

To make the GitHub App path work reliably, you still need to configure the repo secrets that these workflows already expect:

1. Create a GitHub App in the org or user that owns `omniaura/omniclaw`
2. Grant repository permissions:
   - `Contents`: Read and write
   - `Pull requests`: Read and write
   - `Actions`: Read and write
   - `Metadata`: Read-only
3. Install the app on the `omniaura/omniclaw` repository
4. Generate a private key for the app
5. Add these repository secrets on `omniaura/omniclaw`:
   - `APP_ID`
   - `APP_PRIVATE_KEY`

With those secrets present, the workflows will create branches and PRs using the app token. With this PR merged, they will also verify that CI really started and manually dispatch it when GitHub does not enqueue a run.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved CI workflow automation across update procedures to intelligently queue runs only when necessary, preventing duplicate executions and reducing unnecessary resource usage.
  * Enhanced GitHub App token handling and fallback logic for improved reliability and security in workflow authentication.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->