### PR TITLE
feat(webui): System + Settings pages — SolidStart migration

### DIFF
--- a/webui/src/components/shared/MetricCard.tsx
+++ b/webui/src/components/shared/MetricCard.tsx
@@ -1,0 +1,39 @@
+import type { JSX } from 'solid-js';
+
+import Badge from './Badge';
+
+export function MetricRow(props: { label: string; value: string }) {
+  return (
+    <div class="flex justify-between items-center py-1.5 border-b border-border/50 last:border-b-0">
+      <span class="text-text-dim text-xs">{props.label}</span>
+      <span class="text-text-bright text-xs font-medium">{props.value}</span>
+    </div>
+  );
+}
+
+export function BooleanRow(props: {
+  label: string;
+  value: boolean;
+  onLabel?: string;
+  offLabel?: string;
+}) {
+  return (
+    <div class="flex justify-between items-center py-1.5 border-b border-border/50 last:border-b-0">
+      <span class="text-text-dim text-xs">{props.label}</span>
+      <Badge variant={props.value ? 'active' : 'completed'}>
+        {props.value ? (props.onLabel ?? 'enabled') : (props.offLabel ?? 'disabled')}
+      </Badge>
+    </div>
+  );
+}
+
+export function MetricCard(props: { title: string; children: JSX.Element }) {
+  return (
+    <div class="bg-surface rounded-lg border border-border p-4">
+      <div class="text-text-dim text-xs uppercase tracking-wider mb-3 font-medium">
+        {props.title}
+      </div>
+      {props.children}
+    </div>
+  );
+}

--- a/webui/src/routes/(shell)/settings.tsx
+++ b/webui/src/routes/(shell)/settings.tsx
@@ -1,10 +1,206 @@
 import { Title } from '@solidjs/meta';
