### PR TITLE
refactor(ipc): replace _close file sentinel with shutdown IPC message

### DIFF
--- a/container/agent-runner/src/__tests__/opencode-runtime.test.ts
+++ b/container/agent-runner/src/__tests__/opencode-runtime.test.ts
@@ -148,12 +148,15 @@ describe('OpenCode runtime IPC protocol', () => {
     expect(data.text).toBe('hello');
   });
 
-  it('detects close sentinel', () => {
-    const closePath = path.join(TEST_IPC_DIR, '_close');
-    fs.writeFileSync(closePath, '');
-    expect(fs.existsSync(closePath)).toBe(true);
-    fs.unlinkSync(closePath);
-    expect(fs.existsSync(closePath)).toBe(false);
+  it('detects shutdown IPC message as a JSON file', () => {
+    const shutdownPath = path.join(TEST_IPC_DIR, '_shutdown-123.json');
+    fs.writeFileSync(shutdownPath, JSON.stringify({ type: 'shutdown' }));
+    expect(fs.existsSync(shutdownPath)).toBe(true);
+    // Verify it's valid JSON that the drain loop would parse
+    const data = JSON.parse(fs.readFileSync(shutdownPath, 'utf-8'));
+    expect(data.type).toBe('shutdown');
+    fs.unlinkSync(shutdownPath);
+    expect(fs.existsSync(shutdownPath)).toBe(false);
   });
 
   it('handles chatJid in IPC messages', () => {

--- a/container/agent-runner/src/codex-runtime.ts
+++ b/container/agent-runner/src/codex-runtime.ts
@@ -827,8 +827,12 @@ interface IpcMessage {
 }
 
 let ipcInputDir = '/workspace/ipc/input';
-let ipcCloseFile = path.join(ipcInputDir, '_close');
 let currentChatJid = '';
+
+interface IpcDrainResult {
+  messages: IpcMessage[];
+  shutdown: boolean;
+}
 
 function setCurrentChat(chatJid: string): void {
   currentChatJid = chatJid;
@@ -839,19 +843,7 @@ function setCurrentChat(chatJid: string): void {
   }
 }
 
-function shouldClose(): boolean {
-  if (fs.existsSync(ipcCloseFile)) {
-    try {
-      fs.unlinkSync(ipcCloseFile);
-    } catch {
-      /* ignore */
-    }
-    return true;
-  }
-  return false;
-}
-
-function drainIpcInput(): IpcMessage[] {
+function drainIpcInput(): IpcDrainResult {
   try {
     fs.mkdirSync(ipcInputDir, { recursive: true });
     const files = fs
@@ -860,11 +852,17 @@ function drainIpcInput(): IpcMessage[] {
       .sort();
 
     const messages: IpcMessage[] = [];
+    let shutdown = false;
     for (const file of files) {
       const filePath = path.join(ipcInputDir, file);
       try {
         const data = JSON.parse(fs.readFileSync(filePath, 'utf-8'));
         fs.unlinkSync(filePath);
+        if (data.type === 'shutdown') {
+          log('Shutdown IPC message received');
+          shutdown = true;
+          continue;
+        }
         if (data.type === 'message' && data.text) {
           messages.push({ text: data.text, chatJid: data.chatJid });
           if (data.chatJid) setCurrentChat(data.chatJid);
@@ -880,10 +878,21 @@ function drainIpcInput(): IpcMessage[] {
         }
       }
     }
-    return messages;
+    // Legacy _close sentinel backwards compatibility
+    const legacyClose = path.join(ipcInputDir, '_close');
+    if (fs.existsSync(legacyClose)) {
+      try {
+        fs.unlinkSync(legacyClose);
+      } catch {
+        /* ignore */
+      }
+      log('Legacy _close sentinel detected, treating as shutdown');
+      shutdown = true;
+    }
+    return { messages, shutdown };
   } catch (err) {
     log(`IPC drain error: ${err instanceof Error ? err.message : String(err)}`);
-    return [];
+    return { messages: [], shutdown: false };
   }
 }
 
@@ -894,11 +903,11 @@ function formatIpcMessages(messages: IpcMessage[]): string {
 function waitForIpcMessage(): Promise<string | null> {
   return new Promise((resolve) => {
     const poll = () => {
-      if (shouldClose()) {
+      const { messages, shutdown } = drainIpcInput();
+      if (shutdown) {
         resolve(null);
         return;
       }
-      const messages = drainIpcInput();
       if (messages.length > 0) {
         resolve(formatIpcMessages(messages));
         return;
@@ -1020,14 +1029,7 @@ export async function runCodexRuntime(
   log(`Starting Codex runtime for group: ${containerInput.groupFolder}`);
 
   ipcInputDir = resolveIpcInputDir(containerInput.isScheduledTask);
-  ipcCloseFile = path.join(ipcInputDir, '_close');
   fs.mkdirSync(ipcInputDir, { recursive: true });
-
-  try {
-    fs.unlinkSync(ipcCloseFile);
-  } catch {
-    /* ignore */
-  }
 
   setCurrentChat(containerInput.chatJid);
 
@@ -1066,17 +1068,22 @@ export async function runCodexRuntime(
       prompt = `[SCHEDULED TASK - The following message was sent automatically and is not coming directly from the user or group.]\n\n${prompt}`;
     }
 
-    const pending = drainIpcInput();
-    if (pending.length > 0) {
+    const pendingResult = drainIpcInput();
+    if (pendingResult.messages.length > 0) {
       log(
-        `Draining ${pending.length} pending IPC messages into initial prompt`,
+        `Draining ${pendingResult.messages.length} pending IPC messages into initial prompt`,
       );
-      prompt += '\n' + formatIpcMessages(pending);
+      prompt += '\n' + formatIpcMessages(pendingResult.messages);
+    }
+    if (pendingResult.shutdown) {
+      log('Shutdown signal detected before first prompt, exiting');
+      return;
     }
 
     while (true) {
-      if (shouldClose()) {
-        log('Close sentinel detected before prompt, exiting');
+      const { shutdown } = drainIpcInput();
+      if (shutdown) {
+        log('Shutdown signal detected before prompt, exiting');
         break;
       }
 

--- a/container/agent-runner/src/index.ts
+++ b/container/agent-runner/src/index.ts
@@ -323,7 +323,6 @@ interface SDKUserMessage {
 // Defaults to the message lane; reassigned to input-task/ after stdin is parsed
 // when containerInput.isScheduledTask is true.
 let IPC_INPUT_DIR = '/workspace/ipc/input';
-let IPC_INPUT_CLOSE_SENTINEL = path.join(IPC_INPUT_DIR, '_close');
 
 /**
  * Determine the IPC input directory based on whether this is a scheduled task.
@@ -862,24 +861,14 @@ function formatTranscriptMarkdown(
   return lines.join('\n');
 }
 
-/**
- * Check for _close sentinel.
- */
-function shouldClose(): boolean {
-  if (fs.existsSync(IPC_INPUT_CLOSE_SENTINEL)) {
-    try {
-      fs.unlinkSync(IPC_INPUT_CLOSE_SENTINEL);
-    } catch {
-      /* ignore */
-    }
-    return true;
-  }
-  return false;
-}
-
 interface IpcMessage {
   text: string;
   chatJid?: string;
+}
+
+interface IpcDrainResult {
+  messages: IpcMessage[];
+  shutdown: boolean;
 }
 
 // Track the current chat JID for multi-channel agents.
@@ -897,10 +886,11 @@ function setCurrentChat(chatJid: string): void {
 }
 
 /**
- * Drain all pending IPC input messages.
- * Returns structured messages with optional chatJid for multi-channel routing.
+ * Drain all pending IPC input files.
+ * Returns structured messages with optional chatJid for multi-channel routing,
+ * plus a shutdown flag if a `{"type":"shutdown"}` file was consumed.
  */
-function drainIpcInput(): IpcMessage[] {
+function drainIpcInput(): IpcDrainResult {
   try {
     fs.mkdirSync(IPC_INPUT_DIR, { recursive: true });
     const files = fs
@@ -909,11 +899,17 @@ function drainIpcInput(): IpcMessage[] {
       .sort();
 
     const messages: IpcMessage[] = [];
+    let shutdown = false;
     for (const file of files) {
       const filePath = path.join(IPC_INPUT_DIR, file);
       try {
         const data = JSON.parse(fs.readFileSync(filePath, 'utf-8'));
         fs.unlinkSync(filePath);
+        if (data.type === 'shutdown') {
+          log('Shutdown IPC message received');
+          shutdown = true;
+          continue;
+        }
         if (data.type === 'message' && data.text) {
           messages.push({ text: data.text, chatJid: data.chatJid });
           // Update current chat if this message has a chatJid
@@ -932,10 +928,21 @@ function drainIpcInput(): IpcMessage[] {
         }
       }
     }
-    return messages;
+    // Also check for legacy _close sentinel (backwards compatibility)
+    const legacyClose = path.join(IPC_INPUT_DIR, '_close');
+    if (fs.existsSync(legacyClose)) {
+      try {
+        fs.unlinkSync(legacyClose);
+      } catch {
+        /* ignore */
+      }
+      log('Legacy _close sentinel detected, treating as shutdown');
+      shutdown = true;
+    }
+    return { messages, shutdown };
   } catch (err) {
     log(`IPC drain error: ${err instanceof Error ? err.message : String(err)}`);
-    return [];
+    return { messages: [], shutdown: false };
   }
 }
 
@@ -984,17 +991,17 @@ function formatIpcMessages(messages: IpcMessage[]): string {
 }
 
 /**
- * Wait for a new IPC message or _close sentinel.
- * Returns the messages as a single string, or null if _close.
+ * Wait for a new IPC message or shutdown signal.
+ * Returns the messages as a single string, or null if shutdown.
  */
 function waitForIpcMessage(): Promise<string | null> {
   return new Promise((resolve) => {
     const poll = () => {
-      if (shouldClose()) {
+      const { messages, shutdown } = drainIpcInput();
+      if (shutdown) {
         resolve(null);
         return;
       }
-      const messages = drainIpcInput();
       if (messages.length > 0) {
         resolve(formatIpcMessages(messages));
         return;
@@ -1027,19 +1034,19 @@ async function runQuery(
   const stream = new MessageStream();
   stream.push(prompt);
 
-  // Poll IPC for follow-up messages and _close sentinel during the query
+  // Poll IPC for follow-up messages and shutdown signal during the query
   let ipcPolling = true;
   let closedDuringQuery = false;
   const pollIpcDuringQuery = () => {
     if (!ipcPolling) return;
-    if (shouldClose()) {
-      log('Close sentinel detected during query, ending stream');
+    const { messages, shutdown } = drainIpcInput();
+    if (shutdown) {
+      log('Shutdown signal detected during query, ending stream');
       closedDuringQuery = true;
       stream.end();
       ipcPolling = false;
       return;
     }
-    const messages = drainIpcInput();
     if (messages.length > 0) {
       const formatted = formatIpcMessages(messages);
       log(`Piping IPC message into active query (${formatted.length} chars)`);
@@ -1505,7 +1512,6 @@ async function main(): Promise<void> {
   // follow-up messages don't leak into the task lane.
   if (containerInput.isScheduledTask) {
     IPC_INPUT_DIR = '/workspace/ipc/input-task';
-    IPC_INPUT_CLOSE_SENTINEL = path.join(IPC_INPUT_DIR, '_close');
     log('Using task IPC lane: /workspace/ipc/input-task');
   }
 
@@ -1523,12 +1529,7 @@ async function main(): Promise<void> {
   let sessionId = containerInput.sessionId;
   fs.mkdirSync(IPC_INPUT_DIR, { recursive: true });
 
-  // Clean up stale _close sentinel from previous container runs
-  try {
-    fs.unlinkSync(IPC_INPUT_CLOSE_SENTINEL);
-  } catch {
-    /* ignore */
-  }
+  // Legacy _close sentinel cleanup is handled inside drainIpcInput() now.
 
   // Check for auto-update notification
   let updateNotification = '';
@@ -1646,7 +1647,7 @@ Please review these changes to understand your new capabilities and fixes.
       // Don't emit a session-update marker (it would reset the host's
       // idle timer and cause a 30-min delay before the next _close).
       if (effectiveResult.closedDuringQuery) {
-        log('Close sentinel consumed during query, exiting');
+        log('Shutdown signal consumed during query, exiting');
         break;
       }
 
@@ -1663,7 +1664,7 @@ Please review these changes to understand your new capabilities and fixes.
       // Wait for the next message or _close sentinel
       const nextMessage = await waitForIpcMessage();
       if (nextMessage === null) {
-        log('Close sentinel received, exiting');
+        log('Shutdown signal received, exiting');
         break;
       }
 

--- a/container/agent-runner/src/opencode-runtime.ts
+++ b/container/agent-runner/src/opencode-runtime.ts
@@ -104,8 +104,12 @@ interface IpcMessage {
 }
 
 let ipcInputDir = '/workspace/ipc/input';
-let ipcCloseFile = path.join(ipcInputDir, '_close');
 let currentChatJid = '';
+
+interface IpcDrainResult {
+  messages: IpcMessage[];
+  shutdown: boolean;
+}
 
 function setCurrentChat(chatJid: string): void {
   currentChatJid = chatJid;
@@ -116,19 +120,7 @@ function setCurrentChat(chatJid: string): void {
   }
 }
 
-function shouldClose(): boolean {
-  if (fs.existsSync(ipcCloseFile)) {
-    try {
-      fs.unlinkSync(ipcCloseFile);
-    } catch {
-      /* ignore */
-    }
-    return true;
-  }
-  return false;
-}
-
-function drainIpcInput(): IpcMessage[] {
+function drainIpcInput(): IpcDrainResult {
   try {
     fs.mkdirSync(ipcInputDir, { recursive: true });
     const files = fs
@@ -137,11 +129,17 @@ function drainIpcInput(): IpcMessage[] {
       .sort();
 
     const messages: IpcMessage[] = [];
+    let shutdown = false;
     for (const file of files) {
       const filePath = path.join(ipcInputDir, file);
       try {
         const data = JSON.parse(fs.readFileSync(filePath, 'utf-8'));
         fs.unlinkSync(filePath);
+        if (data.type === 'shutdown') {
+          log('Shutdown IPC message received');
+          shutdown = true;
+          continue;
+        }
         if (data.type === 'message' && data.text) {
           messages.push({ text: data.text, chatJid: data.chatJid });
           if (data.chatJid) setCurrentChat(data.chatJid);
@@ -157,10 +155,21 @@ function drainIpcInput(): IpcMessage[] {
         }
       }
     }
-    return messages;
+    // Legacy _close sentinel backwards compatibility
+    const legacyClose = path.join(ipcInputDir, '_close');
+    if (fs.existsSync(legacyClose)) {
+      try {
+        fs.unlinkSync(legacyClose);
+      } catch {
+        /* ignore */
+      }
+      log('Legacy _close sentinel detected, treating as shutdown');
+      shutdown = true;
+    }
+    return { messages, shutdown };
   } catch (err) {
     log(`IPC drain error: ${err instanceof Error ? err.message : String(err)}`);
-    return [];
+    return { messages: [], shutdown: false };
   }
 }
 
@@ -171,11 +180,11 @@ function formatIpcMessages(messages: IpcMessage[]): string {
 function waitForIpcMessage(): Promise<string | null> {
   return new Promise((resolve) => {
     const poll = () => {
-      if (shouldClose()) {
+      const { messages, shutdown } = drainIpcInput();
+      if (shutdown) {
         resolve(null);
         return;
       }
-      const messages = drainIpcInput();
       if (messages.length > 0) {
         resolve(formatIpcMessages(messages));
         return;
@@ -428,7 +437,7 @@ async function injectSystemContext(
 
 /**
  * Run a single prompt against an OpenCode session.
- * Returns the session ID and whether _close was detected during the prompt.
+ * Returns the session ID and whether a shutdown signal was detected during the prompt.
  */
 async function runOpenCodePrompt(
   client: OpencodeClient,
@@ -445,12 +454,13 @@ async function runOpenCodePrompt(
   let closedDuringPrompt = false;
 
   // Poll IPC for follow-up messages during the prompt
-  // (OpenCode prompts are blocking, so we poll in the background and abort if _close)
+  // (OpenCode prompts are blocking, so we poll in the background and abort if shutdown)
   let ipcPolling = true;
   const pollIpc = () => {
     if (!ipcPolling) return;
-    if (shouldClose()) {
-      log('Close sentinel detected during prompt, aborting');
+    const { shutdown } = drainIpcInput();
+    if (shutdown) {
+      log('Shutdown signal detected during prompt, aborting');
       closedDuringPrompt = true;
       ipcPolling = false;
       // Try to abort the running prompt
@@ -644,17 +654,9 @@ export async function runOpenCodeRuntime(
   // Configure IPC directories
   if (containerInput.isScheduledTask) {
     ipcInputDir = '/workspace/ipc/input-task';
-    ipcCloseFile = path.join(ipcInputDir, '_close');
     log('Using task IPC lane: /workspace/ipc/input-task');
   }
   fs.mkdirSync(ipcInputDir, { recursive: true });
-
-  // Clean up stale _close sentinel
-  try {
-    fs.unlinkSync(ipcCloseFile);
-  } catch {
-    /* ignore */
-  }
 
   // Initialize current chat JID
   setCurrentChat(containerInput.chatJid);

--- a/src/backends/local-backend.ts
+++ b/src/backends/local-backend.ts
@@ -1464,7 +1464,15 @@ export class LocalBackend implements AgentBackend {
     assertPathWithin(inputDir, ipcBase, 'closeStdin');
     try {
       fs.mkdirSync(inputDir, { recursive: true });
-      fs.writeFileSync(path.join(inputDir, '_close'), '');
+      // Write a shutdown IPC message (atomic via .tmp rename) instead of the
+      // legacy _close sentinel file. The agent-runner drains this like any
+      // other .json IPC file, eliminating the race condition where _close
+      // could be missed between poll cycles.
+      const filename = `_shutdown-${Date.now()}.json`;
+      const filePath = path.join(inputDir, filename);
+      const tempPath = `${filePath}.tmp`;
+      fs.writeFileSync(tempPath, JSON.stringify({ type: 'shutdown' }));
+      fs.renameSync(tempPath, filePath);
     } catch {
       // ignore
     }

--- a/src/group-queue.ts
+++ b/src/group-queue.ts
@@ -578,12 +578,16 @@ export class GroupQueue {
       return;
     }
 
-    // Fallback: direct local filesystem write
+    // Fallback: direct local filesystem write — atomic shutdown IPC message
     const inputSubdir = lane === 'task' ? 'input-task' : 'input';
     const inputDir = path.join(this.dataDir, 'ipc', groupFolder, inputSubdir);
     try {
       this.fsImpl.mkdirSync(inputDir, { recursive: true });
-      this.fsImpl.writeFileSync(path.join(inputDir, '_close'), '');
+      const filename = `_shutdown-${Date.now()}.json`;
+      const filePath = path.join(inputDir, filename);
+      const tempPath = `${filePath}.tmp`;
+      this.fsImpl.writeFileSync(tempPath, JSON.stringify({ type: 'shutdown' }));
+      this.fsImpl.renameSync(tempPath, filePath);
     } catch {
       // ignore
     }


### PR DESCRIPTION
## Summary

Replaces the fragile `_close` empty file sentinel with a proper `{"type":"shutdown"}` JSON IPC message, consumed atomically in the same `drainIpcInput()` pass as regular messages.

Closes #151

### Problem

The `_close` file sentinel had four race conditions:
- Mid-poll write: orchestrator writes `_close` while agent is mid-drain — agent may miss it until next poll
- No acknowledgment: orchestrator can't confirm agent saw the signal
- Stale sentinels: leftover `_close` files from crashed containers cause immediate shutdown on restart
- Non-atomic: empty file creation isn't atomic on all filesystems

### Solution

- Orchestrator (`local-backend.ts`, `group-queue.ts`) now writes `_shutdown-<timestamp>.json` via atomic `.tmp` + `renameSync`
- All 3 agent runtimes (Claude SDK, OpenCode, Codex) detect `{"type":"shutdown"}` in `drainIpcInput()` and return `{ messages, shutdown: boolean }`
- Shutdown is processed in the same drain pass as regular messages — no separate polling path
- Legacy `_close` file detection kept as backwards-compatible fallback

### Changed files

| File | Change |
|------|--------|
| `src/backends/local-backend.ts` | `closeStdin()` writes `_shutdown-<ts>.json` atomically |
| `src/group-queue.ts` | Fallback close path uses same atomic shutdown message |
| `container/agent-runner/src/index.ts` | `drainIpcInput()` returns `IpcDrainResult`, removed `shouldClose()` |
| `container/agent-runner/src/opencode-runtime.ts` | Same pattern |
| `container/agent-runner/src/codex-runtime.ts` | Same pattern |
| `**/opencode-runtime.test.ts` | Updated test for new shutdown file format |

## Test plan

- [x] 1532 tests pass, 0 fail
- [x] `tsc --noEmit` clean
- [x] Legacy `_close` fallback preserved for backwards compat
