### PR TITLE
refactor: validate startup config with zod

### DIFF
--- a/src/config.test.ts
+++ b/src/config.test.ts
@@ -285,7 +285,7 @@ describe('parseConfigEnv', () => {
       CONTAINER_TIMEOUT: '1234',
       PERSISTENT_TASK_STATE: 'true',
       WEB_UI_PORT: '3000',
-      CHANNEL_ROSTER_SCOPE: 'guild',
+      CHANNEL_ROSTER_SCOPE: 'Guild',
     });
 
     expect(parsed.CONTAINER_TIMEOUT).toBe(1234);

--- a/src/config.ts
+++ b/src/config.ts
@@ -90,7 +90,11 @@ const configSchema = z
       parseIntegerString,
       z.number().int().positive().default(900000),
     ),
-    CHANNEL_ROSTER_SCOPE: z.enum(['channel', 'guild']).default('channel'),
+    CHANNEL_ROSTER_SCOPE: z.preprocess(
+      (value) =>
+        typeof value === 'string' ? value.trim().toLowerCase() : value,
+      z.enum(['channel', 'guild']).default('channel'),
+    ),
     CHANNEL_ROSTER_ROLE_FILTERS: z.string().optional(),
     CHANNEL_ROSTER_CACHE_TTL_MS: z.preprocess(
       parseIntegerString,


### PR DESCRIPTION
## Summary

- add a Zod-backed config parser in `src/config.ts` so invalid numeric and boolean environment variables fail fast at startup with readable error messages instead of silently becoming `NaN` or being ignored
- route existing exported config constants through the validated config object while preserving current defaults and compatibility aliases
- tighten multi-bot env parsing so listed Discord and Slack bot IDs fail immediately when required tokens or runtimes are invalid

## Testing

- `bunx tsc --noEmit`
- `bun test src/config.test.ts`
- `bun test`
