### PR TITLE
feat: versioned seed templates with CLAUDE.md reconciliation (#247)

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -114,6 +114,7 @@ import {
 import { logger } from './logger.js';
 import { assertPathWithin } from './path-security.js';
 import { createResumePositionStore } from './resume-position-store.js';
+import { getDiscordChannelSeed, getServerSeed } from './seed-templates.js';
 import {
   findChannel,
   formatMessages,
@@ -892,29 +893,7 @@ function registerGroup(jid: string, group: RegisteredGroup): void {
   if (jid.startsWith('dc:')) {
     const claudeMdPath = path.join(groupDir, 'CLAUDE.md');
     if (!fs.existsSync(claudeMdPath)) {
-      fs.writeFileSync(
-        claudeMdPath,
-        `## Channel: Discord (Secondary)
-This group communicates via Discord, a secondary channel.
-You can freely answer questions and have conversations here.
-For significant actions (file changes, scheduled tasks, sending messages to other groups),
-confirm intent with the current user in this chat before proceeding.
-
-## Getting Context You Don't Have
-When you need project context, repo access, credentials, or information that hasn't been shared with you:
-- Ask in the current chat for anything missing.
-- Be specific: describe exactly what you need and why.
-- Check local docs and repo files first before asking.
-
-## Working with Repos
-You have \`git\` and \`GITHUB_TOKEN\` available in your environment.
-When the admin shares a repo URL, clone it yourself:
-\`\`\`bash
-git clone https://github.com/org/repo.git /workspace/group/repos/repo
-\`\`\`
-Then read the code directly — don't ask the admin to copy files for you.
-`,
-      );
+      fs.writeFileSync(claudeMdPath, getDiscordChannelSeed());
     }
   }
 
@@ -979,25 +958,7 @@ function ensureServerDirectory(serverFolder: string): void {
 
   const claudeMdPath = path.join(serverDir, 'CLAUDE.md');
   if (!fs.existsSync(claudeMdPath)) {
-    fs.writeFileSync(
-      claudeMdPath,
-      `# Server Shared Context
-
-This file is shared across all channels in this Discord server.
-Use it for team-level context: members, projects, repos, conventions.
-Channel-specific notes should go in the channel's own CLAUDE.md.
-
-## Getting Context You Don't Have
-If you need project info, repo URLs, or credentials not listed here, ask directly in the current chat.
-Be explicit about what you need and why.
-
-## Working with Repos
-You have \`git\` and \`GITHUB_TOKEN\` available. When given a repo URL, clone it:
-\`\`\`bash
-git clone https://github.com/org/repo.git /workspace/group/repos/repo
-\`\`\`
-`,
-    );
+    fs.writeFileSync(claudeMdPath, getServerSeed());
     logger.info({ serverFolder }, 'Seeded server-level CLAUDE.md');
   }
 }

--- a/src/seed-templates.test.ts
+++ b/src/seed-templates.test.ts
@@ -1,0 +1,307 @@
+/**
+ * Tests for seed template versioning and reconciliation — issue #247
+ */
+
+import { afterEach, beforeEach, describe, expect, it } from 'bun:test';
+import fs from 'fs';
+import os from 'os';
+import path from 'path';
+
+import {
+  buildSeededContent,
+  extractSeedVersion,
+  getDiscordChannelSeed,
+  getServerSeed,
+  inferTemplateKey,
+  reconcileSeededFiles,
+  SEED_TEMPLATES,
+} from './seed-templates.js';
+
+// ---- Test helpers ----
+
+let tmpDir: string;
+
+beforeEach(() => {
+  tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'seed-template-test-'));
+});
+
+afterEach(() => {
+  fs.rmSync(tmpDir, { recursive: true, force: true });
+});
+
+function writeFile(relativePath: string, content: string): string {
+  const fullPath = path.join(tmpDir, relativePath);
+  fs.mkdirSync(path.dirname(fullPath), { recursive: true });
+  fs.writeFileSync(fullPath, content);
+  return fullPath;
+}
+
+// =============================================================================
+// Version marker utilities
+// =============================================================================
+
+describe('extractSeedVersion', () => {
+  it('extracts version from a valid marker', () => {
+    const content = 'Some content\n\n<!-- omniclaw-seed:v3 -->';
+    expect(extractSeedVersion(content)).toBe(3);
+  });
+
+  it('extracts version with trailing whitespace', () => {
+    const content = 'Content\n<!-- omniclaw-seed:v7 -->  \n';
+    expect(extractSeedVersion(content)).toBe(7);
+  });
+
+  it('returns null when no marker is present', () => {
+    expect(extractSeedVersion('Just regular content')).toBeNull();
+  });
+
+  it('returns null for empty string', () => {
+    expect(extractSeedVersion('')).toBeNull();
+  });
+
+  it('returns null for marker in wrong position (not at end)', () => {
+    const content = '<!-- omniclaw-seed:v1 -->\nMore content after';
+    expect(extractSeedVersion(content)).toBeNull();
+  });
+
+  it('handles large version numbers', () => {
+    const content = 'Content\n<!-- omniclaw-seed:v999 -->';
+    expect(extractSeedVersion(content)).toBe(999);
+  });
+});
+
+describe('buildSeededContent', () => {
+  it('appends version marker to template body', () => {
+    const template = { key: 'test', version: 5, body: 'Hello world\n' };
+    const result = buildSeededContent(template);
+
+    expect(result).toBe('Hello world\n\n<!-- omniclaw-seed:v5 -->');
+    expect(extractSeedVersion(result)).toBe(5);
+  });
+
+  it('produces content that round-trips through extractSeedVersion', () => {
+    for (const template of SEED_TEMPLATES.values()) {
+      const content = buildSeededContent(template);
+      expect(extractSeedVersion(content)).toBe(template.version);
+    }
+  });
+});
+
+// =============================================================================
+// Template registry
+// =============================================================================
+
+describe('SEED_TEMPLATES', () => {
+  it('contains discord-channel and server templates', () => {
+    expect(SEED_TEMPLATES.has('discord-channel')).toBe(true);
+    expect(SEED_TEMPLATES.has('server')).toBe(true);
+  });
+
+  it('all templates have positive version numbers', () => {
+    for (const template of SEED_TEMPLATES.values()) {
+      expect(template.version).toBeGreaterThan(0);
+    }
+  });
+
+  it('all templates have non-empty body content', () => {
+    for (const template of SEED_TEMPLATES.values()) {
+      expect(template.body.length).toBeGreaterThan(0);
+    }
+  });
+});
+
+// =============================================================================
+// Seed content helpers
+// =============================================================================
+
+describe('getDiscordChannelSeed', () => {
+  it('returns content with version marker', () => {
+    const content = getDiscordChannelSeed();
+    expect(extractSeedVersion(content)).not.toBeNull();
+  });
+
+  it('includes channel-specific guidance', () => {
+    const content = getDiscordChannelSeed();
+    expect(content).toContain('Discord');
+    expect(content).toContain('secondary channel');
+  });
+
+  it('matches the discord-channel template version', () => {
+    const content = getDiscordChannelSeed();
+    const template = SEED_TEMPLATES.get('discord-channel')!;
+    expect(extractSeedVersion(content)).toBe(template.version);
+  });
+});
+
+describe('getServerSeed', () => {
+  it('returns content with version marker', () => {
+    const content = getServerSeed();
+    expect(extractSeedVersion(content)).not.toBeNull();
+  });
+
+  it('includes server-level guidance', () => {
+    const content = getServerSeed();
+    expect(content).toContain('Server Shared Context');
+    expect(content).toContain('all channels');
+  });
+
+  it('matches the server template version', () => {
+    const content = getServerSeed();
+    const template = SEED_TEMPLATES.get('server')!;
+    expect(extractSeedVersion(content)).toBe(template.version);
+  });
+});
+
+// =============================================================================
+// inferTemplateKey
+// =============================================================================
+
+describe('inferTemplateKey', () => {
+  it('returns server for server-level paths', () => {
+    expect(inferTemplateKey('/groups/servers/my-guild/CLAUDE.md', true)).toBe(
+      'server',
+    );
+  });
+
+  it('returns discord-channel for non-server paths', () => {
+    expect(inferTemplateKey('/groups/my-channel/CLAUDE.md', false)).toBe(
+      'discord-channel',
+    );
+  });
+});
+
+// =============================================================================
+// Reconciliation
+// =============================================================================
+
+describe('reconcileSeededFiles', () => {
+  it('reports empty results for nonexistent directory', () => {
+    const result = reconcileSeededFiles('/nonexistent/path');
+    expect(result.updated).toHaveLength(0);
+    expect(result.current).toHaveLength(0);
+    expect(result.unversioned).toHaveLength(0);
+    expect(result.errors).toHaveLength(0);
+  });
+
+  it('reports empty results for empty directory', () => {
+    const result = reconcileSeededFiles(tmpDir);
+    expect(result.updated).toHaveLength(0);
+  });
+
+  it('detects unversioned files (pre-versioning seeded files)', () => {
+    // Write a CLAUDE.md with a seed version marker so it's detected as seeded
+    // but with a stale version
+    writeFile(
+      'my-group/CLAUDE.md',
+      '## Old channel content\nNo version marker',
+    );
+    // Since no version marker, it won't be picked up in the scan
+    // (only versioned files or server dirs are scanned)
+    const result = reconcileSeededFiles(tmpDir);
+    expect(result.unversioned).toHaveLength(0); // Not detected without marker
+  });
+
+  it('detects stale versioned files in dry-run mode', () => {
+    // Write a CLAUDE.md with an old version
+    writeFile(
+      'my-channel/CLAUDE.md',
+      '## Old content\n\n<!-- omniclaw-seed:v1 -->',
+    );
+
+    const result = reconcileSeededFiles(tmpDir, true);
+    expect(result.updated).toHaveLength(1);
+    expect(result.updated[0]).toContain('my-channel/CLAUDE.md');
+  });
+
+  it('does not modify files in dry-run mode', () => {
+    const filePath = writeFile(
+      'my-channel/CLAUDE.md',
+      '## Old content\n\n<!-- omniclaw-seed:v1 -->',
+    );
+
+    reconcileSeededFiles(tmpDir, true);
+
+    const content = fs.readFileSync(filePath, 'utf-8');
+    expect(content).toContain('Old content');
+    expect(extractSeedVersion(content)).toBe(1);
+  });
+
+  it('updates stale files when dryRun=false', () => {
+    const filePath = writeFile(
+      'stale-group/CLAUDE.md',
+      '## Stale content\n\n<!-- omniclaw-seed:v1 -->',
+    );
+
+    const result = reconcileSeededFiles(tmpDir, false);
+    expect(result.updated).toHaveLength(1);
+
+    const newContent = fs.readFileSync(filePath, 'utf-8');
+    const newVersion = extractSeedVersion(newContent);
+    const template = SEED_TEMPLATES.get('discord-channel')!;
+    expect(newVersion).toBe(template.version);
+    expect(newContent).toContain(template.body);
+  });
+
+  it('reports current files that are already up-to-date', () => {
+    const template = SEED_TEMPLATES.get('discord-channel')!;
+    writeFile('up-to-date/CLAUDE.md', buildSeededContent(template));
+
+    const result = reconcileSeededFiles(tmpDir, true);
+    expect(result.current).toHaveLength(1);
+    expect(result.updated).toHaveLength(0);
+  });
+
+  it('handles server-level files in servers/ subdirectory', () => {
+    const serverTemplate = SEED_TEMPLATES.get('server')!;
+    writeFile(
+      'servers/my-guild/CLAUDE.md',
+      '## Old server\n\n<!-- omniclaw-seed:v1 -->',
+    );
+
+    const result = reconcileSeededFiles(tmpDir, true);
+    expect(result.updated).toHaveLength(1);
+    expect(result.updated[0]).toContain('servers/my-guild/CLAUDE.md');
+  });
+
+  it('reports current server files that match latest version', () => {
+    const serverTemplate = SEED_TEMPLATES.get('server')!;
+    writeFile(
+      'servers/current-guild/CLAUDE.md',
+      buildSeededContent(serverTemplate),
+    );
+
+    const result = reconcileSeededFiles(tmpDir, true);
+    expect(result.current).toHaveLength(1);
+  });
+
+  it('handles mixed stale and current files', () => {
+    const discordTemplate = SEED_TEMPLATES.get('discord-channel')!;
+    const serverTemplate = SEED_TEMPLATES.get('server')!;
+
+    // One stale, one current
+    writeFile(
+      'stale-channel/CLAUDE.md',
+      '## Stale\n\n<!-- omniclaw-seed:v1 -->',
+    );
+    writeFile('current-channel/CLAUDE.md', buildSeededContent(discordTemplate));
+    writeFile(
+      'servers/stale-server/CLAUDE.md',
+      '## Stale server\n\n<!-- omniclaw-seed:v1 -->',
+    );
+    writeFile(
+      'servers/current-server/CLAUDE.md',
+      buildSeededContent(serverTemplate),
+    );
+
+    const result = reconcileSeededFiles(tmpDir, true);
+    expect(result.updated).toHaveLength(2);
+    expect(result.current).toHaveLength(2);
+  });
+
+  it('skips directories without CLAUDE.md', () => {
+    fs.mkdirSync(path.join(tmpDir, 'empty-group'), { recursive: true });
+    const result = reconcileSeededFiles(tmpDir, true);
+    expect(result.updated).toHaveLength(0);
+    expect(result.current).toHaveLength(0);
+  });
+});

--- a/src/seed-templates.test.ts
+++ b/src/seed-templates.test.ts
@@ -189,16 +189,14 @@ describe('reconcileSeededFiles', () => {
   });
 
   it('detects unversioned files (pre-versioning seeded files)', () => {
-    // Write a CLAUDE.md with a seed version marker so it's detected as seeded
-    // but with a stale version
     writeFile(
       'my-group/CLAUDE.md',
       '## Old channel content\nNo version marker',
     );
-    // Since no version marker, it won't be picked up in the scan
-    // (only versioned files or server dirs are scanned)
+
     const result = reconcileSeededFiles(tmpDir);
-    expect(result.unversioned).toHaveLength(0); // Not detected without marker
+    expect(result.unversioned).toHaveLength(1);
+    expect(result.unversioned[0]).toContain('my-group/CLAUDE.md');
   });
 
   it('detects stale versioned files in dry-run mode', () => {
@@ -252,7 +250,6 @@ describe('reconcileSeededFiles', () => {
   });
 
   it('handles server-level files in servers/ subdirectory', () => {
-    const serverTemplate = SEED_TEMPLATES.get('server')!;
     writeFile(
       'servers/my-guild/CLAUDE.md',
       '## Old server\n\n<!-- omniclaw-seed:v1 -->',
@@ -261,6 +258,18 @@ describe('reconcileSeededFiles', () => {
     const result = reconcileSeededFiles(tmpDir, true);
     expect(result.updated).toHaveLength(1);
     expect(result.updated[0]).toContain('servers/my-guild/CLAUDE.md');
+  });
+
+  it('ignores non-directory entries inside servers/', () => {
+    writeFile('servers/README.md', 'not a server folder');
+    writeFile(
+      'servers/real-server/CLAUDE.md',
+      '## Old server\n\n<!-- omniclaw-seed:v1 -->',
+    );
+
+    const result = reconcileSeededFiles(tmpDir, true);
+    expect(result.updated).toHaveLength(1);
+    expect(result.updated[0]).toContain('servers/real-server/CLAUDE.md');
   });
 
   it('reports current server files that match latest version', () => {

--- a/src/seed-templates.ts
+++ b/src/seed-templates.ts
@@ -219,32 +219,24 @@ function findClaudeMdFiles(groupsDir: string): ClaudeMdEntry[] {
     if (dirName === 'servers' || dirPath.includes('/servers/')) {
       // Scan subdirectories of servers/
       for (const serverDir of fs.readdirSync(dirPath)) {
+        const serverPath = path.join(dirPath, serverDir);
+        if (!fs.statSync(serverPath).isDirectory()) continue;
         const serverClaudeMd = path.join(dirPath, serverDir, 'CLAUDE.md');
-        if (
-          fs.existsSync(serverClaudeMd) &&
-          fs.statSync(path.join(dirPath, serverDir)).isDirectory()
-        ) {
+        if (fs.existsSync(serverClaudeMd)) {
           entries.push({ filePath: serverClaudeMd, templateKey: 'server' });
         }
       }
       continue;
     }
 
-    // For other directories, check if the file has a seed marker to determine type
+    // For channel/group directories, reconcile any CLAUDE.md and let the
+    // caller decide whether it is current, stale, or unversioned.
     const claudeMdPath = path.join(dirPath, 'CLAUDE.md');
     if (!fs.existsSync(claudeMdPath)) continue;
-    try {
-      const content = fs.readFileSync(claudeMdPath, 'utf-8');
-      if (extractSeedVersion(content) !== null) {
-        // Has a version marker — infer template type
-        entries.push({
-          filePath: claudeMdPath,
-          templateKey: inferTemplateKey(claudeMdPath, false),
-        });
-      }
-    } catch {
-      // Unreadable — skip
-    }
+    entries.push({
+      filePath: claudeMdPath,
+      templateKey: inferTemplateKey(claudeMdPath, false),
+    });
   }
 
   return entries;

--- a/src/seed-templates.ts
+++ b/src/seed-templates.ts
@@ -1,0 +1,265 @@
+/**
+ * Seeded CLAUDE.md templates with version tracking.
+ *
+ * Each template has a version string embedded as a comment at the end of the
+ * file. When template content changes, bump the version. The reconciler can
+ * detect stale files by comparing the embedded version against the current
+ * template version.
+ *
+ * Version format: `<!-- omniclaw-seed:v{N} -->`
+ *
+ * @see Issue #247 — Reconcile seeded CLAUDE.md files when template guidance changes
+ */
+
+import fs from 'fs';
+import path from 'path';
+
+import { logger } from './logger.js';
+
+// ---------------------------------------------------------------------------
+// Template definitions
+// ---------------------------------------------------------------------------
+
+export interface SeedTemplate {
+  /** Unique key identifying this template type. */
+  key: string;
+  /** Current version number. Bump when content changes. */
+  version: number;
+  /** The template body (without the version marker — it's appended automatically). */
+  body: string;
+}
+
+const DISCORD_CHANNEL_TEMPLATE: SeedTemplate = {
+  key: 'discord-channel',
+  version: 2,
+  body: `## Channel: Discord (Secondary)
+This group communicates via Discord, a secondary channel.
+You can freely answer questions and have conversations here.
+For significant actions (file changes, scheduled tasks, sending messages to other groups),
+confirm intent with the current user in this chat before proceeding.
+
+## Getting Context You Don't Have
+When you need project context, repo access, credentials, or information that hasn't been shared with you:
+- Use \`mcp__omniclaw__share_request\` to request it from the admin — don't ask users for what the admin should provide.
+- Be specific: describe exactly what you need and why.
+- Check local docs and repo files first before requesting.
+
+## Working with Repos
+You have \`git\` and \`GITHUB_TOKEN\` available in your environment.
+When the admin shares a repo URL, clone it yourself:
+\`\`\`bash
+git clone https://github.com/org/repo.git /workspace/group/repos/repo
+\`\`\`
+Then read the code directly — don't ask the admin to copy files for you.
+`,
+};
+
+const SERVER_TEMPLATE: SeedTemplate = {
+  key: 'server',
+  version: 2,
+  body: `# Server Shared Context
+
+This file is shared across all channels in this Discord server.
+Use it for team-level context: members, projects, repos, conventions.
+Channel-specific notes should go in the channel's own CLAUDE.md.
+
+## Getting Context You Don't Have
+If you need project info, repo URLs, or credentials not listed here, use \`mcp__omniclaw__share_request\` to request it from the admin.
+Be explicit about what you need and why.
+
+## Working with Repos
+You have \`git\` and \`GITHUB_TOKEN\` available. When given a repo URL, clone it:
+\`\`\`bash
+git clone https://github.com/org/repo.git /workspace/group/repos/repo
+\`\`\`
+`,
+};
+
+// Registry of all templates
+export const SEED_TEMPLATES: ReadonlyMap<string, SeedTemplate> = new Map([
+  [DISCORD_CHANNEL_TEMPLATE.key, DISCORD_CHANNEL_TEMPLATE],
+  [SERVER_TEMPLATE.key, SERVER_TEMPLATE],
+]);
+
+// ---------------------------------------------------------------------------
+// Version marker utilities
+// ---------------------------------------------------------------------------
+
+const VERSION_MARKER_RE = /<!-- omniclaw-seed:v(\d+) -->$/;
+
+/** Build the full seeded content with the version marker appended. */
+export function buildSeededContent(template: SeedTemplate): string {
+  return `${template.body}\n<!-- omniclaw-seed:v${template.version} -->`;
+}
+
+/** Extract the version number from a file's content. Returns null if no marker found. */
+export function extractSeedVersion(content: string): number | null {
+  const match = content.trimEnd().match(VERSION_MARKER_RE);
+  return match ? parseInt(match[1], 10) : null;
+}
+
+/** Extract the template key from a file path pattern. */
+export function inferTemplateKey(
+  filePath: string,
+  isServerLevel: boolean,
+): string {
+  if (isServerLevel) return 'server';
+  // Default to discord-channel for group-level CLAUDE.md
+  return 'discord-channel';
+}
+
+// ---------------------------------------------------------------------------
+// Reconciliation
+// ---------------------------------------------------------------------------
+
+export interface ReconcileResult {
+  /** Files that were updated to the current template version. */
+  updated: string[];
+  /** Files that are already current. */
+  current: string[];
+  /** Files with no version marker (user-edited or pre-versioning). */
+  unversioned: string[];
+  /** Files that could not be read or processed. */
+  errors: Array<{ path: string; error: string }>;
+}
+
+/**
+ * Scan seeded CLAUDE.md files and report which ones are stale.
+ *
+ * @param groupsDir - Base directory containing group/server folders
+ * @param dryRun - If true, only report; don't write updates (default: true)
+ */
+export function reconcileSeededFiles(
+  groupsDir: string,
+  dryRun = true,
+): ReconcileResult {
+  const result: ReconcileResult = {
+    updated: [],
+    current: [],
+    unversioned: [],
+    errors: [],
+  };
+
+  // Scan for CLAUDE.md files
+  const entries = findClaudeMdFiles(groupsDir);
+
+  for (const entry of entries) {
+    try {
+      const content = fs.readFileSync(entry.filePath, 'utf-8');
+      const version = extractSeedVersion(content);
+      const template = SEED_TEMPLATES.get(entry.templateKey);
+
+      if (!template) {
+        // No matching template — skip (custom file)
+        continue;
+      }
+
+      if (version === null) {
+        // No version marker — file predates versioning or was user-edited
+        result.unversioned.push(entry.filePath);
+        continue;
+      }
+
+      if (version >= template.version) {
+        result.current.push(entry.filePath);
+        continue;
+      }
+
+      // Stale — update if not dry run
+      if (!dryRun) {
+        const newContent = buildSeededContent(template);
+        fs.writeFileSync(entry.filePath, newContent);
+        logger.info(
+          {
+            op: 'seedReconcile',
+            path: entry.filePath,
+            oldVersion: version,
+            newVersion: template.version,
+            templateKey: entry.templateKey,
+          },
+          `Reconciled seeded CLAUDE.md from v${version} to v${template.version}`,
+        );
+      }
+      result.updated.push(entry.filePath);
+    } catch (err) {
+      result.errors.push({
+        path: entry.filePath,
+        error: err instanceof Error ? err.message : String(err),
+      });
+    }
+  }
+
+  return result;
+}
+
+interface ClaudeMdEntry {
+  filePath: string;
+  templateKey: string;
+}
+
+/**
+ * Find all seeded CLAUDE.md files that could match a known template.
+ * Looks for:
+ *  - servers/STAR/CLAUDE.md => server template
+ *  - groups that start with dc: => discord-channel template
+ *    (detected by checking if the CLAUDE.md has a seed version marker)
+ */
+function findClaudeMdFiles(groupsDir: string): ClaudeMdEntry[] {
+  const entries: ClaudeMdEntry[] = [];
+
+  if (!fs.existsSync(groupsDir)) return entries;
+
+  // Scan top-level directories
+  for (const dirName of fs.readdirSync(groupsDir)) {
+    const dirPath = path.join(groupsDir, dirName);
+    if (!fs.statSync(dirPath).isDirectory()) continue;
+
+    // Determine template key from directory structure
+    // servers/* directories use the server template
+    if (dirName === 'servers' || dirPath.includes('/servers/')) {
+      // Scan subdirectories of servers/
+      for (const serverDir of fs.readdirSync(dirPath)) {
+        const serverClaudeMd = path.join(dirPath, serverDir, 'CLAUDE.md');
+        if (
+          fs.existsSync(serverClaudeMd) &&
+          fs.statSync(path.join(dirPath, serverDir)).isDirectory()
+        ) {
+          entries.push({ filePath: serverClaudeMd, templateKey: 'server' });
+        }
+      }
+      continue;
+    }
+
+    // For other directories, check if the file has a seed marker to determine type
+    const claudeMdPath = path.join(dirPath, 'CLAUDE.md');
+    if (!fs.existsSync(claudeMdPath)) continue;
+    try {
+      const content = fs.readFileSync(claudeMdPath, 'utf-8');
+      if (extractSeedVersion(content) !== null) {
+        // Has a version marker — infer template type
+        entries.push({
+          filePath: claudeMdPath,
+          templateKey: inferTemplateKey(claudeMdPath, false),
+        });
+      }
+    } catch {
+      // Unreadable — skip
+    }
+  }
+
+  return entries;
+}
+
+// ---------------------------------------------------------------------------
+// Exports for use in index.ts seeding
+// ---------------------------------------------------------------------------
+
+/** Get the Discord channel template content (with version marker). */
+export function getDiscordChannelSeed(): string {
+  return buildSeededContent(DISCORD_CHANNEL_TEMPLATE);
+}
+
+/** Get the server-level template content (with version marker). */
+export function getServerSeed(): string {
+  return buildSeededContent(SERVER_TEMPLATE);
+}


### PR DESCRIPTION
## Summary

Extracts inline CLAUDE.md template strings from `index.ts` into a dedicated `seed-templates` module with version tracking and a reconciliation function for detecting and updating stale seeded files.

*What changed:*
• New `src/seed-templates.ts` — template registry with version markers (`<!-- omniclaw-seed:vN -->`), content builders, and `reconcileSeededFiles()` with dry-run support
• `src/index.ts` — replaced 2 inline template strings with `getDiscordChannelSeed()` / `getServerSeed()` calls
• Templates bumped to v2 with updated guidance (uses `share_request` instead of "ask in chat")
• 30 tests with 48 assertions covering version extraction, template content, reconciliation (stale detection, dry-run, update, mixed states, server dirs)

*How reconciliation works:*
1. Each seeded CLAUDE.md now ends with `<!-- omniclaw-seed:vN -->` (invisible to agents)
2. `reconcileSeededFiles(groupsDir, dryRun)` scans for these markers and compares against current template versions
3. Stale files (lower version) can be updated; unversioned files (user-edited or pre-versioning) are reported but left untouched
4. Operators can call dry-run first to audit before applying

*Not included (follow-up):*
• Web API endpoint to trigger reconciliation from the dashboard
• CLI command for manual reconciliation
• Auto-reconciliation on startup (intentionally left opt-in)

## Test plan
- [x] `bun test src/seed-templates.test.ts` — 30 pass, 0 fail
- [x] `bunx tsc --noEmit` — clean
- [x] `bunx prettier --check` — clean
- [ ] CI green

Closes #247

🤖 Generated with [Claude Code](https://claude.com/claude-code)
