### PR TITLE
feat(whatsapp): download photo and document attachments via shared media pipeline

### DIFF
--- a/src/channels/whatsapp.test.ts
+++ b/src/channels/whatsapp.test.ts
@@ -1,5 +1,21 @@
-import { describe, it, expect, beforeEach, mock, spyOn } from 'bun:test';
+import fs from 'fs';
+import path from 'path';
+import {
+  afterEach,
+  describe,
+  it,
+  expect,
+  beforeEach,
+  mock,
+  spyOn,
+} from 'bun:test';
 
+import { GROUPS_DIR } from '../config.js';
+import {
+  formatImageMarker,
+  formatPlaceholder,
+  formatTextFileMarker,
+} from '../media.js';
 import { WhatsAppChannel } from './whatsapp.js';
 import type { WhatsAppChannelOpts } from './whatsapp.js';
 import type { OnInboundMessage, OnChatMetadata } from '../types.js';
@@ -907,5 +923,115 @@ describe('WhatsAppChannel sender identity', () => {
       sender: 'whatsapp:15551234567@s.whatsapp.net',
       senderUserId: '15551234567@s.whatsapp.net',
     });
+  });
+});
+
+// ===========================================================================
+// WhatsApp media download helpers
+// ===========================================================================
+
+describe('WhatsAppChannel.downloadWhatsAppMedia', () => {
+  it('returns null when sock is not connected', async () => {
+    const channel = makeChannel();
+    // sock is the default BunSocket stub, no updateMediaMessage
+    setPrivate(channel, 'sock', { updateMediaMessage: mock() });
+
+    // downloadMediaMessage will throw because the message has no media keys
+    const result = await (channel as any).downloadWhatsAppMedia({
+      message: { imageMessage: {} },
+    });
+    expect(result).toBeNull();
+  });
+});
+
+// ===========================================================================
+// WhatsApp media marker integration
+// ===========================================================================
+
+describe('WhatsApp media marker formatting', () => {
+  it('formats image marker for downloaded photos', () => {
+    const marker = formatImageMarker('msg123-photo.jpg');
+    expect(marker).toBe('[attachment:image file=msg123-photo.jpg]');
+  });
+
+  it('formats video placeholder', () => {
+    expect(formatPlaceholder('video')).toBe('[Video]');
+  });
+
+  it('formats audio placeholder', () => {
+    expect(formatPlaceholder('audio')).toBe('[Audio]');
+  });
+
+  it('formats file placeholder with name', () => {
+    expect(formatPlaceholder('file', 'report.pdf')).toBe('[File: report.pdf]');
+  });
+
+  it('formats file placeholder without name', () => {
+    expect(formatPlaceholder('file')).toBe('[File]');
+  });
+
+  it('formats inline text file marker', () => {
+    const marker = formatTextFileMarker('config.json', '{"key": "val"}');
+    expect(marker).toBe(
+      '[attachment:file name=config.json]\n{"key": "val"}\n[/attachment:file]',
+    );
+  });
+
+  it('prepends media marker to caption text', () => {
+    const mediaMarker = '[attachment:image file=msg1-photo.jpg]';
+    const caption = 'Check this out';
+    const content = `${mediaMarker} ${caption}`;
+    expect(content).toBe(
+      '[attachment:image file=msg1-photo.jpg] Check this out',
+    );
+  });
+
+  it('uses media marker alone when no caption', () => {
+    const mediaMarker = '[attachment:image file=msg1-photo.jpg]';
+    const caption = '';
+    const content = caption ? `${mediaMarker} ${caption}` : mediaMarker;
+    expect(content).toBe('[attachment:image file=msg1-photo.jpg]');
+  });
+});
+
+describe('WhatsApp media directory operations', () => {
+  const testFolder = `wa-media-test-${Date.now()}`;
+
+  afterEach(() => {
+    const dir = path.join(GROUPS_DIR, testFolder);
+    if (fs.existsSync(dir)) {
+      fs.rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it('creates media directory under group workspace', () => {
+    const { ensureMediaDir } = require('../media.js');
+    const group = {
+      name: 'test',
+      folder: testFolder,
+      trigger: '@test',
+      added_at: new Date().toISOString(),
+    };
+    const mediaDir = ensureMediaDir(group);
+    expect(fs.existsSync(mediaDir)).toBe(true);
+    expect(mediaDir).toBe(path.join(GROUPS_DIR, testFolder, 'media'));
+  });
+
+  it('prevents path traversal in media filenames', () => {
+    const { ensureMediaDir, buildSafeMediaPath } = require('../media.js');
+    const group = {
+      name: 'test',
+      folder: testFolder,
+      trigger: '@test',
+      added_at: new Date().toISOString(),
+    };
+    const mediaDir = ensureMediaDir(group);
+    const filePath = buildSafeMediaPath(
+      mediaDir,
+      'msg1',
+      '../../../etc/passwd',
+    );
+    expect(filePath).not.toContain('..');
+    expect(path.dirname(filePath)).toBe(mediaDir);
   });
 });

--- a/src/channels/whatsapp.ts
+++ b/src/channels/whatsapp.ts
@@ -6,6 +6,7 @@ import makeWASocket, {
   Browsers,
   DisconnectReason,
   WASocket,
+  downloadMediaMessage,
   fetchLatestWaWebVersion,
   makeCacheableSignalKeyStore,
   useMultiFileAuthState,
@@ -14,6 +15,17 @@ import makeWASocket, {
 import { STORE_DIR } from '../config.js';
 import { getLastGroupSync, setLastGroupSync, updateChatName } from '../db.js';
 import { logger } from '../logger.js';
+import {
+  MAX_BINARY_DOWNLOAD_BYTES,
+  MAX_TEXT_DOWNLOAD_BYTES,
+  buildSafeMediaPath,
+  ensureMediaDir,
+  formatImageMarker,
+  formatPlaceholder,
+  formatTextFileMarker,
+  isImageByTypeOrExtension,
+  isTextByExtension,
+} from '../media.js';
 import {
   Channel,
   OnInboundMessage,
@@ -346,7 +358,88 @@ export class WhatsAppChannel implements Channel {
               msg.message?.videoMessage?.caption ||
               '';
 
-            // Skip protocol messages with no text content (encryption keys, read receipts, etc.)
+            // Detect media messages and download attachments
+            const group = groups[chatJid];
+            const m = msg.message!;
+            let mediaMarker = '';
+
+            if (m.imageMessage) {
+              const buffer = await this.downloadWhatsAppMedia(msg);
+              if (buffer) {
+                try {
+                  const mediaDir = ensureMediaDir(group);
+                  const filePath = buildSafeMediaPath(
+                    mediaDir,
+                    msgId,
+                    'photo.jpg',
+                  );
+                  fs.writeFileSync(filePath, buffer);
+                  mediaMarker = formatImageMarker(path.basename(filePath));
+                } catch (err) {
+                  logger.warn({ err, msgId }, 'Failed to store WhatsApp image');
+                  mediaMarker = '[Photo]';
+                }
+              } else {
+                mediaMarker = '[Photo]';
+              }
+            } else if (m.videoMessage) {
+              mediaMarker = formatPlaceholder('video');
+            } else if (m.audioMessage) {
+              mediaMarker = formatPlaceholder('audio');
+            } else if (m.stickerMessage) {
+              mediaMarker = '[Sticker]';
+            } else if (m.documentMessage) {
+              const doc = m.documentMessage;
+              const fileName = doc.fileName || 'file';
+              const mimeType = doc.mimetype || null;
+              const fileSize = doc.fileLength
+                ? Number(doc.fileLength)
+                : Infinity;
+
+              if (isImageByTypeOrExtension(mimeType, fileName)) {
+                const buffer = await this.downloadWhatsAppMedia(msg);
+                if (buffer) {
+                  try {
+                    const mediaDir = ensureMediaDir(group);
+                    const filePath = buildSafeMediaPath(
+                      mediaDir,
+                      msgId,
+                      fileName,
+                    );
+                    fs.writeFileSync(filePath, buffer);
+                    mediaMarker = formatImageMarker(path.basename(filePath));
+                  } catch (err) {
+                    logger.warn(
+                      { err, msgId, fileName },
+                      'Failed to store WhatsApp document image',
+                    );
+                    mediaMarker = formatPlaceholder('file', fileName);
+                  }
+                } else {
+                  mediaMarker = formatPlaceholder('file', fileName);
+                }
+              } else if (
+                isTextByExtension(fileName) &&
+                fileSize <= MAX_TEXT_DOWNLOAD_BYTES
+              ) {
+                const buffer = await this.downloadWhatsAppMedia(msg);
+                if (buffer) {
+                  const safeName = path.basename(fileName);
+                  const text = new TextDecoder().decode(buffer);
+                  mediaMarker = formatTextFileMarker(safeName, text);
+                } else {
+                  mediaMarker = formatPlaceholder('file', fileName);
+                }
+              } else {
+                mediaMarker = formatPlaceholder('file', fileName);
+              }
+            }
+
+            if (mediaMarker) {
+              content = content ? `${mediaMarker} ${content}` : mediaMarker;
+            }
+
+            // Skip protocol messages with no text or media content
             if (!content) continue;
 
             const rawSender = msg.key.participant || msg.key.remoteJid || '';
@@ -567,6 +660,36 @@ export class WhatsAppChannel implements Channel {
     }
 
     return jid;
+  }
+
+  /**
+   * Download media from a WhatsApp message using Baileys' built-in decryption.
+   * Returns the binary buffer, or null on failure.
+   */
+  private async downloadWhatsAppMedia(msg: any): Promise<Buffer | null> {
+    try {
+      const buffer = (await downloadMediaMessage(
+        msg,
+        'buffer',
+        {},
+        {
+          logger: { ...console, child: () => console } as any,
+          reuploadRequest: this.sock.updateMediaMessage,
+        },
+      )) as Buffer;
+      if (!buffer || buffer.length === 0) return null;
+      if (buffer.length > MAX_BINARY_DOWNLOAD_BYTES) {
+        logger.warn(
+          { bytes: buffer.length, max: MAX_BINARY_DOWNLOAD_BYTES },
+          'WhatsApp media exceeds size limit — discarding',
+        );
+        return null;
+      }
+      return buffer;
+    } catch (err) {
+      logger.warn({ err }, 'Failed to download WhatsApp media');
+      return null;
+    }
   }
 
   private async buildSenderIdentity(rawSender: string): Promise<{


### PR DESCRIPTION
## Summary

Follow-up to #430 (shared media pipeline) and #431 (Telegram media). Adds media download support to the WhatsApp adapter using the same shared `src/media.ts` pipeline.

### Photos (`imageMessage`)
- Downloads via Baileys' `downloadMediaMessage` (handles WhatsApp's end-to-end encrypted media)
- Enforces 10 MiB size cap (same as Discord/Telegram)
- Stores in group `media/` dir, emits `[attachment:image file=...]` marker
- Graceful fallback to `[Photo]` placeholder on failure

### Documents (`documentMessage`)
- Image documents (by MIME or extension): downloaded and stored as images
- Text documents (≤100 KiB, by extension): downloaded and inlined via `[attachment:file]` markers
- Other documents: `[File: name]` placeholder

### Key behavioral change
Image-only messages (no caption) were previously silently skipped by the `if (!content) continue;` guard. They now produce media markers and reach the agent.

### Not in scope
- Video/audio/sticker: remain as placeholders (future PRs)
- Slack media downloads (separate follow-up)

## Test plan
- [x] 11 new tests covering `downloadWhatsAppMedia`, marker formatting, media directory operations, path traversal defense
- [x] Full suite: 1495 pass, 0 fail
- [x] Typecheck clean, format clean
- [ ] Manual: send photo to WhatsApp bot, verify agent receives image content
- [ ] Manual: send .json document, verify agent receives inlined text

Partial progress on #258, #178.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * WhatsApp messages now support media attachments including images, videos, audio files, documents, and inline text files.
  * Media files are downloaded and stored appropriately when messages are received.
  * Graceful fallback display for media when downloads fail, files exceed size limits, or media handling is unavailable.

* **Tests**
  * Added comprehensive test coverage for media attachment handling and file operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->