### PR TITLE
fix(scheduler): isolate handoff write failures

### DIFF
--- a/src/task-scheduler-runner.test.ts
+++ b/src/task-scheduler-runner.test.ts
@@ -306,4 +306,100 @@ describe('startSchedulerLoop task execution', () => {
         originalSetTimeout;
     }
   });
+
+  it('clears the execution lease when handoff writing fails', async () => {
+    const task: ScheduledTask = {
+      id: 'task-handoff-error',
+      group_folder: 'main',
+      chat_jid: 'main@g.us',
+      prompt: 'write handoff',
+      schedule_type: 'interval',
+      schedule_value: '300000',
+      context_mode: 'isolated',
+      next_run: '2026-01-01T00:00:00.000Z',
+      last_run: null,
+      last_result: null,
+      status: 'active',
+      created_at: '2026-01-01T00:00:00.000Z',
+      executing_since: null,
+    };
+    const clearTaskExecutingMock = mock(() => {});
+    const loggerMock = createLoggerMock();
+    const enqueuedRuns: Array<Promise<void>> = [];
+    const originalSetTimeout = globalThis.setTimeout;
+
+    (globalThis as { setTimeout: typeof setTimeout }).setTimeout = ((
+      _fn: Parameters<typeof setTimeout>[0],
+    ) => ({ id: 'poll' })) as unknown as typeof setTimeout;
+
+    try {
+      const deps: SchedulerDependencies = {
+        registeredGroups: () => ({}),
+        getGroupForTask: () => ({
+          name: 'Main',
+          folder: 'main',
+          trigger: '@Bot',
+          added_at: '2026-01-01T00:00:00.000Z',
+        }),
+        getSessions: () => ({}),
+        resumePositionStore: {
+          get: () => undefined,
+          set: () => {},
+          getAll: () => ({}),
+          clear: () => {},
+        },
+        queue: {
+          enqueueTask: (
+            _jid: string,
+            _taskId: string,
+            run: () => Promise<void>,
+          ) => {
+            enqueuedRuns.push(run());
+          },
+          notifyIdle: mock(() => {}),
+          closeStdin: mock(() => {}),
+        } as unknown as SchedulerDependencies['queue'],
+        onProcess: mock(() => {}),
+        sendMessage: mock(async () => undefined),
+        findChannel: () => undefined,
+      };
+
+      startSchedulerLoop(deps, {
+        calculateNextRun: mock(() => '2026-01-01T00:05:00.000Z'),
+        resolveBackend: mock(() => ({
+          runAgent: async () =>
+            ({ status: 'success', result: 'done' }) as ContainerOutput,
+        })),
+        writeTasksSnapshot: mock(() => {}),
+        advanceTaskNextRun: mock(() => {}),
+        markTaskExecuting: mock(() => {}),
+        clearTaskExecuting: clearTaskExecutingMock,
+        getStaleExecutingTasks: mock(() => []),
+        getOrphanedOnceTasks: mock(() => []),
+        hasSuccessfulRun: mock(() => false),
+        getAllTasks: mock(() => [task]),
+        getDueTasks: mock(() => [task]),
+        getTaskById: mock((taskId: string) =>
+          taskId === task.id ? task : null,
+        ),
+        logTaskRun: mock(() => {}),
+        updateTaskAfterRun: mock(() => {}),
+        writeScheduledRunHandoff: mock(() => {
+          throw new Error('disk full');
+        }),
+        logger: loggerMock,
+      } as any);
+
+      await Promise.all(enqueuedRuns);
+
+      expect(clearTaskExecutingMock).toHaveBeenCalledWith('task-handoff-error');
+      expect(loggerMock.warn).toHaveBeenCalledWith(
+        expect.objectContaining({ err: expect.any(Error) }),
+        'Failed to write scheduled task handoff',
+      );
+    } finally {
+      (globalThis as { setTimeout: typeof setTimeout }).setTimeout =
+        originalSetTimeout;
+    }
+  });
 });

--- a/src/task-scheduler.ts
+++ b/src/task-scheduler.ts
@@ -137,6 +137,16 @@ async function runTask(
     });
     log.info('Running scheduled task');
 
+    const tryWriteHandoff = (
+      handoff: Parameters<typeof runtime.writeScheduledRunHandoff>[0],
+    ) => {
+      try {
+        runtime.writeScheduledRunHandoff(handoff);
+      } catch (err) {
+        log.warn({ err }, 'Failed to write scheduled task handoff');
+      }
+    };
+
     const group = deps.getGroupForTask(task.chat_jid, task.group_folder);
 
     if (!group) {
@@ -149,7 +159,7 @@ async function runTask(
         result: null,
         error: `Group not found: ${task.group_folder}`,
       });
-      runtime.writeScheduledRunHandoff({
+      tryWriteHandoff({
         task_id: task.id,
         chat_jid: task.chat_jid,
         group_folder: task.group_folder,
@@ -309,7 +319,7 @@ async function runTask(
         ? result.slice(0, 200)
         : 'Completed';
     runtime.updateTaskAfterRun(task.id, nextRun, resultSummary);
-    runtime.writeScheduledRunHandoff({
+    tryWriteHandoff({
       task_id: task.id,
       chat_jid: task.chat_jid,
       group_folder: task.group_folder,


### PR DESCRIPTION
## Summary
- wrap scheduled run handoff writes so disk or permission failures only warn instead of disrupting task cleanup
- add scheduler runner coverage proving `clearTaskExecuting()` still runs when handoff persistence throws

## Testing
- `bun test src/task-scheduler-runner.test.ts src/task-scheduler-loop.harness.ts src/task-scheduler.test.ts src/task-handoffs.test.ts`
- `bunx tsc --noEmit`
- `bunx prettier --check src/task-scheduler.ts src/task-scheduler-runner.test.ts`
