### PR TITLE
feat(webui): context viewer page with layer editor

### DIFF
--- a/webui/src/components/context/LayerEditor.tsx
+++ b/webui/src/components/context/LayerEditor.tsx
@@ -1,0 +1,160 @@
+import { createSignal, createEffect, For, Show, on } from 'solid-js';
+
+import { api, type ContextLayers } from '~/lib/api';
+import { showToast } from '~/components/shared/Toast';
+
+type LayerName = 'channel' | 'category' | 'server' | 'agent';
+
+const LAYER_TABS: { key: LayerName; label: string }[] = [
+  { key: 'channel', label: 'Channel' },
+  { key: 'category', label: 'Category' },
+  { key: 'server', label: 'Server' },
+  { key: 'agent', label: 'Agent' },
+];
+
+interface LayerEditorProps {
+  layers: ContextLayers;
+  /** Called after a successful save so parent can refresh if needed. */
+  onSaved?: () => void;
+}
+
+export default function LayerEditor(props: LayerEditorProps) {
+  const [activeLayer, setActiveLayer] = createSignal<LayerName>('channel');
+  const [content, setContent] = createSignal('');
+  const [originalContent, setOriginalContent] = createSignal('');
+  const [saving, setSaving] = createSignal(false);
+
+  createEffect(
+    on(
+      () => [props.layers, activeLayer()] as const,
+      ([layers, layer]) => {
+        const info = layers[layer];
+        const text = info?.content ?? '';
+        setOriginalContent(text);
+        setContent(text);
+      },
+    ),
+  );
+
+  const dirty = () => content() !== originalContent();
+
+  function layerPath(): string | null {
+    return props.layers[activeLayer()]?.path ?? null;
+  }
+
+  function layerExists(layer: LayerName): boolean {
+    return props.layers[layer]?.exists ?? false;
+  }
+
+  async function save() {
+    const path = layerPath();
+    if (!path || !dirty()) return;
+    setSaving(true);
+    try {
+      await api.writeContextFile(path, content());
+      setOriginalContent(content());
+      showToast('Saved', 'success');
+      props.onSaved?.();
+    } catch (err) {
+      showToast(
+        `Save failed: ${err instanceof Error ? err.message : String(err)}`,
+        'error',
+      );
+    } finally {
+      setSaving(false);
+    }
+  }
+
+  function revert() {
+    setContent(originalContent());
+  }
+
+  function handleKeyDown(e: KeyboardEvent) {
+    if ((e.metaKey || e.ctrlKey) && e.key === 's') {
+      e.preventDefault();
+      if (dirty()) save();
+    }
+  }
+
+  return (
+    <div class="flex flex-col flex-1 min-h-0">
+      {/* Layer tabs */}
+      <div class="flex gap-1 px-4 py-2 border-b border-border bg-surface">
+        <For each={LAYER_TABS}>
+          {(tab) => (
+            <button
+              class={`flex items-center gap-1.5 px-3 py-1 rounded text-xs transition-colors ${
+                activeLayer() === tab.key
+                  ? 'bg-accent/20 text-accent'
+                  : 'text-text-dim hover:text-text hover:bg-surface-2'
+              }`}
+              onClick={() => setActiveLayer(tab.key)}
+            >
+              <span
+                class={`inline-block w-1.5 h-1.5 rounded-full ${
+                  layerExists(tab.key) ? 'bg-green' : 'bg-text-dim/30'
+                }`}
+              />
+              {tab.label}
+            </button>
+          )}
+        </For>
+      </div>
+
+      {/* Path display */}
+      <div class="px-4 py-1.5 text-xs text-text-dim border-b border-border bg-surface font-mono">
+        <Show
+          when={layerPath()}
+          fallback={<span>No path for this layer</span>}
+        >
+          {(path) => (
+            <span>
+              {path()}/CLAUDE.md
+              <span class={`ml-2 ${layerExists(activeLayer()) ? 'text-green' : 'text-yellow'}`}>
+                ({layerExists(activeLayer()) ? 'exists' : 'new'})
+              </span>
+            </span>
+          )}
+        </Show>
+      </div>
+
+      {/* Textarea editor */}
+      <div class="flex-1 min-h-0 overflow-hidden">
+        <textarea
+          class="w-full h-full resize-none p-4 bg-bg text-text text-sm font-mono leading-relaxed border-none outline-none"
+          value={content()}
+          onInput={(e) => setContent(e.currentTarget.value)}
+          onKeyDown={handleKeyDown}
+          placeholder={layerPath() ? 'Enter context content...' : 'No path available for this layer'}
+          disabled={!layerPath()}
+          spellcheck={false}
+        />
+      </div>
+
+      {/* Save bar */}
+      <div class="flex items-center justify-between px-4 py-2 border-t border-border bg-surface">
+        <span
+          class={`text-xs ${saving() || dirty() ? 'text-yellow' : 'text-text-dim'}`}
+        >
+          {saving() ? 'Saving...' : dirty() ? 'Unsaved changes' : 'No changes'}
+        </span>
+        <div class="flex gap-2">
+          <button
+            class="px-3 py-1 rounded text-xs bg-surface-2 text-text-dim hover:text-text transition-colors disabled:opacity-40 disabled:cursor-default"
+            disabled={!dirty()}
+            onClick={revert}
+          >
+            Revert
+          </button>
+          <button
+            class="px-3 py-1 rounded text-xs bg-accent/20 text-accent hover:bg-accent/30 transition-colors disabled:opacity-40 disabled:cursor-default"
+            disabled={!dirty() || saving() || !layerPath()}
+            onClick={save}
+          >
+            Save
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/webui/src/components/context/LayerEditor.tsx
+++ b/webui/src/components/context/LayerEditor.tsx
@@ -14,12 +14,14 @@ const LAYER_TABS: { key: LayerName; label: string }[] = [
 
 interface LayerEditorProps {
   layers: ContextLayers;
+  initialLayer?: LayerName;
+  onLayerChange?: (layer: LayerName) => void;
   /** Called after a successful save so parent can refresh if needed. */
   onSaved?: () => void;
 }
 
 export default function LayerEditor(props: LayerEditorProps) {
-  const [activeLayer, setActiveLayer] = createSignal<LayerName>('channel');
+  const [activeLayer, setActiveLayer] = createSignal<LayerName>(props.initialLayer ?? 'channel');
   const [content, setContent] = createSignal('');
   const [originalContent, setOriginalContent] = createSignal('');
   const [saving, setSaving] = createSignal(false);
@@ -88,7 +90,10 @@ export default function LayerEditor(props: LayerEditorProps) {
                   ? 'bg-accent/20 text-accent'
                   : 'text-text-dim hover:text-text hover:bg-surface-2'
               }`}
-              onClick={() => setActiveLayer(tab.key)}
+              onClick={() => {
+                setActiveLayer(tab.key);
+                props.onLayerChange?.(tab.key);
+              }}
             >
               <span
                 class={`inline-block w-1.5 h-1.5 rounded-full ${

--- a/webui/src/routes/(shell)/context.tsx
+++ b/webui/src/routes/(shell)/context.tsx
@@ -1,10 +1,192 @@
 import { Title } from '@solidjs/meta';
+import { createSignal, createResource, onMount, For, Show } from 'solid-js';
+
+import { api, type AgentChannelData } from '~/lib/api';
+import LayerEditor from '~/components/context/LayerEditor';
+
+interface SelectedChannel {
+  agentId: string;
+  agentName: string;
+  jid: string;
+  displayName: string;
+  folder: string;
+  serverFolder: string;
+  agentContextFolder: string;
+  channelFolder: string;
+  categoryFolder: string;
+}
 
 export default function Context() {
+  const [mounted, setMounted] = createSignal(false);
+  onMount(() => setMounted(true));
+  const [agents] = createResource(mounted, () => api.getAgents());
+  const [selected, setSelected] = createSignal<SelectedChannel | null>(null);
+  const [expandedAgents, setExpandedAgents] = createSignal<Set<string>>(
+    new Set(),
+  );
+
+  const [layers, { refetch: refetchLayers }] = createResource(
+    selected,
+    async (sel) => {
+      if (!sel) return null;
+      return api.getContextLayers({
+        folder: sel.folder,
+        server_folder: sel.serverFolder,
+        agent_context_folder: sel.agentContextFolder,
+        channel_folder: sel.channelFolder,
+        category_folder: sel.categoryFolder,
+      });
+    },
+  );
+
+  function toggleAgent(agentId: string) {
+    setExpandedAgents((prev) => {
+      const next = new Set(prev);
+      if (next.has(agentId)) next.delete(agentId);
+      else next.add(agentId);
+      return next;
+    });
+  }
+
+  function selectChannel(agent: AgentChannelData, channel: AgentChannelData['channels'][0]) {
+    setExpandedAgents((prev) => {
+      const next = new Set(prev);
+      next.add(agent.id);
+      return next;
+    });
+
+    setSelected({
+      agentId: agent.id,
+      agentName: agent.name,
+      jid: channel.jid,
+      displayName: channel.displayName,
+      folder: agent.folder,
+      serverFolder: agent.serverFolder ?? '',
+      agentContextFolder: agent.agentContextFolder ?? '',
+      channelFolder: channel.channelFolder ?? '',
+      categoryFolder: channel.categoryFolder ?? '',
+    });
+  }
+
+  function isChannelSelected(agentId: string, jid: string): boolean {
+    const sel = selected();
+    return sel !== null && sel.agentId === agentId && sel.jid === jid;
+  }
+
   return (
     <>
       <Title>OmniClaw — Context</Title>
-      <div class="p-4 text-text-dim">Context</div>
+      <div class="flex h-full min-h-0">
+        {/* Sidebar: agent/channel list */}
+        <aside class="w-64 shrink-0 border-r border-border bg-surface overflow-y-auto">
+          <div class="px-3 py-2 text-xs font-semibold text-text-dim uppercase tracking-wider">
+            Agents & Channels
+          </div>
+          <Show
+            when={agents() && agents()!.length > 0}
+            fallback={
+              <div class="px-3 py-4 text-xs text-text-dim">
+                No agents found.
+              </div>
+            }
+          >
+            <For each={agents()}>
+              {(agent) => (
+                <div>
+                  <button
+                    class="flex items-center gap-1.5 w-full px-3 py-1.5 text-left text-xs hover:bg-surface-2 transition-colors"
+                    onClick={() => toggleAgent(agent.id)}
+                  >
+                    <span
+                      class={`text-[10px] text-text-dim transition-transform ${
+                        expandedAgents().has(agent.id) ? 'rotate-90' : ''
+                      }`}
+                    >
+                      &#9654;
+                    </span>
+                    <span class="font-medium text-text truncate">
+                      {agent.name}
+                    </span>
+                    <span class="ml-auto text-text-dim">
+                      {agent.channels.length}
+                    </span>
+                  </button>
+                  <Show when={expandedAgents().has(agent.id)}>
+                    <div class="pl-5">
+                      <For each={agent.channels}>
+                        {(channel) => (
+                          <button
+                            class={`block w-full text-left px-2 py-1 text-xs truncate transition-colors rounded ${
+                              isChannelSelected(agent.id, channel.jid)
+                                ? 'bg-accent/20 text-accent'
+                                : 'text-text-dim hover:text-text hover:bg-surface-2'
+                            }`}
+                            onClick={() => selectChannel(agent, channel)}
+                            title={channel.jid}
+                          >
+                            {channel.displayName}
+                          </button>
+                        )}
+                      </For>
+                    </div>
+                  </Show>
+                </div>
+              )}
+            </For>
+          </Show>
+        </aside>
+
+        {/* Main content area */}
+        <div class="flex-1 flex flex-col min-h-0">
+          <Show
+            when={selected()}
+            fallback={
+              <div class="flex-1 flex items-center justify-center">
+                <div class="text-center text-text-dim">
+                  <div class="text-4xl mb-2">&#128196;</div>
+                  <div class="text-sm font-medium">
+                    Select a channel to view its context layers
+                  </div>
+                  <div class="text-xs mt-1">
+                    Click an agent, then choose a channel
+                  </div>
+                </div>
+              </div>
+            }
+          >
+            {(sel) => (
+              <>
+                {/* Header */}
+                <div class="px-4 py-2 border-b border-border bg-surface">
+                  <div class="text-sm font-medium text-text">
+                    {sel().displayName}
+                  </div>
+                  <div class="text-xs text-text-dim">
+                    {sel().agentName} &mdash; {sel().jid}
+                  </div>
+                </div>
+
+                {/* Layer editor */}
+                <Show
+                  when={!layers.loading && layers()}
+                  fallback={
+                    <div class="flex-1 flex items-center justify-center text-text-dim text-sm">
+                      Loading layers...
+                    </div>
+                  }
+                >
+                  {(layerData) => (
+                    <LayerEditor
+                      layers={layerData()}
+                      onSaved={() => refetchLayers()}
+                    />
+                  )}
+                </Show>
+              </>
+            )}
+          </Show>
+        </div>
+      </div>
     </>
   );
 }

--- a/webui/src/routes/(shell)/context.tsx
+++ b/webui/src/routes/(shell)/context.tsx
@@ -1,8 +1,11 @@
 import { Title } from '@solidjs/meta';
-import { createSignal, createResource, onMount, For, Show } from 'solid-js';
+import { useSearchParams } from '@solidjs/router';
+import { createSignal, createResource, createEffect, onMount, For, Show } from 'solid-js';
 
 import { api, type AgentChannelData } from '~/lib/api';
 import LayerEditor from '~/components/context/LayerEditor';
+
+type LayerName = 'channel' | 'category' | 'server' | 'agent';
 
 interface SelectedChannel {
   agentId: string;
@@ -17,6 +20,7 @@ interface SelectedChannel {
 }
 
 export default function Context() {
+  const [searchParams, setSearchParams] = useSearchParams();
   const [mounted, setMounted] = createSignal(false);
   onMount(() => setMounted(true));
   const [agents] = createResource(mounted, () => api.getAgents());
@@ -24,6 +28,31 @@ export default function Context() {
   const [expandedAgents, setExpandedAgents] = createSignal<Set<string>>(
     new Set(),
   );
+
+  // Restore selection from URL params once agents load
+  createEffect(() => {
+    const list = agents();
+    if (!list || selected()) return;
+    const agentParam = searchParams.agent as string | undefined;
+    const channelParam = searchParams.channel as string | undefined;
+    if (!agentParam || !channelParam) return;
+    const agent = list.find((a) => a.id === agentParam);
+    if (!agent) return;
+    const channel = agent.channels.find((c) => c.jid === channelParam);
+    if (!channel) return;
+    setExpandedAgents(new Set([agent.id]));
+    setSelected({
+      agentId: agent.id,
+      agentName: agent.name,
+      jid: channel.jid,
+      displayName: channel.displayName,
+      folder: agent.folder,
+      serverFolder: agent.serverFolder ?? '',
+      agentContextFolder: agent.agentContextFolder ?? '',
+      channelFolder: channel.channelFolder ?? '',
+      categoryFolder: channel.categoryFolder ?? '',
+    });
+  });
 
   const [layers, { refetch: refetchLayers }] = createResource(
     selected,
@@ -66,6 +95,18 @@ export default function Context() {
       channelFolder: channel.channelFolder ?? '',
       categoryFolder: channel.categoryFolder ?? '',
     });
+
+    setSearchParams({ agent: agent.id, channel: channel.jid });
+  }
+
+  function handleLayerChange(layer: LayerName) {
+    setSearchParams({ layer: layer === 'channel' ? undefined : layer });
+  }
+
+  function initialLayer(): LayerName {
+    const p = searchParams.layer as string | undefined;
+    if (p === 'category' || p === 'server' || p === 'agent') return p;
+    return 'channel';
   }
 
   function isChannelSelected(agentId: string, jid: string): boolean {
@@ -178,6 +219,8 @@ export default function Context() {
                   {(layerData) => (
                     <LayerEditor
                       layers={layerData()}
+                      initialLayer={initialLayer()}
+                      onLayerChange={handleLayerChange}
                       onSaved={() => refetchLayers()}
                     />
                   )}


### PR DESCRIPTION
## Summary
- Port the context viewer from Datastar SSE to SolidStart
- Left sidebar lists agents with expandable channel groups, fetched from `/api/agents`
- Selecting a channel loads 4 context layers (channel, category, server, agent) via `/api/context/layers`
- LayerEditor component with tab switching, textarea editing, save/revert, Cmd+S, and toast notifications
- Exists/new indicators per layer, path display, disabled state for missing layers

## Test plan
- [x] Context page renders agent list in sidebar
- [x] Clicking agent expands channel list with correct count
- [x] Clicking channel loads layers and displays in editor
- [x] Tab switching between channel/category/server/agent layers works
- [x] Disabled textarea shown for layers without paths
- [x] Unit tests pass (1313/1315, 2 flaky SSE tests unrelated)
- [x] E2E verified in Chrome via simtest

🤖 Generated with [Claude Code](https://claude.com/claude-code)