### PR TITLE
feat(scheduler): inject recent handoffs into chat prompts

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -126,6 +126,10 @@ import {
   hasPriorRuntimeState,
   STARTUP_CONFIRMATION_PROMPT,
 } from './startup-notifications.js';
+import {
+  formatScheduledRunHandoffsForPrompt,
+  readScheduledRunHandoffs,
+} from './task-handoffs.js';
 import { startSchedulerLoop } from './task-scheduler.js';
 import {
   parseTelegramApiFileUrl,
@@ -1237,6 +1241,16 @@ async function processGroupMessages(dispatchJid: string): Promise<boolean> {
     ),
     channelRosterHasRoleLabels: true,
   });
+
+  const recentHandoffs = readScheduledRunHandoffs(group.folder, {
+    limit: 3,
+    onError: (err, filePath) =>
+      log.warn({ err, filePath }, 'Failed to load scheduled run handoff'),
+  });
+  const handoffBlock = formatScheduledRunHandoffsForPrompt(recentHandoffs);
+  if (handoffBlock) {
+    prompt = `${handoffBlock}\n\n${prompt}`;
+  }
 
   // Inject context about active background tasks
   const activeTask = queue.getActiveTaskInfo(dispatchJid);

--- a/src/task-handoffs.test.ts
+++ b/src/task-handoffs.test.ts
@@ -4,6 +4,8 @@ import os from 'os';
 import path from 'path';
 
 import {
+  formatScheduledRunHandoffsForPrompt,
+  readScheduledRunHandoffs,
   type ScheduledRunHandoff,
   writeScheduledRunHandoff,
 } from './task-handoffs.js';
@@ -63,5 +65,68 @@ describe('writeScheduledRunHandoff', () => {
     expect(files).toHaveLength(2);
     expect(files[0]).toContain('2026-03-27T01-23-41.000Z-task-1.json');
     expect(files[1]).toContain('2026-03-27T01-23-42.000Z-task-2.json');
+  });
+
+  it('reads the newest handoffs first with a bounded limit', () => {
+    for (let i = 0; i < 4; i++) {
+      writeScheduledRunHandoff(
+        makeHandoff({
+          task_id: `task-${i}`,
+          run_at: `2026-03-27T01:23:4${i}.000Z`,
+        }),
+        { baseDir: tempDir },
+      );
+    }
+
+    const handoffs = readScheduledRunHandoffs('main', {
+      baseDir: tempDir,
+      limit: 3,
+    });
+
+    expect(handoffs.map((handoff) => handoff.task_id)).toEqual([
+      'task-3',
+      'task-2',
+      'task-1',
+    ]);
+  });
+
+  it('formats a compact prompt block for recent handoffs', () => {
+    const prompt = formatScheduledRunHandoffsForPrompt([
+      makeHandoff({
+        task_id: 'task-a',
+        run_at: '2026-03-27T01:23:45.000Z',
+        result: 'x'.repeat(220),
+      }),
+      makeHandoff({
+        task_id: 'task-b',
+        status: 'error',
+        error: 'disk full',
+        result: null,
+      }),
+    ]);
+
+    expect(prompt).toContain('[Recent Scheduled Runs]');
+    expect(prompt).toContain('task=task-a');
+    expect(prompt).toContain('task=task-b');
+    expect(prompt).toContain('disk full');
+    expect(prompt).toContain(`${'x'.repeat(200)}...`);
+  });
+
+  it('skips invalid handoff files and reports them through onError', () => {
+    const handoffDir = path.join(tempDir, 'main', 'context', 'scheduled-runs');
+    fs.mkdirSync(handoffDir, { recursive: true });
+    fs.writeFileSync(path.join(handoffDir, 'invalid.json'), '{oops');
+    writeScheduledRunHandoff(makeHandoff({ task_id: 'task-ok' }), {
+      baseDir: tempDir,
+    });
+    const seen: string[] = [];
+
+    const handoffs = readScheduledRunHandoffs('main', {
+      baseDir: tempDir,
+      onError: (_error, filePath) => seen.push(path.basename(filePath)),
+    });
+
+    expect(handoffs.map((handoff) => handoff.task_id)).toEqual(['task-ok']);
+    expect(seen).toEqual(['invalid.json']);
   });
 });

