### PR TITLE
feat: shared Claude VM mode to reduce disk usage

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -29,6 +29,13 @@ DISCOVERY_TRUST_LAN_ADMIN=false
 # Increase to keep a warm idle pool for lower first-token latency.
 # MAX_IDLE_CONTAINERS=0
 
+# Shared Claude VM: consolidate all Claude agent-runner processes into a single
+# long-running Apple Container VM. Each agent runs via `container exec` into
+# the shared VM. Exec containers remain per-agent for isolation.
+# Reduces disk usage from 2N to N+1 containers. Apple Container only.
+# SHARED_CLAUDE_VM=false
+# SHARED_CLAUDE_VM_MEMORY=16G
+
 # GitHub webhook listener
 # Set a shared secret when exposing /webhooks/github.
 # GITHUB_WEBHOOK_SECRET=

--- a/container/Dockerfile
+++ b/container/Dockerfile
@@ -13,11 +13,14 @@ RUN bun install
 # Copy source code
 COPY agent-runner/ ./
 
-# Copy entrypoint script
-# Sources env, configures git, pre-installs cross-platform deps for host mounts,
-# buffers stdin, then runs agent-runner
+# Copy entrypoint scripts
+# entrypoint.sh: legacy per-VM mode (sources env, configures git, buffers stdin, runs agent-runner)
+# shared-entrypoint.sh: shared VM mode (minimal setup, sleeps forever)
+# agent-exec.sh: per-agent wrapper for shared VM mode (invoked via container exec)
 COPY entrypoint.sh /app/entrypoint.sh
-RUN chmod +x /app/entrypoint.sh
+COPY shared-entrypoint.sh /app/shared-entrypoint.sh
+COPY agent-exec.sh /app/agent-exec.sh
+RUN chmod +x /app/entrypoint.sh /app/shared-entrypoint.sh /app/agent-exec.sh
 
 # Install bash shim for split-execution mode.
 # Renames real bash to bash.real, installs shim at /usr/local/bin/bash.

