### PR TITLE
fix: increase reaction IPC timeout from 3s to 8s

### DIFF
--- a/container/agent-runner/src/ipc-mcp-stdio.ts
+++ b/container/agent-runner/src/ipc-mcp-stdio.ts
@@ -890,7 +890,7 @@ if (chatJid.startsWith('dc:') || chatJid.startsWith('tg:')) {
         timestamp: new Date().toISOString(),
       });
 
-      const response = await waitForResponse(requestId);
+      const response = await waitForResponse(requestId, 8000);
       if (!response) {
         return {
           content: [


### PR DESCRIPTION
## Summary
- The default `waitForResponse` timeout (3s) was too tight for emoji reactions — the host-side IPC round-trip often takes slightly over 3s, causing the agent to report "timed out" even when the reaction succeeds
- Bumped to 8s to give comfortable margin for the file-based IPC round-trip

## Test plan
- [x] Verified reaction was succeeding but reporting timeout in logs
- [ ] Send a message that triggers a reaction and confirm no timeout error in logs

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability of message reaction handling by increasing the wait time for response processing, reducing potential timeout issues.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->