### PR TITLE
test: cover IPC snapshot writers

### DIFF
--- a/src/ipc-snapshots.test.ts
+++ b/src/ipc-snapshots.test.ts
@@ -125,7 +125,12 @@ describe('ipc-snapshots', () => {
   describe('task visibility filtering', () => {
     it('writes only matching tasks for non-main groups', () => {
       const groupFolder = uniqueFolder('ipc-snapshot-tasks');
-      const tasksFile = path.join(DATA_DIR, 'ipc', groupFolder, 'current_tasks.json');
+      const tasksFile = path.join(
+        DATA_DIR,
+        'ipc',
+        groupFolder,
+        'current_tasks.json',
+      );
       const allTasks = [
         {
           id: 't1',
@@ -189,7 +194,12 @@ describe('ipc-snapshots', () => {
 
     it('writes all tasks for the main group', () => {
       const groupFolder = uniqueFolder('ipc-snapshot-tasks-main');
-      const tasksFile = path.join(DATA_DIR, 'ipc', groupFolder, 'current_tasks.json');
+      const tasksFile = path.join(
+        DATA_DIR,
+        'ipc',
+        groupFolder,
+        'current_tasks.json',
+      );
       const allTasks = [
         {
           id: 't1',
@@ -321,7 +331,13 @@ describe('ipc-snapshots', () => {
       const subscribedJids = new Set(['j1', 'j3']);
 
       try {
-        writeGroupsSnapshot(groupFolder, false, groups, new Set(), subscribedJids);
+        writeGroupsSnapshot(
+          groupFolder,
+          false,
+          groups,
+          new Set(),
+          subscribedJids,
+        );
         expect(readJson(groupsFile)).toEqual({
           groups: [groups[0], groups[2]],
           lastSync: '2026-03-28T12:34:56.000Z',
@@ -339,34 +355,40 @@ describe('ipc-snapshots', () => {
     it('writes guild rosters and a deterministic lastSync timestamp', () => {
       installFixedDate('2026-03-28T15:00:00.000Z');
       const groupFolder = uniqueFolder('ipc-snapshot-rosters');
-      const rostersFile = path.join(DATA_DIR, 'ipc', groupFolder, 'guild_rosters.json');
-      const rosters: Array<{ guild: GuildInfo; members: GuildRosterMember[] }> = [
-        {
-          guild: {
-            id: 'guild-1',
-            name: 'OmniAura',
-            ownerId: 'user-1',
-            memberCount: 2,
-            lastSynced: '2026-03-28T14:59:00.000Z',
+      const rostersFile = path.join(
+        DATA_DIR,
+        'ipc',
+        groupFolder,
+        'guild_rosters.json',
+      );
+      const rosters: Array<{ guild: GuildInfo; members: GuildRosterMember[] }> =
+        [
+          {
+            guild: {
+              id: 'guild-1',
+              name: 'OmniAura',
+              ownerId: 'user-1',
+              memberCount: 2,
+              lastSynced: '2026-03-28T14:59:00.000Z',
+            },
+            members: [
+              {
+                userId: 'user-1',
+                username: 'peyton',
+                displayName: 'Peyton',
+                isBot: false,
+                roles: ['admin'],
+              },
+              {
+                userId: 'bot-1',
+                username: 'ocpeyton',
+                displayName: 'OCPeyton',
+                isBot: true,
+                roles: ['agent'],
+              },
+            ],
           },
-          members: [
-            {
-              userId: 'user-1',
-              username: 'peyton',
-              displayName: 'Peyton',
-              isBot: false,
-              roles: ['admin'],
-            },
-            {
-              userId: 'bot-1',
-              username: 'ocpeyton',
-              displayName: 'OCPeyton',
-              isBot: true,
-              roles: ['agent'],
-            },
-          ],
-        },
-      ];
+        ];
 
       try {
         writeRostersSnapshot(groupFolder, rosters);


### PR DESCRIPTION
## Summary
- add deterministic filesystem-backed tests for `src/ipc-snapshots.ts` instead of reimplementing its filtering logic inside tests
- verify `writeTasksSnapshot`, `writeGroupsSnapshot`, and `writeRostersSnapshot` serialize the expected payloads and respect main-vs-agent visibility rules
- freeze time in snapshot tests so `lastSync` assertions stay stable across runs

## Coverage
- tests: 1545 -> 1546
- overall line coverage: 82.24% -> 83.26%
- overall function coverage: 85.54% -> 86.32%
- `src/ipc-snapshots.ts`: 19.57% -> 100.00% line coverage, 40.00% -> 100.00% function coverage

## Verification
- `bun test src/ipc-snapshots.test.ts`
- `bun test`
- `bun test --coverage --coverage-reporter=text`

## Remaining gaps
- `src/channels/discord.ts`
- `src/discovery/mdns.ts`
- `src/channels/slack.ts`
- `src/channels/telegram.ts`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Enhanced test infrastructure with snapshot-based verification for improved reliability and maintainability.
  * Implemented deterministic test timing controls to ensure consistent test execution.
  * Expanded test isolation and cleanup procedures.
  * Increased test coverage for roster data persistence and validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->