### PR TITLE
ci: auto-merge dependency bump PRs when CI passes

### DIFF
--- a/.github/workflows/auto-merge-deps.yml
+++ b/.github/workflows/auto-merge-deps.yml
@@ -1,0 +1,70 @@
+name: Auto-merge Dependency Bumps
+
+# Enables auto-merge on existing dependency bump PRs.
+# Run manually to clear backlog, or triggered automatically when CI completes on update/* branches.
+
+on:
+  workflow_dispatch:
+  workflow_run:
+    workflows: [CI]
+    types: [completed]
+    branches: ['update/*']
+
+jobs:
+  auto-merge:
+    runs-on: ubuntu-latest
+    if: >-
+      github.event_name == 'workflow_dispatch' ||
+      github.event.workflow_run.conclusion == 'success'
+    permissions:
+      contents: write
+      pull-requests: write
+
+    steps:
+      - name: Check for GitHub App secrets
+        id: check-secrets
+        run: |
+          if [ -z "$APP_ID" ]; then
+            echo "skip=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "skip=false" >> "$GITHUB_OUTPUT"
+          fi
+        env:
+          APP_ID: ${{ secrets.APP_ID }}
+
+      - name: Create GitHub App token
+        if: steps.check-secrets.outputs.skip != 'true'
+        id: app-token
+        uses: actions/create-github-app-token@v1
+        with:
+          app-id: ${{ secrets.APP_ID }}
+          private-key: ${{ secrets.APP_PRIVATE_KEY }}
+
+      - name: Enable auto-merge on dependency bump PRs
+        run: |
+          if [ "${{ github.event_name }}" == "workflow_run" ]; then
+            # CI just passed on a specific update/* branch — find that PR
+            BRANCH="${{ github.event.workflow_run.head_branch }}"
+            PRS=$(gh pr list --repo omniaura/omniclaw --base main --head "$BRANCH" \
+              --json number,author,headRefName \
+              --jq '.[] | select(.author.login == "github-actions[bot]" or .author.login == "github-actions") | .number')
+          else
+            # Manual dispatch — find all open update/* PRs from bot
+            PRS=$(gh pr list --repo omniaura/omniclaw --base main --state open \
+              --json number,author,headRefName \
+              --jq '.[] | select(.author.login == "github-actions[bot]" or .author.login == "github-actions") | select(.headRefName | startswith("update/")) | .number')
+          fi
+
+          if [ -z "$PRS" ]; then
+            echo "No matching dependency bump PRs found"
+            exit 0
+          fi
+
+          for PR in $PRS; do
+            echo "Enabling auto-merge for PR #$PR..."
+            gh pr merge "$PR" --repo omniaura/omniclaw --auto --squash \
+              && echo "  ✓ Auto-merge enabled for PR #$PR" \
+              || echo "::warning::Could not enable auto-merge for PR #$PR"
+          done
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token != '' && steps.app-token.outputs.token || github.token }}

--- a/.github/workflows/update-claude-sdk.yml
+++ b/.github/workflows/update-claude-sdk.yml
@@ -122,6 +122,19 @@ jobs:
         env:
           GH_TOKEN: ${{ steps.app-token.outputs.token != '' && steps.app-token.outputs.token || github.token }}
 
+      - name: Enable auto-merge
+        if: steps.check.outputs.changed == 'true' && steps.existing_pr.outputs.pr == ''
+        run: |
+          BRANCH="update/claude-sdk-${{ steps.latest.outputs.version }}"
+          PR=$(gh pr list --repo omniaura/omniclaw --base main --head "$BRANCH" --json number --jq '.[0].number // ""')
+          if [ -n "$PR" ]; then
+            gh pr merge "$PR" --repo omniaura/omniclaw --auto --squash \
+              && echo "Auto-merge enabled for PR #$PR" \
+              || echo "::warning::Could not enable auto-merge for PR #$PR (is auto-merge enabled in repo settings?)"
+          fi
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token != '' && steps.app-token.outputs.token || github.token }}
+
       - name: Ensure CI is queued for update PR
         if: steps.check.outputs.changed == 'true' && steps.existing_pr.outputs.pr == ''
         run: |

