### PR TITLE
feat(webui): WU-06 — full logs page with search, filtering, export

### DIFF
--- a/webui/src/components/LogPanel.tsx
+++ b/webui/src/components/LogPanel.tsx
@@ -1,16 +1,7 @@
-import { createSignal, createMemo, For, Show, onMount, onCleanup } from 'solid-js';
+import { createSignal, createMemo, For, onMount, onCleanup } from 'solid-js';
 
-import { logs, clearLogs, type LogLine } from '~/lib/stores/logs';
-
-const LEVELS = ['debug', 'info', 'warn', 'error'] as const;
-
-const levelColors: Record<string, string> = {
-  debug: 'text-text-dim',
-  info: 'text-blue',
-  warn: 'text-yellow',
-  error: 'text-red',
-  fatal: 'text-red',
-};
+import { logs, clearLogs } from '~/lib/stores/logs';
+import LogLine, { LEVELS, toggleLevelSet } from '~/components/shared/LogLine';
 
 export default function LogPanel() {
   const [enabledLevels, setEnabledLevels] = createSignal<Set<string>>(
@@ -24,23 +15,6 @@ export default function LogPanel() {
     return logs.lines.filter((l) => enabled.has(l.level));
   });
 
-  function toggleLevel(level: string) {
-    setEnabledLevels((prev) => {
-      const next = new Set(prev);
-      if (next.has(level)) {
-        next.delete(level);
-      } else {
-        next.add(level);
-      }
-      return next;
-    });
-  }
-
-  function formatTime(ts: number): string {
-    return new Date(ts).toLocaleTimeString();
-  }
-
-  // Auto-scroll to bottom on new logs
   onMount(() => {
     const observer = new MutationObserver(() => {
       if (autoScroll() && containerRef) {
@@ -64,7 +38,7 @@ export default function LogPanel() {
                   ? 'bg-surface-2 text-text'
                   : 'text-text-dim'
               }`}
-              onClick={() => toggleLevel(level)}
+              onClick={() => setEnabledLevels((prev) => toggleLevelSet(prev, level))}
             >
               {level}
             </button>
@@ -81,34 +55,7 @@ export default function LogPanel() {
       </div>
       <div ref={containerRef} class="flex-1 overflow-auto p-1 text-xs min-h-0">
         <For each={filteredLogs()}>
-          {(line) => (
-            <div class="flex gap-1 py-px leading-relaxed">
-              <span class="text-text-dim shrink-0">{formatTime(line.ts)}</span>
-              <span class={`shrink-0 w-10 ${levelColors[line.level] ?? 'text-text-dim'}`}>
-                {line.level}
-              </span>
-              <Show when={line.container || line.group}>
-                <span class="text-accent shrink-0">
-                  {line.container || line.group}
-                </span>
-              </Show>
-              <Show when={line.op}>
-                <span class="text-text-dim">[{line.op}]</span>
-              </Show>
-              <span class="text-text break-all">
-                {line.msg}
-                <Show when={line.durationMs != null}>
-                  {' '}({line.durationMs}ms)
-                </Show>
-                <Show when={line.costUsd != null}>
-                  {' '}${line.costUsd}
-                </Show>
-              </span>
-              <Show when={line.err}>
-                <span class="text-red break-all">{line.err}</span>
-              </Show>
-            </div>
-          )}
+          {(line) => <LogLine line={line} />}
         </For>
       </div>
     </div>

--- a/webui/src/components/shared/LogLine.tsx
+++ b/webui/src/components/shared/LogLine.tsx
@@ -1,0 +1,65 @@
+import { Show } from 'solid-js';
+
+import type { LogLine as LogLineData } from '~/lib/stores/logs';
+
+export const LEVELS = ['debug', 'info', 'warn', 'error'] as const;
+
+export const levelColors: Record<string, string> = {
+  debug: 'text-text-dim',
+  info: 'text-blue',
+  warn: 'text-yellow',
+  error: 'text-red',
+  fatal: 'bg-red text-bg px-1 rounded',
+};
+
+export function formatLogTime(ts: number): string {
+  return new Date(ts).toLocaleTimeString();
+}
+
+export function toggleLevelSet(prev: Set<string>, level: string): Set<string> {
+  const next = new Set(prev);
+  if (next.has(level)) next.delete(level);
+  else next.add(level);
+  return next;
+}
+
+interface LogLineProps {
+  line: LogLineData;
+  class?: string;
+  badgeWidth?: string;
+}
+
+export default function LogLine(props: LogLineProps) {
+  return (
+    <div class={`flex gap-1.5 py-px leading-relaxed ${props.class ?? ''}`}>
+      <span class="text-text-dim shrink-0">
+        {formatLogTime(props.line.ts)}
+      </span>
+      <span
+        class={`shrink-0 ${props.badgeWidth ?? 'w-10'} ${levelColors[props.line.level] ?? 'text-text-dim'}`}
+      >
+        {props.line.level}
+      </span>
+      <Show when={props.line.container || props.line.group}>
+        <span class="text-accent shrink-0">
+          {props.line.container || props.line.group}
+        </span>
+      </Show>
+      <Show when={props.line.op}>
+        <span class="text-text-dim">[{props.line.op}]</span>
+      </Show>
+      <span class="text-text break-all">
+        {props.line.msg}
+        <Show when={props.line.durationMs != null}>
+          {' '}({props.line.durationMs}ms)
+        </Show>
+        <Show when={props.line.costUsd != null}>
+          {' '}${props.line.costUsd}
+        </Show>
+      </span>
+      <Show when={props.line.err}>
+        <span class="text-red break-all">{props.line.err}</span>
+      </Show>
+    </div>
+  );
+}

--- a/webui/src/routes/(shell)/logs.tsx
+++ b/webui/src/routes/(shell)/logs.tsx
@@ -1,10 +1,253 @@
+import {
+  createSignal,
+  createMemo,
+  createEffect,
+  For,
+  Show,
+  onCleanup,
+} from 'solid-js';
 import { Title } from '@solidjs/meta';
 
-export default function Logs() {
+import { logs, clearLogs } from '~/lib/stores/logs';
+import { agents } from '~/lib/stores/agents';
+import { useEventSource } from '~/lib/event-source';
+import { showToast } from '~/components/shared/Toast';
+import LogLine, {
+  LEVELS,
+  toggleLevelSet,
+  formatLogTime,
+} from '~/components/shared/LogLine';
+
+export default function LogsPage() {
+  const { status } = useEventSource();
+
+  const [enabledLevels, setEnabledLevels] = createSignal<Set<string>>(
+    new Set([...LEVELS, 'fatal']),
+  );
+  const [autoScroll, setAutoScroll] = createSignal(true);
+  const [searchTerm, setSearchTerm] = createSignal('');
+  const [useRegex, setUseRegex] = createSignal(false);
+  const [sourceFilter, setSourceFilter] = createSignal('');
+
+  let containerRef: HTMLDivElement | undefined;
+  let searchTimer: ReturnType<typeof setTimeout> | undefined;
+
+  onCleanup(() => {
+    if (searchTimer) clearTimeout(searchTimer);
+  });
+
+  const filteredLogs = createMemo(() => {
+    const enabled = enabledLevels();
+    const source = sourceFilter();
+    const term = searchTerm();
+
+    let compiled: RegExp | null = null;
+    if (term && useRegex()) {
+      try {
+        compiled = new RegExp(term, 'i');
+      } catch {
+        /* invalid regex */
+      }
+    }
+    const lowerTerm = term.toLowerCase();
+
+    return logs.lines.filter((line) => {
+      if (!enabled.has(line.level)) return false;
+
+      if (source) {
+        const lineSource = line.container || line.group || '';
+        if (!lineSource.includes(source)) return false;
+      }
+
+      if (term) {
+        const text = `${line.msg} ${line.op ?? ''} ${line.container ?? ''} ${line.group ?? ''} ${line.err ?? ''}`;
+        if (compiled) return compiled.test(text);
+        return text.toLowerCase().includes(lowerTerm);
+      }
+
+      return true;
+    });
+  });
+
+  createEffect(() => {
+    const _ = filteredLogs().length;
+    if (autoScroll() && containerRef) {
+      queueMicrotask(() => {
+        if (containerRef) containerRef.scrollTop = containerRef.scrollHeight;
+      });
+    }
+  });
+
+  function handleSearchInput(value: string) {
+    if (searchTimer) clearTimeout(searchTimer);
+    searchTimer = setTimeout(() => setSearchTerm(value), 200);
+  }
+
+  function exportLogs() {
+    const lines = filteredLogs();
+    const text = lines
+      .map(
+        (l) =>
+          `${formatLogTime(l.ts)} ${l.level} ${l.container || l.group || ''} ${l.op ? `[${l.op}]` : ''} ${l.msg}${l.err ? ` ${l.err}` : ''}`,
+      )
+      .join('\n');
+    const blob = new Blob([text], { type: 'text/plain' });
+    const a = document.createElement('a');
+    a.href = URL.createObjectURL(blob);
+    a.download = `omniclaw-logs-${new Date().toISOString().slice(0, 19).replace(/:/g, '-')}.txt`;
+    a.click();
+    URL.revokeObjectURL(a.href);
+    showToast(`Exported ${lines.length} log lines`, 'success');
+  }
+
+  function handleClear() {
+    clearLogs();
+    showToast('Logs cleared', 'info');
+  }
+
+  const sourceOptions = createMemo(() =>
+    agents.list.map((a) => ({ id: a.id, name: a.name })),
+  );
+
+  const filterActive = createMemo(() => {
+    const total = logs.lines.length;
+    const shown = filteredLogs().length;
+    return total !== shown;
+  });
+
   return (
     <>
       <Title>OmniClaw — Logs</Title>
-      <div class="p-4 text-text-dim">Logs</div>
+      <div class="flex flex-col h-full">
+        <div class="flex flex-wrap items-center gap-2 px-3 py-2 border-b border-border shrink-0">
+          <h2 class="text-sm font-semibold text-text-bright mr-2">Logs</h2>
+          <span class="text-xs text-text-dim">
+            {filteredLogs().length}
+            <Show when={filterActive()}>
+              {' '}/ {logs.lines.length}
+            </Show>
+            {' '}lines
+          </span>
+
+          <div class="flex-1" />
+
+          <div class="flex items-center gap-1">
+            <input
+              type="text"
+              placeholder="Search logs..."
+              spellcheck={false}
+              autocomplete="off"
+              class="bg-surface text-text text-xs px-2 py-1 rounded border border-border focus:border-accent focus:outline-none w-48"
+              onInput={(e) => handleSearchInput(e.currentTarget.value)}
+            />
+            <label class="flex items-center gap-1 text-xs text-text-dim cursor-pointer select-none">
+              <input
+                type="checkbox"
+                checked={useRegex()}
+                onChange={(e) => setUseRegex(e.currentTarget.checked)}
+                class="accent-accent"
+              />
+              regex
+            </label>
+          </div>
+
+          <div class="flex-1" />
+
+          <div class="flex items-center gap-1">
+            <For each={[...LEVELS]}>
+              {(level) => (
+                <button
+                  class={`px-1.5 py-0.5 rounded text-xs transition-colors ${
+                    enabledLevels().has(level)
+                      ? 'bg-surface-2 text-text'
+                      : 'text-text-dim opacity-50'
+                  }`}
+                  onClick={() =>
+                    setEnabledLevels((prev) => toggleLevelSet(prev, level))
+                  }
+                >
+                  {level}
+                </button>
+              )}
+            </For>
+          </div>
+
+          <select
+            class="bg-surface text-text text-xs px-2 py-1 rounded border border-border"
+            value={sourceFilter()}
+            onChange={(e) => setSourceFilter(e.currentTarget.value)}
+          >
+            <option value="">all sources</option>
+            <For each={sourceOptions()}>
+              {(opt) => <option value={opt.id}>{opt.name}</option>}
+            </For>
+          </select>
+
+          <button
+            class={`px-1.5 py-0.5 rounded text-xs transition-colors ${
+              autoScroll()
+                ? 'bg-surface-2 text-text'
+                : 'text-text-dim opacity-50'
+            }`}
+            onClick={() => {
+              const wasOn = autoScroll();
+              setAutoScroll(!wasOn);
+              if (!wasOn && containerRef) {
+                containerRef.scrollTop = containerRef.scrollHeight;
+              }
+            }}
+            title="Auto-scroll"
+          >
+            ↓ auto
+          </button>
+
+          <button
+            class="px-1.5 py-0.5 rounded text-xs text-text-dim hover:text-text hover:bg-surface-2 transition-colors"
+            onClick={exportLogs}
+            title="Export logs as text"
+          >
+            export
+          </button>
+
+          <button
+            class="px-1.5 py-0.5 rounded text-xs text-red hover:bg-red/10 transition-colors"
+            onClick={handleClear}
+            title="Clear all logs"
+          >
+            clear
+          </button>
+        </div>
+
+        <div
+          ref={containerRef}
+          class="flex-1 overflow-auto p-2 text-xs font-mono min-h-0"
+        >
+          <For each={filteredLogs()}>
+            {(line) => (
+              <LogLine
+                line={line}
+                class="hover:bg-surface-2/50"
+                badgeWidth="w-12 text-center"
+              />
+            )}
+          </For>
+        </div>
+
+        <div class="flex items-center justify-between px-3 py-1 border-t border-border text-xs text-text-dim shrink-0">
+          <span>
+            {status() === 'connected'
+              ? 'Connected'
+              : status() === 'connecting'
+                ? 'Connecting...'
+                : 'Disconnected'}
+          </span>
+          <Show when={filterActive()}>
+            <span>
+              showing {filteredLogs().length} of {logs.lines.length}
+            </span>
+          </Show>
+        </div>
+      </div>
     </>
   );
 }


### PR DESCRIPTION
## Summary
- Replace placeholder `logs.tsx` route with full-page log viewer ported from Datastar `src/web/logs.ts` and `logsScript()`
- Extract shared `LogLine` component and log utilities (`LEVELS`, `levelColors`, `formatLogTime`, `toggleLevelSet`) into `webui/src/components/shared/LogLine.tsx` to eliminate duplication with sidebar `LogPanel`
- Refactor `LogPanel.tsx` to use the shared component

## Features
- SSE-driven log stream via the existing logs store
- Level filter toggle buttons (debug/info/warn/error)
- Source/context filter dropdown (populated from agents store)
- Search input with debounced filtering and regex toggle
- Auto-scroll toggle
- Export filtered logs as text file
- Clear button with toast notification
- Connection status bar with filter summary

## Test plan
- [x] `bun test` — 1315 tests pass
- [x] E2E: `WEB_UI_SOLID=true bun run simtest`, navigate to `/logs`, verify all toolbar elements render
- [x] E2E: Broadcast log events via admin API, verify log lines appear with correct formatting
- [x] No console errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)