### PR TITLE
refactor(queue): make message dispatch transitions atomic

### DIFF
--- a/src/group-queue.test.ts
+++ b/src/group-queue.test.ts
@@ -889,4 +889,89 @@ describe('GroupQueue', () => {
       expect(final.idleContainers).toBe(0);
     });
   });
+
+  describe('atomic message dispatch transitions', () => {
+    it('drains a waiting group exactly once when a slot opens', async () => {
+      queue = new GroupQueue({
+        dataDir: '/tmp/omniclaw-test-data',
+        maxActiveContainers: 1,
+        maxIdleContainers: 0,
+        maxTaskContainers: 2,
+        fsImpl,
+      });
+
+      const started: string[] = [];
+      const resolvers = new Map<string, () => void>();
+      queue.setProcessMessagesFn(
+        mock(
+          (groupJid: string) =>
+            new Promise<boolean>((resolve) => {
+              started.push(groupJid);
+              resolvers.set(groupJid, () => resolve(true));
+            }),
+        ),
+      );
+
+      queue.enqueueMessageCheck('group1@g.us');
+      await Bun.sleep(10);
+
+      queue.enqueueMessageCheck('group2@g.us');
+      queue.enqueueMessageCheck('group2@g.us');
+      await Bun.sleep(10);
+
+      expect(
+        queue.getDetailedStats().find((d) => d.folderKey === 'group2@g.us')
+          ?.messageLane.pendingCount,
+      ).toBe(1);
+
+      resolvers.get('group1@g.us')?.();
+      await Bun.sleep(10);
+
+      expect(started.filter((jid) => jid === 'group2@g.us')).toHaveLength(1);
+      expect(
+        queue.getDetailedStats().find((d) => d.folderKey === 'group2@g.us')
+          ?.messageLane.pendingCount,
+      ).toBe(0);
+
+      resolvers.get('group2@g.us')?.();
+      await Bun.sleep(10);
+    });
+
+    it('resets active counts before scheduling a retry', async () => {
+      const scheduled: Array<() => void> = [];
+      const originalSetTimeout = globalThis.setTimeout;
+      let attempts = 0;
+
+      queue.setProcessMessagesFn(
+        mock(async () => {
+          attempts++;
+          return attempts > 1;
+        }),
+      );
+
+      (globalThis as { setTimeout: typeof setTimeout }).setTimeout = ((
+        fn: Parameters<typeof setTimeout>[0],
+      ) => {
+        scheduled.push(fn as () => void);
+        return { id: 'retry' } as unknown as ReturnType<typeof setTimeout>;
+      }) as unknown as typeof setTimeout;
+
+      try {
+        queue.enqueueMessageCheck('group1@g.us');
+        await Bun.sleep(10);
+
+        expect(queue.getStats().activeContainers).toBe(0);
+        expect(scheduled).toHaveLength(1);
+
+        scheduled[0]();
+        await Bun.sleep(10);
+
+        expect(attempts).toBe(2);
+        expect(queue.getStats().activeContainers).toBe(0);
+      } finally {
+        (globalThis as { setTimeout: typeof setTimeout }).setTimeout =
+          originalSetTimeout;
+      }
+    });
+  });
 });

--- a/src/group-queue.ts
+++ b/src/group-queue.ts
@@ -81,6 +81,11 @@ interface GroupState {
   activeTaskInfo: ActiveTaskInfo | null;
 }
 