--- a/.github/workflows/update-container-deps.yml
+++ b/.github/workflows/update-container-deps.yml
@@ -163,6 +163,19 @@ jobs:
         env:
           GH_TOKEN: ${{ steps.app-token.outputs.token != '' && steps.app-token.outputs.token || github.token }}
 
+      - name: Enable auto-merge
+        if: steps.filter.outputs.skip != 'true' && steps.check.outputs.changed == 'true' && steps.existing_pr.outputs.pr == ''
+        run: |
+          BRANCH="update/${{ matrix.tool }}-${{ steps.latest.outputs.version }}"
+          PR=$(gh pr list --repo omniaura/omniclaw --base main --head "$BRANCH" --json number --jq '.[0].number // ""')
+          if [ -n "$PR" ]; then
+            gh pr merge "$PR" --repo omniaura/omniclaw --auto --squash \
+              && echo "Auto-merge enabled for PR #$PR" \
+              || echo "::warning::Could not enable auto-merge for PR #$PR (is auto-merge enabled in repo settings?)"
+          fi
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token != '' && steps.app-token.outputs.token || github.token }}
+
       - name: Ensure CI is queued for update PR
         if: steps.filter.outputs.skip != 'true' && steps.check.outputs.changed == 'true' && steps.existing_pr.outputs.pr == ''
         run: |

--- a/.github/workflows/update-opencode.yml
+++ b/.github/workflows/update-opencode.yml
@@ -182,6 +182,19 @@ jobs:
         env:
           GH_TOKEN: ${{ steps.app-token.outputs.token != '' && steps.app-token.outputs.token || github.token }}
 
+      - name: Enable auto-merge
+        if: steps.check.outputs.changed == 'true' && steps.existing_pr.outputs.pr == ''
+        run: |
+          BRANCH="update/opencode-${{ steps.check.outputs.branch_suffix }}"
+          PR=$(gh pr list --repo omniaura/omniclaw --base main --head "$BRANCH" --json number --jq '.[0].number // ""')
+          if [ -n "$PR" ]; then
+            gh pr merge "$PR" --repo omniaura/omniclaw --auto --squash \
+              && echo "Auto-merge enabled for PR #$PR" \
+              || echo "::warning::Could not enable auto-merge for PR #$PR (is auto-merge enabled in repo settings?)"
+          fi
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token != '' && steps.app-token.outputs.token || github.token }}
+
       - name: Ensure CI is queued for update PR
         if: steps.check.outputs.changed == 'true' && steps.existing_pr.outputs.pr == ''
         run: |


### PR DESCRIPTION
## Summary

Closes #479. Adds auto-merge for dependency bump PRs so they no longer pile up waiting for manual merge.

### Changes

**Updated workflows** (container-deps, claude-sdk, opencode):
- Added "Enable auto-merge" step after PR creation — calls `gh pr merge --auto --squash`
- Gracefully warns (rather than failing) if auto-merge isn't enabled in repo settings

**New workflow** (`auto-merge-deps.yml`):
- Triggers automatically when CI completes on `update/*` branches
- Can also be manually dispatched to clear existing PR backlog
- Only targets PRs authored by `github-actions[bot]` on `update/*` branches

### Prerequisites

Auto-merge must be enabled in the repo settings (Settings → General → Allow auto-merge). If branch protection rules require status checks, those checks must pass before the merge executes.

### Clearing the backlog

After merging this PR, run the `Auto-merge Dependency Bumps` workflow manually via Actions → workflow_dispatch to enable auto-merge on the 6 existing dependency bump PRs (#472–#477).

## Test plan

- [ ] Verify auto-merge is enabled in repo settings
- [ ] Dispatch `Auto-merge Dependency Bumps` workflow manually to clear existing backlog
- [ ] Confirm existing dep bump PRs with green CI merge automatically
- [ ] Verify next daily dep bump PR gets auto-merge enabled at creation time

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Automated dependency update workflows in CI/CD. Dependency updates for Claude SDK, container images, and third-party packages are now automatically merged when conditions are satisfied. Pull requests are merged with squashed commits for cleaner history, reducing manual review overhead and accelerating the deployment cycle for dependency upgrades.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->