### PR TITLE
test: expand logger and backend factory coverage

### DIFF
--- a/src/backends/index.test.ts
+++ b/src/backends/index.test.ts
@@ -1,11 +1,7 @@
 import { afterEach, describe, expect, it, mock, spyOn } from 'bun:test';
 
 import { logger } from '../logger.js';
-import {
-  getBackend,
-  initializeBackends,
-  shutdownBackends,
-} from './index.js';
+import { getBackend, initializeBackends, shutdownBackends } from './index.js';
 import { LocalBackend } from './local-backend.js';
 
 /**
@@ -66,8 +62,14 @@ describe('backends/index', () => {
     it('initializes only the default backend when no entities are provided', async () => {
       const appleBackend = getBackend('apple-container');
       const dockerBackend = getBackend('docker');
-      const appleInitSpy = spyOn(appleBackend, 'initialize').mockResolvedValue();
-      const dockerInitSpy = spyOn(dockerBackend, 'initialize').mockResolvedValue();
+      const appleInitSpy = spyOn(
+        appleBackend,
+        'initialize',
+      ).mockResolvedValue();
+      const dockerInitSpy = spyOn(
+        dockerBackend,
+        'initialize',
+      ).mockResolvedValue();
 
       await initializeBackends({});
 
@@ -78,8 +80,14 @@ describe('backends/index', () => {
     it('deduplicates backend initialization across entities', async () => {
       const appleBackend = getBackend('apple-container');
       const dockerBackend = getBackend('docker');
-      const appleInitSpy = spyOn(appleBackend, 'initialize').mockResolvedValue();
-      const dockerInitSpy = spyOn(dockerBackend, 'initialize').mockResolvedValue();
+      const appleInitSpy = spyOn(
+        appleBackend,
+        'initialize',
+      ).mockResolvedValue();
+      const dockerInitSpy = spyOn(
+        dockerBackend,
+        'initialize',
+      ).mockResolvedValue();
 
       await initializeBackends({
         alpha: {
@@ -113,8 +121,14 @@ describe('backends/index', () => {
     it('attempts to shut down all initialized backends', async () => {
       const appleBackend = getBackend('apple-container');
       const dockerBackend = getBackend('docker');
-      const appleShutdownSpy = spyOn(appleBackend, 'shutdown').mockResolvedValue();
-      const dockerShutdownSpy = spyOn(dockerBackend, 'shutdown').mockResolvedValue();
+      const appleShutdownSpy = spyOn(
+        appleBackend,
+        'shutdown',
+      ).mockResolvedValue();
+      const dockerShutdownSpy = spyOn(
+        dockerBackend,
+        'shutdown',
+      ).mockResolvedValue();
 
       await shutdownBackends();
 
@@ -129,7 +143,10 @@ describe('backends/index', () => {
       const warnSpy = spyOn(logger, 'warn').mockImplementation(() => {});
 
       spyOn(appleBackend, 'shutdown').mockRejectedValue(failure);
-      const dockerShutdownSpy = spyOn(dockerBackend, 'shutdown').mockResolvedValue();
+      const dockerShutdownSpy = spyOn(
+        dockerBackend,
+        'shutdown',
+      ).mockResolvedValue();
 
       await shutdownBackends();
 

--- a/src/backends/index.test.ts
+++ b/src/backends/index.test.ts
@@ -1,16 +1,26 @@
-import { describe, it, expect } from 'bun:test';
-import { getBackend } from './index.js';
+import { afterEach, describe, expect, it, mock, spyOn } from 'bun:test';
+
+import { logger } from '../logger.js';
+import {
+  getBackend,
+  initializeBackends,
+  shutdownBackends,
+} from './index.js';
 import { LocalBackend } from './local-backend.js';
 
 /**
  * Tests for backends/index.ts — the backend factory.
  *
- * Note: resolveBackend is not tested here because file-transfer.test.ts
- * uses mock.module to replace backends/index.js globally. resolveBackend
- * is a thin wrapper over getBackendType + getBackend, both tested separately.
+ * Note: resolveBackend is intentionally not tested here because
+ * file-transfer.test.ts uses mock.module to replace backends/index.js globally.
+ * resolveBackend is a thin wrapper over getBackendType + getBackend.
  */
 
 describe('backends/index', () => {
+  afterEach(() => {
+    mock.restore();
+  });
+
   describe('getBackend', () => {
     it('returns a LocalBackend for apple-container', () => {
       const backend = getBackend('apple-container');
@@ -49,6 +59,85 @@ describe('backends/index', () => {
       expect(typeof backend.writeFile).toBe('function');
       expect(typeof backend.initialize).toBe('function');
       expect(typeof backend.shutdown).toBe('function');
+    });
+  });
+
+  describe('initializeBackends', () => {
+    it('initializes only the default backend when no entities are provided', async () => {
+      const appleBackend = getBackend('apple-container');
+      const dockerBackend = getBackend('docker');
+      const appleInitSpy = spyOn(appleBackend, 'initialize').mockResolvedValue();
+      const dockerInitSpy = spyOn(dockerBackend, 'initialize').mockResolvedValue();
+
+      await initializeBackends({});
+
+      expect(appleInitSpy).toHaveBeenCalledTimes(1);
+      expect(dockerInitSpy).not.toHaveBeenCalled();
+    });
+
+    it('deduplicates backend initialization across entities', async () => {
+      const appleBackend = getBackend('apple-container');
+      const dockerBackend = getBackend('docker');
+      const appleInitSpy = spyOn(appleBackend, 'initialize').mockResolvedValue();
+      const dockerInitSpy = spyOn(dockerBackend, 'initialize').mockResolvedValue();
+
+      await initializeBackends({
+        alpha: {
+          name: 'Alpha',
+          folder: 'alpha',
+          trigger: '@Alpha',
+          added_at: new Date().toISOString(),
+        },
+        beta: {
+          name: 'Beta',
+          folder: 'beta',
+          trigger: '@Beta',
+          added_at: new Date().toISOString(),
+          backend: 'docker',
+        },
+        gamma: {
+          name: 'Gamma',
+          folder: 'gamma',
+          trigger: '@Gamma',
+          added_at: new Date().toISOString(),
+          backend: 'docker',
+        },
+      });
+
+      expect(appleInitSpy).toHaveBeenCalledTimes(1);
+      expect(dockerInitSpy).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe('shutdownBackends', () => {
+    it('attempts to shut down all initialized backends', async () => {
+      const appleBackend = getBackend('apple-container');
+      const dockerBackend = getBackend('docker');
+      const appleShutdownSpy = spyOn(appleBackend, 'shutdown').mockResolvedValue();
+      const dockerShutdownSpy = spyOn(dockerBackend, 'shutdown').mockResolvedValue();
+
+      await shutdownBackends();
+
+      expect(appleShutdownSpy).toHaveBeenCalledTimes(1);
+      expect(dockerShutdownSpy).toHaveBeenCalledTimes(1);
+    });
+
+    it('logs and continues when a backend shutdown fails', async () => {
+      const appleBackend = getBackend('apple-container');
+      const dockerBackend = getBackend('docker');
+      const failure = new Error('shutdown failed');
+      const warnSpy = spyOn(logger, 'warn').mockImplementation(() => {});
+
+      spyOn(appleBackend, 'shutdown').mockRejectedValue(failure);
+      const dockerShutdownSpy = spyOn(dockerBackend, 'shutdown').mockResolvedValue();
+
+      await shutdownBackends();
+
+      expect(warnSpy).toHaveBeenCalledWith(
+        { backend: 'apple-container', error: failure },
+        'Error shutting down backend',
+      );
+      expect(dockerShutdownSpy).toHaveBeenCalledTimes(1);
     });
   });
 });

--- a/src/logger.test.ts
+++ b/src/logger.test.ts
@@ -390,10 +390,7 @@ describe('logger', () => {
     });
 
     it('truncates long tags to 16 characters in pretty mode', () => {
-      const logger = createLogger(
-        { group: '1234567890abcdefghijk' },
-        'info',
-      );
+      const logger = createLogger({ group: '1234567890abcdefghijk' }, 'info');
       logger.info('hello');
 
       expect(stderrOutput).toHaveLength(1);

--- a/src/logger.test.ts
+++ b/src/logger.test.ts
@@ -1,14 +1,6 @@
-import {
-  describe,
-  it,
-  expect,
-  beforeEach,
-  afterEach,
-  mock,
-  spyOn,
-} from 'bun:test';
+import { describe, it, expect, beforeEach, afterEach, mock } from 'bun:test';
 
-import { createLogger, type Logger } from './logger.js';
+import { createLogger } from './logger.js';
 
 describe('logger', () => {
   let stderrOutput: string[];
@@ -177,6 +169,25 @@ describe('logger', () => {
       const parsed = JSON.parse(stderrOutput[0]);
       expect(parsed.container).toBe('test-container');
     });
+
+    it('includes error stacks when LOG_LEVEL is debug', () => {
+      const originalLevel = process.env.LOG_LEVEL;
+      process.env.LOG_LEVEL = 'debug';
+
+      const logger = createLogger({}, 'error');
+      logger.error({ err: new Error('with stack') }, 'boom');
+
+      const parsed = JSON.parse(stderrOutput[0]);
+      expect(parsed.err).toBe('with stack');
+      expect(typeof parsed.errStack).toBe('string');
+      expect(parsed.errStack).toContain('with stack');
+
+      if (originalLevel === undefined) {
+        delete process.env.LOG_LEVEL;
+      } else {
+        process.env.LOG_LEVEL = originalLevel;
+      }
+    });
   });
 
   describe('child loggers', () => {
@@ -333,6 +344,122 @@ describe('logger', () => {
       const parsed = JSON.parse(stderrOutput[0]);
       expect(parsed.msg).toBe('items processed');
       expect(parsed.count).toBe(5);
+    });
+  });
+
+  describe('pretty output (TTY)', () => {
+    let origTTY: boolean | undefined;
+
+    beforeEach(() => {
+      origTTY = process.stderr.isTTY;
+      Object.defineProperty(process.stderr, 'isTTY', {
+        value: true,
+        configurable: true,
+      });
+    });
+
+    afterEach(() => {
+      Object.defineProperty(process.stderr, 'isTTY', {
+        value: origTTY,
+        configurable: true,
+      });
+    });
+
+    it('renders inline metric suffixes in pretty mode', () => {
+      const logger = createLogger({ group: 'main-group' }, 'info');
+      logger.info(
+        {
+          durationMs: 42,
+          messageCount: 3,
+          turns: 2,
+          costUsd: 0.12,
+          exitCode: 7,
+          err: 'network',
+        },
+        'Processed task',
+      );
+
+      expect(stderrOutput).toHaveLength(1);
+      expect(stderrOutput[0]).toContain('Processed task');
+      expect(stderrOutput[0]).toContain('(42ms)');
+      expect(stderrOutput[0]).toContain('[3 msgs]');
+      expect(stderrOutput[0]).toContain('turns=2');
+      expect(stderrOutput[0]).toContain('$0.12');
+      expect(stderrOutput[0]).toContain('exit=7');
+      expect(stderrOutput[0]).toContain('ERR: network');
+    });
+
+    it('truncates long tags to 16 characters in pretty mode', () => {
+      const logger = createLogger(
+        { group: '1234567890abcdefghijk' },
+        'info',
+      );
+      logger.info('hello');
+
+      expect(stderrOutput).toHaveLength(1);
+      expect(stderrOutput[0]).toContain('1234567890abcdef');
+      expect(stderrOutput[0]).not.toContain('1234567890abcdefghijk');
+    });
+  });
+
+  describe('subscribers', () => {
+    let origTTY: boolean | undefined;
+
+    beforeEach(() => {
+      origTTY = process.stderr.isTTY;
+      Object.defineProperty(process.stderr, 'isTTY', {
+        value: false,
+        configurable: true,
+      });
+    });
+
+    afterEach(() => {
+      Object.defineProperty(process.stderr, 'isTTY', {
+        value: origTTY,
+        configurable: true,
+      });
+    });
+
+    it('notifies subscribers with the emitted record', () => {
+      const logger = createLogger({ group: 'main' }, 'info');
+      const subscriber = mock((record: Record<string, unknown>) => record);
+      logger.subscribe(subscriber);
+
+      logger.info({ op: 'startup' }, 'started');
+
+      expect(subscriber).toHaveBeenCalledTimes(1);
+      expect(subscriber.mock.calls[0]?.[0]).toMatchObject({
+        group: 'main',
+        op: 'startup',
+        msg: 'started',
+        level: 'info',
+      });
+    });
+
+    it('stops notifying a subscriber after unsubscribe', () => {
+      const logger = createLogger({}, 'info');
+      const subscriber = mock(() => {});
+      const unsubscribe = logger.subscribe(subscriber);
+
+      unsubscribe();
+      logger.info('after unsubscribe');
+
+      expect(subscriber).not.toHaveBeenCalled();
+    });
+
+    it('swallows subscriber errors and continues notifying others', () => {
+      const logger = createLogger({}, 'info');
+      const badSubscriber = mock(() => {
+        throw new Error('subscriber failed');
+      });
+      const goodSubscriber = mock(() => {});
+
+      logger.subscribe(badSubscriber);
+      logger.subscribe(goodSubscriber);
+
+      expect(() => logger.info('fan out')).not.toThrow();
+      expect(badSubscriber).toHaveBeenCalledTimes(1);
+      expect(goodSubscriber).toHaveBeenCalledTimes(1);
     });
   });
 });


### PR DESCRIPTION
## Summary
- Expand deterministic coverage for `src/logger.ts` around pretty output formatting, subscriber fan-out, unsubscribe behavior, and debug stack capture.
- Add backend factory tests for default initialization, backend deduplication, clean shutdown, and shutdown warning handling in `src/backends/index.ts`.
- Increase suite coverage without touching production code paths.

## Verification
- `bun test`
- `bun test --coverage`

## Coverage Notes
- Test count before: 1623 tests across 90 files.
- Test count after: 1633 tests across 90 files.
- Coverage before: 86.83% funcs / 83.58% lines.
- Coverage after: 87.79% funcs / 84.76% lines.
- Improved files: `src/logger.ts` to 81.25% funcs / 73.12% lines, `src/backends/index.ts` to 83.33% funcs / 95.24% lines.

## Remaining Gaps
- Lowest remaining coverage reported in the post-change summary: `src/web/solid-handler.ts` and `src/web/server.ts`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Strengthened backend lifecycle tests to verify proper initialization of default backends, deduplication of multiple mappings, and graceful shutdown handling with error resilience.
  * Expanded logger test coverage for JSON formatting, terminal output rendering with metric suffixes and truncation, and subscription notification behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->