### PR TITLE
test: cover github delta fetch flow

### DIFF
--- a/README.md
+++ b/README.md
@@ -238,6 +238,8 @@ Scheduled tasks are first-class:
 
 Tasks run as full agents with the same tool access and isolation model as interactive sessions.
 
+Dependency update workflows can also open PRs for runtime and SDK bumps. If you want those auto-generated PRs to trigger follow-up CI reliably, configure the repository GitHub App secrets described in `docs/GITHUB-AUTO-UPDATE-SETUP.md`.
+
 ## Trusted Peer Discovery
 
 OmniClaw instances can discover and trust each other on the network.

--- a/docs/GITHUB-AUTO-UPDATE-SETUP.md
+++ b/docs/GITHUB-AUTO-UPDATE-SETUP.md
@@ -1,0 +1,89 @@
+# GitHub App Setup for Auto-Update PRs
+
+OmniClaw ships GitHub Actions workflows that open dependency update PRs for:
+
+- OpenCode CLI and SDK
+- Claude Agent SDK
+- repository token-count badge refreshes
+
+Those workflows can fall back to the default `GITHUB_TOKEN`, but GitHub often suppresses downstream `pull_request` workflow runs for branches and PRs created by that token. The workflows now include a CI backstop, but the most reliable setup is still a dedicated GitHub App token.
+
+## What you need
+
+- Admin access to the owner of `omniaura/omniclaw`
+- Permission to create or install a GitHub App
+- Access to repository secrets for `omniaura/omniclaw`
+
+## Create the GitHub App
+
+1. Go to GitHub Settings -> Developer settings -> GitHub Apps.
+2. Click `New GitHub App`.
+3. Use a name that makes the purpose obvious, such as `omniclaw-update-bot`.
+4. Set a homepage URL. The repository URL is fine.
+5. Leave webhook handling disabled for this use case.
+
+## Required permissions
+
+Grant these repository permissions:
+
+- `Actions`: Read and write
+- `Contents`: Read and write
+- `Pull requests`: Read and write
+- `Metadata`: Read-only
+
+No organization permissions are required for the current workflows.
+
+## Install the app
+
+1. Open the app settings page.
+2. Click `Install App`.
+3. Install it on `omniaura/omniclaw`.
+4. If GitHub asks which repositories the app can access, limit it to `omniaura/omniclaw` unless you intentionally want broader reuse.
+
+## Generate credentials
+
+1. From the app settings page, copy the numeric App ID.
+2. Under `Private keys`, generate a new private key.
+3. Save the downloaded `.pem` file immediately. GitHub only shows it once.
+
+## Add repository secrets
+
+In `omniaura/omniclaw` -> `Settings` -> `Secrets and variables` -> `Actions`, add:
+
+- `APP_ID`: the numeric GitHub App ID
+- `APP_PRIVATE_KEY`: the full PEM contents, including the `BEGIN` and `END` lines
+
+Paste the private key as a multi-line secret exactly as downloaded.
+
+## Verify the setup
+
+1. Run `Update OpenCode` or `Update Claude Agent SDK` with `workflow_dispatch` from the Actions tab.
+2. Confirm the workflow log shows `Create GitHub App token` running instead of the fallback path.
+3. Confirm the workflow pushes an `update/...` branch and opens a PR.
+4. Confirm `ci.yml` appears on the PR automatically, or that the workflow log shows the manual backstop dispatching it.
+
+If you want to verify the token path without waiting for a real dependency bump, temporarily rerun after editing the workflow on a branch or trigger the job when a new upstream version exists.
+
+## Expected behavior after setup
+
+- update workflows create branches and PRs with the GitHub App token
+- PRs can trigger follow-up workflows more reliably than the default `GITHUB_TOKEN`
+- if GitHub still does not enqueue `ci.yml`, the workflow now checks for an existing run and dispatches one manually
+
+## Troubleshooting
+
+### `GitHub App secrets not configured`
+
+At least one of `APP_ID` or `APP_PRIVATE_KEY` is missing from repository secrets.
+
+### `Resource not accessible by integration`
+
+The app is installed, but it does not have the required repository permissions or is not installed on `omniaura/omniclaw`.
+
+### PR opens but no CI run appears
+
+Check the `Ensure CI is queued for update PR` step in the workflow logs. If that step fails, verify that the app has `Actions: Read and write` and that `gh workflow run ci.yml --ref <branch>` works for the installation token.
+
+### Invalid private key errors
+
+Re-copy the entire PEM file into `APP_PRIVATE_KEY`, including line breaks and the header/footer lines.

