### PR TITLE
feat: confirm agent restart on startup

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -121,6 +121,11 @@ import {
 import { calculateNextRun } from './schedule-utils.js';
 import { redactSensitiveData } from './security/redaction.js';
 import { parseScopedSlackJid } from './slack-jid.js';
+import {
+  buildStartupConfirmationTargets,
+  hasPriorRuntimeState,
+  STARTUP_CONFIRMATION_PROMPT,
+} from './startup-notifications.js';
 import { startSchedulerLoop } from './task-scheduler.js';
 import {
   parseTelegramApiFileUrl,
@@ -2185,6 +2190,51 @@ function recoverPendingMessages(): void {
   }
 }
 
+function queueStartupConfirmationMessages(): void {
+  if (
+    !hasPriorRuntimeState({
+      lastTimestamp,
+      lastAgentTimestamp,
+      sessions,
+    })
+  ) {
+    return;
+  }
+
+  const targets = buildStartupConfirmationTargets(
+    registeredGroups,
+    channelSubscriptions,
+  );
+
+  for (const target of targets) {
+    const content = target.trigger
+      ? `${target.trigger} ${STARTUP_CONFIRMATION_PROMPT}`
+      : STARTUP_CONFIRMATION_PROMPT;
+    storeMessage({
+      id: `startup-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`,
+      chat_jid: target.chatJid,
+      sender: 'system',
+      sender_name: 'System',
+      content,
+      timestamp: new Date().toISOString(),
+      is_from_me: false,
+      sender_platform: 'system',
+    });
+    queue.enqueueMessageCheck(
+      target.agentId
+        ? makeDispatchKey(target.chatJid, target.agentId)
+        : target.chatJid,
+    );
+  }
+
+  if (targets.length > 0) {
+    logger.info(
+      { targetCount: targets.length },
+      'Queued startup confirmation prompts',
+    );
+  }
+}
+
 /**
  * Build agent registry and write it to all groups' IPC dirs.
  * Every agent can discover every other agent's name, purpose, backend, and dev URL.
@@ -2973,6 +3023,7 @@ async function main(): Promise<void> {
     // findChannel() can route recovered output to the correct channel.
     // (startMessageLoop already runs above for IPC/scheduled task responsiveness.)
     recoverPendingMessages();
+    queueStartupConfirmationMessages();
 
     // Sync agent avatars from platform APIs (non-blocking)
     syncAvatars(agents, channels, (agentId) =>

--- a/src/startup-notifications.test.ts
+++ b/src/startup-notifications.test.ts
@@ -1,0 +1,170 @@
+import { describe, expect, it } from 'bun:test';
+
+import {
+  buildStartupConfirmationTargets,
+  hasPriorRuntimeState,
+} from './startup-notifications.js';
+import type { ChannelSubscription, RegisteredGroup } from './types.js';
+
+describe('hasPriorRuntimeState', () => {
+  it('returns false for a fresh startup with no persisted state', () => {
+    expect(
+      hasPriorRuntimeState({
+        lastTimestamp: '',
+        lastAgentTimestamp: {},
+        sessions: {},
+      }),
+    ).toBe(false);
+  });
+
+  it('returns true when any prior router or session state exists', () => {
+    expect(
+      hasPriorRuntimeState({
+        lastTimestamp: '2026-03-25T20:00:00.000Z',
+        lastAgentTimestamp: {},
+        sessions: {},
+      }),
+    ).toBe(true);
+
+    expect(
+      hasPriorRuntimeState({
+        lastTimestamp: '',
+        lastAgentTimestamp: { main: '2026-03-25T20:00:00.000Z' },
+        sessions: {},
+      }),
+    ).toBe(true);
+
+    expect(
+      hasPriorRuntimeState({
+        lastTimestamp: '',
+        lastAgentTimestamp: {},
+        sessions: { main: 'session-123' },
+      }),
+    ).toBe(true);
+  });
+});
+
+describe('buildStartupConfirmationTargets', () => {
+  it('targets primary subscriptions and standalone groups', () => {
+    const registeredGroups: Record<string, RegisteredGroup> = {
+      'dc:1': {
+        name: 'Agent One',
+        folder: 'agent-one',
+        trigger: '@AgentOne',
+        added_at: '2026-03-25T20:00:00.000Z',
+      },
+      'wa:solo': {
+        name: 'Solo',
+        folder: 'solo',
+        trigger: '@Solo',
+        added_at: '2026-03-25T20:00:00.000Z',
+      },
+    };
+    const channelSubscriptions: Record<string, ChannelSubscription[]> = {
+      'dc:1': [
+        {
+          channelJid: 'dc:1',
+          agentId: 'agent-one',
+          trigger: '@AgentOne',
+          requiresTrigger: true,
+          priority: 100,
+          isPrimary: true,
+          createdAt: '2026-03-25T20:00:00.000Z',
+        },
+      ],
+    };
+
+    expect(
+      buildStartupConfirmationTargets(registeredGroups, channelSubscriptions),
+    ).toEqual([
+      { chatJid: 'dc:1', agentId: 'agent-one', trigger: '@AgentOne' },
+      { chatJid: 'wa:solo', trigger: '@Solo' },
+    ]);
+  });
+
+  it('falls back to the first subscription when none are primary', () => {
+    const registeredGroups: Record<string, RegisteredGroup> = {
+      'dc:2': {
+        name: 'Fallback',
+        folder: 'fallback',
+        trigger: '@Fallback',
+        added_at: '2026-03-25T20:00:00.000Z',
+      },
+    };
+    const channelSubscriptions: Record<string, ChannelSubscription[]> = {
+      'dc:2': [
+        {
+          channelJid: 'dc:2',
+          agentId: 'fallback-agent',
+          trigger: '@Fallback',
+          requiresTrigger: true,
+          priority: 100,
+          isPrimary: false,
+          createdAt: '2026-03-25T20:00:00.000Z',
+        },
+        {
+          channelJid: 'dc:2',
+          agentId: 'other-agent',
+          trigger: '@Other',
+          requiresTrigger: true,
+          priority: 50,
+          isPrimary: false,
+          createdAt: '2026-03-25T20:00:00.000Z',
+        },
+      ],
+    };
+
+    expect(
+      buildStartupConfirmationTargets(registeredGroups, channelSubscriptions),
+    ).toEqual([
+      { chatJid: 'dc:2', agentId: 'fallback-agent', trigger: '@Fallback' },
+    ]);
+  });
+
+  it('dedupes multi-channel agents to one startup target', () => {
+    const registeredGroups: Record<string, RegisteredGroup> = {
+      'dc:3': {
+        name: 'Shared Agent',
+        folder: 'shared-agent',
+        trigger: '@Shared',
+        added_at: '2026-03-25T20:00:00.000Z',
+      },
+      'dc:4': {
+        name: 'Shared Agent Alt',
+        folder: 'shared-agent',
+        trigger: '@Shared',
+        added_at: '2026-03-25T20:00:00.000Z',
+      },
+    };
+    const channelSubscriptions: Record<string, ChannelSubscription[]> = {
+      'dc:3': [
+        {
+          channelJid: 'dc:3',
+          agentId: 'shared-agent',
+          trigger: '@Shared',
+          requiresTrigger: true,
+          priority: 100,
+          isPrimary: true,
+          createdAt: '2026-03-25T20:00:00.000Z',
+        },
+      ],
+      'dc:4': [
+        {
+          channelJid: 'dc:4',
+          agentId: 'shared-agent',
+          trigger: '@Shared',
+          requiresTrigger: true,
+          priority: 100,
+          isPrimary: true,
+          createdAt: '2026-03-25T20:00:00.000Z',
+        },
+      ],
+    };
+
+    expect(
+      buildStartupConfirmationTargets(registeredGroups, channelSubscriptions),
+    ).toEqual([
+      { chatJid: 'dc:3', agentId: 'shared-agent', trigger: '@Shared' },
+    ]);
+  });
+});

--- a/src/startup-notifications.ts
+++ b/src/startup-notifications.ts
@@ -1,0 +1,54 @@
+import type { ChannelSubscription, RegisteredGroup } from './types.js';
+
+export const STARTUP_CONFIRMATION_PROMPT =
+  '[SYSTEM] OmniClaw just restarted. Review any recent context or thoughts files if useful, then send a brief confirmation to this channel that you are back online.';
+
+export interface StartupConfirmationTarget {
+  chatJid: string;
+  agentId?: string;
+  trigger: string;
+}
+
+export function hasPriorRuntimeState(params: {
+  lastTimestamp: string;
+  lastAgentTimestamp: Record<string, string>;
+  sessions: Record<string, string>;
+}): boolean {
+  return Boolean(
+    params.lastTimestamp ||
+    Object.keys(params.lastAgentTimestamp).length > 0 ||
+    Object.keys(params.sessions).length > 0,
+  );
+}
+
+export function buildStartupConfirmationTargets(
+  registeredGroups: Record<string, RegisteredGroup>,
+  channelSubscriptions: Record<string, ChannelSubscription[]>,
+): StartupConfirmationTarget[] {
+  const targets: StartupConfirmationTarget[] = [];
+  const coveredAgents = new Set<string>();
+
+  for (const [chatJid, subs] of Object.entries(channelSubscriptions)) {
+    if (subs.length === 0) continue;
+
+    const preferredSubs = subs.filter((sub) => sub.isPrimary);
+    const chosenSubs = preferredSubs.length > 0 ? preferredSubs : [subs[0]];
+
+    for (const sub of chosenSubs) {
+      if (coveredAgents.has(sub.agentId)) continue;
+      coveredAgents.add(sub.agentId);
+      targets.push({
+        chatJid,
+        agentId: sub.agentId,
+        trigger: sub.trigger || registeredGroups[chatJid]?.trigger || '',
+      });
+    }
+  }
+
+  for (const [chatJid, group] of Object.entries(registeredGroups)) {
+    if ((channelSubscriptions[chatJid] || []).length > 0) continue;
+    targets.push({ chatJid, trigger: group.trigger });
+  }
+
+  return targets;
+}


### PR DESCRIPTION
## Summary

- queue synthetic startup prompts after channel reconnection when the router detects prior runtime state, so restarted agents wake up and post a brief back-online confirmation without waiting for a human message
- target primary channel subscriptions (with standalone-group fallback) and dispatch the startup prompt to the intended agent in multi-agent channels
- add focused unit coverage for startup target selection and restart-state gating

## Testing

- `bunx tsc --noEmit`
- `bun test src/startup-notifications.test.ts`
- `bun test`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added startup confirmation messaging that conditionally activates and routes prompts to relevant channels and groups.

* **Tests**
  * Added unit tests validating startup confirmation message routing and state detection logic.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->