### PR TITLE
fix: unblock web UI CI checks

### DIFF
--- a/src/web/solid-handler.ts
+++ b/src/web/solid-handler.ts
@@ -13,6 +13,8 @@ import { buildSettingsData } from './settings.js';
 import { buildAgentDetailData } from './agent-detail.js';
 import { listLocalContextFiles } from './context-files.js';
 import { logger } from '../logger.js';
+import path from 'node:path';
+import { pathToFileURL } from 'node:url';
 
 type SolidHandler = (req: Request) => Promise<Response>;
 
@@ -40,7 +42,11 @@ export async function initSolidHandler(
     process.env.HOST = '127.0.0.1';
 
     // Dynamically import the compiled SolidStart server
-    await import('../../webui/.output/server/index.mjs');
+    const solidServerEntry = path.join(
+      import.meta.dir,
+      '../../webui/.output/server/index.mjs',
+    );
+    await import(pathToFileURL(solidServerEntry).href);
 
     solidPort = internalPort;
     solidHandler = async (req: Request): Promise<Response> => {
@@ -61,10 +67,7 @@ export async function initSolidHandler(
       return resp;
     };
 
-    logger.info(
-      { solidPort: internalPort },
-      'SolidStart handler initialized',
-    );
+    logger.info({ solidPort: internalPort }, 'SolidStart handler initialized');
     return solidHandler;
   } catch (err) {
     logger.warn(
@@ -97,7 +100,9 @@ export function isMainProcessRoute(pathname: string): boolean {
  * Wrap the WebStateProvider with additional methods that
  * SolidStart API routes expect.
  */
-function createAugmentedState(state: WebStateProvider): Record<string, unknown> {
+function createAugmentedState(
+  state: WebStateProvider,
+): Record<string, unknown> {
   return Object.create(state, {
     getAgentChannelData: {
       value: () => buildAgentChannelData(state),

--- a/webui/src/components/LogPanel.tsx
+++ b/webui/src/components/LogPanel.tsx
@@ -38,7 +38,9 @@ export default function LogPanel() {
                   ? 'bg-surface-2 text-text'
                   : 'text-text-dim'
               }`}
-              onClick={() => setEnabledLevels((prev) => toggleLevelSet(prev, level))}
+              onClick={() =>
+                setEnabledLevels((prev) => toggleLevelSet(prev, level))
+              }
             >
               {level}
             </button>
@@ -54,9 +56,7 @@ export default function LogPanel() {
         </button>
       </div>
       <div ref={containerRef} class="flex-1 overflow-auto p-1 text-xs min-h-0">
-        <For each={filteredLogs()}>
-          {(line) => <LogLine line={line} />}
-        </For>
+        <For each={filteredLogs()}>{(line) => <LogLine line={line} />}</For>
       </div>
     </div>
   );

--- a/webui/src/components/TaskPanel.tsx
+++ b/webui/src/components/TaskPanel.tsx
@@ -20,7 +20,8 @@ export default function TaskPanel() {
       >
         <For each={tasks.list.slice(0, 50)}>
           {(task) => {
-            const agentShort = task.group_folder.split('-')[0] || task.group_folder;
+            const agentShort =
+              task.group_folder.split('-')[0] || task.group_folder;
             const promptShort =
               task.prompt.length > 40
                 ? task.prompt.slice(0, 40) + '\u2026'

--- a/webui/src/components/agents/AgentCard.tsx
+++ b/webui/src/components/agents/AgentCard.tsx
@@ -31,7 +31,10 @@ export default function AgentCard(props: AgentCardProps) {
   return (
     <tr class="border-b border-border hover:bg-surface-2/50 transition-colors">
       <td class="px-3 py-2">
-        <A href={detailHref()} class="flex items-center gap-2 text-text hover:text-accent-hover transition-colors">
+        <A
+          href={detailHref()}
+          class="flex items-center gap-2 text-text hover:text-accent-hover transition-colors"
+        >
           <span class="flex-shrink-0 w-7 h-7 rounded-full bg-surface-2 flex items-center justify-center overflow-hidden text-xs font-medium text-text-dim">
             <Show when={src()} fallback={initial()}>
               <img
@@ -40,17 +43,23 @@ export default function AgentCard(props: AgentCardProps) {
                 class="w-full h-full object-cover"
                 onError={(e) => {
                   (e.currentTarget as HTMLImageElement).style.display = 'none';
-                  (e.currentTarget.nextElementSibling as HTMLElement | null)?.style.setProperty('display', 'flex');
+                  (
+                    e.currentTarget.nextElementSibling as HTMLElement | null
+                  )?.style.setProperty('display', 'flex');
                 }}
               />
-              <span class="hidden items-center justify-center w-full h-full">{initial()}</span>
+              <span class="hidden items-center justify-center w-full h-full">
+                {initial()}
+              </span>
             </Show>
           </span>
           <span class="font-medium">{props.agent.name}</span>
         </A>
       </td>
       <td class="px-3 py-2">
-        <Badge variant={backendVariant(props.agent.backend)}>{props.agent.backend}</Badge>
+        <Badge variant={backendVariant(props.agent.backend)}>
+          {props.agent.backend}
+        </Badge>
       </td>
       <td class="px-3 py-2">
         <Badge>{props.agent.agentRuntime}</Badge>
@@ -63,7 +72,9 @@ export default function AgentCard(props: AgentCardProps) {
             <Badge variant="admin">admin</Badge>
           </Show>
           <Show when={props.agent.remoteInstanceId}>
-            <Badge variant="remote">{props.agent.remoteInstanceName || 'remote'}</Badge>
+            <Badge variant="remote">
+              {props.agent.remoteInstanceName || 'remote'}
+            </Badge>
           </Show>
         </div>
       </td>

--- a/webui/src/components/context/LayerEditor.tsx
+++ b/webui/src/components/context/LayerEditor.tsx
@@ -21,7 +21,9 @@ interface LayerEditorProps {
 }
 
 export default function LayerEditor(props: LayerEditorProps) {
-  const [activeLayer, setActiveLayer] = createSignal<LayerName>(props.initialLayer ?? 'channel');
+  const [activeLayer, setActiveLayer] = createSignal<LayerName>(
+    props.initialLayer ?? 'channel',
+  );
   const [content, setContent] = createSignal('');
   const [originalContent, setOriginalContent] = createSignal('');
   const [saving, setSaving] = createSignal(false);
@@ -108,14 +110,13 @@ export default function LayerEditor(props: LayerEditorProps) {
 
       {/* Path display */}
       <div class="px-4 py-1.5 text-xs text-text-dim border-b border-border bg-surface font-mono">
-        <Show
-          when={layerPath()}
-          fallback={<span>No path for this layer</span>}
-        >
+        <Show when={layerPath()} fallback={<span>No path for this layer</span>}>
           {(path) => (
             <span>
               {path()}/CLAUDE.md
-              <span class={`ml-2 ${layerExists(activeLayer()) ? 'text-green' : 'text-yellow'}`}>
+              <span
+                class={`ml-2 ${layerExists(activeLayer()) ? 'text-green' : 'text-yellow'}`}
+              >
                 ({layerExists(activeLayer()) ? 'exists' : 'new'})
               </span>
             </span>
@@ -130,7 +131,11 @@ export default function LayerEditor(props: LayerEditorProps) {
           value={content()}
           onInput={(e) => setContent(e.currentTarget.value)}
           onKeyDown={handleKeyDown}
-          placeholder={layerPath() ? 'Enter context content...' : 'No path available for this layer'}
+          placeholder={
+            layerPath()
+              ? 'Enter context content...'
+              : 'No path available for this layer'
+          }
           disabled={!layerPath()}
           spellcheck={false}
         />

--- a/webui/src/components/conversations/ChatList.tsx
+++ b/webui/src/components/conversations/ChatList.tsx
@@ -12,9 +12,13 @@ export default function ChatList(props: {
   onSearchQueryChange?: (query: string | null) => void;
 }) {
   const hasInitQuery = !!props.initialSearchQuery;
-  const [mode, setMode] = createSignal<TabMode>(hasInitQuery ? 'search' : 'filter');
+  const [mode, setMode] = createSignal<TabMode>(
+    hasInitQuery ? 'search' : 'filter',
+  );
   const [filterText, setFilterText] = createSignal('');
-  const [searchText, setSearchText] = createSignal(props.initialSearchQuery ?? '');
+  const [searchText, setSearchText] = createSignal(
+    props.initialSearchQuery ?? '',
+  );
   const [searchResults, setSearchResults] = createSignal<MessageInfo[]>([]);
   const [searching, setSearching] = createSignal(false);
   const [searchDone, setSearchDone] = createSignal(false);
@@ -94,7 +98,8 @@ export default function ChatList(props: {
     const lower = text.toLowerCase();
     const ql = query.toLowerCase();
     const idx = lower.indexOf(ql);
-    if (idx === -1) return text.length > 120 ? text.slice(0, 117) + '\u2026' : text;
+    if (idx === -1)
+      return text.length > 120 ? text.slice(0, 117) + '\u2026' : text;
     const start = Math.max(0, idx - 40);
     const end = Math.min(text.length, start + 120);
     let snippet = text.slice(start, end);
@@ -154,7 +159,12 @@ export default function ChatList(props: {
           {filteredChats().length} chat{filteredChats().length !== 1 ? 's' : ''}
         </div>
         <div class="flex-1 overflow-y-auto">
-          <For each={filteredChats()} fallback={<div class="p-3 text-text-dim text-xs">No chats found</div>}>
+          <For
+            each={filteredChats()}
+            fallback={
+              <div class="p-3 text-text-dim text-xs">No chats found</div>
+            }
+          >
             {(chat) => (
               <div
                 class={`px-2.5 py-2 cursor-pointer border-b border-border transition-colors hover:bg-accent/5 ${
@@ -168,7 +178,9 @@ export default function ChatList(props: {
                   if (e.key === 'Enter') props.onSelect(chat.jid);
                 }}
               >
-                <div class="text-xs font-semibold text-text-bright truncate">{chat.name || chat.jid}</div>
+                <div class="text-xs font-semibold text-text-bright truncate">
+                  {chat.name || chat.jid}
+                </div>
                 <div class="text-[10px] text-text-dim truncate">{chat.jid}</div>
                 <div class="text-[10px] text-text-dim">
                   {chat.last_message_time
@@ -184,16 +196,20 @@ export default function ChatList(props: {
       <Show when={mode() === 'search'}>
         <div class="flex-1 overflow-y-auto">
           <Show when={searching()}>
-            <div class="text-[10px] text-text-dim px-2.5 py-1.5">searching\u2026</div>
+            <div class="text-[10px] text-text-dim px-2.5 py-1.5">
+              searching\u2026
+            </div>
           </Show>
           <Show when={searchDone() && !searching()}>
             <div class="text-[10px] text-text-dim px-2.5 py-1.5">
-              {searchResults().length} result{searchResults().length !== 1 ? 's' : ''}
+              {searchResults().length} result
+              {searchResults().length !== 1 ? 's' : ''}
             </div>
           </Show>
           <For each={searchResults()}>
             {(result) => {
-              const snippet = () => buildSnippet(result.content || '', searchText());
+              const snippet = () =>
+                buildSnippet(result.content || '', searchText());
               return (
                 <div
                   class="px-2.5 py-2 cursor-pointer border-b border-border transition-colors hover:bg-accent/5"
@@ -208,7 +224,8 @@ export default function ChatList(props: {
                   }}
                 >
                   <div class="text-[10px] text-accent font-semibold mb-0.5">
-                    {result.sender_name || result.sender || 'Unknown'} in {result.chat_jid}
+                    {result.sender_name || result.sender || 'Unknown'} in{' '}
+                    {result.chat_jid}
                   </div>
                   <div class="text-[11px] truncate">{snippet()}</div>
                   <div class="text-[9px] text-text-dim mt-0.5">

--- a/webui/src/components/conversations/MessageList.tsx
+++ b/webui/src/components/conversations/MessageList.tsx
@@ -34,7 +34,9 @@ export default function MessageList(props: {
         }
       >
         <div class="px-3 py-2 border-b border-border flex items-center gap-2 bg-surface shrink-0">
-          <h2 class="text-[13px] font-semibold text-text-bright">{props.chatName}</h2>
+          <h2 class="text-[13px] font-semibold text-text-bright">
+            {props.chatName}
+          </h2>
           <span class="text-[10px] text-text-dim">{props.chatJid}</span>
           <span class="text-[10px] text-text-dim ml-auto">
             {props.messages.length} msg{props.messages.length !== 1 ? 's' : ''}
@@ -67,7 +69,11 @@ export default function MessageList(props: {
           >
             <Show
               when={props.messages.length > 0}
-              fallback={<div class="text-text-dim text-xs text-center py-4">No messages</div>}
+              fallback={
+                <div class="text-text-dim text-xs text-center py-4">
+                  No messages
+                </div>
+              }
             >
               <For each={props.messages}>
                 {(msg) => {
@@ -92,12 +98,16 @@ export default function MessageList(props: {
                       >
                         <div
                           class={`text-[10px] font-semibold mb-0.5 ${
-                            fromMe ? 'text-accent-hover text-right' : 'text-accent'
+                            fromMe
+                              ? 'text-accent-hover text-right'
+                              : 'text-accent'
                           }`}
                         >
                           {msg.sender_name || msg.sender || 'Unknown'}
                         </div>
-                        <div class="text-xs whitespace-pre-wrap break-words">{displayText()}</div>
+                        <div class="text-xs whitespace-pre-wrap break-words">
+                          {displayText()}
+                        </div>
                         <div
                           class={`text-[9px] text-text-dim mt-0.5 ${fromMe ? 'text-right' : ''}`}
                         >

--- a/webui/src/components/dashboard/TopologyCanvas.tsx
+++ b/webui/src/components/dashboard/TopologyCanvas.tsx
@@ -109,7 +109,9 @@ function buildGraph(
   const categorySet: Record<string, boolean> = {};
   const channelSet: Record<string, boolean> = {};
 
-  function makeNode(overrides: Partial<TopoNode> & { id: string; type: TopoNode['type'] }): TopoNode {
+  function makeNode(
+    overrides: Partial<TopoNode> & { id: string; type: TopoNode['type'] },
+  ): TopoNode {
     return {
       label: '',
       sub: '',
@@ -167,7 +169,8 @@ function buildGraph(
         const catK = 'cat:' + ch.categoryFolder;
         if (!categorySet[catK]) {
           categorySet[catK] = true;
-          const catLabel = ch.categoryFolder.split('/').pop() || ch.categoryFolder;
+          const catLabel =
+            ch.categoryFolder.split('/').pop() || ch.categoryFolder;
           const cn = makeNode({
             id: catK,
             type: 'category',
@@ -185,7 +188,10 @@ function buildGraph(
 
           if (a.serverFolder) {
             const sk = 's:' + a.serverFolder;
-            if (nodeMap[sk] && ch.categoryFolder.indexOf(a.serverFolder) === 0) {
+            if (
+              nodeMap[sk] &&
+              ch.categoryFolder.indexOf(a.serverFolder) === 0
+            ) {
               edges.push({ from: sk, to: catK, type: 'hierarchy' });
             }
           }
@@ -214,9 +220,17 @@ function buildGraph(
         nodeMap[chK] = chNode;
 
         if (ch.categoryFolder) {
-          edges.push({ from: 'cat:' + ch.categoryFolder, to: chK, type: 'hierarchy' });
+          edges.push({
+            from: 'cat:' + ch.categoryFolder,
+            to: chK,
+            type: 'hierarchy',
+          });
         } else if (a.serverFolder) {
-          edges.push({ from: 's:' + a.serverFolder, to: chK, type: 'hierarchy' });
+          edges.push({
+            from: 's:' + a.serverFolder,
+            to: chK,
+            type: 'hierarchy',
+          });
         }
       } else {
         nodeMap[chK].r = Math.min(14, nodeMap[chK].r + 1);
@@ -233,7 +247,9 @@ function buildGraph(
       label: a.name,
       sub: a.backend,
       detail:
-        (a.remoteInstanceName ? 'remote:' + a.remoteInstanceName + ' \u2022 ' : '') +
+        (a.remoteInstanceName
+          ? 'remote:' + a.remoteInstanceName + ' \u2022 '
+          : '') +
         a.agentRuntime +
         (a.isAdmin ? ' (admin)' : ''),
       fullName: a.name,
@@ -259,12 +275,14 @@ function buildGraph(
   const agentNodes = nodes.filter((n) => n.type === 'agent');
 
   serverNodes.forEach((n, i) => {
-    const angle = (2 * Math.PI * i) / Math.max(1, serverNodes.length) - Math.PI / 2;
+    const angle =
+      (2 * Math.PI * i) / Math.max(1, serverNodes.length) - Math.PI / 2;
     n.x = centerX + Math.cos(angle) * 60;
     n.y = centerY + Math.sin(angle) * 60;
   });
   catNodes.forEach((n, i) => {
-    const angle = (2 * Math.PI * i) / Math.max(1, catNodes.length) - Math.PI / 4;
+    const angle =
+      (2 * Math.PI * i) / Math.max(1, catNodes.length) - Math.PI / 4;
     n.x = centerX + Math.cos(angle) * 180;
     n.y = centerY + Math.sin(angle) * 180;
   });
@@ -274,7 +292,8 @@ function buildGraph(
     n.y = centerY + Math.sin(angle) * 320;
   });
   agentNodes.forEach((n, i) => {
-    const angle = (2 * Math.PI * i) / Math.max(1, agentNodes.length) + Math.PI / 6;
+    const angle =
+      (2 * Math.PI * i) / Math.max(1, agentNodes.length) + Math.PI / 6;
     n.x = centerX + Math.cos(angle) * 140;
     n.y = centerY + Math.sin(angle) * 140;
   });
@@ -294,7 +313,10 @@ export default function TopologyCanvas() {
   // Fetch full agent topology data when SSE agent list changes (includes initial load)
   createEffect(() => {
     const _count = agents.list.length;
-    api.getAgents().then(setAgentData).catch(() => {});
+    api
+      .getAgents()
+      .then(setAgentData)
+      .catch(() => {});
   });
 
   onMount(() => {
@@ -478,7 +500,13 @@ export default function TopologyCanvas() {
       const a = nodeMap[e.from];
       const b = nodeMap[e.to];
       if (!a || !b) return;
-      particles.push({ from: a, to: b, t: 0, speed: 0.6 + Math.random() * 0.4, color: a.color });
+      particles.push({
+        from: a,
+        to: b,
+        t: 0,
+        speed: 0.6 + Math.random() * 0.4,
+        color: a.color,
+      });
     }
 
     function draw() {
@@ -512,11 +540,15 @@ export default function TopologyCanvas() {
         ctx2d!.moveTo(a.x, a.y);
         ctx2d!.lineTo(b.x, b.y);
         if (e.type === 'hierarchy') {
-          ctx2d!.strokeStyle = isActive ? COLORS.edgeHierarchyActive : COLORS.edgeHierarchy;
+          ctx2d!.strokeStyle = isActive
+            ? COLORS.edgeHierarchyActive
+            : COLORS.edgeHierarchy;
           ctx2d!.lineWidth = isActive ? 2 : 1.2;
           ctx2d!.setLineDash([]);
         } else {
-          ctx2d!.strokeStyle = isActive ? COLORS.edgeAgentActive : COLORS.edgeAgent;
+          ctx2d!.strokeStyle = isActive
+            ? COLORS.edgeAgentActive
+            : COLORS.edgeAgent;
           ctx2d!.lineWidth = isActive ? 1.5 : 0.6;
           ctx2d!.setLineDash([4, 4]);
         }
@@ -543,7 +575,8 @@ export default function TopologyCanvas() {
           const r2 = parseInt(c.slice(1, 3), 16);
           const g2 = parseInt(c.slice(3, 5), 16);
           const b2 = parseInt(c.slice(5, 7), 16);
-          ctx2d!.fillStyle = 'rgba(' + r2 + ',' + g2 + ',' + b2 + ',' + alpha + ')';
+          ctx2d!.fillStyle =
+            'rgba(' + r2 + ',' + g2 + ',' + b2 + ',' + alpha + ')';
         } else {
           ctx2d!.fillStyle = c;
         }
@@ -556,7 +589,9 @@ export default function TopologyCanvas() {
         const isHover = hoverNode === n;
         const isConn = connSet ? !!connSet[n.id] : true;
         const dimmed = connSet && !isConn;
-        const pulse = isHover ? 1.15 : 1 + Math.sin(time * 1.8 + ni * 0.5) * 0.03;
+        const pulse = isHover
+          ? 1.15
+          : 1 + Math.sin(time * 1.8 + ni * 0.5) * 0.03;
         const r = n.r * pulse;
         const nodeAlpha = dimmed ? 0.2 : 1;
 
@@ -571,7 +606,14 @@ export default function TopologyCanvas() {
         // Body gradient
         ctx2d!.beginPath();
         ctx2d!.arc(n.x, n.y, r, 0, Math.PI * 2);
-        const grad = ctx2d!.createRadialGradient(n.x - r * 0.3, n.y - r * 0.3, 0, n.x, n.y, r);
+        const grad = ctx2d!.createRadialGradient(
+          n.x - r * 0.3,
+          n.y - r * 0.3,
+          0,
+          n.x,
+          n.y,
+          r,
+        );
         grad.addColorStop(0, n.color);
         grad.addColorStop(1, n.color + '99');
         ctx2d!.fillStyle = grad;
@@ -590,7 +632,13 @@ export default function TopologyCanvas() {
           ctx2d!.beginPath();
           ctx2d!.arc(n.x, n.y, r * 0.85, 0, Math.PI * 2);
           ctx2d!.clip();
-          ctx2d!.drawImage(n.avatarImg, n.x - r * 0.85, n.y - r * 0.85, r * 1.7, r * 1.7);
+          ctx2d!.drawImage(
+            n.avatarImg,
+            n.x - r * 0.85,
+            n.y - r * 0.85,
+            r * 1.7,
+            r * 1.7,
+          );
           ctx2d!.restore();
         } else {
           ctx2d!.font = '600 ' + r * 0.7 + "px 'JetBrains Mono',monospace";
@@ -598,20 +646,34 @@ export default function TopologyCanvas() {
           ctx2d!.textBaseline = 'middle';
           ctx2d!.fillStyle = 'rgba(0,0,0,.35)';
           const icon =
-            n.type === 'server' ? 'S' : n.type === 'category' ? 'C' : n.type === 'agent' ? 'A' : '#';
+            n.type === 'server'
+              ? 'S'
+              : n.type === 'category'
+                ? 'C'
+                : n.type === 'agent'
+                  ? 'A'
+                  : '#';
           ctx2d!.fillText(icon, n.x, n.y + 1);
         }
 
         // Label
         const fontSize =
-          n.type === 'agent' || n.type === 'server' ? 11 : n.type === 'category' ? 10 : 9;
+          n.type === 'agent' || n.type === 'server'
+            ? 11
+            : n.type === 'category'
+              ? 10
+              : 9;
         ctx2d!.font =
           (n.type === 'agent' || n.type === 'server' ? '600 ' : '500 ') +
           fontSize +
           "px 'JetBrains Mono',monospace";
         ctx2d!.textAlign = 'center';
         ctx2d!.textBaseline = 'top';
-        ctx2d!.fillStyle = isHover ? '#fff' : dimmed ? COLORS.textDim : COLORS.text;
+        ctx2d!.fillStyle = isHover
+          ? '#fff'
+          : dimmed
+            ? COLORS.textDim
+            : COLORS.text;
         ctx2d!.fillText(n.label, n.x, n.y + r + 4);
 
         ctx2d!.globalAlpha = 1;
@@ -651,7 +713,11 @@ export default function TopologyCanvas() {
     }
 
     function escapeHtml(s: string): string {
-      return s.replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;').replace(/"/g, '&quot;');
+      return s
+        .replace(/&/g, '&amp;')
+        .replace(/</g, '&lt;')
+        .replace(/>/g, '&gt;')
+        .replace(/"/g, '&quot;');
     }
 
     // ---- Mouse move ----
@@ -777,19 +843,31 @@ export default function TopologyCanvas() {
         <h2 class="text-sm font-semibold text-text-bright">agent topology</h2>
         <div class="flex items-center gap-3 text-xs text-text-dim">
           <span class="flex items-center gap-1">
-            <span class="inline-block w-2 h-2 rounded-full" style={{ background: COLORS.agent }} />
+            <span
+              class="inline-block w-2 h-2 rounded-full"
+              style={{ background: COLORS.agent }}
+            />
             agent
           </span>
           <span class="flex items-center gap-1">
-            <span class="inline-block w-2 h-2 rounded-full" style={{ background: COLORS.server }} />
+            <span
+              class="inline-block w-2 h-2 rounded-full"
+              style={{ background: COLORS.server }}
+            />
             server
           </span>
           <span class="flex items-center gap-1">
-            <span class="inline-block w-2 h-2 rounded-full" style={{ background: COLORS.category }} />
+            <span
+              class="inline-block w-2 h-2 rounded-full"
+              style={{ background: COLORS.category }}
+            />
             category
           </span>
           <span class="flex items-center gap-1">
-            <span class="inline-block w-2 h-2 rounded-full" style={{ background: COLORS.channel }} />
+            <span
+              class="inline-block w-2 h-2 rounded-full"
+              style={{ background: COLORS.channel }}
+            />
             channel
           </span>
         </div>

--- a/webui/src/components/shared/LogLine.tsx
+++ b/webui/src/components/shared/LogLine.tsx
@@ -32,9 +32,7 @@ interface LogLineProps {
 export default function LogLine(props: LogLineProps) {
   return (
     <div class={`flex gap-1.5 py-px leading-relaxed ${props.class ?? ''}`}>
-      <span class="text-text-dim shrink-0">
-        {formatLogTime(props.line.ts)}
-      </span>
+      <span class="text-text-dim shrink-0">{formatLogTime(props.line.ts)}</span>
       <span
         class={`shrink-0 ${props.badgeWidth ?? 'w-10'} ${levelColors[props.line.level] ?? 'text-text-dim'}`}
       >
@@ -51,11 +49,10 @@ export default function LogLine(props: LogLineProps) {
       <span class="text-text break-all">
         {props.line.msg}
         <Show when={props.line.durationMs != null}>
-          {' '}({props.line.durationMs}ms)
+          {' '}
+          ({props.line.durationMs}ms)
         </Show>
-        <Show when={props.line.costUsd != null}>
-          {' '}${props.line.costUsd}
-        </Show>
+        <Show when={props.line.costUsd != null}> ${props.line.costUsd}</Show>
       </span>
       <Show when={props.line.err}>
         <span class="text-red break-all">{props.line.err}</span>

--- a/webui/src/components/shared/MetricCard.tsx
+++ b/webui/src/components/shared/MetricCard.tsx
@@ -21,7 +21,9 @@ export function BooleanRow(props: {
     <div class="flex justify-between items-center py-1.5 border-b border-border/50 last:border-b-0">
       <span class="text-text-dim text-xs">{props.label}</span>
       <Badge variant={props.value ? 'active' : 'completed'}>
-        {props.value ? (props.onLabel ?? 'enabled') : (props.offLabel ?? 'disabled')}
+        {props.value
+          ? (props.onLabel ?? 'enabled')
+          : (props.offLabel ?? 'disabled')}
       </Badge>
     </div>
   );

--- a/webui/src/components/tasks/TaskCard.tsx
+++ b/webui/src/components/tasks/TaskCard.tsx
@@ -93,7 +93,10 @@ export default function TaskCard(props: TaskCardProps) {
         <Badge>{props.task.schedule_type}</Badge>{' '}
         <span class="text-text-dim">{schedLabel()}</span>
       </td>
-      <td class="px-3 py-2 whitespace-nowrap text-text-dim" title={props.task.next_run ?? ''}>
+      <td
+        class="px-3 py-2 whitespace-nowrap text-text-dim"
+        title={props.task.next_run ?? ''}
+      >
         {nextRun()}
       </td>
       <td

--- a/webui/src/lib/api.ts
+++ b/webui/src/lib/api.ts
@@ -6,8 +6,17 @@ export interface HealthData {
   uptime_seconds: number;
   memory: { rss_mb: number; heap_used_mb: number; heap_total_mb: number };
   runtime: { bun: string; platform: string; arch: string };
-  agents: { total: number; by_backend: Record<string, number>; by_runtime: Record<string, number> };
-  containers: { active: number; idle: number; max_active: number; max_idle: number };
+  agents: {
+    total: number;
+    by_backend: Record<string, number>;
+    by_runtime: Record<string, number>;
+  };
+  containers: {
+    active: number;
+    idle: number;
+    max_active: number;
+    max_idle: number;
+  };
   tasks: { active: number; paused: number; completed: number; total: number };
   sse_clients: number;
   started_at: string;
@@ -149,20 +158,53 @@ export interface AgentDetailData {
 }
 
 export interface SettingsData {
-  general: { timezone: string; anthropicModel: string | null; localRuntime: string };
-  webUi: { port: number | null; hostname: string; authEnabled: boolean; corsOrigin: string | null };
+  general: {
+    timezone: string;
+    anthropicModel: string | null;
+    localRuntime: string;
+  };
+  webUi: {
+    port: number | null;
+    hostname: string;
+    authEnabled: boolean;
+    corsOrigin: string | null;
+  };
   containers: {
-    image: string; memory: string; timeoutMs: number; startupTimeoutMs: number;
-    idleTimeoutMs: number; maxOutputSize: number; maxActive: number; maxIdle: number; maxTask: number;
+    image: string;
+    memory: string;
+    timeoutMs: number;
+    startupTimeoutMs: number;
+    idleTimeoutMs: number;
+    maxOutputSize: number;
+    maxActive: number;
+    maxIdle: number;
+    maxTask: number;
   };
   channels: {
-    discordBots: number; discordBotIds: string[]; discordDefaultBot: string | null;
-    telegramBots: number; slackBots: number; slackDefaultBot: string | null;
+    discordBots: number;
+    discordBotIds: string[];
+    discordDefaultBot: string | null;
+    telegramBots: number;
+    slackBots: number;
+    slackDefaultBot: string | null;
   };
-  scheduling: { sessionMaxAgeMs: number; persistentTaskState: boolean; pollIntervalMs: number };
-  roster: { scope: string; roleFilters: string[]; cacheTtlMs: number; refreshIntervalMs: number };
+  scheduling: {
+    sessionMaxAgeMs: number;
+    persistentTaskState: boolean;
+    pollIntervalMs: number;
+  };
+  roster: {
+    scope: string;
+    roleFilters: string[];
+    cacheTtlMs: number;
+    refreshIntervalMs: number;
+  };
   discovery: { enabled: boolean; instanceName: string; trustLanAdmin: boolean };
-  github: { webhookPort: number; webhookPath: string; secretConfigured: boolean };
+  github: {
+    webhookPort: number;
+    webhookPath: string;
+    secretConfigured: boolean;
+  };
   paths: { store: string; groups: string; data: string };
 }
 
@@ -252,14 +294,31 @@ export const api = {
   // Tasks
   getTasks: (status?: string) =>
     get<ScheduledTask[]>(`/api/tasks${status ? `?status=${status}` : ''}`),
-  getTask: (id: string) => get<ScheduledTask>(`/api/tasks/${encodeURIComponent(id)}`),
-  createTask: (task: Omit<ScheduledTask, 'id' | 'last_run' | 'last_result' | 'executing_since' | 'created_at'>) =>
-    post<ScheduledTask>('/api/tasks', task),
-  updateTask: (id: string, updates: Partial<Pick<ScheduledTask, 'prompt' | 'schedule_type' | 'schedule_value' | 'status'>>) =>
-    patch<ScheduledTask>(`/api/tasks/${encodeURIComponent(id)}`, updates),
-  deleteTask: (id: string) => del<{ deleted: boolean; id: string }>(`/api/tasks/${encodeURIComponent(id)}`),
+  getTask: (id: string) =>
+    get<ScheduledTask>(`/api/tasks/${encodeURIComponent(id)}`),
+  createTask: (
+    task: Omit<
+      ScheduledTask,
+      'id' | 'last_run' | 'last_result' | 'executing_since' | 'created_at'
+    >,
+  ) => post<ScheduledTask>('/api/tasks', task),
+  updateTask: (
+    id: string,
+    updates: Partial<
+      Pick<
+        ScheduledTask,
+        'prompt' | 'schedule_type' | 'schedule_value' | 'status'
+      >
+    >,
+  ) => patch<ScheduledTask>(`/api/tasks/${encodeURIComponent(id)}`, updates),
+  deleteTask: (id: string) =>
+    del<{ deleted: boolean; id: string }>(
+      `/api/tasks/${encodeURIComponent(id)}`,
+    ),
   getTaskRuns: (id: string, limit?: number) =>
-    get<TaskRunLog[]>(`/api/tasks/${encodeURIComponent(id)}/runs${limit ? `?limit=${limit}` : ''}`),
+    get<TaskRunLog[]>(
+      `/api/tasks/${encodeURIComponent(id)}/runs${limit ? `?limit=${limit}` : ''}`,
+    ),
 
   // Chats & messages
   getChats: () => get<ChatInfo[]>('/api/chats'),
@@ -268,7 +327,9 @@ export const api = {
     if (since) params.set('since', since);
     if (limit) params.set('limit', String(limit));
     const qs = params.toString();
-    return get<MessageInfo[]>(`/api/messages/${encodeURIComponent(chatJid)}${qs ? `?${qs}` : ''}`);
+    return get<MessageInfo[]>(
+      `/api/messages/${encodeURIComponent(chatJid)}${qs ? `?${qs}` : ''}`,
+    );
   },
   searchMessages: (query: string, chatJid?: string, limit?: number) => {
     const params = new URLSearchParams({ q: query });
@@ -279,7 +340,13 @@ export const api = {
 
   // Context
   getContextFiles: () => get<ContextFileEntry[]>('/api/context/files'),
-  getContextLayers: (params: { folder?: string; server_folder?: string; agent_context_folder?: string; channel_folder?: string; category_folder?: string }) => {
+  getContextLayers: (params: {
+    folder?: string;
+    server_folder?: string;
+    agent_context_folder?: string;
+    channel_folder?: string;
+    category_folder?: string;
+  }) => {
     const qs = new URLSearchParams(params as Record<string, string>).toString();
     return get<ContextLayers>(`/api/context/layers?${qs}`);
   },
@@ -295,9 +362,14 @@ export const api = {
   getAgentDetail: (id: string) =>
     get<AgentDetailData>(`/api/agents/${encodeURIComponent(id)}/detail`),
   getAgentAvatar: (id: string) =>
-    get<{ avatarUrl: string | null; avatarSource: string | null }>(`/api/agents/${encodeURIComponent(id)}/avatar`),
+    get<{ avatarUrl: string | null; avatarSource: string | null }>(
+      `/api/agents/${encodeURIComponent(id)}/avatar`,
+    ),
   setAgentAvatar: (id: string, url: string | null, source: string | null) =>
-    post<{ success: boolean }>(`/api/agents/${encodeURIComponent(id)}/avatar`, { url, source }),
+    post<{ success: boolean }>(`/api/agents/${encodeURIComponent(id)}/avatar`, {
+      url,
+      source,
+    }),
   getAgentAvatarImageUrl: (id: string) =>
     `/api/agents/${encodeURIComponent(id)}/avatar/image`,
 

--- a/webui/src/lib/event-source.ts
+++ b/webui/src/lib/event-source.ts
@@ -17,7 +17,8 @@ const EventSourceContext = createContext<EventSourceState>();
 
 export function useEventSource() {
   const ctx = useContext(EventSourceContext);
-  if (!ctx) throw new Error('useEventSource must be used within EventSourceProvider');
+  if (!ctx)
+    throw new Error('useEventSource must be used within EventSourceProvider');
   return ctx;
 }
 
@@ -68,9 +69,7 @@ export function createEventSource(): EventSourceState {
     es.addEventListener('task_update', (e) =>
       onSseEvent<TaskState[]>(e, updateTasks),
     );
-    es.addEventListener('log', (e) =>
-      onSseEvent<LogLine>(e, appendLog),
-    );
+    es.addEventListener('log', (e) => onSseEvent<LogLine>(e, appendLog));
     es.addEventListener('stats', (e) =>
       onSseEvent<Partial<StatsState>>(e, updateStats),
     );

--- a/webui/src/routes/(shell).tsx
+++ b/webui/src/routes/(shell).tsx
@@ -4,10 +4,7 @@ import { Suspense } from 'solid-js';
 import Nav from '~/components/Nav';
 import Sidebar from '~/components/Sidebar';
 import ToastContainer from '~/components/shared/Toast';
-import {
-  createEventSource,
-  EventSourceContext,
-} from '~/lib/event-source';
+import { createEventSource, EventSourceContext } from '~/lib/event-source';
 
 export default function ShellLayout(props: RouteSectionProps) {
   const eventSource = createEventSource();

--- a/webui/src/routes/(shell)/agents/[id].tsx
+++ b/webui/src/routes/(shell)/agents/[id].tsx
@@ -70,8 +70,12 @@ export default function AgentDetail() {
             when={agent()}
             fallback={
               <div class="text-text-dim">
-                <p>Agent not found: <code class="text-accent">{params.id}</code></p>
-                <A href="/agents" class="text-sm mt-2 inline-block">back to agents</A>
+                <p>
+                  Agent not found: <code class="text-accent">{params.id}</code>
+                </p>
+                <A href="/agents" class="text-sm mt-2 inline-block">
+                  back to agents
+                </A>
               </div>
             }
           >
@@ -98,19 +102,27 @@ export default function AgentDetail() {
                   </Show>
 
                   <div class="min-w-0">
-                    <h2 class="text-xl text-text-bright font-semibold mb-1">{data().name}</h2>
+                    <h2 class="text-xl text-text-bright font-semibold mb-1">
+                      {data().name}
+                    </h2>
                     <div class="flex flex-wrap gap-1.5 mb-1">
-                      <Badge variant={backendVariant(data().backend)}>{data().backend}</Badge>
+                      <Badge variant={backendVariant(data().backend)}>
+                        {data().backend}
+                      </Badge>
                       <Badge>{data().agentRuntime}</Badge>
                       <Show when={data().remoteInstanceId}>
-                        <Badge variant="remote">{data().remoteInstanceName || data().remoteInstanceId}</Badge>
+                        <Badge variant="remote">
+                          {data().remoteInstanceName || data().remoteInstanceId}
+                        </Badge>
                       </Show>
                       <Show when={data().isAdmin}>
                         <Badge variant="admin">admin</Badge>
                       </Show>
                     </div>
                     <Show when={data().description}>
-                      <p class="text-sm text-text-dim mt-1">{data().description}</p>
+                      <p class="text-sm text-text-dim mt-1">
+                        {data().description}
+                      </p>
                     </Show>
                   </div>
                 </div>
@@ -119,15 +131,26 @@ export default function AgentDetail() {
                 <div class="grid grid-cols-2 md:grid-cols-3 gap-3 mb-6 text-sm">
                   <InfoItem label="id" value={data().id} />
                   <InfoItem label="folder" value={data().folder} />
-                  <InfoItem label="created" value={formatDate(data().createdAt)} />
+                  <InfoItem
+                    label="created"
+                    value={formatDate(data().createdAt)}
+                  />
                   <Show when={data().remoteInstanceId}>
-                    <InfoItem label="remote peer" value={data().remoteInstanceName || data().remoteInstanceId!} />
+                    <InfoItem
+                      label="remote peer"
+                      value={
+                        data().remoteInstanceName || data().remoteInstanceId!
+                      }
+                    />
                   </Show>
                   <Show when={data().serverFolder}>
                     <InfoItem label="server" value={data().serverFolder!} />
                   </Show>
                   <Show when={data().agentContextFolder}>
-                    <InfoItem label="context folder" value={data().agentContextFolder!} />
+                    <InfoItem
+                      label="context folder"
+                      value={data().agentContextFolder!}
+                    />
                   </Show>
                 </div>
 
@@ -153,7 +176,9 @@ export default function AgentDetail() {
                         >
                           {tab.label}
                           <Show when={count() !== undefined}>
-                            <span class="ml-1 text-xs text-text-dim">({count()})</span>
+                            <span class="ml-1 text-xs text-text-dim">
+                              ({count()})
+                            </span>
                           </Show>
                         </button>
                       );
@@ -192,23 +217,39 @@ export default function AgentDetail() {
                         <Show
                           when={data().channels.length > 0}
                           fallback={
-                            <tr><td colspan="4" class="py-3 text-text-dim">No channels subscribed</td></tr>
+                            <tr>
+                              <td colspan="4" class="py-3 text-text-dim">
+                                No channels subscribed
+                              </td>
+                            </tr>
                           }
                         >
                           <For each={data().channels}>
                             {(ch) => (
                               <tr class="border-b border-border/50 hover:bg-surface-2/50">
                                 <td class="py-2 pr-4">{ch.displayName}</td>
-                                <td class="py-2 pr-4 text-text-dim">{ch.jid}</td>
-                                <td class="py-2 pr-4 text-text-dim">{ch.channelFolder ?? '\u2014'}</td>
+                                <td class="py-2 pr-4 text-text-dim">
+                                  {ch.jid}
+                                </td>
+                                <td class="py-2 pr-4 text-text-dim">
+                                  {ch.channelFolder ?? '\u2014'}
+                                </td>
                                 <td class="py-2">
                                   <Show
                                     when={!data().remoteInstanceId}
-                                    fallback={<span class="text-text-dim text-xs">remote</span>}
+                                    fallback={
+                                      <span class="text-text-dim text-xs">
+                                        remote
+                                      </span>
+                                    }
                                   >
                                     <button
                                       class="px-2 py-0.5 text-xs rounded bg-surface-2 text-text-dim hover:text-text hover:bg-border"
-                                      onClick={() => navigate(`/conversations?chat=${encodeURIComponent(ch.jid)}`)}
+                                      onClick={() =>
+                                        navigate(
+                                          `/conversations?chat=${encodeURIComponent(ch.jid)}`,
+                                        )
+                                      }
                                     >
                                       messages
                                     </button>
@@ -238,14 +279,20 @@ export default function AgentDetail() {
                         <Show
                           when={data().tasks.length > 0}
                           fallback={
-                            <tr><td colspan="4" class="py-3 text-text-dim">No scheduled tasks</td></tr>
+                            <tr>
+                              <td colspan="4" class="py-3 text-text-dim">
+                                No scheduled tasks
+                              </td>
+                            </tr>
                           }
                         >
                           <For each={data().tasks}>
                             {(task) => (
                               <tr class="border-b border-border/50 hover:bg-surface-2/50">
                                 <td class="py-2 pr-4">
-                                  <Badge variant={statusVariant(task.status)}>{task.status}</Badge>
+                                  <Badge variant={statusVariant(task.status)}>
+                                    {task.status}
+                                  </Badge>
                                 </td>
                                 <td class="py-2 pr-4" title={task.prompt}>
                                   {truncate(task.prompt, 80)}
@@ -253,7 +300,9 @@ export default function AgentDetail() {
                                 <td class="py-2 pr-4 text-text-dim">
                                   {task.schedule_type}: {task.schedule_value}
                                 </td>
-                                <td class="py-2 text-text-dim">{formatDate(task.next_run)}</td>
+                                <td class="py-2 text-text-dim">
+                                  {formatDate(task.next_run)}
+                                </td>
                               </tr>
                             )}
                           </For>
@@ -277,18 +326,28 @@ export default function AgentDetail() {
                         <Show
                           when={data().recentChats.length > 0}
                           fallback={
-                            <tr><td colspan="3" class="py-3 text-text-dim">No conversations</td></tr>
+                            <tr>
+                              <td colspan="3" class="py-3 text-text-dim">
+                                No conversations
+                              </td>
+                            </tr>
                           }
                         >
                           <For each={data().recentChats}>
                             {(chat) => (
                               <tr class="border-b border-border/50 hover:bg-surface-2/50">
                                 <td class="py-2 pr-4">{chat.name}</td>
-                                <td class="py-2 pr-4 text-text-dim">{formatDate(chat.last_message_time)}</td>
+                                <td class="py-2 pr-4 text-text-dim">
+                                  {formatDate(chat.last_message_time)}
+                                </td>
                                 <td class="py-2">
                                   <button
                                     class="px-2 py-0.5 text-xs rounded bg-surface-2 text-text-dim hover:text-text hover:bg-border"
-                                    onClick={() => navigate(`/conversations?chat=${encodeURIComponent(chat.jid)}`)}
+                                    onClick={() =>
+                                      navigate(
+                                        `/conversations?chat=${encodeURIComponent(chat.jid)}`,
+                                      )
+                                    }
                                   >
                                     view
                                   </button>

--- a/webui/src/routes/(shell)/agents/index.tsx
+++ b/webui/src/routes/(shell)/agents/index.tsx
@@ -14,7 +14,10 @@ import AgentCard from '~/components/agents/AgentCard';
 
 export default function Agents() {
   // Skip fetch during SSR — relative URLs have no origin on the server
-  const [agents] = createResource(() => !isServer, (ok) => ok ? api.getAgents() : []);
+  const [agents] = createResource(
+    () => !isServer,
+    (ok) => (ok ? api.getAgents() : []),
+  );
   const [search, setSearch] = createSignal('');
   const [backendFilter, setBackendFilter] = createSignal('');
   const [runtimeFilter, setRuntimeFilter] = createSignal('');
@@ -34,7 +37,12 @@ export default function Agents() {
     const be = backendFilter();
     const rt = runtimeFilter();
     return list().filter((a) => {
-      if (q && !a.name.toLowerCase().includes(q) && !a.id.toLowerCase().includes(q)) return false;
+      if (
+        q &&
+        !a.name.toLowerCase().includes(q) &&
+        !a.id.toLowerCase().includes(q)
+      )
+        return false;
       if (be && a.backend !== be) return false;
       if (rt && a.agentRuntime !== rt) return false;
       return true;
@@ -82,9 +90,7 @@ export default function Agents() {
             class="px-3 py-1.5 rounded bg-surface-2 border border-border text-text text-sm focus:outline-none focus:border-accent"
           >
             <option value="">All backends</option>
-            <For each={backends()}>
-              {(b) => <option value={b}>{b}</option>}
-            </For>
+            <For each={backends()}>{(b) => <option value={b}>{b}</option>}</For>
           </select>
           <select
             value={runtimeFilter()}
@@ -92,13 +98,13 @@ export default function Agents() {
             class="px-3 py-1.5 rounded bg-surface-2 border border-border text-text text-sm focus:outline-none focus:border-accent"
           >
             <option value="">All runtimes</option>
-            <For each={runtimes()}>
-              {(r) => <option value={r}>{r}</option>}
-            </For>
+            <For each={runtimes()}>{(r) => <option value={r}>{r}</option>}</For>
           </select>
         </div>
 
-        <Suspense fallback={<div class="text-text-dim text-sm">Loading agents...</div>}>
+        <Suspense
+          fallback={<div class="text-text-dim text-sm">Loading agents...</div>}
+        >
           <div class="overflow-x-auto rounded border border-border">
             <table class="w-full text-sm">
               <thead>
@@ -112,15 +118,24 @@ export default function Agents() {
                 </tr>
               </thead>
               <tbody>
-                <For each={filtered()} fallback={
-                  <tr>
-                    <td colspan="6" class="px-3 py-8 text-center text-text-dim">
-                      <Show when={list().length > 0} fallback="No agents registered.">
-                        No agents match the current filters.
-                      </Show>
-                    </td>
-                  </tr>
-                }>
+                <For
+                  each={filtered()}
+                  fallback={
+                    <tr>
+                      <td
+                        colspan="6"
+                        class="px-3 py-8 text-center text-text-dim"
+                      >
+                        <Show
+                          when={list().length > 0}
+                          fallback="No agents registered."
+                        >
+                          No agents match the current filters.
+                        </Show>
+                      </td>
+                    </tr>
+                  }
+                >
                   {(agent) => <AgentCard agent={agent} taskCount={0} />}
                 </For>
               </tbody>

--- a/webui/src/routes/(shell)/context.tsx
+++ b/webui/src/routes/(shell)/context.tsx
@@ -1,6 +1,13 @@
 import { Title } from '@solidjs/meta';
 import { useSearchParams } from '@solidjs/router';
-import { createSignal, createResource, createEffect, onMount, For, Show } from 'solid-js';
+import {
+  createSignal,
+  createResource,
+  createEffect,
+  onMount,
+  For,
+  Show,
+} from 'solid-js';
 
 import { api, type AgentChannelData } from '~/lib/api';
 import LayerEditor from '~/components/context/LayerEditor';
@@ -77,7 +84,10 @@ export default function Context() {
     });
   }
 
-  function selectChannel(agent: AgentChannelData, channel: AgentChannelData['channels'][0]) {
+  function selectChannel(
+    agent: AgentChannelData,
+    channel: AgentChannelData['channels'][0],
+  ) {
     setExpandedAgents((prev) => {
       const next = new Set(prev);
       next.add(agent.id);

--- a/webui/src/routes/(shell)/conversations.tsx
+++ b/webui/src/routes/(shell)/conversations.tsx
@@ -83,7 +83,10 @@ export default function Conversations() {
           chatName={selectedChatName()}
           messages={messages() ?? []}
           loading={messages.loading}
-          hasMore={messageLimit() === PAGE_SIZE && (messages()?.length ?? 0) >= PAGE_SIZE}
+          hasMore={
+            messageLimit() === PAGE_SIZE &&
+            (messages()?.length ?? 0) >= PAGE_SIZE
+          }
           onLoadMore={handleLoadMore}
         />
       </div>

--- a/webui/src/routes/(shell)/ipc.tsx
+++ b/webui/src/routes/(shell)/ipc.tsx
@@ -79,18 +79,28 @@ export default function Ipc() {
         <div class="grid grid-cols-2 sm:grid-cols-4 gap-3">
           <StatCard
             label="processing"
-            value={() => `${Math.max(0, stats.activeContainers - stats.idleContainers)}/${stats.maxActive}`}
+            value={() =>
+              `${Math.max(0, stats.activeContainers - stats.idleContainers)}/${stats.maxActive}`
+            }
           />
           <StatCard
             label="idle"
             value={() => `${stats.idleContainers}/${stats.maxIdle}`}
           />
-          <StatCard label="groups tracked" value={() => String(queue().length)} />
-          <StatCard label="recent events" value={() => String(events().length)} />
+          <StatCard
+            label="groups tracked"
+            value={() => String(queue().length)}
+          />
+          <StatCard
+            label="recent events"
+            value={() => String(events().length)}
+          />
         </div>
 
         <section>
-          <h2 class="text-text-bright text-sm font-semibold mb-3">group queue state</h2>
+          <h2 class="text-text-bright text-sm font-semibold mb-3">
+            group queue state
+          </h2>
           <Show
             when={queue().length > 0}
             fallback={
@@ -108,7 +118,9 @@ export default function Ipc() {
                     <th class="text-left px-3 py-2 font-medium">msg queue</th>
                     <th class="text-left px-3 py-2 font-medium">tasks</th>
                     <th class="text-left px-3 py-2 font-medium">task queue</th>
-                    <th class="text-left px-3 py-2 font-medium">running task</th>
+                    <th class="text-left px-3 py-2 font-medium">
+                      running task
+                    </th>
                     <th class="text-left px-3 py-2 font-medium">retries</th>
                   </tr>
                 </thead>
@@ -119,28 +131,44 @@ export default function Ipc() {
                       const tStatus = taskLaneStatus(group.taskLane);
                       return (
                         <tr class="border-t border-border hover:bg-surface-2/50">
-                          <td class="px-3 py-2 text-accent">{group.folderKey}</td>
+                          <td class="px-3 py-2 text-accent">
+                            {group.folderKey}
+                          </td>
                           <td class="px-3 py-2">
                             <LaneBadge status={msgStatus} />
                           </td>
-                          <td class="px-3 py-2">{group.messageLane.pendingCount}</td>
+                          <td class="px-3 py-2">
+                            {group.messageLane.pendingCount}
+                          </td>
                           <td class="px-3 py-2">
                             <LaneBadge status={tStatus} />
                           </td>
-                          <td class="px-3 py-2">{group.taskLane.pendingCount}</td>
+                          <td class="px-3 py-2">
+                            {group.taskLane.pendingCount}
+                          </td>
                           <td class="px-3 py-2 text-text-dim">
-                            <Show when={group.taskLane.activeTask} fallback={<span>{'\u2014'}</span>}>
+                            <Show
+                              when={group.taskLane.activeTask}
+                              fallback={<span>{'\u2014'}</span>}
+                            >
                               {(task) => (
                                 <span>
                                   {task().taskId}{' '}
-                                  <span class="text-text-dim">({formatDuration(task().runningMs)})</span>
+                                  <span class="text-text-dim">
+                                    ({formatDuration(task().runningMs)})
+                                  </span>
                                 </span>
                               )}
                             </Show>
                           </td>
                           <td class="px-3 py-2">
-                            <Show when={group.retryCount > 0} fallback={<span>{'\u2014'}</span>}>
-                              <span class="text-yellow font-semibold">{group.retryCount}</span>
+                            <Show
+                              when={group.retryCount > 0}
+                              fallback={<span>{'\u2014'}</span>}
+                            >
+                              <span class="text-yellow font-semibold">
+                                {group.retryCount}
+                              </span>
                             </Show>
                           </td>
                         </tr>
@@ -154,7 +182,9 @@ export default function Ipc() {
         </section>
 
         <section>
-          <h2 class="text-text-bright text-sm font-semibold mb-3">ipc event timeline</h2>
+          <h2 class="text-text-bright text-sm font-semibold mb-3">
+            ipc event timeline
+          </h2>
           <Show
             when={events().length > 0}
             fallback={
@@ -176,7 +206,9 @@ export default function Ipc() {
                 <tbody>
                   <For each={events()}>
                     {(event) => (
-                      <tr class={`border-t border-border ${eventRowBg(event.kind)}`}>
+                      <tr
+                        class={`border-t border-border ${eventRowBg(event.kind)}`}
+                      >
                         <td class="px-3 py-2 text-text-dim whitespace-nowrap">
                           {formatTime(event.timestamp)}
                         </td>
@@ -187,7 +219,9 @@ export default function Ipc() {
                             {event.kind}
                           </span>
                         </td>
-                        <td class="px-3 py-2 text-accent">{event.sourceGroup}</td>
+                        <td class="px-3 py-2 text-accent">
+                          {event.sourceGroup}
+                        </td>
                         <td class="px-3 py-2">{event.summary}</td>
                       </tr>
                     )}
@@ -205,7 +239,9 @@ export default function Ipc() {
 function StatCard(props: { label: string; value: () => string }) {
   return (
     <div class="bg-surface rounded border border-border p-3">
-      <div class="text-text-dim text-[10px] uppercase tracking-wider mb-1">{props.label}</div>
+      <div class="text-text-dim text-[10px] uppercase tracking-wider mb-1">
+        {props.label}
+      </div>
       <div class="text-text-bright text-lg font-semibold">{props.value()}</div>
     </div>
   );
@@ -213,7 +249,9 @@ function StatCard(props: { label: string; value: () => string }) {
 
 function LaneBadge(props: { status: string }) {
   return (
-    <span class={`inline-block px-1.5 py-0.5 rounded text-[10px] font-medium ${laneColor(props.status)}`}>
+    <span
+      class={`inline-block px-1.5 py-0.5 rounded text-[10px] font-medium ${laneColor(props.status)}`}
+    >
       {props.status}
     </span>
   );

--- a/webui/src/routes/(shell)/logs.tsx
+++ b/webui/src/routes/(shell)/logs.tsx
@@ -123,10 +123,7 @@ export default function LogsPage() {
           <h2 class="text-sm font-semibold text-text-bright mr-2">Logs</h2>
           <span class="text-xs text-text-dim">
             {filteredLogs().length}
-            <Show when={filterActive()}>
-              {' '}/ {logs.lines.length}
-            </Show>
-            {' '}lines
+            <Show when={filterActive()}> / {logs.lines.length}</Show> lines
           </span>
 
           <div class="flex-1" />

--- a/webui/src/routes/(shell)/network.tsx
+++ b/webui/src/routes/(shell)/network.tsx
@@ -90,7 +90,8 @@ async function fetchJson<T>(url: string, init?: RequestInit): Promise<T> {
   if (!res.ok) {
     const body = await res.json().catch(() => ({}));
     throw new Error(
-      (body as Record<string, string>).error ?? `Request failed (${res.status})`,
+      (body as Record<string, string>).error ??
+        `Request failed (${res.status})`,
     );
   }
   return res.json() as Promise<T>;
@@ -152,16 +153,28 @@ function PeerActions(props: {
     >
       <Match when={props.peer.status === 'trusted'}>
         <div class="flex gap-1 flex-wrap">
-          <button class={BTN_DEFAULT} onClick={() => props.onBrowse(props.peer.instanceId)}>
+          <button
+            class={BTN_DEFAULT}
+            onClick={() => props.onBrowse(props.peer.instanceId)}
+          >
             Browse
           </button>
-          <button class={BTN_DEFAULT} onClick={() => props.onLogs(props.peer.instanceId)}>
+          <button
+            class={BTN_DEFAULT}
+            onClick={() => props.onLogs(props.peer.instanceId)}
+          >
             Logs
           </button>
-          <button class={BTN_PRIMARY} onClick={() => props.onSync(props.peer.instanceId)}>
+          <button
+            class={BTN_PRIMARY}
+            onClick={() => props.onSync(props.peer.instanceId)}
+          >
             Sync
           </button>
-          <button class={BTN_DANGER} onClick={() => props.onRevoke(props.peer.instanceId)}>
+          <button
+            class={BTN_DANGER}
+            onClick={() => props.onRevoke(props.peer.instanceId)}
+          >
             Revoke
           </button>
         </div>
@@ -235,10 +248,16 @@ function PendingRequestsPanel(props: {
                   ID: <code>{req.fromInstanceId.slice(0, 8)}...</code>
                 </div>
                 <div class="flex gap-2">
-                  <button class={BTN_PRIMARY} onClick={() => props.onApprove(req.id)}>
+                  <button
+                    class={BTN_PRIMARY}
+                    onClick={() => props.onApprove(req.id)}
+                  >
                     Approve
                   </button>
-                  <button class={BTN_DANGER} onClick={() => props.onReject(req.id)}>
+                  <button
+                    class={BTN_DANGER}
+                    onClick={() => props.onReject(req.id)}
+                  >
                     Reject
                   </button>
                 </div>
@@ -378,15 +397,23 @@ function SyncPanel(props: {
 
       <div class="flex gap-4 px-4 py-3 bg-surface-2 rounded text-xs mx-4 mt-4 mb-4">
         <span class="text-green">{props.comparison.same.length} identical</span>
-        <span class="text-yellow">{props.comparison.differs.length} differ</span>
-        <span class="text-blue">{props.comparison.localOnly.length} local only</span>
-        <span class="text-accent">{props.comparison.remoteOnly.length} remote only</span>
+        <span class="text-yellow">
+          {props.comparison.differs.length} differ
+        </span>
+        <span class="text-blue">
+          {props.comparison.localOnly.length} local only
+        </span>
+        <span class="text-accent">
+          {props.comparison.remoteOnly.length} remote only
+        </span>
       </div>
 
       <Show
         when={total() > 0}
         fallback={
-          <div class="p-8 text-center text-text-dim">No context files found</div>
+          <div class="p-8 text-center text-text-dim">
+            No context files found
+          </div>
         }
       >
         <div class="overflow-x-auto">
@@ -405,7 +432,9 @@ function SyncPanel(props: {
                 {(f) => (
                   <tr class="border-b border-border">
                     <td class="px-4 py-2">
-                      <code class="text-xs">{f.path || '(root)'}/CLAUDE.md</code>
+                      <code class="text-xs">
+                        {f.path || '(root)'}/CLAUDE.md
+                      </code>
                     </td>
                     <td class="px-4 py-2 text-green">identical</td>
                     <td class="px-4 py-2 text-text-dim">{fmtBytes(f.size)}</td>
@@ -418,22 +447,32 @@ function SyncPanel(props: {
                 {(d) => (
                   <tr class="border-b border-border bg-yellow/5">
                     <td class="px-4 py-2">
-                      <code class="text-xs">{d.local.path || '(root)'}/CLAUDE.md</code>
+                      <code class="text-xs">
+                        {d.local.path || '(root)'}/CLAUDE.md
+                      </code>
                     </td>
                     <td class="px-4 py-2 text-yellow">differs</td>
-                    <td class="px-4 py-2 text-text-dim">{fmtBytes(d.local.size)}</td>
-                    <td class="px-4 py-2 text-text-dim">{fmtBytes(d.remote.size)}</td>
+                    <td class="px-4 py-2 text-text-dim">
+                      {fmtBytes(d.local.size)}
+                    </td>
+                    <td class="px-4 py-2 text-text-dim">
+                      {fmtBytes(d.remote.size)}
+                    </td>
                     <td class="px-4 py-2">
                       <div class="flex gap-1">
                         <button
                           class={BTN_DEFAULT}
-                          onClick={() => props.onPush(props.instanceId, d.local.path)}
+                          onClick={() =>
+                            props.onPush(props.instanceId, d.local.path)
+                          }
                         >
                           Push
                         </button>
                         <button
                           class={BTN_DEFAULT}
-                          onClick={() => props.onPull(props.instanceId, d.local.path)}
+                          onClick={() =>
+                            props.onPull(props.instanceId, d.local.path)
+                          }
                         >
                           Pull
                         </button>
@@ -446,7 +485,9 @@ function SyncPanel(props: {
                 {(f) => (
                   <tr class="border-b border-border bg-blue/5">
                     <td class="px-4 py-2">
-                      <code class="text-xs">{f.path || '(root)'}/CLAUDE.md</code>
+                      <code class="text-xs">
+                        {f.path || '(root)'}/CLAUDE.md
+                      </code>
                     </td>
                     <td class="px-4 py-2 text-blue">local only</td>
                     <td class="px-4 py-2 text-text-dim">{fmtBytes(f.size)}</td>
@@ -466,7 +507,9 @@ function SyncPanel(props: {
                 {(f) => (
                   <tr class="border-b border-border bg-accent/5">
                     <td class="px-4 py-2">
-                      <code class="text-xs">{f.path || '(root)'}/CLAUDE.md</code>
+                      <code class="text-xs">
+                        {f.path || '(root)'}/CLAUDE.md
+                      </code>
                     </td>
                     <td class="px-4 py-2 text-accent">remote only</td>
                     <td class="px-4 py-2 text-text-dim">-</td>
@@ -521,19 +564,20 @@ function StatCard(props: { label: string; children: JSX.Element }) {
 }
 
 export default function Network() {
-  const [runtime, { refetch: refetchRuntime }] = createResource<DiscoveryRuntime>(
-    () => fetchJson('/api/discovery/state'),
+  const [runtime, { refetch: refetchRuntime }] =
+    createResource<DiscoveryRuntime>(() => fetchJson('/api/discovery/state'));
+
+  const [peers, { refetch: refetchPeers }] = createResource<PeerView[]>(() =>
+    fetchJson('/api/discovery/peers'),
   );
 
-  const [peers, { refetch: refetchPeers }] = createResource<PeerView[]>(
-    () => fetchJson('/api/discovery/peers'),
-  );
+  const [requests, { refetch: refetchRequests }] = createResource<
+    PairRequest[]
+  >(() => fetchJson('/api/discovery/requests'));
 
-  const [requests, { refetch: refetchRequests }] = createResource<PairRequest[]>(
-    () => fetchJson('/api/discovery/requests'),
+  const [remoteAgents, setRemoteAgents] = createSignal<RemoteAgent[] | null>(
+    null,
   );
-
-  const [remoteAgents, setRemoteAgents] = createSignal<RemoteAgent[] | null>(null);
   const [logLines, setLogLines] = createSignal<string[]>([]);
   const [logStatus, setLogStatus] = createSignal(
     'Select a trusted peer to start streaming logs.',
@@ -693,7 +737,9 @@ export default function Network() {
 
     remoteLogsSource.addEventListener('log', (event) => {
       try {
-        const payload: RemoteLogRecord = JSON.parse((event as MessageEvent).data);
+        const payload: RemoteLogRecord = JSON.parse(
+          (event as MessageEvent).data,
+        );
         const level = (payload.level ?? 'info').toUpperCase();
         const time = payload.time ?? payload.timestamp ?? '';
         const source = payload.source ?? 'remote';
@@ -731,13 +777,21 @@ export default function Network() {
     setSyncComparison(null);
   }
 
-  async function syncFile(direction: 'push' | 'pull', instanceId: string, path: string) {
+  async function syncFile(
+    direction: 'push' | 'pull',
+    instanceId: string,
+    path: string,
+  ) {
     try {
       const d = await postJson<{ ok?: boolean; error?: string }>(
         `/api/discovery/peers/${encodeURIComponent(instanceId)}/context/${direction}`,
         { path },
       );
-      if (d.ok) showToast(`${direction === 'push' ? 'Pushed' : 'Pulled'} ${path}`, 'success');
+      if (d.ok)
+        showToast(
+          `${direction === 'push' ? 'Pushed' : 'Pulled'} ${path}`,
+          'success',
+        );
       else showToast(`Error: ${d.error ?? 'unknown'}`, 'error');
       const sid = syncPeerId();
       if (sid) openSyncPanel(sid);
@@ -763,7 +817,12 @@ export default function Network() {
         showToast(`Nothing to ${direction}`, 'info');
         return;
       }
-      if (!confirm(`${direction === 'push' ? 'Push' : 'Pull'} ${paths.length} file(s)?`)) return;
+      if (
+        !confirm(
+          `${direction === 'push' ? 'Push' : 'Pull'} ${paths.length} file(s)?`,
+        )
+      )
+        return;
 
       let done = 0;
       let errs = 0;
@@ -791,7 +850,8 @@ export default function Network() {
   }
 
   const onlineCount = () => (peers() ?? []).filter((p) => p.online).length;
-  const trustedCount = () => (peers() ?? []).filter((p) => p.status === 'trusted').length;
+  const trustedCount = () =>
+    (peers() ?? []).filter((p) => p.status === 'trusted').length;
 
   return (
     <>
@@ -820,31 +880,42 @@ export default function Network() {
         </div>
 
         <div class="bg-surface rounded-lg border border-border p-4">
-          <h2 class="text-sm font-semibold text-text mb-4">discovery controls</h2>
+          <h2 class="text-sm font-semibold text-text mb-4">
+            discovery controls
+          </h2>
           <div class="flex flex-wrap gap-3 items-center mb-4">
             <Show when={runtime()}>
               <button
-                class={runtime()!.enabled
-                  ? `${BTN} bg-red/20 text-red hover:bg-red/30`
-                  : `${BTN} bg-accent/20 text-accent hover:bg-accent/30`}
+                class={
+                  runtime()!.enabled
+                    ? `${BTN} bg-red/20 text-red hover:bg-red/30`
+                    : `${BTN} bg-accent/20 text-accent hover:bg-accent/30`
+                }
                 onClick={() => toggleDiscovery(!runtime()!.enabled)}
               >
-                {runtime()!.enabled ? 'Turn discovery off' : 'Turn discovery on'}
+                {runtime()!.enabled
+                  ? 'Turn discovery off'
+                  : 'Turn discovery on'}
               </button>
             </Show>
             <button class={BTN_DEFAULT} onClick={trustCurrentNetwork}>
               Trust Wi-Fi
             </button>
             <span class="text-text-dim text-sm">
-              <Show when={runtime()?.currentNetwork} fallback="No Wi-Fi network detected">
+              <Show
+                when={runtime()?.currentNetwork}
+                fallback="No Wi-Fi network detected"
+              >
                 Current Wi-Fi:{' '}
-                <strong class="text-text">{runtime()!.currentNetwork!.label}</strong>
+                <strong class="text-text">
+                  {runtime()!.currentNetwork!.label}
+                </strong>
               </Show>
             </span>
           </div>
           <div class="text-xs text-text-dim mb-3">
-            Trusted networks gate discovery when present. Leave the list empty to
-            allow discovery anywhere the toggle is on.
+            Trusted networks gate discovery when present. Leave the list empty
+            to allow discovery anywhere the toggle is on.
           </div>
           <TrustedNetworksList
             networks={runtime()?.trustedNetworks ?? []}
@@ -881,7 +952,9 @@ export default function Network() {
                     <For each={peers() ?? []}>
                       {(peer) => (
                         <tr class="border-b border-border">
-                          <td class="px-4 py-2 font-semibold text-text">{peer.name}</td>
+                          <td class="px-4 py-2 font-semibold text-text">
+                            {peer.name}
+                          </td>
                           <td class="px-4 py-2">
                             <code class="text-xs text-text-dim">
                               {peer.host}:{peer.port}
@@ -893,7 +966,9 @@ export default function Network() {
                           <td class="px-4 py-2">
                             <Show
                               when={peer.online}
-                              fallback={<span class="text-text-dim">&#9675;</span>}
+                              fallback={
+                                <span class="text-text-dim">&#9675;</span>
+                              }
                             >
                               <span class="text-green">&#9679;</span>
                             </Show>
@@ -932,7 +1007,9 @@ export default function Network() {
           status={logStatus()}
           statusIsError={logStatusIsError()}
           lines={logLines()}
-          scrollRef={(el) => { logOutputEl = el; }}
+          scrollRef={(el) => {
+            logOutputEl = el;
+          }}
         />
 
         <Show when={syncPeerId() && syncComparison()}>

--- a/webui/src/routes/(shell)/settings.tsx
+++ b/webui/src/routes/(shell)/settings.tsx
@@ -3,7 +3,11 @@ import { query, createAsync } from '@solidjs/router';
 import { Show } from 'solid-js';
 
 import Badge from '~/components/shared/Badge';
-import { BooleanRow, MetricCard, MetricRow } from '~/components/shared/MetricCard';
+import {
+  BooleanRow,
+  MetricCard,
+  MetricRow,
+} from '~/components/shared/MetricCard';
 import { api } from '~/lib/api';
 
 const fetchSettings = query(() => api.getSettings(), 'settings');
@@ -50,13 +54,18 @@ export default function Settings() {
                   label="model override"
                   value={s().general.anthropicModel ?? 'default'}
                 />
-                <MetricRow label="local runtime" value={s().general.localRuntime} />
+                <MetricRow
+                  label="local runtime"
+                  value={s().general.localRuntime}
+                />
               </MetricCard>
 
               <MetricCard title="web ui">
                 <MetricRow
                   label="port"
-                  value={s().webUi.port != null ? String(s().webUi.port) : 'disabled'}
+                  value={
+                    s().webUi.port != null ? String(s().webUi.port) : 'disabled'
+                  }
                 />
                 <MetricRow label="hostname" value={s().webUi.hostname} />
                 <BooleanRow label="auth" value={s().webUi.authEnabled} />
@@ -69,7 +78,10 @@ export default function Settings() {
               <MetricCard title="containers">
                 <MetricRow label="image" value={s().containers.image} />
                 <MetricRow label="memory" value={s().containers.memory} />
-                <MetricRow label="timeout" value={formatMs(s().containers.timeoutMs)} />
+                <MetricRow
+                  label="timeout"
+                  value={formatMs(s().containers.timeoutMs)}
+                />
                 <MetricRow
                   label="startup timeout"
                   value={formatMs(s().containers.startupTimeoutMs)}
@@ -82,9 +94,18 @@ export default function Settings() {
                   label="max output"
                   value={formatBytes(s().containers.maxOutputSize)}
                 />
-                <MetricRow label="max active" value={String(s().containers.maxActive)} />
-                <MetricRow label="max idle" value={String(s().containers.maxIdle)} />
-                <MetricRow label="max task" value={String(s().containers.maxTask)} />
+                <MetricRow
+                  label="max active"
+                  value={String(s().containers.maxActive)}
+                />
+                <MetricRow
+                  label="max idle"
+                  value={String(s().containers.maxIdle)}
+                />
+                <MetricRow
+                  label="max task"
+                  value={String(s().containers.maxTask)}
+                />
               </MetricCard>
 
               <MetricCard title="channels">
@@ -99,9 +120,7 @@ export default function Settings() {
                   />
                 </Show>
                 <Show when={s().channels.discordDefaultBot}>
-                  {(bot) => (
-                    <MetricRow label="discord default" value={bot()} />
-                  )}
+                  {(bot) => <MetricRow label="discord default" value={bot()} />}
                 </Show>
                 <MetricRow
                   label="telegram bots"
@@ -112,9 +131,7 @@ export default function Settings() {
                   value={String(s().channels.slackBots)}
                 />
                 <Show when={s().channels.slackDefaultBot}>
-                  {(bot) => (
-                    <MetricRow label="slack default" value={bot()} />
-                  )}
+                  {(bot) => <MetricRow label="slack default" value={bot()} />}
                 </Show>
               </MetricCard>
 
@@ -183,7 +200,10 @@ export default function Settings() {
                       : 'disabled'
                   }
                 />
-                <MetricRow label="webhook path" value={s().github.webhookPath} />
+                <MetricRow
+                  label="webhook path"
+                  value={s().github.webhookPath}
+                />
                 <BooleanRow
                   label="webhook secret"
                   value={s().github.secretConfigured}

--- a/webui/src/routes/(shell)/system.tsx
+++ b/webui/src/routes/(shell)/system.tsx
@@ -22,8 +22,7 @@ function formatUptime(seconds: number): string {
 }
 
 function BreakdownList(props: { items: Record<string, number> }) {
-  const sorted = () =>
-    Object.entries(props.items).sort((a, b) => b[1] - a[1]);
+  const sorted = () => Object.entries(props.items).sort((a, b) => b[1] - a[1]);
 
   return (
     <For each={sorted()}>
@@ -106,10 +105,7 @@ export default function System() {
               </MetricCard>
 
               <MetricCard title="agents">
-                <MetricRow
-                  label="total"
-                  value={String(h().agents.total)}
-                />
+                <MetricRow label="total" value={String(h().agents.total)} />
                 <div class="text-text-dim text-[10px] uppercase tracking-wider mt-2 mb-1">
                   by backend
                 </div>
@@ -121,22 +117,13 @@ export default function System() {
               </MetricCard>
 
               <MetricCard title="tasks">
-                <MetricRow
-                  label="active"
-                  value={String(h().tasks.active)}
-                />
-                <MetricRow
-                  label="paused"
-                  value={String(h().tasks.paused)}
-                />
+                <MetricRow label="active" value={String(h().tasks.active)} />
+                <MetricRow label="paused" value={String(h().tasks.paused)} />
                 <MetricRow
                   label="completed"
                   value={String(h().tasks.completed)}
                 />
-                <MetricRow
-                  label="total"
-                  value={String(h().tasks.total)}
-                />
+                <MetricRow label="total" value={String(h().tasks.total)} />
               </MetricCard>
             </div>
           )}

--- a/webui/src/routes/(shell)/tasks.tsx
+++ b/webui/src/routes/(shell)/tasks.tsx
@@ -1,11 +1,5 @@
 import { Title } from '@solidjs/meta';
-import {
-  createSignal,
-  createResource,
-  For,
-  Show,
-  createMemo,
-} from 'solid-js';
+import { createSignal, createResource, For, Show, createMemo } from 'solid-js';
 import { createStore } from 'solid-js/store';
 
 import Modal from '~/components/shared/Modal';
@@ -64,7 +58,13 @@ function cronPreview(expr: string): string {
   const p = expr.trim().split(/\s+/);
   if (p.length < 5) return '';
   const [min, hr, dom, mon, dow] = p;
-  if (min.includes('/') && hr === '*' && dom === '*' && mon === '*' && dow === '*') {
+  if (
+    min.includes('/') &&
+    hr === '*' &&
+    dom === '*' &&
+    mon === '*' &&
+    dow === '*'
+  ) {
     const n = min.split('/')[1];
     return `Every ${n} minute${n === '1' ? '' : 's'}`;
   }
@@ -72,16 +72,31 @@ function cronPreview(expr: string): string {
     const n = hr.split('/')[1];
     return `Every ${n} hour${n === '1' ? '' : 's'}`;
   }
-  if (/^\d+$/.test(min) && /^\d+$/.test(hr) && dom === '*' && mon === '*' && dow === '*') {
+  if (
+    /^\d+$/.test(min) &&
+    /^\d+$/.test(hr) &&
+    dom === '*' &&
+    mon === '*' &&
+    dow === '*'
+  ) {
     const h = parseInt(hr, 10);
     const m = parseInt(min, 10);
     const ampm = h >= 12 ? 'PM' : 'AM';
     const h12 = h === 0 ? 12 : h > 12 ? h - 12 : h;
     return `Daily at ${h12}:${m < 10 ? '0' : ''}${m} ${ampm}`;
   }
-  if (/^\d+$/.test(min) && /^\d+$/.test(hr) && dom === '*' && mon === '*' && dow !== '*') {
+  if (
+    /^\d+$/.test(min) &&
+    /^\d+$/.test(hr) &&
+    dom === '*' &&
+    mon === '*' &&
+    dow !== '*'
+  ) {
     const days = ['Sun', 'Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat'];
-    const dayNames = dow.split(',').map((d) => days[parseInt(d, 10)] || d).join(', ');
+    const dayNames = dow
+      .split(',')
+      .map((d) => days[parseInt(d, 10)] || d)
+      .join(', ');
     const h = parseInt(hr, 10);
     const m = parseInt(min, 10);
     const ampm = h >= 12 ? 'PM' : 'AM';
@@ -105,7 +120,9 @@ export default function Tasks() {
   const [formError, setFormError] = createSignal('');
   const [submitting, setSubmitting] = createSignal(false);
 
-  const [createForm, setCreateForm] = createStore<TaskFormState>({ ...EMPTY_FORM });
+  const [createForm, setCreateForm] = createStore<TaskFormState>({
+    ...EMPTY_FORM,
+  });
   const [editForm, setEditForm] = createStore<TaskFormState>({ ...EMPTY_FORM });
 
   const agentOptions = createMemo(() => {
@@ -130,7 +147,9 @@ export default function Tasks() {
 
   const stats = createMemo(() => {
     const all = tasks() ?? [];
-    let active = 0, paused = 0, completed = 0;
+    let active = 0,
+      paused = 0,
+      completed = 0;
     for (const t of all) {
       if (t.status === 'active') active++;
       else if (t.status === 'paused') paused++;
@@ -142,7 +161,10 @@ export default function Tasks() {
   async function handleToggle(id: string, newStatus: 'active' | 'paused') {
     try {
       await api.updateTask(id, { status: newStatus });
-      showToast(`Task ${newStatus === 'paused' ? 'paused' : 'resumed'}`, 'success');
+      showToast(
+        `Task ${newStatus === 'paused' ? 'paused' : 'resumed'}`,
+        'success',
+      );
       refetch();
     } catch (err) {
       showToast(err instanceof Error ? err.message : 'Failed', 'error');
@@ -193,7 +215,10 @@ export default function Tasks() {
       setFormError('');
       setEditOpen(true);
     } catch (err) {
-      showToast(`Failed to load task: ${err instanceof Error ? err.message : 'unknown'}`, 'error');
+      showToast(
+        `Failed to load task: ${err instanceof Error ? err.message : 'unknown'}`,
+        'error',
+      );
     }
   }
 
@@ -311,9 +336,12 @@ export default function Tasks() {
               </For>
             </tbody>
           </table>
-          <Show when={(filteredTasks()).length === 0}>
+          <Show when={filteredTasks().length === 0}>
             <div class="text-text-dim text-xs p-4 text-center">
-              <Show when={(tasks() ?? []).length === 0} fallback="No tasks match the current filter.">
+              <Show
+                when={(tasks() ?? []).length === 0}
+                fallback="No tasks match the current filter."
+              >
                 No scheduled tasks yet. Create one to get started.
               </Show>
             </div>
@@ -488,9 +516,7 @@ function TaskForm(props: TaskFormProps) {
         <select
           class="w-full bg-surface-2 border border-border rounded px-2 py-1 text-xs text-text"
           value={props.form.context_mode}
-          onChange={(e) =>
-            props.setForm('context_mode', e.currentTarget.value)
-          }
+          onChange={(e) => props.setForm('context_mode', e.currentTarget.value)}
         >
           <option value="isolated">Isolated</option>
           <option value="group">Group (with history)</option>

--- a/webui/src/routes/api/agents/[id]/avatar.ts
+++ b/webui/src/routes/api/agents/[id]/avatar.ts
@@ -5,7 +5,8 @@ export function GET({ params }: APIEvent) {
   const state = getState();
   const agents = state.getAgents();
   const agent = agents[params.id];
-  if (!agent) return Response.json({ error: 'Agent not found' }, { status: 404 });
+  if (!agent)
+    return Response.json({ error: 'Agent not found' }, { status: 404 });
   return Response.json({
     avatarUrl: agent.avatarUrl || null,
     avatarSource: agent.avatarSource || null,
@@ -16,7 +17,8 @@ export async function POST({ params, request }: APIEvent) {
   const state = getState();
   const agents = state.getAgents();
   const agent = agents[params.id];
-  if (!agent) return Response.json({ error: 'Agent not found' }, { status: 404 });
+  if (!agent)
+    return Response.json({ error: 'Agent not found' }, { status: 404 });
 
   let body: Record<string, unknown>;
   try {
@@ -27,9 +29,16 @@ export async function POST({ params, request }: APIEvent) {
 
   const validSources = new Set(['discord', 'telegram', 'slack', 'custom']);
   if (body.source && !validSources.has(body.source as string)) {
-    return Response.json({ error: '"source" must be discord | telegram | slack | custom' }, { status: 400 });
+    return Response.json(
+      { error: '"source" must be discord | telegram | slack | custom' },
+      { status: 400 },
+    );
   }
 
-  state.updateAgentAvatar(params.id, (body.url as string) || null, (body.source as string) || null);
+  state.updateAgentAvatar(
+    params.id,
+    (body.url as string) || null,
+    (body.source as string) || null,
+  );
   return Response.json({ success: true, agentId: params.id });
 }

--- a/webui/src/routes/api/agents/[id]/avatar/image.ts
+++ b/webui/src/routes/api/agents/[id]/avatar/image.ts
@@ -5,8 +5,10 @@ export async function GET({ params }: APIEvent) {
   const state = getState();
   const agents = state.getAgents();
   const agent = agents[params.id];
-  if (!agent) return Response.json({ error: 'Agent not found' }, { status: 404 });
-  if (!agent.avatarUrl) return Response.json({ error: 'Avatar not found' }, { status: 404 });
+  if (!agent)
+    return Response.json({ error: 'Agent not found' }, { status: 404 });
+  if (!agent.avatarUrl)
+    return Response.json({ error: 'Avatar not found' }, { status: 404 });
 
   // Delegate to the main process avatar resolver if available
   if (typeof state.resolveAgentAvatarImage === 'function') {
@@ -14,5 +16,8 @@ export async function GET({ params }: APIEvent) {
     if (response) return response;
   }
 
-  return Response.json({ error: 'Avatar resolution not available' }, { status: 404 });
+  return Response.json(
+    { error: 'Avatar resolution not available' },
+    { status: 404 },
+  );
 }

--- a/webui/src/routes/api/agents/[id]/detail.ts
+++ b/webui/src/routes/api/agents/[id]/detail.ts
@@ -10,12 +10,14 @@ export function GET({ params }: APIEvent) {
 
   if (typeof state.getAgentDetail === 'function') {
     const data = state.getAgentDetail(agentId);
-    if (!data) return Response.json({ error: 'Agent not found' }, { status: 404 });
+    if (!data)
+      return Response.json({ error: 'Agent not found' }, { status: 404 });
     return Response.json(data);
   }
 
   const agents = state.getAgents();
   const agent = agents[agentId];
-  if (!agent) return Response.json({ error: 'Agent not found' }, { status: 404 });
+  if (!agent)
+    return Response.json({ error: 'Agent not found' }, { status: 404 });
   return Response.json(agent);
 }

--- a/webui/src/routes/api/context/file.ts
+++ b/webui/src/routes/api/context/file.ts
@@ -13,19 +13,31 @@ export async function PUT({ request }: APIEvent) {
 
   const { path: layerPath, content } = body;
   if (!layerPath || typeof layerPath !== 'string') {
-    return Response.json({ error: 'Missing or invalid "path"' }, { status: 400 });
+    return Response.json(
+      { error: 'Missing or invalid "path"' },
+      { status: 400 },
+    );
   }
   if (typeof content !== 'string') {
-    return Response.json({ error: 'Missing or invalid "content"' }, { status: 400 });
+    return Response.json(
+      { error: 'Missing or invalid "content"' },
+      { status: 400 },
+    );
   }
   if (layerPath.includes('..') || layerPath.startsWith('/')) {
-    return Response.json({ error: 'Invalid path: must be relative, no ".."' }, { status: 400 });
+    return Response.json(
+      { error: 'Invalid path: must be relative, no ".."' },
+      { status: 400 },
+    );
   }
 
   try {
     state.writeContextFile(layerPath, content);
   } catch (err: any) {
-    return Response.json({ error: `Failed to write: ${err.message}` }, { status: 500 });
+    return Response.json(
+      { error: `Failed to write: ${err.message}` },
+      { status: 500 },
+    );
   }
 
   return Response.json({ ok: true });

--- a/webui/src/routes/api/context/layers.ts
+++ b/webui/src/routes/api/context/layers.ts
@@ -15,7 +15,10 @@ export function GET({ request }: APIEvent) {
   const categoryPath = categoryFolder || null;
   const serverPath = serverFolder || null;
 
-  const layers: Record<string, { path: string | null; content: string | null; exists: boolean }> = {
+  const layers: Record<
+    string,
+    { path: string | null; content: string | null; exists: boolean }
+  > = {
     channel: {
       path: channelPath || null,
       content: channelPath ? state.readContextFile(channelPath) : null,
@@ -29,7 +32,9 @@ export function GET({ request }: APIEvent) {
     category: {
       path: categoryPath,
       content: categoryPath ? state.readContextFile(categoryPath) : null,
-      exists: categoryPath ? state.readContextFile(categoryPath) !== null : false,
+      exists: categoryPath
+        ? state.readContextFile(categoryPath) !== null
+        : false,
     },
     server: {
       path: serverPath,

--- a/webui/src/routes/api/discord/guilds/[guildId]/icon.ts
+++ b/webui/src/routes/api/discord/guilds/[guildId]/icon.ts
@@ -11,7 +11,10 @@ export async function GET({ params, request }: APIEvent) {
   const botId = url.searchParams.get('botId') || undefined;
 
   if (typeof state.resolveDiscordGuildImageResponse === 'function') {
-    const response = await state.resolveDiscordGuildImageResponse(params.guildId, botId);
+    const response = await state.resolveDiscordGuildImageResponse(
+      params.guildId,
+      botId,
+    );
     if (response) return response;
   }
 

--- a/webui/src/routes/api/health.ts
+++ b/webui/src/routes/api/health.ts
@@ -14,7 +14,9 @@ export function GET() {
     byRuntime[agent.agentRuntime] = (byRuntime[agent.agentRuntime] || 0) + 1;
   }
 
-  let activeTasks = 0, pausedTasks = 0, completedTasks = 0;
+  let activeTasks = 0,
+    pausedTasks = 0,
+    completedTasks = 0;
   for (const t of tasks) {
     if (t.status === 'active') activeTasks++;
     else if (t.status === 'paused') pausedTasks++;
@@ -46,7 +48,12 @@ export function GET() {
       max_active: stats.maxActive,
       max_idle: stats.maxIdle,
     },
-    tasks: { active: activeTasks, paused: pausedTasks, completed: completedTasks, total: tasks.length },
+    tasks: {
+      active: activeTasks,
+      paused: pausedTasks,
+      completed: completedTasks,
+      total: tasks.length,
+    },
     sse_clients: 0,
     started_at: new Date().toISOString(),
   });

--- a/webui/src/routes/api/ipc/events.ts
+++ b/webui/src/routes/api/ipc/events.ts
@@ -5,6 +5,8 @@ export function GET({ request }: APIEvent) {
   const state = getState();
   const url = new URL(request.url);
   const countParam = url.searchParams.get('count');
-  const count = countParam ? Math.min(Math.max(1, parseInt(countParam, 10) || 50), 200) : 50;
+  const count = countParam
+    ? Math.min(Math.max(1, parseInt(countParam, 10) || 50), 200)
+    : 50;
   return Response.json(state.getIpcEvents(count));
 }

--- a/webui/src/routes/api/messages/[chatJid].ts
+++ b/webui/src/routes/api/messages/[chatJid].ts
@@ -4,11 +4,15 @@ import { getState } from '~/lib/server-state';
 export function GET({ params, request }: APIEvent) {
   const state = getState();
   const chatJid = params.chatJid;
-  if (!chatJid) return Response.json({ error: 'Missing chatJid' }, { status: 400 });
+  if (!chatJid)
+    return Response.json({ error: 'Missing chatJid' }, { status: 400 });
 
   const url = new URL(request.url);
   const since = url.searchParams.get('since') || '1970-01-01T00:00:00.000Z';
-  const limit = Math.min(Math.max(1, parseInt(url.searchParams.get('limit') || '100', 10) || 100), 500);
+  const limit = Math.min(
+    Math.max(1, parseInt(url.searchParams.get('limit') || '100', 10) || 100),
+    500,
+  );
   const messages = state.getMessages(chatJid, since, limit);
   return Response.json(messages);
 }

--- a/webui/src/routes/api/messages/search.ts
+++ b/webui/src/routes/api/messages/search.ts
@@ -5,10 +5,14 @@ export function GET({ request }: APIEvent) {
   const state = getState();
   const url = new URL(request.url);
   const query = url.searchParams.get('q') || '';
-  if (!query.trim()) return Response.json({ error: 'Missing search query' }, { status: 400 });
+  if (!query.trim())
+    return Response.json({ error: 'Missing search query' }, { status: 400 });
 
   const chatJid = url.searchParams.get('chatJid') || undefined;
-  const limit = Math.min(Math.max(1, parseInt(url.searchParams.get('limit') || '50', 10) || 50), 200);
+  const limit = Math.min(
+    Math.max(1, parseInt(url.searchParams.get('limit') || '50', 10) || 50),
+    200,
+  );
   const results = state.searchMessages(query, chatJid, limit);
   return Response.json(results);
 }

--- a/webui/src/routes/api/stats.ts
+++ b/webui/src/routes/api/stats.ts
@@ -6,7 +6,9 @@ export function GET() {
   const agents = state.getAgents();
   const tasks = state.getTasks() as any[];
 
-  let activeTasks = 0, pausedTasks = 0, completedTasks = 0;
+  let activeTasks = 0,
+    pausedTasks = 0,
+    completedTasks = 0;
   for (const t of tasks) {
     if (t.status === 'active') activeTasks++;
     else if (t.status === 'paused') pausedTasks++;

--- a/webui/src/routes/api/tasks/[id]/index.ts
+++ b/webui/src/routes/api/tasks/[id]/index.ts
@@ -11,7 +11,8 @@ export function GET({ params }: APIEvent) {
 export async function PATCH({ params, request }: APIEvent) {
   const state = getState();
   const existing = state.getTaskById(params.id);
-  if (!existing) return Response.json({ error: 'Task not found' }, { status: 404 });
+  if (!existing)
+    return Response.json({ error: 'Task not found' }, { status: 404 });
 
   let body: Record<string, unknown>;
   try {
@@ -24,39 +25,56 @@ export async function PATCH({ params, request }: APIEvent) {
 
   if (body.prompt !== undefined) {
     if (typeof body.prompt !== 'string' || !body.prompt) {
-      return Response.json({ error: '"prompt" must be a non-empty string' }, { status: 400 });
+      return Response.json(
+        { error: '"prompt" must be a non-empty string' },
+        { status: 400 },
+      );
     }
     updates.prompt = body.prompt;
   }
   if (body.schedule_type !== undefined) {
     if (!['cron', 'interval', 'once'].includes(body.schedule_type as string)) {
-      return Response.json({ error: '"schedule_type" must be cron | interval | once' }, { status: 400 });
+      return Response.json(
+        { error: '"schedule_type" must be cron | interval | once' },
+        { status: 400 },
+      );
     }
     updates.schedule_type = body.schedule_type;
   }
   if (body.schedule_value !== undefined) {
     if (typeof body.schedule_value !== 'string' || !body.schedule_value) {
-      return Response.json({ error: '"schedule_value" must be a non-empty string' }, { status: 400 });
+      return Response.json(
+        { error: '"schedule_value" must be a non-empty string' },
+        { status: 400 },
+      );
     }
     updates.schedule_value = body.schedule_value;
   }
   if (body.status !== undefined) {
     if (!['active', 'paused'].includes(body.status as string)) {
-      return Response.json({ error: '"status" must be active | paused' }, { status: 400 });
+      return Response.json(
+        { error: '"status" must be active | paused' },
+        { status: 400 },
+      );
     }
     updates.status = body.status;
   }
 
   if (Object.keys(updates).length === 0) {
-    return Response.json({ error: 'No valid fields to update' }, { status: 400 });
+    return Response.json(
+      { error: 'No valid fields to update' },
+      { status: 400 },
+    );
   }
 
   // Recalculate next_run when schedule changes or task is being resumed
   const effectiveStatus = (updates.status as string) ?? existing.status;
   const scheduleChanged = !!(updates.schedule_type || updates.schedule_value);
-  const beingResumed = updates.status === 'active' && existing.status !== 'active';
+  const beingResumed =
+    updates.status === 'active' && existing.status !== 'active';
   const newType = (updates.schedule_type ?? existing.schedule_type) as string;
-  const newValue = (updates.schedule_value ?? existing.schedule_value) as string;
+  const newValue = (updates.schedule_value ??
+    existing.schedule_value) as string;
 
   if (scheduleChanged) {
     const validated = state.calculateNextRun(newType, newValue);
@@ -64,7 +82,11 @@ export async function PATCH({ params, request }: APIEvent) {
       return Response.json({ error: 'Invalid schedule' }, { status: 400 });
     }
     if (effectiveStatus === 'active') updates.next_run = validated;
-  } else if (effectiveStatus === 'active' && beingResumed && newType !== 'once') {
+  } else if (
+    effectiveStatus === 'active' &&
+    beingResumed &&
+    newType !== 'once'
+  ) {
     const nextRun = state.calculateNextRun(newType, newValue);
     if (nextRun === null) {
       return Response.json({ error: 'Invalid schedule' }, { status: 400 });
@@ -75,7 +97,10 @@ export async function PATCH({ params, request }: APIEvent) {
   try {
     state.updateTask(params.id, updates);
   } catch (err: any) {
-    return Response.json({ error: `Failed to update task: ${err.message}` }, { status: 500 });
+    return Response.json(
+      { error: `Failed to update task: ${err.message}` },
+      { status: 500 },
+    );
   }
 
   const updated = state.getTaskById(params.id);
@@ -85,12 +110,16 @@ export async function PATCH({ params, request }: APIEvent) {
 export function DELETE({ params }: APIEvent) {
   const state = getState();
   const existing = state.getTaskById(params.id);
-  if (!existing) return Response.json({ error: 'Task not found' }, { status: 404 });
+  if (!existing)
+    return Response.json({ error: 'Task not found' }, { status: 404 });
 
   try {
     state.deleteTask(params.id);
   } catch (err: any) {
-    return Response.json({ error: `Failed to delete task: ${err.message}` }, { status: 500 });
+    return Response.json(
+      { error: `Failed to delete task: ${err.message}` },
+      { status: 500 },
+    );
   }
 
   return Response.json({ deleted: true, id: params.id });

--- a/webui/src/routes/api/tasks/[id]/runs.ts
+++ b/webui/src/routes/api/tasks/[id]/runs.ts
@@ -8,7 +8,9 @@ export function GET({ params, request }: APIEvent) {
 
   const url = new URL(request.url);
   const limitParam = url.searchParams.get('limit');
-  const limit = limitParam ? Math.min(Math.max(1, parseInt(limitParam, 10) || 20), 100) : 20;
+  const limit = limitParam
+    ? Math.min(Math.max(1, parseInt(limitParam, 10) || 20), 100)
+    : 20;
   const runs = state.getTaskRunLogs(params.id, limit);
   return Response.json(runs);
 }

--- a/webui/src/routes/api/tasks/index.ts
+++ b/webui/src/routes/api/tasks/index.ts
@@ -22,26 +22,57 @@ export async function POST({ request }: APIEvent) {
     return Response.json({ error: 'Invalid JSON body' }, { status: 400 });
   }
 
-  const { group_folder, chat_jid, prompt, schedule_type, schedule_value, context_mode } = body;
+  const {
+    group_folder,
+    chat_jid,
+    prompt,
+    schedule_type,
+    schedule_value,
+    context_mode,
+  } = body;
 
   if (!prompt || typeof prompt !== 'string') {
-    return Response.json({ error: 'Missing or invalid "prompt"' }, { status: 400 });
+    return Response.json(
+      { error: 'Missing or invalid "prompt"' },
+      { status: 400 },
+    );
   }
-  if (!schedule_type || !['cron', 'interval', 'once'].includes(schedule_type as string)) {
-    return Response.json({ error: 'Missing or invalid "schedule_type"' }, { status: 400 });
+  if (
+    !schedule_type ||
+    !['cron', 'interval', 'once'].includes(schedule_type as string)
+  ) {
+    return Response.json(
+      { error: 'Missing or invalid "schedule_type"' },
+      { status: 400 },
+    );
   }
   if (!schedule_value || typeof schedule_value !== 'string') {
-    return Response.json({ error: 'Missing or invalid "schedule_value"' }, { status: 400 });
+    return Response.json(
+      { error: 'Missing or invalid "schedule_value"' },
+      { status: 400 },
+    );
   }
   if (!group_folder || typeof group_folder !== 'string') {
-    return Response.json({ error: 'Missing or invalid "group_folder"' }, { status: 400 });
+    return Response.json(
+      { error: 'Missing or invalid "group_folder"' },
+      { status: 400 },
+    );
   }
   if (!chat_jid || typeof chat_jid !== 'string') {
-    return Response.json({ error: 'Missing or invalid "chat_jid"' }, { status: 400 });
+    return Response.json(
+      { error: 'Missing or invalid "chat_jid"' },
+      { status: 400 },
+    );
   }
 
-  const validContextMode = context_mode === 'group' || context_mode === 'isolated' ? context_mode : 'isolated';
-  const nextRun = state.calculateNextRun(schedule_type as string, schedule_value as string);
+  const validContextMode =
+    context_mode === 'group' || context_mode === 'isolated'
+      ? context_mode
+      : 'isolated';
+  const nextRun = state.calculateNextRun(
+    schedule_type as string,
+    schedule_value as string,
+  );
   if (nextRun === null) {
     return Response.json({ error: 'Invalid schedule' }, { status: 400 });
   }
@@ -63,8 +94,14 @@ export async function POST({ request }: APIEvent) {
   try {
     state.createTask(task);
   } catch (err: any) {
-    return Response.json({ error: `Failed to create task: ${err.message}` }, { status: 500 });
+    return Response.json(
+      { error: `Failed to create task: ${err.message}` },
+      { status: 500 },
+    );
   }
 
-  return Response.json({ ...task, last_run: null, last_result: null }, { status: 201 });
+  return Response.json(
+    { ...task, last_run: null, last_result: null },
+    { status: 201 },
+  );
 }


### PR DESCRIPTION
## Summary

- format the remaining SolidStart `webui/` files that were breaking the repo-wide Prettier check on `main`
- switch `src/web/solid-handler.ts` to import the generated SolidStart server entry via a runtime-resolved file URL so fresh checkouts pass `tsc --noEmit` without a prior `webui` build

## Verification

- `bunx prettier --check .`
- `bunx tsc --noEmit`

Closes #261
Closes #423


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Style**
  * Code formatting and structure improvements throughout the application for enhanced maintainability and readability. All changes are internal refactoring with no impact on functionality or user experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->