+import { query, createAsync } from '@solidjs/router';
+import { Show } from 'solid-js';
+
+import Badge from '~/components/shared/Badge';
+import { BooleanRow, MetricCard, MetricRow } from '~/components/shared/MetricCard';
+import { api } from '~/lib/api';
+
+const fetchSettings = query(() => api.getSettings(), 'settings');
+
+function formatMs(ms: number): string {
+  if (ms < 1000) return `${ms}ms`;
+  const seconds = ms / 1000;
+  if (seconds < 60) return `${seconds}s`;
+  const minutes = seconds / 60;
+  if (minutes < 60) return `${Math.round(minutes)}m`;
+  const hours = minutes / 60;
+  return `${Math.round(hours * 10) / 10}h`;
+}
+
+function formatBytes(bytes: number): string {
+  if (bytes < 1024) return `${bytes} B`;
+  const kb = bytes / 1024;
+  if (kb < 1024) return `${Math.round(kb)} KB`;
+  const mb = kb / 1024;
+  return `${Math.round(mb * 10) / 10} MB`;
+}
 
 export default function Settings() {
+  const settings = createAsync(() => fetchSettings());
+
   return (
     <>
       <Title>OmniClaw — Settings</Title>
-      <div class="p-4 text-text-dim">Settings</div>
+      <div class="p-6">
+        <div class="flex items-center gap-3 mb-6">
+          <h2 class="text-text-bright text-lg font-medium">settings</h2>
+          <Badge variant="default">read-only</Badge>
+        </div>
+
+        <Show
+          when={settings()}
+          fallback={<div class="text-text-dim">Loading...</div>}
+        >
+          {(s) => (
+            <div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4">
+              <MetricCard title="general">
+                <MetricRow label="timezone" value={s().general.timezone} />
+                <MetricRow
+                  label="model override"
+                  value={s().general.anthropicModel ?? 'default'}
+                />
+                <MetricRow label="local runtime" value={s().general.localRuntime} />
+              </MetricCard>
+
+              <MetricCard title="web ui">
+                <MetricRow
+                  label="port"
+                  value={s().webUi.port != null ? String(s().webUi.port) : 'disabled'}
+                />
+                <MetricRow label="hostname" value={s().webUi.hostname} />
+                <BooleanRow label="auth" value={s().webUi.authEnabled} />
+                <MetricRow
+                  label="cors origin"
+                  value={s().webUi.corsOrigin ?? 'disabled'}
+                />
+              </MetricCard>
+
+              <MetricCard title="containers">
+                <MetricRow label="image" value={s().containers.image} />
+                <MetricRow label="memory" value={s().containers.memory} />
+                <MetricRow label="timeout" value={formatMs(s().containers.timeoutMs)} />
+                <MetricRow
+                  label="startup timeout"
+                  value={formatMs(s().containers.startupTimeoutMs)}
+                />
+                <MetricRow
+                  label="idle timeout"
+                  value={formatMs(s().containers.idleTimeoutMs)}
+                />
+                <MetricRow
+                  label="max output"
+                  value={formatBytes(s().containers.maxOutputSize)}
+                />
+                <MetricRow label="max active" value={String(s().containers.maxActive)} />
+                <MetricRow label="max idle" value={String(s().containers.maxIdle)} />
+                <MetricRow label="max task" value={String(s().containers.maxTask)} />
+              </MetricCard>
+
+              <MetricCard title="channels">
+                <MetricRow
+                  label="discord bots"
+                  value={String(s().channels.discordBots)}
+                />
+                <Show when={s().channels.discordBotIds.length > 0}>
+                  <MetricRow
+                    label="discord bot ids"
+                    value={s().channels.discordBotIds.join(', ')}
+                  />
+                </Show>
+                <Show when={s().channels.discordDefaultBot}>
+                  {(bot) => (
+                    <MetricRow label="discord default" value={bot()} />
+                  )}
+                </Show>
+                <MetricRow
+                  label="telegram bots"
+                  value={String(s().channels.telegramBots)}
+                />
+                <MetricRow
+                  label="slack bots"
+                  value={String(s().channels.slackBots)}
+                />
+                <Show when={s().channels.slackDefaultBot}>
+                  {(bot) => (
+                    <MetricRow label="slack default" value={bot()} />
+                  )}
+                </Show>
+              </MetricCard>
+
+              <MetricCard title="scheduling">
+                <MetricRow
+                  label="session max age"
+                  value={formatMs(s().scheduling.sessionMaxAgeMs)}
+                />
+                <BooleanRow
+                  label="persistent state"
+                  value={s().scheduling.persistentTaskState}
+                  onLabel="on"
+                  offLabel="off"
+                />
+                <MetricRow
+                  label="poll interval"
+                  value={formatMs(s().scheduling.pollIntervalMs)}
+                />
+              </MetricCard>
+
+              <MetricCard title="roster">
+                <MetricRow label="scope" value={s().roster.scope} />
+                <MetricRow
+                  label="role filters"
+                  value={
+                    s().roster.roleFilters.length > 0
+                      ? s().roster.roleFilters.join(', ')
+                      : 'none'
+                  }
+                />
+                <MetricRow
+                  label="cache ttl"
+                  value={formatMs(s().roster.cacheTtlMs)}
+                />
+                <MetricRow
+                  label="refresh interval"
+                  value={formatMs(s().roster.refreshIntervalMs)}
+                />
+              </MetricCard>
+
+              <MetricCard title="discovery">
+                <BooleanRow
+                  label="enabled"
+                  value={s().discovery.enabled}
+                  onLabel="yes"
+                  offLabel="no"
+                />
+                <MetricRow
+                  label="instance name"
+                  value={s().discovery.instanceName}
+                />
+                <BooleanRow
+                  label="trust lan admin"
+                  value={s().discovery.trustLanAdmin}
+                  onLabel="yes"
+                  offLabel="no"
+                />
+              </MetricCard>
+
+              <MetricCard title="github">
+                <MetricRow
+                  label="webhook port"
+                  value={
+                    s().github.webhookPort > 0
+                      ? String(s().github.webhookPort)
+                      : 'disabled'
+                  }
+                />
+                <MetricRow label="webhook path" value={s().github.webhookPath} />
+                <BooleanRow
+                  label="webhook secret"
+                  value={s().github.secretConfigured}
+                  onLabel="configured"
+                  offLabel="not set"
+                />
+              </MetricCard>
+
+              <MetricCard title="paths">
+                <MetricRow label="store" value={s().paths.store} />
+                <MetricRow label="groups" value={s().paths.groups} />
+                <MetricRow label="data" value={s().paths.data} />
+              </MetricCard>
+            </div>
+          )}
+        </Show>
+      </div>
     </>
   );
 }

--- a/webui/src/routes/(shell)/system.tsx
+++ b/webui/src/routes/(shell)/system.tsx
@@ -1,10 +1,147 @@
 import { Title } from '@solidjs/meta';
