### PR TITLE
fix: close SDK query to prevent orphaned CLI subprocesses

### DIFF
--- a/container/agent-runner/src/index.ts
+++ b/container/agent-runner/src/index.ts
@@ -1333,6 +1333,7 @@ async function runQuery(
             status: 'success',
             result: parts.join('\n'),
             newSessionId,
+            resumeAt: lastAssistantUuid,
             intermediate: true,
           });
         }
@@ -1361,6 +1362,7 @@ async function runQuery(
               status: 'success',
               result: '```\n' + truncated + '\n```',
               newSessionId,
+              resumeAt: lastAssistantUuid,
               intermediate: true,
             });
           }
@@ -1445,6 +1447,7 @@ async function runQuery(
         status: 'success',
         result: effectiveResult,
         newSessionId,
+        resumeAt: lastAssistantUuid,
       });
       lastAssistantText = undefined;
 


### PR DESCRIPTION
## Summary
- When the agent-runner's query loop receives a result and breaks out of the `for await`, the underlying `claude-agent-sdk` CLI subprocess was never killed
- Each subsequent `runQuery` call (from IPC follow-up messages) accumulated another orphaned process — all resuming the same session — until the container exhausted memory and stalled
- Observed in production: 7 concurrent SDK processes inside one container, using 2.8GB of the 8GB limit, producing only heartbeats

## Fix
- Capture the `Query` object returned by `query()` and call `.close()` after the `for await` loop exits
- `Query.close()` kills the CLI subprocess, closes MCP transports, and frees resources
- Also added `close()` to the stale-session early-return path

## Test plan
- [ ] Deploy to staging, trigger a long-running agent task with multiple follow-up messages
- [ ] Verify via `docker exec <container> ps aux` that only one `claude-agent-sdk` process exists at a time
- [ ] Confirm the agent still resumes correctly after each query cycle

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved cleanup of active queries and streams to prevent hanging streams and leftover subprocesses, reducing resource leaks and stale sessions.
* **New Features**
  * Streamed and final assistant outputs now include a resume anchor so hosts can reliably resume or correlate streamed responses.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->