### PR TITLE
fix(security): cap peer-auth request bodies

### DIFF
--- a/src/web/server.test.ts
+++ b/src/web/server.test.ts
@@ -462,7 +462,10 @@ describe('basic auth', () => {
       makePeerTrustStore(),
     );
 
-    const body = JSON.stringify({ path: 'team/CLAUDE.md', content: 'peer sync' });
+    const body = JSON.stringify({
+      path: 'team/CLAUDE.md',
+      content: 'peer sync',
+    });
     const res = await fetch(url('/api/context/file'), {
       method: 'PUT',
       headers: buildPeerAuthHeaders('/api/context/file', 'PUT', body),

--- a/src/web/server.ts
+++ b/src/web/server.ts
@@ -93,9 +93,13 @@ async function hashRequestBodyWithLimit(
   req: Request,
   maxBytes: number,
 ): Promise<RequestBodyHashResult> {
-  const contentLength = Number.parseInt(req.headers.get('content-length') || '', 10);
+  const contentLength = Number.parseInt(
+    req.headers.get('content-length') || '',
+    10,
+  );
   if (Number.isFinite(contentLength) && contentLength > maxBytes) {
     return {
+      // Placeholder; callers reject over-limit requests before using the hash.
       hash: createHash('sha256').update('').digest('hex'),
       exceededLimit: true,
     };
@@ -127,6 +131,7 @@ async function hashRequestBodyWithLimit(
           // Ignore cancellation failures; the caller only needs the limit signal.
         }
         return {
+          // Placeholder; callers reject over-limit requests before using the hash.
           hash: createHash('sha256').update('').digest('hex'),
           exceededLimit: true,
         };


### PR DESCRIPTION
## Summary
- stream peer-auth request hashing instead of buffering full bodies up front
- reject peer-auth route bodies over 1 MiB with `413` before auth verification or routing
- cover both valid peer writes and oversize rejection in `src/web/server.test.ts`

## Security context
- before this change, any request with `X-OmniClaw-Instance` on a peer-auth route triggered `req.clone().text()` in `src/web/server.ts`
- that let unauthenticated callers force the web server to buffer arbitrarily large request bodies before signature validation
- the new capped stream preserves body-integrity verification for legitimate peer sync traffic without leaving the server open to pre-auth memory pressure

## Testing
- `bun test src/web/server.test.ts`
- `bun run typecheck`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Peer-authenticated requests exceeding the maximum body size now return a 413 error response instead of continuing with processing.

* **Tests**
  * Added test utilities for peer authentication headers and signature validation.
  * Extended test coverage with scenarios for successful peer-authenticated file uploads and oversized request body handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->