### PR TITLE
feat(webui): Conversations page — SolidStart migration

### DIFF
--- a/webui/src/components/conversations/ChatList.tsx
+++ b/webui/src/components/conversations/ChatList.tsx
@@ -1,4 +1,4 @@
-import { createSignal, createMemo, For, Show } from 'solid-js';
+import { createSignal, createMemo, onMount, For, Show } from 'solid-js';
 import type { ChatInfo, MessageInfo } from '~/lib/api';
 
 type TabMode = 'filter' | 'search';
@@ -6,12 +6,15 @@ type TabMode = 'filter' | 'search';
 export default function ChatList(props: {
   chats: ChatInfo[];
   selectedJid: string | null;
+  initialSearchQuery?: string | null;
   onSelect: (jid: string) => void;
   onSearch: (query: string) => Promise<MessageInfo[]>;
+  onSearchQueryChange?: (query: string | null) => void;
 }) {
-  const [mode, setMode] = createSignal<TabMode>('filter');
+  const hasInitQuery = !!props.initialSearchQuery;
+  const [mode, setMode] = createSignal<TabMode>(hasInitQuery ? 'search' : 'filter');
   const [filterText, setFilterText] = createSignal('');
-  const [searchText, setSearchText] = createSignal('');
+  const [searchText, setSearchText] = createSignal(props.initialSearchQuery ?? '');
   const [searchResults, setSearchResults] = createSignal<MessageInfo[]>([]);
   const [searching, setSearching] = createSignal(false);
   const [searchDone, setSearchDone] = createSignal(false);
@@ -57,8 +60,13 @@ export default function ChatList(props: {
       });
   }
 