--- a/src/github-delta.fetch.test.ts
+++ b/src/github-delta.fetch.test.ts
@@ -1,0 +1,329 @@
+import fs from 'fs';
+import path from 'path';
+
+import { afterEach, beforeEach, describe, expect, it, mock } from 'bun:test';
+
+import { DATA_DIR } from './config.js';
+import type { GitHubWatchesConfig } from './types.js';
+
+const { fetchGitHubDelta, getDeltaCursor, setDeltaCursor } =
+  await import('./github-delta.js');
+
+const originalFetch = globalThis.fetch;
+const originalGitHubToken = process.env.GITHUB_TOKEN;
+const configPath = path.join(DATA_DIR, 'github-watches.json');
+const originalConfigExists = fs.existsSync(configPath);
+const originalConfigContents = originalConfigExists
+  ? fs.readFileSync(configPath, 'utf8')
+  : null;
+
+function makeChannelJid(prefix: string): string {
+  return `dc:${prefix}-${Date.now()}-${Math.random().toString(36).slice(2)}`;
+}
+
+function jsonResponse(data: unknown): Response {
+  return new Response(JSON.stringify(data), {
+    headers: { 'Content-Type': 'application/json' },
+  });
+}
+
+function writeGitHubWatchesConfig(config: GitHubWatchesConfig): void {
+  fs.mkdirSync(DATA_DIR, { recursive: true });
+  fs.writeFileSync(configPath, JSON.stringify(config));
+}
+
+function installGitHubFetchMock(responses: Record<string, unknown | Error>) {
+  const fetchMock = mock((input: string | URL | Request) => {
+    const url = typeof input === 'string' ? input : input.toString();
+    const apiPath = url.replace('https://api.github.com', '');
+    const response = responses[apiPath];
+
+    if (response instanceof Error) {
+      return Promise.reject(response);
+    }
+
+    if (response === undefined) {
+      throw new Error(`Unexpected GitHub fetch: ${apiPath}`);
+    }
+
+    return Promise.resolve(jsonResponse(response));
+  });
+
+  globalThis.fetch = fetchMock as unknown as typeof globalThis.fetch;
+  return fetchMock;
+}
+
+describe('fetchGitHubDelta', () => {
+  beforeEach(() => {
+    process.env.GITHUB_TOKEN = 'test-token';
+    globalThis.fetch = originalFetch;
+  });
+
+  afterEach(() => {
+    globalThis.fetch = originalFetch;
+
+    if (originalConfigExists && originalConfigContents !== null) {
+      fs.writeFileSync(configPath, originalConfigContents);
+    } else if (fs.existsSync(configPath)) {
+      fs.rmSync(configPath);
+    }
+
+    if (originalGitHubToken === undefined) {
+      delete process.env.GITHUB_TOKEN;
+    } else {
+      process.env.GITHUB_TOKEN = originalGitHubToken;
+    }
+  });
+
+  it('initializes the cursor on the first message without fetching activity', async () => {
+    const channelJid = makeChannelJid('first-message');
+    const timestamp = '2026-03-25T12:00:00.000Z';
+    const fetchMock = mock(() => {
+      throw new Error('fetch should not run before a cursor exists');
+    });
+
+    globalThis.fetch = fetchMock as unknown as typeof globalThis.fetch;
+    writeGitHubWatchesConfig({
+      watches: [],
+      githubDeltaContextEnabled: true,
+      channelWatches: [
+        {
+          channelJid,
+          repos: [{ owner: 'omniaura', repo: 'omniclaw' }],
+        },
+      ],
+    });
+
+    const digest = await fetchGitHubDelta(channelJid, timestamp);
+
+    expect(digest).toBeNull();
+    expect(getDeltaCursor(channelJid)).toBe(timestamp);
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it('skips API calls for windows shorter than five seconds and still advances the cursor', async () => {
+    const channelJid = makeChannelJid('narrow-window');
+    const since = '2026-03-25T12:00:00.000Z';
+    const until = '2026-03-25T12:00:04.000Z';
+    const fetchMock = mock(() => {
+      throw new Error('fetch should not run for a narrow window');
+    });
+
+    globalThis.fetch = fetchMock as unknown as typeof globalThis.fetch;
+    writeGitHubWatchesConfig({
+      watches: [],
+      githubDeltaContextEnabled: true,
+      channelWatches: [
+        {
+          channelJid,
+          repos: [{ owner: 'omniaura', repo: 'omniclaw' }],
+        },
+      ],
+    });
+    setDeltaCursor(channelJid, since);
+
+    const digest = await fetchGitHubDelta(channelJid, until);
+
+    expect(digest).toBeNull();
+    expect(getDeltaCursor(channelJid)).toBe(until);
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it('collects PR and issue activity, dedupes repeated events, and advances the cursor', async () => {
+    const channelJid = makeChannelJid('digest');
+    const since = '2026-03-25T12:00:00.000Z';
+    const until = '2026-03-25T12:30:00.000Z';
+
+    writeGitHubWatchesConfig({
+      watches: [],
+      githubDeltaContextEnabled: true,
+      channelWatches: [
+        {
+          channelJid,
+          repos: [{ owner: 'omniaura', repo: 'omniclaw' }],
+        },
+      ],
+    });
+    setDeltaCursor(channelJid, since);
+
+    const fetchMock = installGitHubFetchMock({
+      '/repos/omniaura/omniclaw/pulls?state=all&sort=updated&direction=desc&per_page=30':
+        [
+          {
+            number: 12,
+            title: 'Tighten CI checks',
+            state: 'open',
+            merged_at: null,
+            created_at: '2026-03-25T12:10:00.000Z',
+            updated_at: '2026-03-25T12:29:00.000Z',
+            closed_at: null,
+            user: { login: 'alice' },
+            html_url: 'https://github.com/omniaura/omniclaw/pull/12',
+            draft: false,
+          },
+        ],
+      '/repos/omniaura/omniclaw/pulls/12/reviews?per_page=20': [
+        {
+          id: 401,
+          user: { login: 'bob' },
+          state: 'APPROVED',
+          body: 'Looks good\nwith one nit',
+          submitted_at: '2026-03-25T12:20:00.000Z',
+          html_url:
+            'https://github.com/omniaura/omniclaw/pull/12#pullrequestreview-401',
+        },
+      ],
+      '/repos/omniaura/omniclaw/pulls/12/comments?sort=created&direction=desc&per_page=20':
+        [
+          {
+            id: 501,
+            user: { login: 'carol' },
+            body: 'Please rename this helper',
+            path: 'src/index.ts',
+            line: 42,
+            created_at: '2026-03-25T12:25:00.000Z',
+            html_url:
+              'https://github.com/omniaura/omniclaw/pull/12#discussion_r501',
+          },
+          {
+            id: 501,
+            user: { login: 'carol' },
+            body: 'Please rename this helper',
+            path: 'src/index.ts',
+            line: 42,
+            created_at: '2026-03-25T12:25:00.000Z',
+            html_url:
+              'https://github.com/omniaura/omniclaw/pull/12#discussion_r501',
+          },
+        ],
+      '/repos/omniaura/omniclaw/pulls/12/commits?per_page=20': [
+        {
+          sha: 'abc123',
+          commit: {
+            message: 'Add CI backstop',
+            author: { name: 'Alice', date: '2026-03-25T12:15:00.000Z' },
+          },
+          html_url: 'https://github.com/omniaura/omniclaw/commit/abc123',
+          author: { login: 'alice' },
+        },
+        {
+          sha: 'def456',
+          commit: {
+            message: 'Polish logging',
+            author: { name: 'Alice', date: '2026-03-25T12:28:00.000Z' },
+          },
+          html_url: 'https://github.com/omniaura/omniclaw/commit/def456',
+          author: { login: 'alice' },
+        },
+      ],
+      [`/repos/omniaura/omniclaw/issues?state=all&sort=updated&direction=desc&per_page=30&since=${since}`]:
+        [
+          {
+            number: 22,
+            title: 'Document app setup',
+            state: 'open',
+            created_at: '2026-03-25T12:05:00.000Z',
+            updated_at: '2026-03-25T12:22:00.000Z',
+            closed_at: null,
+            user: { login: 'dana' },
+            html_url: 'https://github.com/omniaura/omniclaw/issues/22',
+          },
+        ],
+      [`/repos/omniaura/omniclaw/issues/22/comments?since=${since}&per_page=10`]:
+        [
+          {
+            id: 601,
+            body: 'I can take this',
+            created_at: '2026-03-25T12:21:00.000Z',
+            updated_at: '2026-03-25T12:21:00.000Z',
+            user: { login: 'erin' },
+            html_url:
+              'https://github.com/omniaura/omniclaw/issues/22#issuecomment-601',
+          },
+          {
+            id: 601,
+            body: 'I can take this',
+            created_at: '2026-03-25T12:21:00.000Z',
+            updated_at: '2026-03-25T12:21:00.000Z',
+            user: { login: 'erin' },
+            html_url:
+              'https://github.com/omniaura/omniclaw/issues/22#issuecomment-601',
+          },
+        ],
+    });
+
+    const digest = await fetchGitHubDelta(channelJid, until);
+
+    expect(fetchMock).toHaveBeenCalledTimes(6);
+    expect(digest).not.toBeNull();
+    expect(digest).toContain('# GitHub Activity Since Last Message');
+    expect(digest).toContain('## omniaura/omniclaw');
+    expect(digest).toContain('Issue #22 opened: Document app setup');
+    expect(digest).toContain('PR #12 opened: Tighten CI checks');
+    expect(digest).toContain(
+      'APPROVED review on PR #12 by bob: "Looks good with one nit"',
+    );
+    expect(digest).toContain(
+      'Review comment on PR #12 (src/index.ts:42): "Please rename this helper"',
+    );
+    expect(digest).toContain('2 new commits on PR #12');
+    expect(digest).toContain('Comment on issue #22 by erin: "I can take this"');
+    expect(digest).not.toContain('2 comments on Issue #22: Document app setup');
+    expect(digest).not.toContain('2 comments on PR #12: Tighten CI checks');
+    expect(getDeltaCursor(channelJid)).toBe(until);
+  });
+
+  it('suppresses already injected events on repeated windows for the same channel', async () => {
+    const channelJid = makeChannelJid('ring-buffer');
+    const since = '2026-03-25T12:00:00.000Z';
+    const until = '2026-03-25T12:10:00.000Z';
+
+    writeGitHubWatchesConfig({
+      watches: [],
+      githubDeltaContextEnabled: true,
+      channelWatches: [
+        {
+          channelJid,
+          repos: [{ owner: 'omniaura', repo: 'omniclaw' }],
+        },
+      ],
+    });
+
+    const responses = {
+      '/repos/omniaura/omniclaw/pulls?state=all&sort=updated&direction=desc&per_page=30':
+        [
+          {
+            number: 88,
+            title: 'Wire delta context',
+            state: 'open',
+            merged_at: null,
+            created_at: '2026-03-25T12:05:00.000Z',
+            updated_at: '2026-03-25T12:05:00.000Z',
+            closed_at: null,
+            user: { login: 'alice' },
+            html_url: 'https://github.com/omniaura/omniclaw/pull/88',
+            draft: false,
+          },
+        ],
+      '/repos/omniaura/omniclaw/pulls/88/reviews?per_page=20': [],
+      '/repos/omniaura/omniclaw/pulls/88/comments?sort=created&direction=desc&per_page=20':
+        [],
+      '/repos/omniaura/omniclaw/pulls/88/commits?per_page=20': [],
+      [`/repos/omniaura/omniclaw/issues?state=all&sort=updated&direction=desc&per_page=30&since=${since}`]:
+        [],
+    };
+
+    setDeltaCursor(channelJid, since);
+    installGitHubFetchMock(responses);
+    const firstDigest = await fetchGitHubDelta(channelJid, until);
+
+    expect(firstDigest).toContain('PR #88 opened: Wire delta context');
+
+    setDeltaCursor(channelJid, since);
+    installGitHubFetchMock(responses);
+    const secondDigest = await fetchGitHubDelta(channelJid, until);
+
+    expect(secondDigest).toBeNull();
+    expect(getDeltaCursor(channelJid)).toBe(until);
+  });
+});

--- a/src/github-delta.ts
+++ b/src/github-delta.ts
@@ -11,7 +11,9 @@
 import { logger } from './logger.js';
 import type { GitHubChannelWatch, GitHubWatchesConfig } from './types.js';
 
-const GITHUB_TOKEN = process.env.GITHUB_TOKEN || '';
+function getGitHubToken(): string {
+  return process.env.GITHUB_TOKEN || '';
+}
 
 // --- GitHub API types ---
 
@@ -105,12 +107,13 @@ export interface DeltaEvent {
 // --- GitHub API helpers ---
 
 async function githubFetch<T>(urlPath: string): Promise<T | null> {
-  if (!GITHUB_TOKEN) return null;
+  const token = getGitHubToken();
+  if (!token) return null;
   const url = `https://api.github.com${urlPath}`;
   try {
     const res = await fetch(url, {
       headers: {
-        Authorization: `Bearer ${GITHUB_TOKEN}`,
+        Authorization: `Bearer ${token}`,
         Accept: 'application/vnd.github.v3+json',
         'User-Agent': 'OmniClaw/1.0',
       },
@@ -477,7 +480,7 @@ export async function fetchGitHubDelta(
   channelJid: string,
   currentMessageTimestamp: string,
 ): Promise<string | null> {
-  if (!GITHUB_TOKEN) return null;
+  if (!getGitHubToken()) return null;
 
   // Load config
   let config: GitHubWatchesConfig;


### PR DESCRIPTION
## Summary

- add deterministic fetch-path coverage for `src/github-delta.ts`, including first-message initialization, narrow-window skips, digest generation, deduplication, and ring-buffer suppression
- switch `src/github-delta.ts` to read `GITHUB_TOKEN` lazily so the fetch path can be exercised in tests without changing runtime behavior
- document the GitHub App secret setup and verification flow needed for auto-update PRs to trigger CI reliably in `docs/GITHUB-AUTO-UPDATE-SETUP.md`

## Testing

- `bun test src/github-delta.test.ts src/github-delta.fetch.test.ts src/github.test.ts src/github-linked.test.ts src/routing.test.ts`
- `bun test`
