### PR TITLE
fix(ipc): return reaction failures to agents

### DIFF
--- a/container/agent-runner/src/ipc-mcp-stdio.ts
+++ b/container/agent-runner/src/ipc-mcp-stdio.ts
@@ -14,6 +14,7 @@ import { CronExpressionParser } from 'cron-parser';
 const IPC_DIR = '/workspace/ipc';
 const MESSAGES_DIR = path.join(IPC_DIR, 'messages');
 const TASKS_DIR = path.join(IPC_DIR, 'tasks');
+const RESPONSES_DIR = path.join(IPC_DIR, 'responses');
 const USER_REGISTRY_PATH = path.join(IPC_DIR, 'user_registry.json');
 
 // Context from environment variables (set by the agent runner)
@@ -118,6 +119,43 @@ function writeIpcFile(dir: string, data: object): string {
   fs.renameSync(tempPath, filepath);
 
   return filename;
+}
+
+function sanitizeRequestId(requestId: string): string {
+  return requestId.replace(/[^a-zA-Z0-9_-]/g, '');
+}
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+async function waitForResponse(
+  requestId: string,
+  timeoutMs = 3000,
+): Promise<Record<string, unknown> | null> {
+  const safeRequestId = sanitizeRequestId(requestId);
+  if (!safeRequestId) return null;
+
+  const responsePath = path.join(RESPONSES_DIR, `${safeRequestId}.json`);
+  const deadline = Date.now() + timeoutMs;
+
+  while (Date.now() < deadline) {
+    if (fs.existsSync(responsePath)) {
+      try {
+        const payload = JSON.parse(
+          fs.readFileSync(responsePath, 'utf-8'),
+        ) as Record<string, unknown>;
+        fs.rmSync(responsePath, { force: true });
+        return payload;
+      } catch {
+        fs.rmSync(responsePath, { force: true });
+        return null;
+      }
+    }
+    await sleep(50);
+  }
+
+  return null;
 }
 
 /** Check task ownership from the snapshot. Returns an error response if the
@@ -846,20 +884,56 @@ if (chatJid.startsWith('dc:') || chatJid.startsWith('tg:')) {
         .describe('Set to true to remove the reaction instead of adding it'),
     },
     async (args) => {
+      const requestId = `reaction-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
       writeIpcFile(MESSAGES_DIR, {
         type: 'react_to_message',
         chatJid: getCurrentChatJid(),
         messageId: args.message_id,
         emoji: args.emoji,
         remove: args.remove || false,
+        requestId,
         groupFolder,
         timestamp: new Date().toISOString(),
       });
+
+      const response = await waitForResponse(requestId);
+      if (!response) {
+        return {
+          content: [
+            {
+              type: 'text' as const,
+              text: 'Timed out waiting for reaction result.',
+            },
+          ],
+          isError: true,
+        };
+      }
+
+      if (response.ok === false) {
+        return {
+          content: [
+            {
+              type: 'text' as const,
+              text:
+                typeof response.error === 'string'
+                  ? response.error
+                  : 'Reaction failed.',
+            },
+          ],
+          isError: true,
+        };
+      }
+
       return {
         content: [
           {
             type: 'text' as const,
-            text: args.remove ? 'Reaction removed.' : 'Reaction added.',
+            text:
+              typeof response.result === 'string'
+                ? response.result
+                : args.remove
+                  ? 'Reaction removed.'
+                  : 'Reaction added.',
           },
         ],
       };

--- a/src/ipc-messages.test.ts
+++ b/src/ipc-messages.test.ts
@@ -112,6 +112,16 @@ async function processMsg(
 // =============================================================================
 
 describe('processMessageIpc: react_to_message', () => {
+  function readResponse(sourceGroup: string, requestId: string) {
+    const responsePath = path.join(
+      tmpDir,
+      sourceGroup,
+      'responses',
+      `${requestId}.json`,
+    );
+    return JSON.parse(fs.readFileSync(responsePath, 'utf8'));
+  }
+
   it('adds a reaction via channel', async () => {
     const result = await processMsg({
       type: 'react_to_message',
@@ -156,6 +166,84 @@ describe('processMessageIpc: react_to_message', () => {
 
     expect(result).toEqual({ action: 'handled' });
     expect(reactions).toHaveLength(0);
+  });
+
+  it('writes a success response file when requestId is provided', async () => {
+    const result = await processMsg({
+      type: 'react_to_message',
+      chatJid: 'other@g.us',
+      messageId: 'msg-111',
+      emoji: '👍',
+      requestId: 'req-111',
+    });
+
+    expect(result).toEqual({ action: 'handled' });
+    expect(readResponse('main', 'req-111')).toEqual({
+      type: 'react_to_message_response',
+      requestId: 'req-111',
+      ok: true,
+      result: 'Reaction added.',
+    });
+  });
+
+  it('writes an error response file when channel is missing', async () => {
+    deps.findChannel = () => undefined;
+
+    const result = await processMsg({
+      type: 'react_to_message',
+      chatJid: 'unknown@g.us',
+      messageId: 'msg-222',
+      emoji: '🔥',
+      requestId: 'req-222',
+    });
+
+    expect(result).toEqual({ action: 'handled' });
+    expect(readResponse('main', 'req-222')).toEqual({
+      type: 'react_to_message_response',
+      requestId: 'req-222',
+      ok: false,
+      error: 'No channel found for unknown@g.us.',
+    });
+  });
+
+  it('writes an error response file when the channel rejects the reaction', async () => {
+    deps.findChannel = () =>
+      ({
+        addReaction: async () => {
+          throw new Error('Telegram 400: REACTION_INVALID');
+        },
+      }) as Partial<Channel> as Channel;
+
+    const result = await processMsg({
+      type: 'react_to_message',
+      chatJid: 'tg:123',
+      messageId: 'msg-333',
+      emoji: '🧨',
+      requestId: 'req-333',
+    });
+
+    expect(result).toEqual({ action: 'handled' });
+    expect(readResponse('main', 'req-333')).toEqual({
+      type: 'react_to_message_response',
+      requestId: 'req-333',
+      ok: false,
+      error: 'Telegram 400: REACTION_INVALID',
+    });
+  });
+
+  it('blocks when reaction requestId sanitizes to empty string', async () => {
+    const result = await processMsg({
+      type: 'react_to_message',
+      chatJid: 'other@g.us',
+      messageId: 'msg-444',
+      emoji: '👍',
+      requestId: '../../..',
+    });
+
+    expect(result).toEqual({
+      action: 'blocked',
+      reason: 'requestId sanitized to empty',
+    });
   });
 
   it('handles findChannel not set (undefined deps.findChannel)', async () => {

--- a/src/ipc.ts
+++ b/src/ipc.ts
@@ -135,6 +135,49 @@ export type MessageResult =
   | { action: 'blocked'; reason: string }
   | { action: 'unknown' };
 
+function sanitizeIpcRequestId(requestId: string): string {
+  return String(requestId).replace(/[^a-zA-Z0-9_-]/g, '');
+}
+
+function writeIpcMessageResponse(
+  ipcBaseDir: string,
+  sourceGroup: string,
+  requestId: string | undefined,
+  body: Record<string, unknown>,
+): { ok: true } | { ok: false; result: MessageResult } {
+  if (!requestId) return { ok: true };
+
+  const safeRequestId = sanitizeIpcRequestId(requestId);
+  if (!safeRequestId) {
+    logger.warn(
+      { requestId },
+      'IPC message response requestId sanitized to empty string — skipping response',
+    );
+    return {
+      ok: false,
+      result: { action: 'blocked', reason: 'requestId sanitized to empty' },
+    };
+  }
+
+  const responseDir = path.join(ipcBaseDir, sourceGroup, 'responses');
+  fs.mkdirSync(responseDir, { recursive: true });
+  const responseFile = path.join(responseDir, `${safeRequestId}.json`);
+  const tempPath = `${responseFile}.tmp`;
+  fs.writeFileSync(
+    tempPath,
+    JSON.stringify(
+      {
+        requestId: safeRequestId,
+        ...body,
+      },
+      null,
+      2,
+    ),
+  );
+  fs.renameSync(tempPath, responseFile);
+  return { ok: true };
+}
+
 /**
  * Process a single IPC message payload. Extracted from startIpcWatcher to
  * enable direct unit testing of message dispatch logic.
@@ -158,22 +201,74 @@ export async function processMessageIpc(
     const messageId = data.messageId;
     const emoji = data.emoji;
     const ch = deps.findChannel?.(chatJid);
-    if (data.remove) {
-      await (ch?.removeReaction?.(chatJid, messageId, emoji) ??
-        Promise.resolve());
+    let reactionError: string | null = null;
+
+    if (!ch) {
+      reactionError = `No channel found for ${chatJid}.`;
+    } else if (data.remove) {
+      if (!ch.removeReaction) {
+        reactionError = 'Channel does not support removing reactions.';
+      } else {
+        try {
+          await ch.removeReaction(chatJid, messageId, emoji);
+        } catch (err) {
+          reactionError = err instanceof Error ? err.message : String(err);
+        }
+      }
+    } else if (!ch.addReaction) {
+      reactionError = 'Channel does not support adding reactions.';
     } else {
-      await (ch?.addReaction?.(chatJid, messageId, emoji) ?? Promise.resolve());
+      try {
+        await ch.addReaction(chatJid, messageId, emoji);
+      } catch (err) {
+        reactionError = err instanceof Error ? err.message : String(err);
+      }
     }
-    logger.info(
-      {
-        chatJid,
-        messageId,
-        emoji,
-        remove: !!data.remove,
-        sourceGroup,
-      },
-      'IPC reaction processed',
+
+    const responseWrite = writeIpcMessageResponse(
+      ipcBaseDir,
+      sourceGroup,
+      data.requestId,
+      reactionError
+        ? {
+            type: 'react_to_message_response',
+            ok: false,
+            error: reactionError,
+          }
+        : {
+            type: 'react_to_message_response',
+            ok: true,
+            result: data.remove ? 'Reaction removed.' : 'Reaction added.',
+          },
     );
+    if (!responseWrite.ok) {
+      return responseWrite.result;
+    }
+
+    if (reactionError) {
+      logger.warn(
+        {
+          chatJid,
+          messageId,
+          emoji,
+          remove: !!data.remove,
+          sourceGroup,
+          err: reactionError,
+        },
+        'IPC reaction failed',
+      );
+    } else {
+      logger.info(
+        {
+          chatJid,
+          messageId,
+          emoji,
+          remove: !!data.remove,
+          sourceGroup,
+        },
+        'IPC reaction processed',
+      );
+    }
     return { action: 'handled' };
   }
 
@@ -209,35 +304,17 @@ export async function processMessageIpc(
       );
     }
     // Write response back so the agent can read the result
-    if (data.requestId) {
-      const safeRequestId = String(data.requestId).replace(
-        /[^a-zA-Z0-9_-]/g,
-        '',
-      );
-      if (!safeRequestId) {
-        logger.warn(
-          { requestId: data.requestId },
-          'format_mention: requestId sanitized to empty string — skipping response',
-        );
-        return { action: 'blocked', reason: 'requestId sanitized to empty' };
-      }
-      const responseDir = path.join(ipcBaseDir, sourceGroup, 'responses');
-      fs.mkdirSync(responseDir, { recursive: true });
-      const responseFile = path.join(responseDir, `${safeRequestId}.json`);
-      const tempPath = `${responseFile}.tmp`;
-      fs.writeFileSync(
-        tempPath,
-        JSON.stringify(
-          {
-            type: 'format_mention_response',
-            requestId: safeRequestId,
-            result: formattedMention,
-          },
-          null,
-          2,
-        ),
-      );
-      fs.renameSync(tempPath, responseFile);
+    const responseWrite = writeIpcMessageResponse(
+      ipcBaseDir,
+      sourceGroup,
+      data.requestId,
+      {
+        type: 'format_mention_response',
+        result: formattedMention,
+      },
+    );
+    if (!responseWrite.ok) {
+      return responseWrite.result;
     }
     logger.info(
       {


### PR DESCRIPTION
## Summary
- write structured IPC response files for `react_to_message` so agents get accurate success or failure feedback
- surface missing-channel and platform API failures back through the MCP reaction tool instead of always returning optimistic success
- add reaction IPC coverage for success, channel lookup failure, platform rejection, and invalid request ids

## Testing
- `bun test src/ipc-messages.test.ts`
- `bunx tsc --noEmit`
- `bunx prettier --check src/ipc.ts src/ipc-messages.test.ts container/agent-runner/src/ipc-mcp-stdio.ts`
- `bun run build`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added request/response coordination for reaction operations with proper timeout handling and error reporting.

* **Bug Fixes**
  * Improved error handling for message reactions with clearer feedback when operations fail.

* **Tests**
  * Added test coverage for reaction operations, validating success cases, error scenarios, and edge cases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->