### PR TITLE
feat(scheduler): add agent outcome signaling (done/blocked/abandoned)

### DIFF
--- a/src/backends/types.ts
+++ b/src/backends/types.ts
@@ -115,6 +115,8 @@ export interface ContainerOutput {
   intermediate?: boolean;
   /** The chat JID this output should be routed to (multi-channel agents). */
   chatJid?: string;
+  /** Explicit agent outcome signal (done/blocked/abandoned). */
+  outcome?: import('../types.js').TaskOutcomeSignal;
 }
 
 export interface VolumeMount {

--- a/src/db.ts
+++ b/src/db.ts
@@ -421,6 +421,23 @@ export function createSchema(database: Database): void {
   );
   dropColumnIfExists(database, 'registered_groups', 'stream_intermediates');
 
+  // Agent outcome signaling (#161)
+  addColumnIfNotExists(database, 'task_run_logs', 'outcome_state', 'TEXT');
+  addColumnIfNotExists(database, 'task_run_logs', 'outcome_reason', 'TEXT');
+  addColumnIfNotExists(database, 'task_run_logs', 'outcome_question', 'TEXT');
+  addColumnIfNotExists(
+    database,
+    'scheduled_tasks',
+    'last_outcome_state',
+    'TEXT',
+  );
+  addColumnIfNotExists(
+    database,
+    'scheduled_tasks',
+    'last_outcome_reason',
+    'TEXT',
+  );
+
   // Heartbeat feature removed — clear any existing heartbeat config so it doesn't
   // get re-created on startup (reconcileHeartbeats is also removed).
   try {
@@ -1098,7 +1115,14 @@ function escapeSqlLikePattern(value: string): string {
 }
 
 export function createTask(
-  task: Omit<ScheduledTask, 'last_run' | 'last_result' | 'executing_since'>,
+  task: Omit<
+    ScheduledTask,
+    | 'last_run'
+    | 'last_result'
+    | 'executing_since'
+    | 'last_outcome_state'
+    | 'last_outcome_reason'
+  >,
 ): void {
   db.query(
     `
@@ -1224,23 +1248,34 @@ export function updateTaskAfterRun(
   id: string,
   nextRun: string | null,
   lastResult: string,
+  outcome?: { state: string; reason?: string },
 ): void {
   const now = new Date().toISOString();
   db.query(
     `
     UPDATE scheduled_tasks
-    SET next_run = ?, last_run = ?, last_result = ?, status = CASE WHEN ? IS NULL THEN 'completed' ELSE status END
+    SET next_run = ?, last_run = ?, last_result = ?,
+        status = CASE WHEN ? IS NULL THEN 'completed' ELSE status END,
+        last_outcome_state = ?, last_outcome_reason = ?
     WHERE id = ?
   `,
-  ).run(nextRun, now, lastResult, nextRun, id);
+  ).run(
+    nextRun,
+    now,
+    lastResult,
+    nextRun,
+    outcome?.state ?? null,
+    outcome?.reason ?? null,
+    id,
+  );
 }
 
 export function logTaskRun(log: TaskRunLog): void {
   // Use SELECT ... WHERE EXISTS to skip gracefully if the task was deleted while running.
   db.query(
     `
-    INSERT INTO task_run_logs (task_id, run_at, duration_ms, status, result, error)
-    SELECT ?, ?, ?, ?, ?, ?
+    INSERT INTO task_run_logs (task_id, run_at, duration_ms, status, result, error, outcome_state, outcome_reason, outcome_question)
+    SELECT ?, ?, ?, ?, ?, ?, ?, ?, ?
     WHERE EXISTS (SELECT 1 FROM scheduled_tasks WHERE id = ?)
   `,
   ).run(
@@ -1250,6 +1285,9 @@ export function logTaskRun(log: TaskRunLog): void {
     log.status,
     log.result,
     log.error,
+    log.outcome_state ?? null,
+    log.outcome_reason ?? null,
+    log.outcome_question ?? null,
     log.task_id,
   );
 }

--- a/src/ipc-snapshots.test.ts
+++ b/src/ipc-snapshots.test.ts
@@ -37,6 +37,8 @@ describe('ipc-snapshots', () => {
         schedule_value: '60000',
         status: 'active',
         next_run: '2025-06-01T12:00:00.000Z',
+        last_outcome_state: null,
+        last_outcome_reason: null,
       });
     });
 
@@ -59,6 +61,25 @@ describe('ipc-snapshots', () => {
       const tasks = [makeTask({ next_run: null })];
       const result = mapTasksForSnapshot(tasks);
       expect(result[0].next_run).toBeNull();
+    });
+
+    it('includes outcome state and reason when present', () => {
+      const tasks = [
+        makeTask({
+          last_outcome_state: 'blocked',
+          last_outcome_reason: 'Need user input',
+        }),
+      ];
+      const result = mapTasksForSnapshot(tasks);
+      expect(result[0].last_outcome_state).toBe('blocked');
+      expect(result[0].last_outcome_reason).toBe('Need user input');
+    });
+
+    it('returns null outcome fields when task has no outcome', () => {
+      const tasks = [makeTask()];
+      const result = mapTasksForSnapshot(tasks);
+      expect(result[0].last_outcome_state).toBeNull();
+      expect(result[0].last_outcome_reason).toBeNull();
     });
   });
 

--- a/src/ipc-snapshots.ts
+++ b/src/ipc-snapshots.ts
@@ -30,6 +30,8 @@ export function mapTasksForSnapshot(tasks: ScheduledTask[]) {
     schedule_value: t.schedule_value,
     status: t.status,
     next_run: t.next_run,
+    last_outcome_state: t.last_outcome_state ?? null,
+    last_outcome_reason: t.last_outcome_reason ?? null,
   }));
 }
 

--- a/src/task-handoffs.ts
+++ b/src/task-handoffs.ts
@@ -15,6 +15,12 @@ export interface ScheduledRunHandoff {
   next_run: string | null;
   result: string | null;
   error: string | null;
+  /** Explicit agent outcome state (done/blocked/abandoned). */
+  outcome_state?: string;
+  /** Why the task ended in this state. */
+  outcome_reason?: string;
+  /** For blocked: what input does the agent need? */
+  outcome_question?: string;
 }
 
 interface TaskHandoffFs {

--- a/src/task-outcome.test.ts
+++ b/src/task-outcome.test.ts
@@ -1,0 +1,108 @@
+import { describe, it, expect } from 'bun:test';
+
+import type { ContainerOutput } from './backends/types.js';
+import { inferOutcome } from './task-scheduler.js';
+
+describe('inferOutcome', () => {
+  it('returns done when output is successful with no explicit signal', () => {
+    const output: ContainerOutput = { status: 'success', result: 'ok' };
+    expect(inferOutcome(output, null, false)).toEqual({ state: 'done' });
+  });
+
+  it('returns blocked when there is an error and no explicit signal', () => {
+    const output: ContainerOutput = {
+      status: 'error',
+      result: null,
+      error: 'API rate limited',
+    };
+    expect(inferOutcome(output, 'API rate limited', false)).toEqual({
+      state: 'blocked',
+      reason: 'API rate limited',
+    });
+  });
+
+  it('returns abandoned when timed out', () => {
+    expect(inferOutcome(null, 'timed out waiting', true)).toEqual({
+      state: 'abandoned',
+      reason: 'Execution timed out',
+    });
+  });
+
+  it('prefers explicit agent signal over inference', () => {
+    const output: ContainerOutput = {
+      status: 'success',
+      result: 'partial',
+      outcome: {
+        state: 'blocked',
+        reason: 'Need user API key',
+        question: 'What is your OpenAI API key?',
+      },
+    };
+    expect(inferOutcome(output, null, false)).toEqual({
+      state: 'blocked',
+      reason: 'Need user API key',
+      question: 'What is your OpenAI API key?',
+    });
+  });
+
+  it('prefers explicit abandoned signal over error inference', () => {
+    const output: ContainerOutput = {
+      status: 'error',
+      result: null,
+      error: 'some error',
+      outcome: {
+        state: 'abandoned',
+        reason: 'Unrecoverable — missing credentials',
+      },
+    };
+    expect(inferOutcome(output, 'some error', false)).toEqual({
+      state: 'abandoned',
+      reason: 'Unrecoverable — missing credentials',
+    });
+  });
+
+  it('falls back to inference when outcome state is invalid', () => {
+    const output: ContainerOutput = {
+      status: 'success',
+      result: 'ok',
+      outcome: { state: 'invalid' as any },
+    };
+    expect(inferOutcome(output, null, false)).toEqual({ state: 'done' });
+  });
+
+  it('falls back to inference when outcome is malformed (missing state)', () => {
+    const output: ContainerOutput = {
+      status: 'error',
+      result: null,
+      error: 'oops',
+      outcome: {} as any,
+    };
+    expect(inferOutcome(output, 'oops', false)).toEqual({
+      state: 'blocked',
+      reason: 'oops',
+    });
+  });
+
+  it('returns done for null output with no error', () => {
+    expect(inferOutcome(null, null, false)).toEqual({ state: 'done' });
+  });
+
+  it('timeout takes priority over error', () => {
+    expect(inferOutcome(null, 'connection refused', true)).toEqual({
+      state: 'abandoned',
+      reason: 'Execution timed out',
+    });
+  });
+
+  it('explicit done signal passes through reason', () => {
+    const output: ContainerOutput = {
+      status: 'success',
+      result: 'done',
+      outcome: { state: 'done', reason: 'All steps completed' },
+    };
+    expect(inferOutcome(output, null, false)).toEqual({
+      state: 'done',
+      reason: 'All steps completed',
+    });
+  });
+});

--- a/src/task-scheduler-loop.harness.ts
+++ b/src/task-scheduler-loop.harness.ts
@@ -241,6 +241,7 @@ describe('startSchedulerLoop harness', () => {
         'task-success',
         '2026-01-01T01:00:00.000Z',
         'final result',
+        { state: 'done' },
       );
 
       expect(timeoutCalls).toContain(60000);

--- a/src/task-scheduler-runner.test.ts
+++ b/src/task-scheduler-runner.test.ts
@@ -289,6 +289,7 @@ describe('startSchedulerLoop task execution', () => {
         'task-error',
         '2026-01-01T00:05:00.000Z',
         'Error: final failure',
+        { state: 'blocked', reason: 'final failure' },
       );
       expect(writeScheduledRunHandoffMock).toHaveBeenCalledWith(
         expect.objectContaining({

--- a/src/task-scheduler.ts
+++ b/src/task-scheduler.ts
@@ -9,8 +9,7 @@ import {
 } from './config.js';
 import { calculateNextRun } from './schedule-utils.js';
 import { resolveBackend } from './backends/index.js';
-import type { AgentBackend } from './backends/types.js';
-import type { ContainerOutput } from './backends/types.js';
+import type { AgentBackend, ContainerOutput } from './backends/types.js';
 import { writeTasksSnapshot } from './ipc-snapshots.js';
 import {
   advanceTaskNextRun,
@@ -32,12 +31,43 @@ import { GroupQueue } from './group-queue.js';
 import { logger } from './logger.js';
 import { ResumePositionStore } from './resume-position-store.js';
 import { writeScheduledRunHandoff } from './task-handoffs.js';
-import {
+import type {
   Channel,
   ContainerProcess,
   RegisteredGroup,
   ScheduledTask,
+  TaskOutcomeSignal,
+  TaskOutcomeState,
 } from './types.js';
+
+const VALID_OUTCOME_STATES = new Set<TaskOutcomeState>([
+  'done',
+  'blocked',
+  'abandoned',
+]);
+
+/**
+ * Extract the outcome signal from agent output. If the agent signaled
+ * explicitly, use that. Otherwise, infer from error/success:
+ *   success → done, error → blocked, catch/timeout → abandoned.
+ */
+export function inferOutcome(
+  output: ContainerOutput | null,
+  error: string | null,
+  timedOut: boolean,
+): TaskOutcomeSignal {
+  // Prefer explicit agent signal if present and valid
+  if (output?.outcome && VALID_OUTCOME_STATES.has(output.outcome.state)) {
+    return {
+      state: output.outcome.state,
+      reason: output.outcome.reason,
+      question: output.outcome.question,
+    };
+  }
+  if (timedOut) return { state: 'abandoned', reason: 'Execution timed out' };
+  if (error) return { state: 'blocked', reason: error };
+  return { state: 'done' };
+}
 
 interface SchedulerRuntime {
   calculateNextRun: typeof calculateNextRun;
@@ -151,13 +181,16 @@ async function runTask(
 
     if (!group) {
       log.error('Group not found for task');
+      const groupError = `Group not found: ${task.group_folder}`;
       runtime.logTaskRun({
         task_id: task.id,
         run_at: runAt,
         duration_ms: Date.now() - startTime,
         status: 'error',
         result: null,
-        error: `Group not found: ${task.group_folder}`,
+        error: groupError,
+        outcome_state: 'abandoned',
+        outcome_reason: groupError,
       });
       tryWriteHandoff({
         task_id: task.id,
@@ -169,7 +202,9 @@ async function runTask(
         duration_ms: Date.now() - startTime,
         next_run: task.next_run,
         result: null,
-        error: `Group not found: ${task.group_folder}`,
+        error: groupError,
+        outcome_state: 'abandoned',
+        outcome_reason: groupError,
       });
       return;
     }
@@ -194,11 +229,15 @@ async function runTask(
         schedule_value: t.schedule_value,
         status: t.status,
         next_run: t.next_run,
+        last_outcome_state: t.last_outcome_state ?? null,
+        last_outcome_reason: t.last_outcome_reason ?? null,
       })),
     );
 
     let result: string | null = null;
     let error: string | null = null;
+    let finalOutput: ContainerOutput | null = null;
+    let timedOut = false;
 
     // Always use isolated sessions for tasks to prevent session ID conflicts
     // between message and task containers running concurrently.
@@ -282,6 +321,7 @@ async function runTask(
       );
 
       if (closeTimer) clearTimeout(closeTimer);
+      finalOutput = output;
 
       if (output.status === 'error') {
         error = output.error || 'Unknown error';
@@ -293,10 +333,12 @@ async function runTask(
     } catch (err) {
       if (closeTimer) clearTimeout(closeTimer);
       error = err instanceof Error ? err.message : String(err);
+      timedOut = error.includes('timed out') || error.includes('timeout');
       log.error({ err: error }, 'Task failed');
     }
 
     const durationMs = Date.now() - startTime;
+    const outcome = inferOutcome(finalOutput, error, timedOut);
 
     runtime.logTaskRun({
       task_id: task.id,
@@ -305,6 +347,9 @@ async function runTask(
       status: error ? 'error' : 'success',
       result,
       error,
+      outcome_state: outcome.state,
+      outcome_reason: outcome.reason,
+      outcome_question: outcome.question,
     });
 
     // Calculate next run time (null for one-shot 'once' tasks)
@@ -318,7 +363,7 @@ async function runTask(
       : result
         ? result.slice(0, 200)
         : 'Completed';
-    runtime.updateTaskAfterRun(task.id, nextRun, resultSummary);
+    runtime.updateTaskAfterRun(task.id, nextRun, resultSummary, outcome);
     tryWriteHandoff({
       task_id: task.id,
       chat_jid: task.chat_jid,
@@ -330,6 +375,9 @@ async function runTask(
       next_run: nextRun,
       result,
       error,
+      outcome_state: outcome.state,
+      outcome_reason: outcome.reason,
+      outcome_question: outcome.question,
     });
   } finally {
     runtime.clearTaskExecuting(task.id);

--- a/src/types.ts
+++ b/src/types.ts
@@ -159,6 +159,21 @@ export interface ScheduledTask {
   created_at: string;
   /** ISO timestamp set when a task starts executing; cleared on completion. */
   executing_since: string | null;
+  /** Outcome state from the most recent run (done/blocked/abandoned). */
+  last_outcome_state?: TaskOutcomeState | null;
+  /** Reason string from the most recent outcome signal. */
+  last_outcome_reason?: string | null;
+}
+
+/** Explicit agent outcome signal for scheduled task runs. */
+export type TaskOutcomeState = 'done' | 'blocked' | 'abandoned';
+
+export interface TaskOutcomeSignal {
+  state: TaskOutcomeState;
+  /** Why the task ended in this state (e.g. "Rate limited", "Missing credentials"). */
+  reason?: string;
+  /** For blocked: what input is needed from the user? */
+  question?: string;
 }
 
 export interface TaskRunLog {
@@ -168,6 +183,9 @@ export interface TaskRunLog {
   status: 'success' | 'error';
   result: string | null;
   error: string | null;
+  outcome_state?: TaskOutcomeState;
+  outcome_reason?: string;
+  outcome_question?: string;
 }
 
 // --- Channel abstraction ---

--- a/src/web/routes.ts
+++ b/src/web/routes.ts
@@ -478,7 +478,11 @@ async function handleCreateTask(
   const taskId = `task-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
   const task: Omit<
     ScheduledTask,
-    'last_run' | 'last_result' | 'executing_since'
+    | 'last_run'
+    | 'last_result'
+    | 'executing_since'
+    | 'last_outcome_state'
+    | 'last_outcome_reason'
   > = {
     id: taskId,
     group_folder: group_folder as string,


### PR DESCRIPTION
## Summary
- Define `TaskOutcomeSignal` type (`done | blocked | abandoned`) with optional `reason` and `question` fields
- Add `outcome` field to `ContainerOutput` so agents can explicitly signal their outcome
- Add 5 new DB columns: `outcome_state`, `outcome_reason`, `outcome_question` on `task_run_logs` + `last_outcome_state`, `last_outcome_reason` cached on `scheduled_tasks`
- Update `runTask()` to extract outcome from agent output with simple fallback: success→done, error→blocked, timeout→abandoned
- Persist outcome through `logTaskRun()`, `updateTaskAfterRun()`, and handoff files
- Expose `last_outcome_state`/`last_outcome_reason` in task snapshots via `mapTasksForSnapshot()`
- 12 new tests covering signal inference, explicit signals, malformed signals, and snapshot exposure

Partial #161 — "persist first, policy later." No retry policy changes, no blocked-task notifications, no UI. The smarter inference and behavior (e.g. blocked tasks skip retry) comes in a follow-up PR.

## Test plan
- [x] `bun test src/task-outcome.test.ts` — 10 pass (inferOutcome coverage)
- [x] `bun test src/ipc-snapshots.test.ts` — 11 pass (snapshot outcome fields)
- [x] `bun test src/task-scheduler-runner.test.ts` — 3 pass (updated assertions)
- [x] `bun test src/task-scheduler-loop.harness.ts` — 1 pass (harness assertions)
- [x] `bun run typecheck` — clean
- [x] `bun test` — 1530 pass, 0 fail

🤖 Generated with [Claude Code](https://claude.com/claude-code)