+  onMount(() => {
+    if (hasInitQuery) doSearch(props.initialSearchQuery!);
+  });
+
   function handleSearchInput(value: string) {
     setSearchText(value);
+    props.onSearchQueryChange?.(value.trim() || null);
     if (searchTimer) clearTimeout(searchTimer);
     if (!value.trim()) {
       setSearchResults([]);
@@ -78,6 +86,7 @@ export default function ChatList(props: {
 
   function handleResultClick(jid: string) {
     setMode('filter');
+    props.onSearchQueryChange?.(null);
     props.onSelect(jid);
   }
 

--- a/webui/src/components/conversations/ChatList.tsx
+++ b/webui/src/components/conversations/ChatList.tsx
@@ -1,0 +1,216 @@
+import { createSignal, createMemo, For, Show } from 'solid-js';
+import type { ChatInfo, MessageInfo } from '~/lib/api';
+
+type TabMode = 'filter' | 'search';
+
+export default function ChatList(props: {
+  chats: ChatInfo[];
+  selectedJid: string | null;
+  onSelect: (jid: string) => void;
+  onSearch: (query: string) => Promise<MessageInfo[]>;
+}) {
+  const [mode, setMode] = createSignal<TabMode>('filter');
+  const [filterText, setFilterText] = createSignal('');
+  const [searchText, setSearchText] = createSignal('');
+  const [searchResults, setSearchResults] = createSignal<MessageInfo[]>([]);
+  const [searching, setSearching] = createSignal(false);
+  const [searchDone, setSearchDone] = createSignal(false);
+
+  let searchTimer: ReturnType<typeof setTimeout> | undefined;
+  let searchToken = 0;
+
+  const filteredChats = createMemo(() => {
+    const q = filterText().toLowerCase();
+    if (!q) return props.chats;
+    return props.chats.filter(
+      (c) =>
+        (c.name || c.jid).toLowerCase().includes(q) ||
+        c.jid.toLowerCase().includes(q),
+    );
+  });
+
+  function doSearch(query: string) {
+    const trimmed = query.trim();
+    if (!trimmed) {
+      setSearchResults([]);
+      setSearchDone(false);
+      return;
+    }
+    searchToken += 1;
+    const token = searchToken;
+    setSearching(true);
+    setSearchDone(false);
+    props
+      .onSearch(trimmed)
+      .then((results) => {
+        if (token !== searchToken) return;
+        setSearchResults(results);
+        setSearchDone(true);
+      })
+      .catch(() => {
+        if (token !== searchToken) return;
+        setSearchResults([]);
+        setSearchDone(true);
+      })
+      .finally(() => {
+        if (token === searchToken) setSearching(false);
+      });
+  }
+
+  function handleSearchInput(value: string) {
+    setSearchText(value);
+    if (searchTimer) clearTimeout(searchTimer);
+    if (!value.trim()) {
+      setSearchResults([]);
+      setSearchDone(false);
+      return;
+    }
+    searchTimer = setTimeout(() => doSearch(value), 300);
+  }
+
+  function handleSearchKeyDown(e: KeyboardEvent) {
+    if (e.key === 'Enter') {
+      e.preventDefault();
+      if (searchTimer) clearTimeout(searchTimer);
+      doSearch(searchText());
+    }
+  }
+
+  function handleResultClick(jid: string) {
+    setMode('filter');
+    props.onSelect(jid);
+  }
+
+  function buildSnippet(text: string, query: string): string {
+    const lower = text.toLowerCase();
+    const ql = query.toLowerCase();
+    const idx = lower.indexOf(ql);
+    if (idx === -1) return text.length > 120 ? text.slice(0, 117) + '\u2026' : text;
+    const start = Math.max(0, idx - 40);
+    const end = Math.min(text.length, start + 120);
+    let snippet = text.slice(start, end);
+    if (start > 0) snippet = '\u2026' + snippet;
+    if (end < text.length) snippet = snippet + '\u2026';
+    return snippet;
+  }
+
+  return (
+    <aside class="w-64 shrink-0 border-r border-border flex flex-col bg-surface">
+      <div class="p-2 border-b border-border">
+        <div class="flex mb-1.5">
+          <button
+            class={`flex-1 py-1 text-[10px] font-mono border border-border cursor-pointer transition-all rounded-l ${
+              mode() === 'filter'
+                ? 'bg-accent/10 text-accent border-accent'
+                : 'bg-bg text-text-dim'
+            }`}
+            onClick={() => setMode('filter')}
+          >
+            filter
+          </button>
+          <button
+            class={`flex-1 py-1 text-[10px] font-mono border border-border border-l-0 cursor-pointer transition-all rounded-r ${
+              mode() === 'search'
+                ? 'bg-accent/10 text-accent border-accent'
+                : 'bg-bg text-text-dim'
+            }`}
+            onClick={() => setMode('search')}
+          >
+            search
+          </button>
+        </div>
+        <Show when={mode() === 'filter'}>
+          <input
+            type="text"
+            placeholder="filter chats\u2026"
+            class="w-full py-1 px-2 bg-bg border border-border rounded text-text font-mono text-[11px] focus:outline-none focus:border-accent"
+            value={filterText()}
+            onInput={(e) => setFilterText(e.currentTarget.value)}
+          />
+        </Show>
+        <Show when={mode() === 'search'}>
+          <input
+            type="text"
+            placeholder="search messages\u2026"
+            class="w-full py-1 px-2 bg-bg border border-border rounded text-text font-mono text-[11px] focus:outline-none focus:border-accent"
+            value={searchText()}
+            onInput={(e) => handleSearchInput(e.currentTarget.value)}
+            onKeyDown={handleSearchKeyDown}
+          />
+        </Show>
+      </div>
+
+      <Show when={mode() === 'filter'}>
+        <div class="text-[10px] text-text-dim px-2.5 py-1.5 border-b border-border">
+          {filteredChats().length} chat{filteredChats().length !== 1 ? 's' : ''}
+        </div>
+        <div class="flex-1 overflow-y-auto">
+          <For each={filteredChats()} fallback={<div class="p-3 text-text-dim text-xs">No chats found</div>}>
+            {(chat) => (
+              <div
+                class={`px-2.5 py-2 cursor-pointer border-b border-border transition-colors hover:bg-accent/5 ${
+                  props.selectedJid === chat.jid
+                    ? 'bg-accent/5 border-l-2 border-l-accent'
+                    : ''
+                }`}
+                tabindex="0"
+                onClick={() => props.onSelect(chat.jid)}
+                onKeyDown={(e) => {
+                  if (e.key === 'Enter') props.onSelect(chat.jid);
+                }}
+              >
+                <div class="text-xs font-semibold text-text-bright truncate">{chat.name || chat.jid}</div>
+                <div class="text-[10px] text-text-dim truncate">{chat.jid}</div>
+                <div class="text-[10px] text-text-dim">
+                  {chat.last_message_time
+                    ? new Date(chat.last_message_time).toLocaleString()
+                    : '\u2014'}
+                </div>
+              </div>
+            )}
+          </For>
+        </div>
+      </Show>
+
+      <Show when={mode() === 'search'}>
+        <div class="flex-1 overflow-y-auto">
+          <Show when={searching()}>
+            <div class="text-[10px] text-text-dim px-2.5 py-1.5">searching\u2026</div>
+          </Show>
+          <Show when={searchDone() && !searching()}>
+            <div class="text-[10px] text-text-dim px-2.5 py-1.5">
+              {searchResults().length} result{searchResults().length !== 1 ? 's' : ''}
+            </div>
+          </Show>
+          <For each={searchResults()}>
+            {(result) => {
+              const snippet = () => buildSnippet(result.content || '', searchText());
+              return (
+                <div
+                  class="px-2.5 py-2 cursor-pointer border-b border-border transition-colors hover:bg-accent/5"
+                  tabindex="0"
+                  role="button"
+                  onClick={() => handleResultClick(result.chat_jid)}
+                  onKeyDown={(e) => {
+                    if (e.key === 'Enter' || e.key === ' ') {
+                      e.preventDefault();
+                      handleResultClick(result.chat_jid);
+                    }
+                  }}
+                >
+                  <div class="text-[10px] text-accent font-semibold mb-0.5">
+                    {result.sender_name || result.sender || 'Unknown'} in {result.chat_jid}
+                  </div>
+                  <div class="text-[11px] truncate">{snippet()}</div>
+                  <div class="text-[9px] text-text-dim mt-0.5">
+                    {new Date(result.timestamp).toLocaleString()}
+                  </div>
+                </div>
+              );
+            }}
+          </For>
+        </div>
+      </Show>
+    </aside>
+  );
+}

--- a/webui/src/components/conversations/MessageList.tsx
+++ b/webui/src/components/conversations/MessageList.tsx
@@ -1,0 +1,117 @@
+import { For, Show } from 'solid-js';
+import type { MessageInfo } from '~/lib/api';
+
+const MAX_TEXT_LENGTH = 2000;
+
+function isFromMe(msg: MessageInfo): boolean {
+  return msg.sender === 'me' || msg.sender === 'bot';
+}
+
+export default function MessageList(props: {
+  chatJid: string | null;
+  chatName: string;
+  messages: MessageInfo[];
+  loading: boolean;
+  hasMore: boolean;
+  onLoadMore: () => void;
+}) {
+  let containerRef: HTMLDivElement | undefined;
+
+  function scrollToBottom() {
+    if (containerRef) {
+      containerRef.scrollTop = containerRef.scrollHeight;
+    }
+  }
+
+  return (
+    <main class="flex-1 flex flex-col min-w-0">
+      <Show
+        when={props.chatJid}
+        fallback={
+          <div class="flex-1 flex items-center justify-center text-text-dim text-xs">
+            Select a conversation to view messages
+          </div>
+        }
+      >
+        <div class="px-3 py-2 border-b border-border flex items-center gap-2 bg-surface shrink-0">
+          <h2 class="text-[13px] font-semibold text-text-bright">{props.chatName}</h2>
+          <span class="text-[10px] text-text-dim">{props.chatJid}</span>
+          <span class="text-[10px] text-text-dim ml-auto">
+            {props.messages.length} msg{props.messages.length !== 1 ? 's' : ''}
+          </span>
+        </div>
+
+        <Show when={props.hasMore}>
+          <div class="flex justify-center py-2 border-b border-border">
+            <button
+              class="px-3 py-1 text-[11px] bg-surface-2 border border-border rounded text-text hover:bg-accent/10 hover:border-accent transition-colors"
+              onClick={() => props.onLoadMore()}
+            >
+              Load older
+            </button>
+          </div>
+        </Show>
+
+        <Show when={props.loading}>
+          <div class="flex-1 flex items-center justify-center text-text-dim text-xs">
+            Loading\u2026
+          </div>
+        </Show>
+        <Show when={!props.loading}>
+          <div
+            ref={(el) => {
+              containerRef = el;
+              requestAnimationFrame(scrollToBottom);
+            }}
+            class="flex-1 overflow-y-auto p-3 flex flex-col gap-2"
+          >
+            <Show
+              when={props.messages.length > 0}
+              fallback={<div class="text-text-dim text-xs text-center py-4">No messages</div>}
+            >
+              <For each={props.messages}>
+                {(msg) => {
+                  const fromMe = isFromMe(msg);
+                  const displayText = () => {
+                    const text = msg.content || '';
+                    return text.length > MAX_TEXT_LENGTH
+                      ? text.slice(0, MAX_TEXT_LENGTH) + '\u2026 [truncated]'
+                      : text;
+                  };
+
+                  return (
+                    <div
+                      class={`flex gap-2 max-w-[80%] ${fromMe ? 'self-end flex-row-reverse' : ''}`}
+                    >
+                      <div
+                        class={`border rounded-md px-2.5 py-1.5 min-w-0 ${
+                          fromMe
+                            ? 'bg-accent/10 border-accent/20'
+                            : 'bg-surface border-border'
+                        }`}
+                      >
+                        <div
+                          class={`text-[10px] font-semibold mb-0.5 ${
+                            fromMe ? 'text-accent-hover text-right' : 'text-accent'
+                          }`}
+                        >
+                          {msg.sender_name || msg.sender || 'Unknown'}
+                        </div>
+                        <div class="text-xs whitespace-pre-wrap break-words">{displayText()}</div>
+                        <div
+                          class={`text-[9px] text-text-dim mt-0.5 ${fromMe ? 'text-right' : ''}`}
+                        >
+                          {new Date(msg.timestamp).toLocaleString()}
+                        </div>
+                      </div>
+                    </div>
+                  );
+                }}
+              </For>
+            </Show>
+          </div>
+        </Show>
+      </Show>
+    </main>
+  );
+}

--- a/webui/src/routes/(shell)/conversations.tsx
+++ b/webui/src/routes/(shell)/conversations.tsx
@@ -1,10 +1,82 @@
+import { createSignal, createResource } from 'solid-js';
 import { Title } from '@solidjs/meta';
+import { useSearchParams } from '@solidjs/router';
+
+import { api, type MessageInfo } from '~/lib/api';
+import ChatList from '~/components/conversations/ChatList';
+import MessageList from '~/components/conversations/MessageList';
+
+const PAGE_SIZE = 100;
+const LOAD_MORE_LIMIT = 500;
+
+/** Extract first string from a search param that may be string | string[]. */
+function paramStr(val: string | string[] | undefined): string | null {
+  if (Array.isArray(val)) return val[0] ?? null;
+  return val ?? null;
+}
 
 export default function Conversations() {
+  const [searchParams, setSearchParams] = useSearchParams();
+  const initChat = paramStr(searchParams.chat);
+  const [selectedJid, setSelectedJid] = createSignal<string | null>(initChat);
+  const [messageLimit, setMessageLimit] = createSignal(PAGE_SIZE);
+
+  const [chats] = createResource(() => api.getChats());
+
+  const [messages, messagesActions] = createResource(
+    () => {
+      const jid = selectedJid();
+      if (!jid) return null;
+      return { jid, limit: messageLimit() };
+    },
+    (params) => {
+      if (!params) return [];
+      return api.getMessages(params.jid, undefined, params.limit);
+    },
+  );
+
+  function selectedChatName(): string {
+    const jid = selectedJid();
+    if (!jid) return '';
+    const chat = chats()?.find((c) => c.jid === jid);
+    return chat?.name || jid;
+  }
+
+  function handleSelectChat(jid: string) {
+    if (jid === selectedJid()) return;
+    setMessageLimit(PAGE_SIZE);
+    setSelectedJid(jid);
+    setSearchParams({ chat: jid });
+  }
+
+  function handleLoadMore() {
+    setMessageLimit(LOAD_MORE_LIMIT);
+    messagesActions.refetch();
+  }
+
+  async function handleSearch(query: string): Promise<MessageInfo[]> {
+    return api.searchMessages(query, undefined, 50);
+  }
+
   return (
     <>
       <Title>OmniClaw — Conversations</Title>
-      <div class="p-4 text-text-dim">Conversations</div>
+      <div class="flex flex-1 min-h-0 overflow-hidden">
+        <ChatList
+          chats={chats() ?? []}
+          selectedJid={selectedJid()}
+          onSelect={handleSelectChat}
+          onSearch={handleSearch}
+        />
+        <MessageList
+          chatJid={selectedJid()}
+          chatName={selectedChatName()}
+          messages={messages() ?? []}
+          loading={messages.loading}
+          hasMore={messageLimit() === PAGE_SIZE && (messages()?.length ?? 0) >= PAGE_SIZE}
+          onLoadMore={handleLoadMore}
+        />
+      </div>
     </>
   );
 }

--- a/webui/src/routes/(shell)/conversations.tsx
+++ b/webui/src/routes/(shell)/conversations.tsx
@@ -18,6 +18,7 @@ function paramStr(val: string | string[] | undefined): string | null {
 export default function Conversations() {
   const [searchParams, setSearchParams] = useSearchParams();
   const initChat = paramStr(searchParams.chat);
+  const initQuery = paramStr(searchParams.q);
   const [selectedJid, setSelectedJid] = createSignal<string | null>(initChat);
   const [messageLimit, setMessageLimit] = createSignal(PAGE_SIZE);
 
@@ -46,7 +47,14 @@ export default function Conversations() {
     if (jid === selectedJid()) return;
     setMessageLimit(PAGE_SIZE);
     setSelectedJid(jid);
-    setSearchParams({ chat: jid });
+    setSearchParams({ chat: jid, q: undefined });
+  }
+
+  function handleSearchQueryChange(query: string | null) {
+    setSearchParams({
+      q: query?.trim() || undefined,
+      chat: query ? undefined : selectedJid() || undefined,
+    });
   }
 
   function handleLoadMore() {
@@ -65,8 +73,10 @@ export default function Conversations() {
         <ChatList
           chats={chats() ?? []}
           selectedJid={selectedJid()}
+          initialSearchQuery={initQuery}
           onSelect={handleSelectChat}
           onSearch={handleSearch}
+          onSearchQueryChange={handleSearchQueryChange}
         />
         <MessageList
           chatJid={selectedJid()}


### PR DESCRIPTION
## Summary
- Port Conversations page with split-pane layout (chat list + message thread)
- `ChatList` and `MessageList` components with search and pagination
- Message search via `/api/messages/search`

## Test plan
- [x] Simplify review pass completed
- [ ] Verify `/conversations` renders with simtest data

🤖 Generated with [Claude Code](https://claude.com/claude-code)