--- a/container/agent-exec.sh
+++ b/container/agent-exec.sh
@@ -1,0 +1,138 @@
+#!/bin/bash.real
+set -e
+
+# Per-agent exec wrapper for shared Claude VM.
+# Invoked via: container exec -i -e AGENT_WORKSPACE=... -e AGENT_IPC_DIR=... <vm> /app/agent-exec.sh
+#
+# Expects these env vars (set by container exec -e):
+#   AGENT_WORKSPACE   - e.g. /workspace/groups/main
+#   AGENT_IPC_DIR     - e.g. /data/ipc/main
+#   AGENT_SESSION_DIR - e.g. /data/sessions/main/.claude
+#   AGENT_ENV_DIR     - e.g. /data/env/main
+#   AGENT_GLOBAL_DIR  - e.g. /workspace/groups/global
+#   AGENT_CONTEXT_DIR - e.g. /workspace/groups/agent-context-folder (optional)
+#   AGENT_CATEGORY_DIR - (optional)
+#   AGENT_SERVER_DIR  - (optional)
+#   AGENT_PROJECT_DIR - e.g. /workspace/project
+
+# Source per-agent environment variables
+if [ -n "$AGENT_ENV_DIR" ] && [ -f "$AGENT_ENV_DIR/env" ]; then
+  while IFS= read -r line || [ -n "$line" ]; do
+    [[ "$line" =~ ^[[:space:]]*$ ]] && continue
+    [[ "$line" =~ ^[[:space:]]*# ]] && continue
+    [[ "$line" =~ ^[A-Za-z_][A-Za-z0-9_]*= ]] || continue
+    export "$line"
+  done < "$AGENT_ENV_DIR/env"
+fi
+
+# Normalize GitHub auth env so both gh CLI aliases work
+if [ -n "$GH_TOKEN" ] && [ -z "$GITHUB_TOKEN" ]; then
+  export GITHUB_TOKEN="$GH_TOKEN"
+elif [ -n "$GITHUB_TOKEN" ] && [ -z "$GH_TOKEN" ]; then
+  export GH_TOKEN="$GITHUB_TOKEN"
+fi
+
+# Configure git with GitHub token
+if [ -n "$GITHUB_TOKEN" ]; then
+  gh auth setup-git 2>/dev/null || true
+  git config --global user.name "${GIT_AUTHOR_NAME:-OmniClaw Agent}"
+  git config --global user.email "${GIT_AUTHOR_EMAIL:-omniclaw@users.noreply.github.com}"
+
+  if command -v gt &> /dev/null; then
+    if ! gt auth status &> /dev/null; then
+      gt auth --token "$GITHUB_TOKEN" 2>/dev/null || true
+    fi
+  fi
+fi
+
+# Set HOME to per-agent session dir's parent so .claude/ lands correctly
+if [ -n "$AGENT_SESSION_DIR" ]; then
+  export HOME=$(dirname "$AGENT_SESSION_DIR")
+fi
+
+# SSH key setup: use workspace-persisted key or generate new
+AGENT_FOLDER=$(basename "${AGENT_WORKSPACE:-/workspace/group}")
+mkdir -p ~/.ssh
+
+generate_deterministic_key() {
+  node -e "
+const crypto = require('crypto');
+const fs = require('fs');
+const os = require('os');
+
+const seed = crypto.createHmac('sha256', process.env.SSH_KEY_SEED)
+  .update('$AGENT_FOLDER')
+  .digest();
+
+const key = crypto.createPrivateKey({
+  key: Buffer.concat([
+    Buffer.from('302e020100300506032b657004220420', 'hex'),
+    seed
+  ]),
+  format: 'der',
+  type: 'pkcs8',
+});
+
+const privPem = key.export({ type: 'pkcs8', format: 'pem' });
+const pubKey = crypto.createPublicKey(key);
+const pubSsh = pubKey.export({ type: 'spki', format: 'der' });
+
+const keyType = Buffer.from('ssh-ed25519');
+const rawPub = pubSsh.subarray(-32);
+const typeLen = Buffer.alloc(4); typeLen.writeUInt32BE(keyType.length);
+const pubLen = Buffer.alloc(4); pubLen.writeUInt32BE(rawPub.length);
+const sshPub = 'ssh-ed25519 ' + Buffer.concat([typeLen, keyType, pubLen, rawPub]).toString('base64') + ' omniclaw-$AGENT_FOLDER';
+
+const home = process.env.HOME || '/home/bun';
+
+fs.writeFileSync(home + '/.ssh/id_ed25519.pem', privPem, { mode: 0o600 });
+fs.writeFileSync(home + '/.ssh/id_ed25519.pub', sshPub + '\n', { mode: 0o644 });
+" && ssh-keygen -p -N "" -m pem -f ~/.ssh/id_ed25519.pem -q 2>/dev/null && mv ~/.ssh/id_ed25519.pem ~/.ssh/id_ed25519 || {
+    rm -f ~/.ssh/id_ed25519.pem
+    return 1
+  }
+  chmod 600 ~/.ssh/id_ed25519
+}
+
+WORKSPACE="${AGENT_WORKSPACE:-/workspace/group}"
+
+if [ -n "$SSH_KEY_SEED" ]; then
+  if generate_deterministic_key; then
+    mkdir -p "$WORKSPACE/.ssh"
+    cp ~/.ssh/id_ed25519 "$WORKSPACE/.ssh/id_ed25519"
+    cp ~/.ssh/id_ed25519.pub "$WORKSPACE/.ssh/id_ed25519.pub"
+    chmod 600 "$WORKSPACE/.ssh/id_ed25519"
+  elif [ -f "$WORKSPACE/.ssh/id_ed25519" ]; then
+    cp "$WORKSPACE/.ssh/id_ed25519" ~/.ssh/id_ed25519
+    chmod 600 ~/.ssh/id_ed25519
+  else
+    ssh-keygen -t ed25519 -N "" -f ~/.ssh/id_ed25519 -q
+    mkdir -p "$WORKSPACE/.ssh"
+    cp ~/.ssh/id_ed25519 "$WORKSPACE/.ssh/id_ed25519"
+    cp ~/.ssh/id_ed25519.pub "$WORKSPACE/.ssh/id_ed25519.pub"
+    chmod 600 "$WORKSPACE/.ssh/id_ed25519"
+    PUBKEY=$(cat ~/.ssh/id_ed25519.pub)
+    IPC_DIR="${AGENT_IPC_DIR:-/workspace/ipc}"
+    echo "{\"type\":\"ssh_pubkey\",\"pubkey\":\"$PUBKEY\"}" > "$IPC_DIR/messages/ssh_pubkey_$(date +%s%N).json"
+  fi
+elif [ -f "$WORKSPACE/.ssh/id_ed25519" ]; then
+  cp "$WORKSPACE/.ssh/id_ed25519" ~/.ssh/id_ed25519
+  chmod 600 ~/.ssh/id_ed25519
+else
+  ssh-keygen -t ed25519 -N "" -f ~/.ssh/id_ed25519 -q
+  mkdir -p "$WORKSPACE/.ssh"
+  cp ~/.ssh/id_ed25519 "$WORKSPACE/.ssh/id_ed25519"
+  cp ~/.ssh/id_ed25519.pub "$WORKSPACE/.ssh/id_ed25519.pub"
+  chmod 600 "$WORKSPACE/.ssh/id_ed25519"
+  PUBKEY=$(cat ~/.ssh/id_ed25519.pub)
+  IPC_DIR="${AGENT_IPC_DIR:-/workspace/ipc}"
+  echo "{\"type\":\"ssh_pubkey\",\"pubkey\":\"$PUBKEY\"}" > "$IPC_DIR/messages/ssh_pubkey_$(date +%s%N).json"
+fi
+ssh-keyscan github.com gitlab.com >> ~/.ssh/known_hosts 2>/dev/null || true
+
+# Buffer stdin then run agent (per-agent temp file to avoid conflicts in shared VM)
+INPUT_FILE="/tmp/input-$$.json"
+cat > "$INPUT_FILE"
+cd "${AGENT_WORKSPACE:-/workspace/group}"
+bun /app/src/index.ts < "$INPUT_FILE"
+rm -f "$INPUT_FILE"

--- a/container/agent-exec.sh
+++ b/container/agent-exec.sh
@@ -15,6 +15,11 @@ set -e
 #   AGENT_SERVER_DIR  - (optional)
 #   AGENT_PROJECT_DIR - e.g. /workspace/project
 
+# Shared-VM execs must always receive isolated per-agent paths.
+: "${AGENT_WORKSPACE:?AGENT_WORKSPACE is required}"
+: "${AGENT_IPC_DIR:?AGENT_IPC_DIR is required}"
+: "${AGENT_SESSION_DIR:?AGENT_SESSION_DIR is required}"
+
 # Source per-agent environment variables
 if [ -n "$AGENT_ENV_DIR" ] && [ -f "$AGENT_ENV_DIR/env" ]; then
   while IFS= read -r line || [ -n "$line" ]; do
@@ -46,12 +51,11 @@ if [ -n "$GITHUB_TOKEN" ]; then
 fi
 
 # Set HOME to per-agent session dir's parent so .claude/ lands correctly
-if [ -n "$AGENT_SESSION_DIR" ]; then
-  export HOME=$(dirname "$AGENT_SESSION_DIR")
-fi
+HOME="$(dirname "$AGENT_SESSION_DIR")"
+export HOME
 
 # SSH key setup: use workspace-persisted key or generate new
-AGENT_FOLDER=$(basename "${AGENT_WORKSPACE:-/workspace/group}")
+AGENT_FOLDER=$(basename "$AGENT_WORKSPACE")
 mkdir -p ~/.ssh
 
 generate_deterministic_key() {
@@ -94,7 +98,9 @@ fs.writeFileSync(home + '/.ssh/id_ed25519.pub', sshPub + '\n', { mode: 0o644 });
   chmod 600 ~/.ssh/id_ed25519
 }
 
-WORKSPACE="${AGENT_WORKSPACE:-/workspace/group}"
+WORKSPACE="$AGENT_WORKSPACE"
+IPC_DIR="$AGENT_IPC_DIR"
+mkdir -p "$IPC_DIR/messages"
 
 if [ -n "$SSH_KEY_SEED" ]; then
   if generate_deterministic_key; then
@@ -112,7 +118,6 @@ if [ -n "$SSH_KEY_SEED" ]; then
     cp ~/.ssh/id_ed25519.pub "$WORKSPACE/.ssh/id_ed25519.pub"
     chmod 600 "$WORKSPACE/.ssh/id_ed25519"
     PUBKEY=$(cat ~/.ssh/id_ed25519.pub)
-    IPC_DIR="${AGENT_IPC_DIR:-/workspace/ipc}"
     echo "{\"type\":\"ssh_pubkey\",\"pubkey\":\"$PUBKEY\"}" > "$IPC_DIR/messages/ssh_pubkey_$(date +%s%N).json"
   fi
 elif [ -f "$WORKSPACE/.ssh/id_ed25519" ]; then
@@ -125,14 +130,13 @@ else
   cp ~/.ssh/id_ed25519.pub "$WORKSPACE/.ssh/id_ed25519.pub"
   chmod 600 "$WORKSPACE/.ssh/id_ed25519"
   PUBKEY=$(cat ~/.ssh/id_ed25519.pub)
-  IPC_DIR="${AGENT_IPC_DIR:-/workspace/ipc}"
   echo "{\"type\":\"ssh_pubkey\",\"pubkey\":\"$PUBKEY\"}" > "$IPC_DIR/messages/ssh_pubkey_$(date +%s%N).json"
 fi
 ssh-keyscan github.com gitlab.com >> ~/.ssh/known_hosts 2>/dev/null || true
 
 # Buffer stdin then run agent (per-agent temp file to avoid conflicts in shared VM)
 INPUT_FILE="/tmp/input-$$.json"
+trap 'rm -f "$INPUT_FILE"' EXIT
 cat > "$INPUT_FILE"
-cd "${AGENT_WORKSPACE:-/workspace/group}"
+cd "$AGENT_WORKSPACE"
 bun /app/src/index.ts < "$INPUT_FILE"
-rm -f "$INPUT_FILE"

--- a/container/agent-runner/src/__tests__/mcp-config.test.ts
+++ b/container/agent-runner/src/__tests__/mcp-config.test.ts
@@ -2,7 +2,9 @@ import { describe, expect, it } from 'bun:test';
 
 import {
   buildAllowedTools,
+  isPathAllowedForSharedVmAgent,
   normalizeExternalMcpServers,
+  resolveCurrentChatFile,
   validateExternalMcpCommand,
 } from '../index.ts';
 
@@ -58,6 +60,21 @@ describe('external MCP config security', () => {
 
   it('accepts bare executable names for stdio MCP servers', () => {
     expect(validateExternalMcpCommand('gmail', 'npx')).toBe('npx');
+  });
+
+  it('uses a process-scoped current chat file by default', () => {
+    expect(resolveCurrentChatFile()).toBe(
+      `/tmp/current_chat_jid-${process.pid}`,
+    );
+  });
+
+  it('does not allow shared-VM agents to target sibling group folders', () => {
+    expect(isPathAllowedForSharedVmAgent('/workspace/group/CLAUDE.md')).toBe(
+      true,
+    );
+    expect(
+      isPathAllowedForSharedVmAgent('/workspace/groups/other/CLAUDE.md'),
+    ).toBe(false);
   });
 
   it('rejects non-http MCP URLs', () => {

--- a/container/agent-runner/src/codex-runtime.ts
+++ b/container/agent-runner/src/codex-runtime.ts
@@ -113,7 +113,8 @@ function log(message: string): void {
 
 /** Resolve IPC input directory based on whether this is a scheduled task. */
 function resolveIpcInputDir(isScheduledTask?: boolean): string {
-  return isScheduledTask ? '/workspace/ipc/input-task' : '/workspace/ipc/input';
+  const ipcDir = process.env.AGENT_IPC_DIR || '/workspace/ipc';
+  return isScheduledTask ? `${ipcDir}/input-task` : `${ipcDir}/input`;
 }
 
 function asObject(value: unknown): Record<string, unknown> | undefined {
@@ -785,13 +786,16 @@ async function runCodexTurn(
 // IPC helpers (same protocol as Claude SDK and OpenCode runtimes)
 // ---------------------------------------------------------------------------
 
-let ipcInputDir = '/workspace/ipc/input';
+let ipcInputDir = resolveIpcInputDir(false);
 let currentChatJid = '';
+const currentChatFile =
+  process.env.OMNICLAW_CURRENT_CHAT_FILE ||
+  path.join('/tmp', `current_chat_jid-${process.pid}`);
 
 function setCurrentChat(chatJid: string): void {
   currentChatJid = chatJid;
   try {
-    fs.writeFileSync('/tmp/current_chat_jid', chatJid);
+    fs.writeFileSync(currentChatFile, chatJid);
   } catch {
     /* ignore */
   }

--- a/container/agent-runner/src/index.ts
+++ b/container/agent-runner/src/index.ts
@@ -96,6 +96,14 @@ function resolveWorkspacePaths() {
 }
 
 const PATHS = resolveWorkspacePaths();
+const IS_SHARED_VM_MODE = !!process.env.AGENT_WORKSPACE;
+
+export function resolveCurrentChatFile(): string {
+  return (
+    process.env.OMNICLAW_CURRENT_CHAT_FILE ||
+    path.join('/tmp', `current_chat_jid-${process.pid}`)
+  );
+}
 
 const ALLOWED_EXTERNAL_MCP_COMMAND_ROOTS = [
   PATHS.group,
@@ -106,6 +114,66 @@ const ALLOWED_EXTERNAL_MCP_COMMAND_ROOTS = [
   PATHS.server,
   '/workspace/extra',
 ] as const;
+
+const SHARED_VM_VISIBLE_PARENT_ROOTS = [
+  '/workspace/groups',
+  '/data/ipc',
+  '/data/sessions',
+] as const;
+
+const ALLOWED_AGENT_PATH_ROOTS = [
+  PATHS.group,
+  PATHS.global,
+  PATHS.agent,
+  PATHS.category,
+  PATHS.server,
+  PATHS.project,
+  '/workspace/extra',
+] as const;
+
+function isPathWithinRoot(filePath: string, root: string): boolean {
+  const resolved = path.resolve(filePath);
+  const resolvedRoot = path.resolve(root);
+  return (
+    resolved === resolvedRoot ||
+    resolved.startsWith(`${resolvedRoot}${path.sep}`)
+  );
+}
+
+export function isPathAllowedForSharedVmAgent(filePath: string): boolean {
+  return ALLOWED_AGENT_PATH_ROOTS.some((root) =>
+    isPathWithinRoot(filePath, root),
+  );
+}
+
+function referencesSharedVmParentRoot(filePath: string): boolean {
+  return SHARED_VM_VISIBLE_PARENT_ROOTS.some((root) =>
+    isPathWithinRoot(filePath, root),
+  );
+}
+
+function assertSharedVmPathAllowed(filePath: string): void {
+  if (!IS_SHARED_VM_MODE) return;
+  if (!referencesSharedVmParentRoot(filePath)) return;
+  if (isPathAllowedForSharedVmAgent(filePath)) return;
+  throw new Error(
+    `Access to ${filePath} is not allowed in shared-VM mode because it is outside this agent's mounted workspace allowlist.`,
+  );
+}
+
+function assertSharedVmCommandAllowed(command: string): void {
+  if (!IS_SHARED_VM_MODE) return;
+  const referencedPaths = command.match(
+    /\/(?:workspace\/groups|data\/(?:ipc|sessions))[^\s'"`;|&)]*/g,
+  );
+  for (const referencedPath of referencedPaths || []) {
+    if (!isPathAllowedForSharedVmAgent(referencedPath)) {
+      throw new Error(
+        "This command references shared-VM parent mounts outside this agent's workspace allowlist.",
+      );
+    }
+  }
+}
 
 function isPlainObject(value: unknown): value is Record<string, unknown> {
   return typeof value === 'object' && value !== null && !Array.isArray(value);
@@ -635,6 +703,8 @@ export function createSanitizeBashHook(): HookCallback {
       }
     }
 
+    assertSharedVmCommandAllowed(command);
+
     // Prepend unset for defense-in-depth
     // (Even though secrets shouldn't be in process.env, unset provides extra safety)
     const unsetPrefix = `unset ${SECRET_ENV_VARS.join(' ')} 2>/dev/null; `;
@@ -750,6 +820,30 @@ export function createSanitizeReadHook(): HookCallback {
       }
     }
 
+    assertSharedVmPathAllowed(normalized);
+
+    return {};
+  };
+}
+
+export function createWorkspaceIsolationHook(): HookCallback {
+  return async (input, _toolUseId, _context) => {
+    const preInput = input as PreToolUseHookInput;
+    const toolInput = preInput.tool_input as {
+      file_path?: string;
+      path?: string;
+    };
+    const filePath = toolInput.file_path || toolInput.path;
+    if (!filePath) return {};
+
+    let normalized = path.resolve(filePath);
+    try {
+      normalized = fs.realpathSync(normalized);
+    } catch {
+      // Non-existent writes still need path-level validation.
+    }
+
+    assertSharedVmPathAllowed(normalized);
     return {};
   };
 }
@@ -837,8 +931,8 @@ function formatTranscriptMarkdown(
 }
 
 // Track the current chat JID for multi-channel agents.
-// Written to /tmp/current_chat_jid so the MCP server can read it.
-const CURRENT_CHAT_FILE = '/tmp/current_chat_jid';
+// In shared-VM mode, multiple runner processes share /tmp, so this must be per exec.
+const CURRENT_CHAT_FILE = resolveCurrentChatFile();
 let currentChatJidValue = '';
 
 function setCurrentChat(chatJid: string): void {
@@ -1155,6 +1249,8 @@ async function runQuery(
             OMNICLAW_CHAT_JID: containerInput.chatJid,
             OMNICLAW_GROUP_FOLDER: containerInput.groupFolder,
             OMNICLAW_IS_MAIN: containerInput.isMain ? '1' : '0',
+            OMNICLAW_IPC_DIR: PATHS.ipc,
+            OMNICLAW_CURRENT_CHAT_FILE: CURRENT_CHAT_FILE,
             ...(containerInput.discordGuildId
               ? { OMNICLAW_DISCORD_GUILD_ID: containerInput.discordGuildId }
               : {}),
@@ -1190,6 +1286,10 @@ async function runQuery(
             matcher: 'Read',
             hooks: [createSanitizeReadHook(), createFileSizeHook()],
           },
+          { matcher: 'Write', hooks: [createWorkspaceIsolationHook()] },
+          { matcher: 'Edit', hooks: [createWorkspaceIsolationHook()] },
+          { matcher: 'Glob', hooks: [createWorkspaceIsolationHook()] },
+          { matcher: 'Grep', hooks: [createWorkspaceIsolationHook()] },
         ],
       },
     },

--- a/container/agent-runner/src/index.ts
+++ b/container/agent-runner/src/index.ts
@@ -76,13 +76,34 @@ const BUILTIN_ALLOWED_TOOLS = [
 const RESERVED_MCP_SERVER_NAME = 'omniclaw';
 const MCP_SERVER_NAME_RE = /^[A-Za-z0-9_-]+$/;
 const SAFE_BINARY_NAME_RE = /^[A-Za-z0-9._-]+$/;
+
+/**
+ * Resolve workspace paths from environment variables (shared VM mode)
+ * or fall back to legacy hardcoded paths (per-VM mode).
+ */
+function resolveWorkspacePaths() {
+  return {
+    group: process.env.AGENT_WORKSPACE || '/workspace/group',
+    ipc: process.env.AGENT_IPC_DIR || '/workspace/ipc',
+    sessions: process.env.AGENT_SESSION_DIR || '/home/bun/.claude',
+    global: process.env.AGENT_GLOBAL_DIR || '/workspace/global',
+    agent: process.env.AGENT_CONTEXT_DIR || '/workspace/agent',
+    category: process.env.AGENT_CATEGORY_DIR || '/workspace/category',
+    server: process.env.AGENT_SERVER_DIR || '/workspace/server',
+    project: process.env.AGENT_PROJECT_DIR || '/workspace/project',
+    envDir: process.env.AGENT_ENV_DIR || '/workspace/env-dir',
+  };
+}
+
+const PATHS = resolveWorkspacePaths();
+
 const ALLOWED_EXTERNAL_MCP_COMMAND_ROOTS = [
-  '/workspace/group',
-  '/workspace/project',
-  '/workspace/global',
-  '/workspace/agent',
-  '/workspace/category',
-  '/workspace/server',
+  PATHS.group,
+  PATHS.project,
+  PATHS.global,
+  PATHS.agent,
+  PATHS.category,
+  PATHS.server,
   '/workspace/extra',
 ] as const;
 
@@ -135,7 +156,7 @@ export function validateExternalMcpCommand(
 
   const resolved = trimmed.startsWith('/')
     ? path.resolve(trimmed)
-    : path.resolve('/workspace/group', trimmed);
+    : path.resolve(PATHS.group, trimmed);
   const isAllowed = ALLOWED_EXTERNAL_MCP_COMMAND_ROOTS.some((root) => {
     const resolvedRoot = path.resolve(root);
     return (
@@ -274,14 +295,14 @@ interface SDKUserMessage {
 
 // Defaults to the message lane; reassigned to input-task/ after stdin is parsed
 // when containerInput.isScheduledTask is true.
-let IPC_INPUT_DIR = '/workspace/ipc/input';
+let IPC_INPUT_DIR = `${PATHS.ipc}/input`;
 
 /**
  * Determine the IPC input directory based on whether this is a scheduled task.
  * Exported for testing.
  */
 export function resolveIpcInputDir(isScheduledTask?: boolean): string {
-  return isScheduledTask ? '/workspace/ipc/input-task' : '/workspace/ipc/input';
+  return isScheduledTask ? `${PATHS.ipc}/input-task` : `${PATHS.ipc}/input`;
 }
 const IPC_POLL_MS = 500;
 
@@ -386,7 +407,7 @@ const EXT_TO_MEDIA_TYPE: Record<string, string> = {
   '.webp': 'image/webp',
 };
 
-const MEDIA_DIR = '/workspace/group/media';
+const MEDIA_DIR = `${PATHS.group}/media`;
 
 /**
  * Parse [attachment:image file=...] markers in text.
@@ -516,7 +537,7 @@ function createPreCompactHook(assistantName: string): HookCallback {
       const summary = getSessionSummary(sessionId, transcriptPath);
       const name = summary ? sanitizeFilename(summary) : generateFallbackName();
 
-      const conversationsDir = '/workspace/group/conversations';
+      const conversationsDir = `${PATHS.group}/conversations`;
       fs.mkdirSync(conversationsDir, { recursive: true });
 
       const date = new Date().toISOString().split('T')[0];
@@ -595,8 +616,9 @@ export function createSanitizeBashHook(): HookCallback {
 
     // Block other sensitive paths
     const blockedPaths = [
-      /\/tmp\/input\.json/, // Stdin buffer
-      /\/workspace\/env-dir(?:\/|$)/, // Mounted env directory (with or without trailing slash)
+      /\/tmp\/input(?:-\d+)?\.json/, // Stdin buffer (input.json or input-<pid>.json)
+      /\/workspace\/env-dir(?:\/|$)/, // Mounted env directory (legacy per-VM mode)
+      /\/data\/env(?:\/|$)/, // Mounted env directory (shared VM mode)
       /\/workspace\/project\/\.env(?:\s|$|[;|&><)\n]|\$\()/, // Project root .env (masked by /dev/null mount, defense-in-depth)
       /\/proc\/.*\/mountinfo/, // Mount enumeration
       /\/proc\/.*\/mounts/, // Mount list
@@ -708,8 +730,9 @@ export function createSanitizeReadHook(): HookCallback {
     // Block reads of sensitive files
     const blockedPatterns = [
       /^\/proc\/(?:\d+|self)(?:\/[^/]+)*\/environ$/, // Process/task environ (any depth: /proc/<pid>/task/<tid>/environ)
-      /^\/tmp\/input\.json$/, // Stdin buffer
-      /^\/workspace\/env-dir\//, // Mounted env directory
+      /^\/tmp\/input(?:-\d+)?\.json$/, // Stdin buffer (input.json or input-<pid>.json)
+      /^\/workspace\/env-dir\//, // Mounted env directory (legacy per-VM mode)
+      /^\/data\/env\//, // Mounted env directory (shared VM mode)
       /^\/workspace\/project\/\.env$/, // Project root .env (masked by /dev/null mount, defense-in-depth)
       /^\/proc\/(\d+|self)\/mountinfo$/, // Mount enumeration for any PID (Issue #79)
       /^\/proc\/(\d+|self)\/mounts$/, // Mount list for any PID
@@ -1005,17 +1028,17 @@ async function runQuery(
   let resultCount = 0;
 
   // Load global CLAUDE.md as additional system context (shared across all groups)
-  const globalClaudeMdPath = '/workspace/global/CLAUDE.md';
+  const globalClaudeMdPath = `${PATHS.global}/CLAUDE.md`;
   let globalClaudeMd: string | undefined;
   if (!containerInput.isMain && fs.existsSync(globalClaudeMdPath)) {
     globalClaudeMd = fs.readFileSync(globalClaudeMdPath, 'utf-8');
   }
 
-  // Append agent identity as a fallback for agents without /workspace/agent/CLAUDE.md
+  // Append agent identity as a fallback for agents without agent context CLAUDE.md
   // When the agent has an identity file, the SDK auto-loads it via additionalDirectories
   if (
     containerInput.agentName &&
-    !fs.existsSync('/workspace/agent/CLAUDE.md')
+    !fs.existsSync(`${PATHS.agent}/CLAUDE.md`)
   ) {
     const identityParts = [`You are **${containerInput.agentName}**.`];
     if (containerInput.agentTrigger) {
@@ -1081,13 +1104,13 @@ async function runQuery(
   }
 
   // Discover additional directories for CLAUDE.md auto-loading:
-  // 1. Context layers: /workspace/agent, /workspace/server, /workspace/category
+  // 1. Context layers: agent, server, category
   // 2. Extra mounts: /workspace/extra/*
   const extraDirs: string[] = [];
   const contextDirs = [
-    '/workspace/agent',
-    '/workspace/server',
-    '/workspace/category',
+    PATHS.agent,
+    PATHS.server,
+    PATHS.category,
   ];
   for (const dir of contextDirs) {
     if (fs.existsSync(dir)) extraDirs.push(dir);
@@ -1114,7 +1137,7 @@ async function runQuery(
     prompt: stream,
     options: {
       model: sdkEnv.CLAUDE_MODEL || 'claude-opus-4-6',
-      cwd: '/workspace/group',
+      cwd: PATHS.group,
       additionalDirectories: extraDirs.length > 0 ? extraDirs : undefined,
       resume: sessionId,
       resumeSessionAt: sessionId ? resumeAt : undefined,
@@ -1485,8 +1508,8 @@ async function main(): Promise<void> {
   // Scheduled tasks use a separate IPC input directory so reactions and
   // follow-up messages don't leak into the task lane.
   if (containerInput.isScheduledTask) {
-    IPC_INPUT_DIR = '/workspace/ipc/input-task';
-    log('Using task IPC lane: /workspace/ipc/input-task');
+    IPC_INPUT_DIR = `${PATHS.ipc}/input-task`;
+    log(`Using task IPC lane: ${PATHS.ipc}/input-task`);
   }
 
   // Build SDK env: merge secrets into process.env for the SDK only.

--- a/container/agent-runner/src/index.ts
+++ b/container/agent-runner/src/index.ts
@@ -1036,10 +1036,7 @@ async function runQuery(
 
   // Append agent identity as a fallback for agents without agent context CLAUDE.md
   // When the agent has an identity file, the SDK auto-loads it via additionalDirectories
-  if (
-    containerInput.agentName &&
-    !fs.existsSync(`${PATHS.agent}/CLAUDE.md`)
-  ) {
+  if (containerInput.agentName && !fs.existsSync(`${PATHS.agent}/CLAUDE.md`)) {
     const identityParts = [`You are **${containerInput.agentName}**.`];
     if (containerInput.agentTrigger) {
       identityParts.push(`Your trigger is \`${containerInput.agentTrigger}\`.`);
@@ -1107,11 +1104,7 @@ async function runQuery(
   // 1. Context layers: agent, server, category
   // 2. Extra mounts: /workspace/extra/*
   const extraDirs: string[] = [];
-  const contextDirs = [
-    PATHS.agent,
-    PATHS.server,
-    PATHS.category,
-  ];
+  const contextDirs = [PATHS.agent, PATHS.server, PATHS.category];
   for (const dir of contextDirs) {
     if (fs.existsSync(dir)) extraDirs.push(dir);
   }

--- a/container/agent-runner/src/ipc-mcp-stdio.ts
+++ b/container/agent-runner/src/ipc-mcp-stdio.ts
@@ -11,7 +11,7 @@ import fs from 'fs';
 import path from 'path';
 import { CronExpressionParser } from 'cron-parser';
 
-const IPC_DIR = '/workspace/ipc';
+const IPC_DIR = process.env.OMNICLAW_IPC_DIR || '/workspace/ipc';
 const MESSAGES_DIR = path.join(IPC_DIR, 'messages');
 const TASKS_DIR = path.join(IPC_DIR, 'tasks');
 const RESPONSES_DIR = path.join(IPC_DIR, 'responses');
@@ -21,6 +21,9 @@ const USER_REGISTRY_PATH = path.join(IPC_DIR, 'user_registry.json');
 const initialChatJid = process.env.OMNICLAW_CHAT_JID!;
 const groupFolder = process.env.OMNICLAW_GROUP_FOLDER!;
 const isMain = process.env.OMNICLAW_IS_MAIN === '1';
+const currentChatFile =
+  process.env.OMNICLAW_CURRENT_CHAT_FILE ||
+  path.join('/tmp', `current_chat_jid-${process.ppid || process.pid}`);
 
 // Shared protocol types — import type only (erased at runtime, no module needed in container).
 import type { ChannelInfo } from '@omniclaw/protocol';
@@ -68,7 +71,7 @@ function resolveTargetJid(target: string): string {
 function getCurrentChatJid(): string {
   if (isMultiChannel) {
     try {
-      const current = fs.readFileSync('/tmp/current_chat_jid', 'utf-8').trim();
+      const current = fs.readFileSync(currentChatFile, 'utf-8').trim();
       if (current) return current;
     } catch {
       /* ignore */

--- a/container/agent-runner/src/opencode-runtime.ts
+++ b/container/agent-runner/src/opencode-runtime.ts
@@ -56,20 +56,24 @@ function log(message: string): void {
 
 /** Resolve IPC input directory based on whether this is a scheduled task. */
 function resolveIpcInputDir(isScheduledTask?: boolean): string {
-  return isScheduledTask ? '/workspace/ipc/input-task' : '/workspace/ipc/input';
+  const ipcDir = process.env.AGENT_IPC_DIR || '/workspace/ipc';
+  return isScheduledTask ? `${ipcDir}/input-task` : `${ipcDir}/input`;
 }
 
 // ---------------------------------------------------------------------------
 // IPC helpers (same protocol as Claude SDK runtime)
 // ---------------------------------------------------------------------------
 
-let ipcInputDir = '/workspace/ipc/input';
+let ipcInputDir = resolveIpcInputDir(false);
 let currentChatJid = '';
+const currentChatFile =
+  process.env.OMNICLAW_CURRENT_CHAT_FILE ||
+  path.join('/tmp', `current_chat_jid-${process.pid}`);
 
 function setCurrentChat(chatJid: string): void {
   currentChatJid = chatJid;
   try {
-    fs.writeFileSync('/tmp/current_chat_jid', chatJid);
+    fs.writeFileSync(currentChatFile, chatJid);
   } catch {
     /* ignore */
   }
@@ -608,8 +612,8 @@ export async function runOpenCodeRuntime(
 
   // Configure IPC directories
   if (containerInput.isScheduledTask) {
-    ipcInputDir = '/workspace/ipc/input-task';
-    log('Using task IPC lane: /workspace/ipc/input-task');
+    ipcInputDir = resolveIpcInputDir(true);
+    log(`Using task IPC lane: ${ipcInputDir}`);
   }
   fs.mkdirSync(ipcInputDir, { recursive: true });
 
@@ -668,6 +672,8 @@ export async function runOpenCodeRuntime(
     OMNICLAW_CHAT_JID: containerInput.chatJid,
     OMNICLAW_GROUP_FOLDER: containerInput.groupFolder,
     OMNICLAW_IS_MAIN: containerInput.isMain ? '1' : '0',
+    OMNICLAW_IPC_DIR: ipcInputDir.replace(/\/input-task$|\/input$/, ''),
+    OMNICLAW_CURRENT_CHAT_FILE: currentChatFile,
   };
   if (containerInput.discordGuildId)
     mcpEnv.OMNICLAW_DISCORD_GUILD_ID = containerInput.discordGuildId;

--- a/container/shared-entrypoint.sh
+++ b/container/shared-entrypoint.sh
@@ -1,0 +1,20 @@
+#!/bin/bash.real
+set -e
+
+# Shared Claude VM entrypoint — minimal setup, sleeps forever.
+# Individual agent processes are started via `container exec` using agent-exec.sh.
+
+# When running as host uid (--user 501:20), there's no /etc/passwd entry.
+if ! id -un &>/dev/null 2>&1; then
+  echo "omniclaw:x:$(id -u):$(id -g):OmniClaw Agent:${HOME:-/home/bun}:/bin/bash" >> /etc/passwd
+fi
+
+# Cap JS heap to prevent OOM (inherited by exec'd processes)
+export NODE_OPTIONS="--max-old-space-size=2048"
+
+# Cap Go heap for tsgo — Go doesn't auto-detect container memory limits.
+TOTAL_KB=$(grep MemTotal /proc/meminfo | awk '{print $2}')
+export GOMEMLIMIT=$(( TOTAL_KB * 3 / 4 / 1024 ))MiB
+
+echo "Shared Claude VM ready (PID $$)"
+while true; do sleep 3600; done

--- a/src/backends/local-backend.test.ts
+++ b/src/backends/local-backend.test.ts
@@ -14,6 +14,8 @@ import {
   readExecBrokerText,
   resolveGitHubTokenForContainer,
   runExecBrokerRequest,
+  sharedVmNetworkIsolationError,
+  SHARED_VM_NETWORK_ISOLATION_ERROR_CODE,
 } from './local-backend.js';
 
 function uniqueId(): string {
@@ -939,6 +941,18 @@ describe('LocalBackend', () => {
       expect(args.at(-1)).not.toContain('exec sleep infinity');
       expect(args.at(-1)).toContain('export GITHUB_TOKEN="$GH_TOKEN"');
       expect(args.at(-1)).toContain('export GH_TOKEN="$GITHUB_TOKEN"');
+    });
+  });
+
+  describe('shared VM network isolation', () => {
+    it('returns a structured rejection for network-isolated agents', () => {
+      const result = sharedVmNetworkIsolationError('restricted-agent');
+
+      expect(result.status).toBe('error');
+      expect(result.result).toBeNull();
+      expect(result.error).toContain(SHARED_VM_NETWORK_ISOLATION_ERROR_CODE);
+      expect(result.error).toContain('restricted-agent');
+      expect(result.error).toContain('network isolation');
     });
   });
 });

--- a/src/backends/local-backend.ts
+++ b/src/backends/local-backend.ts
@@ -1131,6 +1131,19 @@ function isSharedVmEnabled(): boolean {
   );
 }
 
+export const SHARED_VM_NETWORK_ISOLATION_ERROR_CODE =
+  'SHARED_VM_NETWORK_ISOLATION_UNSUPPORTED';
+
+export function sharedVmNetworkIsolationError(
+  groupName: string,
+): ContainerOutput {
+  return {
+    status: 'error',
+    result: null,
+    error: `${SHARED_VM_NETWORK_ISOLATION_ERROR_CODE}: Shared-VM mode does not enforce per-agent network isolation. Disable shared-VM mode for ${groupName} or set containerConfig.networkMode to 'full' explicitly.`,
+  };
+}
+
 export class LocalBackend implements AgentBackend {
   readonly name = LOCAL_RUNTIME === 'docker' ? 'docker' : 'apple-container';
   private sharedVm = new SharedVmManager();
@@ -1553,6 +1566,18 @@ export class LocalBackend implements AgentBackend {
 
     const effectiveNetwork =
       containerCfg?.networkMode ?? (input.isMain ? 'full' : 'none');
+    if (effectiveNetwork === 'none') {
+      logger.error(
+        {
+          code: SHARED_VM_NETWORK_ISOLATION_ERROR_CODE,
+          group: groupName,
+          runtimeFolder,
+          backend: this.name,
+        },
+        'Refusing shared-VM agent run because network isolation cannot be enforced per exec',
+      );
+      return sharedVmNetworkIsolationError(groupName);
+    }
     const splitExecutionEnabled = isSplitExecutionEnabled();
 
     // Exec container stays per-agent (unchanged from per-VM mode)

--- a/src/backends/local-backend.ts
+++ b/src/backends/local-backend.ts
@@ -1616,10 +1616,7 @@ export class LocalBackend implements AgentBackend {
     }
     const srvFolder = getServerFolder(group);
     if (srvFolder) {
-      execArgs.push(
-        '-e',
-        `AGENT_SERVER_DIR=/workspace/groups/${srvFolder}`,
-      );
+      execArgs.push('-e', `AGENT_SERVER_DIR=/workspace/groups/${srvFolder}`);
     }
 
     // Exec container env vars
@@ -1655,10 +1652,9 @@ export class LocalBackend implements AgentBackend {
     fs.mkdirSync(logsDir, { recursive: true });
 
     let container: ReturnType<typeof Bun.spawn>;
-    const execBroker =
-      execContainer
-        ? startExecBroker(runtimeFolder, execContainer.name, log)
-        : null;
+    const execBroker = execContainer
+      ? startExecBroker(runtimeFolder, execContainer.name, log)
+      : null;
     try {
       container = Bun.spawn([LOCAL_RUNTIME, ...execArgs], {
         stdin: 'pipe',

--- a/src/backends/local-backend.ts
+++ b/src/backends/local-backend.ts
@@ -21,6 +21,7 @@ import {
   GROUPS_DIR,
   IDLE_TIMEOUT,
   LOCAL_RUNTIME,
+  SHARED_CLAUDE_VM,
   SPLIT_EXECUTION,
   TIMEZONE,
 } from '../config.js';
@@ -28,6 +29,7 @@ import { logger } from '../logger.js';
 import { validateAdditionalMounts } from '../mount-security.js';
 import { assertPathWithin } from '../path-security.js';
 import { ContainerProcess } from '../types.js';
+import { SharedVmManager } from './shared-vm.js';
 import { StreamParser } from './stream-parser.js';
 import {
   AgentBackend,
@@ -1122,8 +1124,16 @@ function startExecBroker(
   };
 }
 
+function isSharedVmEnabled(): boolean {
+  return (
+    (SHARED_CLAUDE_VM || process.env.SHARED_CLAUDE_VM === 'true') &&
+    LOCAL_RUNTIME !== 'docker'
+  );
+}
+
 export class LocalBackend implements AgentBackend {
   readonly name = LOCAL_RUNTIME === 'docker' ? 'docker' : 'apple-container';
+  private sharedVm = new SharedVmManager();
 
   async runAgent(
     group: AgentOrGroup,
@@ -1131,6 +1141,9 @@ export class LocalBackend implements AgentBackend {
     onProcess: (proc: ContainerProcess, containerName: string) => void,
     onOutput?: (output: ContainerOutput) => Promise<void>,
   ): Promise<ContainerOutput> {
+    if (isSharedVmEnabled()) {
+      return this.runAgentSharedVm(group, input, onProcess, onOutput);
+    }
     const startTime = Date.now();
     const folder = getFolder(group);
     const runtimeFolder = input.runtimeFolder || folder;
@@ -1502,6 +1515,367 @@ export class LocalBackend implements AgentBackend {
     }
   }
 
+  /**
+   * Run agent in the shared Claude VM via `container exec`.
+   * The shared VM is long-running with broad parent mounts;
+   * each agent gets its own stdin/stdout pipe and isolated workspace paths.
+   */
+  private async runAgentSharedVm(
+    group: AgentOrGroup,
+    input: ContainerInput,
+    onProcess: (proc: ContainerProcess, containerName: string) => void,
+    onOutput?: (output: ContainerOutput) => Promise<void>,
+  ): Promise<ContainerOutput> {
+    const startTime = Date.now();
+    const folder = getFolder(group);
+    const runtimeFolder = input.runtimeFolder || folder;
+    const groupName = getName(group);
+    const containerCfg = getContainerConfig(group);
+
+    const groupDir = path.join(GROUPS_DIR, folder);
+    fs.mkdirSync(groupDir, { recursive: true });
+
+    // Prepare agent directories (IPC, sessions, env) — same side effects as per-VM mode
+    const mounts = buildVolumeMounts(
+      group,
+      input.isMain,
+      input.isScheduledTask,
+      runtimeFolder,
+      input.agentRuntime || getAgentRuntime(group),
+      {
+        channelFolder: input.channelFolder,
+        categoryFolder: input.categoryFolder,
+        agentContextFolder: input.agentContextFolder,
+      },
+      undefined,
+      { allowGcpCredentials: !!containerCfg?.allowGcpCredentials },
+    );
+
+    const effectiveNetwork =
+      containerCfg?.networkMode ?? (input.isMain ? 'full' : 'none');
+    const splitExecutionEnabled = isSplitExecutionEnabled();
+
+    // Exec container stays per-agent (unchanged from per-VM mode)
+    let execContainer: { name: string; cleanup: () => Promise<void> } | null =
+      null;
+    const agentContainerName = makeContainerName(folder, runtimeFolder);
+    if (splitExecutionEnabled) {
+      try {
+        execContainer = await spawnExecutionContainer(
+          mounts,
+          agentContainerName,
+          input.isMain,
+          effectiveNetwork,
+        );
+      } catch (err) {
+        logger.warn(
+          { err, group: groupName, backend: this.name },
+          'Failed to start execution sidecar, falling back to single container',
+        );
+      }
+    }
+
+    // Ensure shared VM is running
+    const vmName = await this.sharedVm.ensureRunning();
+
+    // Build `container exec` args with per-agent env vars
+    const workspaceFolder = input.channelFolder || folder;
+    const execArgs: string[] = [
+      'exec',
+      '-i',
+      '-w',
+      `/workspace/groups/${workspaceFolder}`,
+      '-e',
+      `AGENT_WORKSPACE=/workspace/groups/${workspaceFolder}`,
+      '-e',
+      `AGENT_IPC_DIR=/data/ipc/${runtimeFolder}`,
+      '-e',
+      `AGENT_SESSION_DIR=/data/sessions/${runtimeFolder}/.claude`,
+      '-e',
+      `AGENT_GLOBAL_DIR=/workspace/groups/global`,
+      '-e',
+      `AGENT_ENV_DIR=/data/env/${runtimeFolder}`,
+      '-e',
+      `AGENT_PROJECT_DIR=/workspace/project`,
+      '-e',
+      `TZ=${TIMEZONE}`,
+    ];
+
+    // Optional context directories
+    if (input.agentContextFolder) {
+      execArgs.push(
+        '-e',
+        `AGENT_CONTEXT_DIR=/workspace/groups/${input.agentContextFolder}`,
+      );
+    }
+    if (input.categoryFolder) {
+      execArgs.push(
+        '-e',
+        `AGENT_CATEGORY_DIR=/workspace/groups/${input.categoryFolder}`,
+      );
+    }
+    const srvFolder = getServerFolder(group);
+    if (srvFolder) {
+      execArgs.push(
+        '-e',
+        `AGENT_SERVER_DIR=/workspace/groups/${srvFolder}`,
+      );
+    }
+
+    // Exec container env vars
+    if (execContainer) {
+      execArgs.push(
+        '-e',
+        `EXEC_CONTAINER_NAME=${execContainer.name}`,
+        '-e',
+        `EXEC_RUNTIME=apple-container`,
+        '-e',
+        `EXEC_BROKER_REQUEST_DIR=/data/ipc/${runtimeFolder}/exec-requests`,
+        '-e',
+        `EXEC_BROKER_RESPONSE_DIR=/data/ipc/${runtimeFolder}/exec-responses`,
+      );
+    }
+
+    execArgs.push(vmName, '/app/agent-exec.sh');
+
+    const configTimeout = containerCfg?.timeout || CONTAINER_TIMEOUT;
+    const timeoutMs = Math.max(configTimeout, IDLE_TIMEOUT + 30_000);
+
+    const log = logger.child({
+      op: 'containerExec',
+      group: groupName,
+      sharedVm: vmName,
+      backend: this.name,
+      splitExecutionEnabled,
+    });
+
+    log.info({ isMain: input.isMain }, 'Exec-ing agent in shared Claude VM');
+
+    const logsDir = path.join(GROUPS_DIR, folder, 'logs');
+    fs.mkdirSync(logsDir, { recursive: true });
+
+    let container: ReturnType<typeof Bun.spawn>;
+    const execBroker =
+      execContainer
+        ? startExecBroker(runtimeFolder, execContainer.name, log)
+        : null;
+    try {
+      container = Bun.spawn([LOCAL_RUNTIME, ...execArgs], {
+        stdin: 'pipe',
+        stdout: 'pipe',
+        stderr: 'pipe',
+      });
+    } catch (err) {
+      log.error({ err }, 'Container exec spawn error');
+      execBroker?.stop();
+      if (execContainer) execContainer.cleanup().catch(() => {});
+      return {
+        status: 'error',
+        result: null,
+        error: `Container exec spawn error: ${err instanceof Error ? err.message : String(err)}`,
+      };
+    }
+
+    onProcess(container, `${vmName}:${runtimeFolder}`);
+
+    // Write input and close stdin
+    if (typeof container.stdin === 'number' || !container.stdin) {
+      throw new Error('Container stdin is not a writable stream');
+    }
+    container.stdin.write(
+      JSON.stringify({
+        ...input,
+        networkMode: effectiveNetwork,
+      }),
+    );
+    container.stdin.end();
+
+    const killOnTimeout = () => {
+      log.error('Agent exec timeout, killing process');
+      execBroker?.stop();
+      if (execContainer) execContainer.cleanup().catch(() => {});
+      container.kill(9);
+    };
+
+    const parser = new StreamParser({
+      groupName,
+      containerName: `${vmName}:${runtimeFolder}`,
+      timeoutMs,
+      startupTimeoutMs: CONTAINER_STARTUP_TIMEOUT,
+      maxOutputSize: CONTAINER_MAX_OUTPUT_SIZE,
+      onOutput,
+      onTimeout: killOnTimeout,
+    });
+
+    // Read stderr concurrently
+    if (typeof container.stderr === 'number' || !container.stderr) {
+      throw new Error('Container stderr is not a readable stream');
+    }
+    const stderrReader = container.stderr.getReader();
+    const stderrDecoder = new TextDecoder();
+    const stderrPromise = (async () => {
+      try {
+        while (true) {
+          const { done, value } = await stderrReader.read();
+          if (done) break;
+          const chunk = stderrDecoder.decode(value, { stream: true });
+          parser.feedStderr(chunk);
+        }
+      } catch {
+        // stream closed
+      }
+    })();
+
+    // Read stdout
+    if (typeof container.stdout === 'number' || !container.stdout) {
+      throw new Error('Container stdout is not a readable stream');
+    }
+    const stdoutReader = container.stdout.getReader();
+    const stdoutDecoder = new TextDecoder();
+    try {
+      while (true) {
+        const { done, value } = await stdoutReader.read();
+        if (done) break;
+        const chunk = stdoutDecoder.decode(value, { stream: true });
+        parser.feedStdout(chunk);
+      }
+    } catch {
+      // stream closed
+    }
+
+    // Wait for process exit
+    const exitCode = await container.exited;
+    await stderrPromise;
+    parser.cleanup();
+
+    // Clean up execution sidecar
+    execBroker?.stop();
+    if (execBroker) {
+      await execBroker.done.catch((err) => {
+        log.warn({ err }, 'Execution broker shutdown failed');
+      });
+    }
+    if (execContainer) {
+      execContainer.cleanup().catch((err) => {
+        log.warn({ err }, 'Failed to stop execution sidecar');
+      });
+    }
+
+    const duration = Date.now() - startTime;
+    const state = parser.getState();
+    const exitLog = log.child({
+      op: 'containerExit',
+      exitCode,
+      durationMs: duration,
+    });
+
+    if (state.timedOut) {
+      const ts = new Date().toISOString().replace(/[:.]/g, '-');
+      const timeoutLog = path.join(logsDir, `container-${ts}.log`);
+      fs.writeFileSync(
+        timeoutLog,
+        [
+          `=== Container Run Log (TIMEOUT) ===`,
+          `Timestamp: ${new Date().toISOString()}`,
+          `Group: ${groupName}`,
+          `SharedVM: ${vmName}`,
+          `Duration: ${duration}ms`,
+          `Exit Code: ${exitCode}`,
+          `Had Streaming Output: ${state.hadStreamingOutput}`,
+        ].join('\n'),
+      );
+
+      if (state.hadStreamingOutput) {
+        exitLog.info('Agent exec timed out after output (idle cleanup)');
+        await state.outputChain;
+        return {
+          status: 'success',
+          result: null,
+          newSessionId: state.newSessionId,
+        };
+      }
+
+      exitLog.error({ timedOut: true }, 'Agent exec timed out with no output');
+      return {
+        status: 'error',
+        result: null,
+        error: `Agent exec timed out after ${configTimeout}ms`,
+      };
+    }
+
+    // Write log file
+    const timestamp = new Date().toISOString().replace(/[:.]/g, '-');
+    const logFile = path.join(logsDir, `container-${timestamp}.log`);
+    const isVerbose =
+      process.env.LOG_LEVEL === 'debug' || process.env.LOG_LEVEL === 'trace';
+    const logLines = [
+      `=== Container Exec Log ===`,
+      `Timestamp: ${new Date().toISOString()}`,
+      `Group: ${groupName}`,
+      `SharedVM: ${vmName}`,
+      `IsMain: ${input.isMain}`,
+      `Duration: ${duration}ms`,
+      `Exit Code: ${exitCode}`,
+    ];
+    if (isVerbose || exitCode !== 0) {
+      logLines.push(
+        ``,
+        `=== Stderr ===`,
+        state.stderr,
+        ``,
+        `=== Stdout ===`,
+        state.stdout,
+      );
+    }
+    fs.writeFileSync(logFile, logLines.join('\n'));
+
+    if (exitCode !== 0) {
+      exitLog.error(
+        { stderr: state.stderr, logFile },
+        'Agent exec exited with error',
+      );
+      return {
+        status: 'error',
+        result: null,
+        error: `Agent exec exited with code ${exitCode}: ${state.stderr.slice(-200)}`,
+      };
+    }
+
+    // Streaming mode
+    if (onOutput) {
+      await state.outputChain;
+      exitLog.info(
+        { newSessionId: state.newSessionId },
+        'Agent exec completed (streaming mode)',
+      );
+      return {
+        status: 'success',
+        result: null,
+        newSessionId: state.newSessionId,
+      };
+    }
+
+    // Legacy mode
+    try {
+      const output = parser.parseFinalOutput();
+      exitLog.info(
+        { status: output.status, hasResult: !!output.result },
+        'Agent exec completed',
+      );
+      return output;
+    } catch (err) {
+      exitLog.error(
+        { stdout: state.stdout, stderr: state.stderr, err },
+        'Failed to parse agent exec output',
+      );
+      return {
+        status: 'error',
+        result: null,
+        error: `Failed to parse agent exec output: ${err instanceof Error ? err.message : String(err)}`,
+      };
+    }
+  }
+
   sendMessage(
     groupFolder: string,
     text: string,
@@ -1688,6 +2062,13 @@ export class LocalBackend implements AgentBackend {
     }
 
     await this.cleanupOrphanedContainers();
+
+    // Start shared Claude VM if enabled
+    if (isSharedVmEnabled()) {
+      await this.sharedVm.cleanupOrphans();
+      await this.sharedVm.ensureRunning();
+      logger.info('Shared Claude VM mode enabled');
+    }
   }
 
   private printContainerSystemError(): void {
@@ -1725,7 +2106,11 @@ export class LocalBackend implements AgentBackend {
       // CLI flag injection (e.g. a name like "--all").
       const SAFE_CONTAINER_NAME =
         /^omniclaw-[a-zA-Z0-9_-]+-[a-f0-9-]+(-exec)?$/;
+      // Don't kill the shared Claude VM — it's managed separately
+      const sharedVmName = this.sharedVm.getName();
       const safeOrphans = orphans.filter((name) => {
+        if (name === sharedVmName) return false;
+        if (name.startsWith('omniclaw-shared-claude-')) return false;
         if (!SAFE_CONTAINER_NAME.test(name)) {
           logger.warn(
             { name },
@@ -1756,6 +2141,7 @@ export class LocalBackend implements AgentBackend {
   }
 
   async shutdown(): Promise<void> {
-    // Containers clean themselves up via --rm flag
+    // Stop shared Claude VM if running
+    await this.sharedVm.stop();
   }
 }

--- a/src/backends/shared-vm.ts
+++ b/src/backends/shared-vm.ts
@@ -95,7 +95,7 @@ export class SharedVmManager {
         );
       }
     } catch (err) {
-      logger.warn(err, 'Failed to clean up orphaned shared VMs');
+      logger.warn({ err }, 'Failed to clean up orphaned shared VMs');
     }
   }
 

--- a/src/backends/shared-vm.ts
+++ b/src/backends/shared-vm.ts
@@ -20,6 +20,7 @@ import {
 import { logger } from '../logger.js';
 
 const SHARED_VM_PREFIX = 'omniclaw-shared-claude';
+const EXTRA_DIR = process.env.OMNICLAW_EXTRA_DIR || '/workspace/extra';
 
 export class SharedVmManager {
   private containerName: string | null = null;
@@ -108,6 +109,7 @@ export class SharedVmManager {
     fs.mkdirSync(path.join(DATA_DIR, 'ipc'), { recursive: true });
     fs.mkdirSync(path.join(DATA_DIR, 'sessions'), { recursive: true });
     fs.mkdirSync(path.join(DATA_DIR, 'env'), { recursive: true });
+    fs.mkdirSync(EXTRA_DIR, { recursive: true });
 
     const args: string[] = [
       'run',
@@ -127,6 +129,8 @@ export class SharedVmManager {
       `type=bind,source=${path.join(DATA_DIR, 'env')},target=/data/env,readonly`,
       '-v',
       `${projectRoot}:/workspace/project:ro`,
+      '-v',
+      `${EXTRA_DIR}:/workspace/extra:ro`,
       // Agent runner source (shared, read-only)
       '--mount',
       `type=bind,source=${path.join(projectRoot, 'container', 'agent-runner', 'src')},target=/app/src,readonly`,

--- a/src/backends/shared-vm.ts
+++ b/src/backends/shared-vm.ts
@@ -1,0 +1,177 @@
+/**
+ * SharedVmManager — manages a single long-running Apple Container VM
+ * that hosts multiple Claude agent-runner processes via `container exec`.
+ *
+ * The shared VM is started with broad parent mounts (groups/, data/)
+ * so it doesn't need to be recreated when agents register/unregister.
+ */
+
+import { $ } from 'bun';
+import fs from 'fs';
+import path from 'path';
+
+import {
+  CONTAINER_IMAGE,
+  DATA_DIR,
+  GROUPS_DIR,
+  LOCAL_RUNTIME,
+  SHARED_CLAUDE_VM_MEMORY,
+} from '../config.js';
+import { logger } from '../logger.js';
+
+const SHARED_VM_PREFIX = 'omniclaw-shared-claude';
+
+export class SharedVmManager {
+  private containerName: string | null = null;
+  private starting: Promise<string> | null = null;
+
+  /**
+   * Ensure the shared VM is running. Returns the container name.
+   * Safe to call concurrently — deduplicates start attempts.
+   */
+  async ensureRunning(): Promise<string> {
+    if (this.containerName && (await this.isAlive(this.containerName))) {
+      return this.containerName;
+    }
+
+    // Deduplicate concurrent start calls
+    if (this.starting) return this.starting;
+    this.starting = this.start();
+    try {
+      const name = await this.starting;
+      return name;
+    } finally {
+      this.starting = null;
+    }
+  }
+
+  getName(): string | null {
+    return this.containerName;
+  }
+
+  async stop(): Promise<void> {
+    if (!this.containerName) return;
+    const name = this.containerName;
+    this.containerName = null;
+    try {
+      const proc = Bun.spawn([LOCAL_RUNTIME, 'stop', name], {
+        stdout: 'ignore',
+        stderr: 'ignore',
+      });
+      await proc.exited;
+      logger.info({ container: name }, 'Shared Claude VM stopped');
+    } catch (err) {
+      logger.warn({ err, container: name }, 'Failed to stop shared Claude VM');
+    }
+  }
+
+  /** Stop any orphaned shared VMs from previous runs. */
+  async cleanupOrphans(): Promise<void> {
+    try {
+      const lsResult = await $`container ls --format json`.quiet();
+      const containers: { status: string; configuration: { id: string } }[] =
+        JSON.parse(lsResult.text() || '[]');
+      const orphans = containers
+        .filter(
+          (c) =>
+            c.status === 'running' &&
+            c.configuration.id.startsWith(SHARED_VM_PREFIX) &&
+            c.configuration.id !== this.containerName,
+        )
+        .map((c) => c.configuration.id);
+      if (orphans.length > 0) {
+        await Promise.all(
+          orphans.map((name) => {
+            const proc = Bun.spawn([LOCAL_RUNTIME, 'stop', name], {
+              stdout: 'ignore',
+              stderr: 'ignore',
+            });
+            return proc.exited;
+          }),
+        );
+        logger.info(
+          { count: orphans.length, names: orphans },
+          'Stopped orphaned shared Claude VMs',
+        );
+      }
+    } catch (err) {
+      logger.warn(err, 'Failed to clean up orphaned shared VMs');
+    }
+  }
+
+  private async start(): Promise<string> {
+    const name = `${SHARED_VM_PREFIX}-${Date.now()}`;
+    const projectRoot = process.cwd();
+
+    // Ensure parent dirs exist
+    fs.mkdirSync(GROUPS_DIR, { recursive: true });
+    fs.mkdirSync(path.join(DATA_DIR, 'ipc'), { recursive: true });
+    fs.mkdirSync(path.join(DATA_DIR, 'sessions'), { recursive: true });
+    fs.mkdirSync(path.join(DATA_DIR, 'env'), { recursive: true });
+
+    const args: string[] = [
+      'run',
+      '-d',
+      '--memory',
+      SHARED_CLAUDE_VM_MEMORY,
+      '--name',
+      name,
+      // Broad parent mounts — all agents' subdirs are accessible
+      '-v',
+      `${GROUPS_DIR}:/workspace/groups`,
+      '-v',
+      `${path.join(DATA_DIR, 'ipc')}:/data/ipc`,
+      '-v',
+      `${path.join(DATA_DIR, 'sessions')}:/data/sessions`,
+      '--mount',
+      `type=bind,source=${path.join(DATA_DIR, 'env')},target=/data/env,readonly`,
+      '-v',
+      `${projectRoot}:/workspace/project:ro`,
+      // Agent runner source (shared, read-only)
+      '--mount',
+      `type=bind,source=${path.join(projectRoot, 'container', 'agent-runner', 'src')},target=/app/src,readonly`,
+      // OpenCode data (if exists)
+      ...(fs.existsSync(path.join(DATA_DIR, 'opencode-data'))
+        ? ['-v', `${path.join(DATA_DIR, 'opencode-data')}:/data/opencode-data`]
+        : []),
+      '--entrypoint',
+      '/app/shared-entrypoint.sh',
+      CONTAINER_IMAGE,
+    ];
+
+    logger.info(
+      { container: name, memory: SHARED_CLAUDE_VM_MEMORY },
+      'Starting shared Claude VM',
+    );
+
+    const proc = Bun.spawn([LOCAL_RUNTIME, ...args], {
+      stdout: 'pipe',
+      stderr: 'pipe',
+    });
+    const stderr = await new Response(proc.stderr).text();
+    const exitCode = await proc.exited;
+
+    if (exitCode !== 0) {
+      throw new Error(
+        `Failed to start shared Claude VM: exit ${exitCode}\n${stderr}`,
+      );
+    }
+
+    this.containerName = name;
+    logger.info({ container: name }, 'Shared Claude VM started');
+    return name;
+  }
+
+  private async isAlive(name: string): Promise<boolean> {
+    try {
+      const lsResult = await $`container ls --format json`.quiet();
+      const containers: { status: string; configuration: { id: string } }[] =
+        JSON.parse(lsResult.text() || '[]');
+      return containers.some(
+        (c) => c.configuration.id === name && c.status === 'running',
+      );
+    } catch {
+      return false;
+    }
+  }
+}

--- a/src/config.ts
+++ b/src/config.ts
@@ -69,6 +69,11 @@ const configSchema = z
       parseBooleanString,
       z.boolean().default(false),
     ),
+    SHARED_CLAUDE_VM: z.preprocess(
+      parseBooleanString,
+      z.boolean().default(false),
+    ),
+    SHARED_CLAUDE_VM_MEMORY: z.string().default('16G'),
     EXEC_CONTAINER_MEMORY: z.string().optional(),
     CONTAINER_TIMEOUT: z.preprocess(
       parseIntegerString,
@@ -341,6 +346,8 @@ export const STARTUP_CONFIRMATIONS = CONFIG.STARTUP_CONFIRMATIONS;
 export const CONTAINER_IMAGE = CONFIG.CONTAINER_IMAGE;
 export const CONTAINER_MEMORY = CONFIG.CONTAINER_MEMORY;
 export const SPLIT_EXECUTION = CONFIG.SPLIT_EXECUTION;
+export const SHARED_CLAUDE_VM = CONFIG.SHARED_CLAUDE_VM;
+export const SHARED_CLAUDE_VM_MEMORY = CONFIG.SHARED_CLAUDE_VM_MEMORY;
 export const EXEC_CONTAINER_MEMORY =
   CONFIG.EXEC_CONTAINER_MEMORY || CONTAINER_MEMORY;
 export const CONTAINER_TIMEOUT = CONFIG.CONTAINER_TIMEOUT; // 2h default — inactivity timeout for agent output (tool calls, results, text)


### PR DESCRIPTION
## Summary

- Adds opt-in `SHARED_CLAUDE_VM` mode that consolidates all Claude agent-runner processes into a single long-running Apple Container VM
- Each agent runs via `container exec -i` with isolated workspace paths passed as env vars, getting its own stdin/stdout pipe
- Exec containers remain per-agent for full VM-level isolation of code execution
- Reduces container count from 2N to N+1, saving ~32GB+ of SSD-backed VM disk (Apple Container VMs pre-allocate disk for memory backing)
- Also includes `just clean` / `just clean-all` commands for pruning stopped containers and buildkit cache

### Key changes

| File | Change |
|------|--------|
| `src/backends/shared-vm.ts` | New `SharedVmManager` class — manages long-running VM with broad parent mounts |
| `container/shared-entrypoint.sh` | Minimal VM entrypoint (passwd fix, sleep forever) |
| `container/agent-exec.sh` | Per-agent exec wrapper (env sourcing, git/SSH, runs agent-runner) |
| `container/agent-runner/src/index.ts` | Path parameterization via `AGENT_*` env vars with legacy fallbacks |
| `src/backends/local-backend.ts` | `runAgentSharedVm()` method, lifecycle management |
| `src/config.ts` | `SHARED_CLAUDE_VM` + `SHARED_CLAUDE_VM_MEMORY` config |

### Isolation limitations

- Shared-VM mode does not enforce per-agent network isolation. Agents requesting `networkMode: 'none'` are rejected when shared-VM is enabled; disable shared-VM mode for those agents or explicitly opt them into `networkMode: 'full'`.
- Shared-VM mode uses broad parent mounts for long-lived VM reuse. Agent tool access is restricted at the agent-runner hook boundary to the current workspace/context allowlist to prevent sibling workspace reads through standard tools.

### Usage

```env
SHARED_CLAUDE_VM=true
SHARED_CLAUDE_VM_MEMORY=16G
```

Then rebuild container (`just build-container`) and restart (`just restart`).

## Test plan

- [ ] Set `SHARED_CLAUDE_VM=true`, rebuild container, restart
- [ ] Send messages to 2+ agents, verify both respond correctly
- [ ] Verify exec containers still work (git clone, bash commands)
- [ ] Check `container ls` shows N+1 containers instead of 2N
- [ ] Check `container system df` for disk savings
- [ ] Disable `SHARED_CLAUDE_VM`, verify legacy per-VM mode still works
- [ ] Test `just clean` and `just clean-all`

## Verification

- `bun test src/__tests__/mcp-config.test.ts src/__tests__/ipc-lane.test.ts` from `container/agent-runner/`
- `bun test src/backends/local-backend.test.ts`
- `bun run typecheck`
- `bun run format:check`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for shared VM mode, allowing multiple agents to run efficiently within a single shared container instance with configurable memory allocation.
  * New environment variables available for shared VM configuration and optimization.

* **Chores**
  * Updated container infrastructure and entrypoint scripts to support shared VM deployments and per-agent execution management.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
