### PR TITLE
fix(identity): populate sender_user_id for telegram and whatsapp

### DIFF
--- a/src/channels/telegram.test.ts
+++ b/src/channels/telegram.test.ts
@@ -226,6 +226,32 @@ describe('TelegramChannel bot identity', () => {
   });
 });
 
+describe('TelegramChannel sender identity', () => {
+  const makeChannel = () =>
+    new TelegramChannel('123456:token', {
+      onMessage: () => {},
+      onChatMetadata: () => {},
+      registeredGroups: () => ({}),
+    });
+
+  it('derives sender and sender_user_id from the Telegram user id', () => {
+    const channel = makeChannel();
+
+    expect((channel as any).buildSenderIdentity({ id: 987654321 })).toEqual({
+      sender: 'telegram:987654321',
+      senderUserId: '987654321',
+    });
+  });
+
+  it('returns an empty sender when the Telegram user id is missing', () => {
+    const channel = makeChannel();
+
+    expect((channel as any).buildSenderIdentity(undefined)).toEqual({
+      sender: '',
+    });
+  });
+});
+
 describe('telegram avatar descriptors', () => {
   it('round-trips safe Telegram avatar descriptors', () => {
     const descriptor = buildTelegramFileDescriptor(

--- a/src/channels/telegram.ts
+++ b/src/channels/telegram.ts
@@ -139,6 +139,19 @@ export class TelegramChannel implements Channel {
     this.allowLegacyJidRouting = opts.allowLegacyJidRouting !== false;
   }
 
+  private buildSenderIdentity(
+    from: { id?: string | number | bigint } | null | undefined,
+  ): {
+    sender: string;
+    senderUserId?: string;
+  } {
+    const senderUserId = from?.id != null ? String(from.id) : undefined;
+    return {
+      sender: senderUserId ? `telegram:${senderUserId}` : '',
+      senderUserId,
+    };
+  }
+
   async connect(): Promise<void> {
     this.bot = new Bot(this.botToken);
 
@@ -175,8 +188,7 @@ export class TelegramChannel implements Channel {
       const legacyChatJid = `tg:${chatId}`;
       let content = ctx.message.text;
       const timestamp = new Date(ctx.message.date * 1000).toISOString();
-      const senderId = ctx.from?.id?.toString() || '';
-      const sender = senderId ? `telegram:${senderId}` : '';
+      const { sender, senderUserId } = this.buildSenderIdentity(ctx.from);
       const senderName =
         ctx.from?.first_name || ctx.from?.username || 'Unknown';
       const msgId = ctx.message.message_id.toString();
@@ -238,6 +250,7 @@ export class TelegramChannel implements Channel {
         timestamp,
         is_from_me: false,
         sender_platform: 'telegram',
+        sender_user_id: senderUserId,
       });
 
       logger.info(
@@ -256,8 +269,7 @@ export class TelegramChannel implements Channel {
       if (!group) return;
 
       const timestamp = new Date(ctx.message.date * 1000).toISOString();
-      const senderId = ctx.from?.id?.toString() || '';
-      const sender = senderId ? `telegram:${senderId}` : '';
+      const { sender, senderUserId } = this.buildSenderIdentity(ctx.from);
       const senderName =
         ctx.from?.first_name || ctx.from?.username || 'Unknown';
       const caption = ctx.message.caption ? ` ${ctx.message.caption}` : '';
@@ -273,6 +285,7 @@ export class TelegramChannel implements Channel {
         timestamp,
         is_from_me: false,
         sender_platform: 'telegram',
+        sender_user_id: senderUserId,
       });
     };
 

--- a/src/channels/whatsapp.test.ts
+++ b/src/channels/whatsapp.test.ts
@@ -881,3 +881,31 @@ describe('WhatsAppChannel LID mapping', () => {
     expect(Object.keys(getPrivate(channel, 'lidToPhoneMap'))).toHaveLength(0);
   });
 });
+
+describe('WhatsAppChannel sender identity', () => {
+  it('uses translated participant JIDs for sender and sender_user_id', async () => {
+    const channel = makeChannel();
+    setPrivate(channel, 'sock', makeMockSocket());
+    setPrivate(channel, 'lidToPhoneMap', {
+      '15551234567': '15551234567@s.whatsapp.net',
+    });
+
+    await expect(
+      (channel as any).buildSenderIdentity('15551234567:12@lid'),
+    ).resolves.toEqual({
+      sender: 'whatsapp:15551234567@s.whatsapp.net',
+      senderUserId: '15551234567@s.whatsapp.net',
+    });
+  });
+
+  it('falls back to the raw JID when no translation is needed', async () => {
+    const channel = makeChannel();
+
+    await expect(
+      (channel as any).buildSenderIdentity('15551234567@s.whatsapp.net'),
+    ).resolves.toEqual({
+      sender: 'whatsapp:15551234567@s.whatsapp.net',
+      senderUserId: '15551234567@s.whatsapp.net',
+    });
+  });
+});

--- a/src/channels/whatsapp.ts
+++ b/src/channels/whatsapp.ts
@@ -350,7 +350,8 @@ export class WhatsAppChannel implements Channel {
             if (!content) continue;
 
             const rawSender = msg.key.participant || msg.key.remoteJid || '';
-            const sender = rawSender ? `whatsapp:${rawSender}` : '';
+            const { sender, senderUserId } =
+              await this.buildSenderIdentity(rawSender);
             const senderName = msg.pushName?.trim() || '';
 
             if (!senderName) {
@@ -403,6 +404,7 @@ export class WhatsAppChannel implements Channel {
               // which would cause the DB query to drop real user messages.
               is_from_me: false,
               sender_platform: 'whatsapp',
+              sender_user_id: senderUserId,
             });
           }
         } catch (err) {
@@ -565,6 +567,21 @@ export class WhatsAppChannel implements Channel {
     }
 
     return jid;
+  }
+
+  private async buildSenderIdentity(rawSender: string): Promise<{
+    sender: string;
+    senderUserId?: string;
+  }> {
+    if (!rawSender) {
+      return { sender: '' };
+    }
+
+    const senderUserId = await this.translateJid(rawSender);
+    return {
+      sender: `whatsapp:${senderUserId}`,
+      senderUserId,
+    };
   }
 
   private async flushOutgoingQueue(): Promise<void> {


### PR DESCRIPTION
## Summary
- populate `sender_user_id` for Telegram text and non-text inbound messages
- populate `sender_user_id` for WhatsApp inbound messages using the same translated JID path as `sender`
- add adapter-focused tests for Telegram sender identity derivation and WhatsApp LID translation alignment

## Testing
- `bun test src/channels/telegram.test.ts src/channels/whatsapp.test.ts`
- `bunx tsc --noEmit`
- `bunx prettier --check src/channels/telegram.ts src/channels/whatsapp.ts src/channels/telegram.test.ts src/channels/whatsapp.test.ts`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added test suites validating sender identity handling for Telegram and WhatsApp channels.

* **Refactor**
  * Enhanced sender identity derivation across Telegram and WhatsApp channels to include sender user ID tracking in message storage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->