+interface StartMessageRunResult {
+  started: boolean;
+  processingCount: number;
+}
+
 function toChannelJid(jid: string): string {
   const marker = '::agent::';
   const idx = jid.indexOf(marker);
@@ -186,6 +191,52 @@ export class GroupQueue {
     this.processMessagesFn = fn;
   }
 
+  private queuePendingMessage(
+    groupJid: string,
+    addToWaitingList = false,
+  ): void {
+    const state = this.getGroup(groupJid);
+    if (!state.pendingMessageJids.includes(groupJid)) {
+      state.pendingMessageJids.push(groupJid);
+    }
+    if (addToWaitingList && !this.waitingMessageGroups.includes(groupJid)) {
+      this.waitingMessageGroups.push(groupJid);
+    }
+  }
+
+  private dequeuePendingMessage(groupJid: string): void {
+    const state = this.getGroup(groupJid);
+    state.pendingMessageJids = state.pendingMessageJids.filter(
+      (jid) => jid !== groupJid,
+    );
+    this.waitingMessageGroups = this.waitingMessageGroups.filter(
+      (jid) => jid !== groupJid,
+    );
+  }
+
+  private startMessageRun(groupJid: string): StartMessageRunResult {
+    const state = this.getGroup(groupJid);
+    const processingCount = this.activeCount - this.idleCount;
+    if (state.messageLaneState !== 'idle') {
+      return { started: false, processingCount };
+    }
+
+    this.transitionMessageLaneState(groupJid, 'running');
+    this.dequeuePendingMessage(groupJid);
+    this.activeCount++;
+    return { started: true, processingCount };
+  }
+
+  private finishMessageRun(groupJid: string): void {
+    const state = this.getGroup(groupJid);
+    this.transitionMessageLaneState(groupJid, 'idle');
+    state.messageProcess = null;
+    state.messageContainerName = null;
+    state.messageGroupFolder = null;
+    state.messageBackend = null;
+    this.activeCount--;
+  }
+
   enqueueMessageCheck(groupJid: string): void {
     if (this.shuttingDown) {
       logger.info({ groupJid }, 'enqueueMessageCheck: shutting down, skipping');
@@ -197,9 +248,7 @@ export class GroupQueue {
 
     // Only check the message lane — task lane is independent
     if (state.messageLaneState !== 'idle') {
-      if (!state.pendingMessageJids.includes(groupJid)) {
-        state.pendingMessageJids.push(groupJid);
-      }
+      this.queuePendingMessage(groupJid);
       logger.info(
         { groupJid, folderKey },
         'Message container active, message queued',
@@ -218,12 +267,7 @@ export class GroupQueue {
         );
         this._closeIdleContainer(oldest);
       }
-      if (!state.pendingMessageJids.includes(groupJid)) {
-        state.pendingMessageJids.push(groupJid);
-      }
-      if (!this.waitingMessageGroups.includes(groupJid)) {
-        this.waitingMessageGroups.push(groupJid);
-      }
+      this.queuePendingMessage(groupJid, true);
       logger.info(
         { groupJid, folderKey, processingCount, activeCount: this.activeCount },
         'At active container limit, message queued',
@@ -559,41 +603,16 @@ export class GroupQueue {
     groupJid: string,
     reason: 'messages' | 'drain',
   ): Promise<void> {
-    const state = this.getGroup(groupJid);
-    this.transitionMessageLaneState(groupJid, 'running');
-    // Remove this JID from pending (it's being processed now)
-    state.pendingMessageJids = state.pendingMessageJids.filter(
-      (j) => j !== groupJid,
-    );
-    this.activeCount++;
-
-    logger.debug(
-      { groupJid, reason, activeCount: this.activeCount },
-      'Starting message container for group',
-    );
-
-    try {
-      if (this.processMessagesFn) {
-        const success = await this.processMessagesFn(groupJid);
-        if (success) {
-          state.retryCount = 0;
-        } else {
-          this.scheduleRetry(groupJid, state);
-        }
-      }
-    } catch (err) {
-      logger.error({ groupJid, err }, 'Error processing messages for group');
-      this.scheduleRetry(groupJid, state);
-    } finally {
-      // Clean up idle tracking if container exited while idle
-      this.transitionMessageLaneState(groupJid, 'idle');
-      state.messageProcess = null;
-      state.messageContainerName = null;
-      state.messageGroupFolder = null;
-      state.messageBackend = null;
-      this.activeCount--;
-      this.drainMessageLane(groupJid);
+    const start = this.startMessageRun(groupJid);
+    if (!start.started) {
+      const state = this.getGroup(groupJid);
+      logger.debug(
+        { groupJid, reason, laneState: state.messageLaneState },
+        'Skipping duplicate message dispatch start',
+      );
+      return;
     }
+    await this.runStartedMessageGroup(groupJid, reason);
   }
 
   private async runTask(groupJid: string, task: QueuedTask): Promise<void> {
@@ -732,6 +751,35 @@ export class GroupQueue {
           ),
         );
       }
+    }
+  }
+
+  private async runStartedMessageGroup(
+    groupJid: string,
+    reason: 'messages' | 'drain',
+  ): Promise<void> {
+    const state = this.getGroup(groupJid);
+
+    logger.debug(
+      { groupJid, reason, activeCount: this.activeCount },
+      'Starting message container for group',
+    );
+
+    try {
+      if (this.processMessagesFn) {
+        const success = await this.processMessagesFn(groupJid);
+        if (success) {
+          state.retryCount = 0;
+        } else {
+          this.scheduleRetry(groupJid, state);
+        }
+      }
+    } catch (err) {
+      logger.error({ groupJid, err }, 'Error processing messages for group');
+      this.scheduleRetry(groupJid, state);
+    } finally {
+      this.finishMessageRun(groupJid);
+      this.drainMessageLane(groupJid);
     }
   }
 


### PR DESCRIPTION
## Summary
- move message-lane queueing, dequeueing, start, and finish bookkeeping behind focused `GroupQueue` helpers
- make pending JID updates and active container accounting change together during message dispatch transitions
- add invariant coverage for waiting-group drain and retry cleanup while keeping the existing `src/group-queue.test.ts` behavior intact

## Testing
- `bun test src/group-queue.test.ts`
- `bunx tsc --noEmit`
- `bunx prettier --check src/group-queue.ts src/group-queue.test.ts`
- `bun run build`