--- a/src/task-handoffs.ts
+++ b/src/task-handoffs.ts
@@ -30,8 +30,16 @@ interface WriteScheduledRunHandoffOptions {
   maxFiles?: number;
 }
 
+interface ReadScheduledRunHandoffsOptions {
+  baseDir?: string;
+  limit?: number;
+  onError?: (error: unknown, filePath: string) => void;
+}
+
 const HANDOFFS_SUBDIR = path.join('context', 'scheduled-runs');
 const DEFAULT_MAX_HANDOFF_FILES = 50;
+const DEFAULT_HANDOFF_READ_LIMIT = 3;
+const MAX_PROMPT_VALUE_CHARS = 200;
 
 function sanitizeFilePart(value: string): string {
   return value.replace(/[^a-zA-Z0-9._-]+/g, '_');
@@ -86,4 +94,55 @@ export function writeScheduledRunHandoff(
   fsImpl.writeFileSync(filePath, JSON.stringify(handoff, null, 2));
   pruneOldHandoffs(handoffDir, fsImpl, maxFiles);
   return filePath;
+}
+
+export function readScheduledRunHandoffs(
+  groupFolder: string,
+  options: ReadScheduledRunHandoffsOptions = {},
+): ScheduledRunHandoff[] {
+  const baseDir = options.baseDir ?? GROUPS_DIR;
+  const limit = options.limit ?? DEFAULT_HANDOFF_READ_LIMIT;
+  const onError = options.onError;
+  const handoffDir = getHandoffDir(baseDir, groupFolder);
+
+  if (!fs.existsSync(handoffDir)) {
+    return [];
+  }
+
+  return fs
+    .readdirSync(handoffDir, { withFileTypes: true })
+    .filter((entry) => entry.isFile() && entry.name.endsWith('.json'))
+    .sort((a, b) => b.name.localeCompare(a.name))
+    .slice(0, limit)
+    .flatMap((entry) => {
+      const filePath = path.join(handoffDir, entry.name);
+      try {
+        assertPathWithin(filePath, handoffDir, 'scheduled run handoff file');
+        const parsed = JSON.parse(fs.readFileSync(filePath, 'utf8'));
+        return parsed ? [parsed as ScheduledRunHandoff] : [];
+      } catch (error) {
+        onError?.(error, filePath);
+        return [];
+      }
+    });
+}
+
+function truncatePromptValue(value: string | null): string | null {
+  if (!value) return null;
+  if (value.length <= MAX_PROMPT_VALUE_CHARS) return value;
+  return `${value.slice(0, MAX_PROMPT_VALUE_CHARS)}...`;
+}
+
+export function formatScheduledRunHandoffsForPrompt(
+  handoffs: ScheduledRunHandoff[],
+): string {
+  if (handoffs.length === 0) return '';
+
+  const lines = handoffs.map((handoff) => {
+    const detail =
+      truncatePromptValue(handoff.error ?? handoff.result) ?? 'No details';
+    return `- ${handoff.run_at} | ${handoff.status} | task=${handoff.task_id} | ${detail}`;
+  });
+
+  return `[Recent Scheduled Runs]\n${lines.join('\n')}`;
 }


### PR DESCRIPTION
## Summary
- read the most recent scheduled-run handoff JSON files for a group and inject a compact summary block into fresh chat-run prompts
- cap the prompt context to the last three handoffs and truncate long result or error text to 200 characters
- skip unreadable or invalid handoff files with warnings instead of blocking chat runs

## Testing
- `bun test src/task-handoffs.test.ts`
- `bunx tsc --noEmit`
- `bunx prettier --check src/task-handoffs.ts src/task-handoffs.test.ts src/index.ts`
- `bun run build`
