### PR TITLE
refactor: harden resume position persistence

### DIFF
--- a/src/resume-position-store.test.ts
+++ b/src/resume-position-store.test.ts
@@ -38,6 +38,13 @@ describe('MemoryResumePositionStore', () => {
     });
   });
 
+  it('returns a defensive copy from getAll', () => {
+    const snapshot = store.getAll();
+    snapshot.alpha = 'mutated';
+
+    expect(store.get('alpha')).toBe('2026-03-01T00:00:00.000Z');
+  });
+
   it('clears all tracked positions', () => {
     store.set('beta', '2026-03-02T00:00:00.000Z');
 
@@ -86,16 +93,26 @@ describe('PersistentResumePositionStore', () => {
 
   it('persists updates and clears through the adapter', () => {
     const writes: Array<{ key: string; value: unknown }> = [];
+    const scheduled: Array<() => void> = [];
     const adapter: PersistentStateAdapter = {
       read: <T>() => ({ alpha: '2026-03-01T00:00:00.000Z' }) as T,
       write: (key, value) => {
         writes.push({ key, value: structuredClone(value) });
       },
     };
-    const store = new PersistentResumePositionStore({ stateAdapter: adapter });
+    const store = new PersistentResumePositionStore({
+      stateAdapter: adapter,
+      schedulePersist: (flush) => {
+        scheduled.push(flush);
+      },
+    });
 
     store.set('beta', '2026-03-02T00:00:00.000Z');
+    expect(scheduled).toHaveLength(1);
+    scheduled.shift()?.();
     store.clear();
+    expect(scheduled).toHaveLength(1);
+    scheduled.shift()?.();
 
     expect(writes).toEqual([
       {
@@ -110,6 +127,74 @@ describe('PersistentResumePositionStore', () => {
         value: {},
       },
     ]);
+  });
+
+  it('coalesces multiple writes scheduled in the same tick', () => {
+    const writes: Array<{ key: string; value: unknown }> = [];
+    const scheduled: Array<() => void> = [];
+    const store = new PersistentResumePositionStore({
+      stateAdapter: {
+        read: <T>() => ({}) as T,
+        write: (key, value) => {
+          writes.push({ key, value: structuredClone(value) });
+        },
+      },
+      schedulePersist: (flush) => {
+        scheduled.push(flush);
+      },
+    });
+
+    store.set('alpha', 'one');
+    store.set('beta', 'two');
+    store.set('beta', 'three');
+
+    expect(scheduled).toHaveLength(1);
+    scheduled[0]?.();
+
+    expect(writes).toEqual([
+      {
+        key: 'resume_positions',
+        value: {
+          alpha: 'one',
+          beta: 'three',
+        },
+      },
+    ]);
+  });
+
+  it('does not persist when setting an unchanged value', () => {
+    const writes: Array<{ key: string; value: unknown }> = [];
+    const scheduled: Array<() => void> = [];
+    const store = new PersistentResumePositionStore({
+      stateAdapter: {
+        read: <T>() => ({ alpha: '2026-03-01T00:00:00.000Z' }) as T,
+        write: (key, value) => {
+          writes.push({ key, value: structuredClone(value) });
+        },
+      },
+      schedulePersist: (flush) => {
+        scheduled.push(flush);
+      },
+    });
+
+    store.set('alpha', '2026-03-01T00:00:00.000Z');
+
+    expect(scheduled).toHaveLength(0);
+    expect(writes).toEqual([]);
+  });
+
+  it('returns a defensive copy from persistent getAll', () => {
+    const store = new PersistentResumePositionStore({
+      stateAdapter: {
+        read: <T>() => ({ alpha: '2026-03-01T00:00:00.000Z' }) as T,
+        write: () => {},
+      },
+    });
+
+    const snapshot = store.getAll();
+    snapshot.alpha = 'mutated';
+
+    expect(store.get('alpha')).toBe('2026-03-01T00:00:00.000Z');
   });
 
   it('warns and continues when initial load fails', () => {
@@ -144,6 +229,9 @@ describe('PersistentResumePositionStore', () => {
             throw new Error('disk full');
           },
         },
+        schedulePersist: (flush) => {
+          flush();
+        },
       });
 
       expect(() => {
@@ -163,6 +251,34 @@ describe('PersistentResumePositionStore', () => {
     } finally {
       stop();
     }
+  });
+
+  it('clears persisted state fully after flush', () => {
+    const writes: Array<{ key: string; value: unknown }> = [];
+    const scheduled: Array<() => void> = [];
+    const store = new PersistentResumePositionStore({
+      stateAdapter: {
+        read: <T>() => ({ alpha: '2026-03-01T00:00:00.000Z' }) as T,
+        write: (key, value) => {
+          writes.push({ key, value: structuredClone(value) });
+        },
+      },
+      schedulePersist: (flush) => {
+        scheduled.push(flush);
+      },
+    });
+
+    store.clear();
+    expect(scheduled).toHaveLength(1);
+    scheduled[0]?.();
+
+    expect(store.getAll()).toEqual({});
+    expect(writes).toEqual([
+      {
+        key: 'resume_positions',
+        value: {},
+      },
+    ]);
   });
 });
 

--- a/src/resume-position-store.ts
+++ b/src/resume-position-store.ts
@@ -22,7 +22,7 @@ export class MemoryResumePositionStore implements ResumePositionStore {
   }
 
   getAll(): Record<string, string> {
-    return this.state;
+    return { ...this.state };
   }
 
   clear(): void {
@@ -39,6 +39,7 @@ export interface PersistentStateAdapter {
 
 interface PersistentStoreOptions {
   stateAdapter?: PersistentStateAdapter;
+  schedulePersist?: (flush: () => void) => void;
 }
 
 const defaultStateAdapter: PersistentStateAdapter = {
@@ -49,9 +50,12 @@ const defaultStateAdapter: PersistentStateAdapter = {
 export class PersistentResumePositionStore implements ResumePositionStore {
   private readonly memoryStore: MemoryResumePositionStore;
   private readonly stateAdapter: PersistentStateAdapter;
+  private readonly schedulePersistFn: (flush: () => void) => void;
+  private persistScheduled = false;
 
   constructor(options?: PersistentStoreOptions) {
     this.stateAdapter = options?.stateAdapter ?? defaultStateAdapter;
+    this.schedulePersistFn = options?.schedulePersist ?? queueMicrotask;
     this.memoryStore = new MemoryResumePositionStore(this.loadInitialState());
   }
 
@@ -60,8 +64,9 @@ export class PersistentResumePositionStore implements ResumePositionStore {
   }
 
   set(groupFolder: string, resumeAt: string): void {
+    if (this.memoryStore.get(groupFolder) === resumeAt) return;
     this.memoryStore.set(groupFolder, resumeAt);
-    this.persist();
+    this.schedulePersist();
   }
 
   getAll(): Record<string, string> {
@@ -69,8 +74,9 @@ export class PersistentResumePositionStore implements ResumePositionStore {
   }
 
   clear(): void {
+    if (Object.keys(this.memoryStore.getAll()).length === 0) return;
     this.memoryStore.clear();
-    this.persist();
+    this.schedulePersist();
   }
 
   private loadInitialState(): Record<string, string> {
@@ -83,6 +89,15 @@ export class PersistentResumePositionStore implements ResumePositionStore {
       logger.warn({ err }, 'Failed to load persisted resume positions');
       return {};
     }
+  }
+
+  private schedulePersist(): void {
+    if (this.persistScheduled) return;
+    this.persistScheduled = true;
+    this.schedulePersistFn(() => {
+      this.persistScheduled = false;
+      this.persist();
+    });
   }
 
   private persist(): void {


### PR DESCRIPTION
## Summary

- return defensive copies from `ResumePositionStore.getAll()` so callers cannot mutate internal in-memory state accidentally
- coalesce repeated persistent resume-position writes onto a scheduled flush, reducing synchronous write churn during high-frequency resume position updates while preserving the current API
- add focused coverage for clear behavior, defensive copies, unchanged-value no-ops, and coalesced persistence scheduling

## Testing

- `bun test src/resume-position-store.test.ts`
- `bunx tsc --noEmit`
- `bun test`