+import { query, createAsync, revalidate } from '@solidjs/router';
+import { For, Show, onCleanup } from 'solid-js';
+
+import Badge from '~/components/shared/Badge';
+import { MetricCard, MetricRow } from '~/components/shared/MetricCard';
+import { api } from '~/lib/api';
+
+const fetchHealth = query(() => api.getHealth(), 'health');
+
+function formatUptime(seconds: number): string {
+  const d = Math.floor(seconds / 86400);
+  const h = Math.floor((seconds % 86400) / 3600);
+  const m = Math.floor((seconds % 3600) / 60);
+  const s = seconds % 60;
+  const parts: string[] = [];
+  if (d > 0) parts.push(`${d}d`);
+  if (h > 0) parts.push(`${h}h`);
+  if (m > 0) parts.push(`${m}m`);
+  parts.push(`${s}s`);
+  return parts.join(' ');
+}
+
+function BreakdownList(props: { items: Record<string, number> }) {
+  const sorted = () =>
+    Object.entries(props.items).sort((a, b) => b[1] - a[1]);
+
+  return (
+    <For each={sorted()}>
+      {(entry) => (
+        <div class="flex justify-between items-center py-1 pl-2">
+          <span class="text-text-dim text-xs">{entry[0]}</span>
+          <span class="text-text text-xs">{entry[1]}</span>
+        </div>
+      )}
+    </For>
+  );
+}
 
 export default function System() {
+  const health = createAsync(() => fetchHealth());
+
+  const interval = setInterval(() => void revalidate('health'), 5000);
+  onCleanup(() => clearInterval(interval));
+
   return (
     <>
       <Title>OmniClaw — System</Title>
-      <div class="p-4 text-text-dim">System</div>
+      <div class="p-6">
+        <div class="flex items-center gap-3 mb-6">
+          <h2 class="text-text-bright text-lg font-medium">system health</h2>
+          <Show when={health()}>
+            {(h) => <Badge variant="active">{h().status}</Badge>}
+          </Show>
+        </div>
+
+        <Show
+          when={health()}
+          fallback={<div class="text-text-dim">Loading...</div>}
+        >
+          {(h) => (
+            <div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4">
+              <MetricCard title="server">
+                <MetricRow label="version" value={h().version} />
+                <MetricRow
+                  label="uptime"
+                  value={formatUptime(h().uptime_seconds)}
+                />
+                <MetricRow
+                  label="started"
+                  value={new Date(h().started_at).toLocaleString()}
+                />
+                <MetricRow
+                  label="sse clients"
+                  value={String(h().sse_clients)}
+                />
+              </MetricCard>
+
+              <MetricCard title="runtime">
+                <MetricRow label="bun" value={h().runtime.bun} />
+                <MetricRow label="platform" value={h().runtime.platform} />
+                <MetricRow label="arch" value={h().runtime.arch} />
+              </MetricCard>
+
+              <MetricCard title="memory">
+                <MetricRow label="rss" value={`${h().memory.rss_mb} MB`} />
+                <MetricRow
+                  label="heap used"
+                  value={`${h().memory.heap_used_mb} MB`}
+                />
+                <MetricRow
+                  label="heap total"
+                  value={`${h().memory.heap_total_mb} MB`}
+                />
+              </MetricCard>
+
+              <MetricCard title="containers">
+                <MetricRow
+                  label="active"
+                  value={`${h().containers.active}/${h().containers.max_active}`}
+                />
+                <MetricRow
+                  label="idle"
+                  value={`${h().containers.idle}/${h().containers.max_idle}`}
+                />
+              </MetricCard>
+
+              <MetricCard title="agents">
+                <MetricRow
+                  label="total"
+                  value={String(h().agents.total)}
+                />
+                <div class="text-text-dim text-[10px] uppercase tracking-wider mt-2 mb-1">
+                  by backend
+                </div>
+                <BreakdownList items={h().agents.by_backend} />
+                <div class="text-text-dim text-[10px] uppercase tracking-wider mt-2 mb-1">
+                  by runtime
+                </div>
+                <BreakdownList items={h().agents.by_runtime} />
+              </MetricCard>
+
+              <MetricCard title="tasks">
+                <MetricRow
+                  label="active"
+                  value={String(h().tasks.active)}
+                />
+                <MetricRow
+                  label="paused"
+                  value={String(h().tasks.paused)}
+                />
+                <MetricRow
+                  label="completed"
+                  value={String(h().tasks.completed)}
+                />
+                <MetricRow
+                  label="total"
+                  value={String(h().tasks.total)}
+                />
+              </MetricCard>
+            </div>
+          )}
+        </Show>
+      </div>
     </>
   );
 }


### PR DESCRIPTION
## Summary
- Port System health page with auto-refresh polling, formatted metrics
- Port Settings page with read-only config display, masked sensitive values
- Extract shared `MetricCard` component used by both pages

## Test plan
- [x] Simplify review pass completed
- [ ] Verify `/system` and `/settings` render with simtest data

🤖 Generated with [Claude Code](https://claude.com/claude-code)