### PR TITLE
fix(security): cap web and discovery JSON request bodies

### DIFF
--- a/src/discovery/routes.test.ts
+++ b/src/discovery/routes.test.ts
@@ -275,6 +275,45 @@ describe('handleDiscoveryRequest', () => {
       expect((res as Response).status).toBe(400);
     }
   });
+
+  it('rejects oversized pair requests before creating trust-store state', async () => {
+    let createPairRequestCalls = 0;
+    const req = withSocketAddress(
+      new Request('http://localhost/api/discovery/pair', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          instanceId: 'remote-instance',
+          name: 'Remote',
+          port: 6001,
+          callbackToken: 'x'.repeat(70 * 1024),
+          keyAgreementPublicKey: 'test-public-key',
+        }),
+      }),
+      '10.0.0.22',
+    );
+
+    const res = await handleDiscoveryRequest(
+      req,
+      new URL(req.url),
+      makeContext({
+        trustStore: {
+          isPeerTrusted: () => false,
+          createPairRequest: () => {
+            createPairRequestCalls += 1;
+            throw new Error('should not be called');
+          },
+        } as any,
+      }),
+    );
+
+    expect(res).not.toBeNull();
+    expect((res as Response).status).toBe(413);
+    expect((await (res as Response).json()) as { error: string }).toEqual({
+      error: 'Request body too large',
+    });
+    expect(createPairRequestCalls).toBe(0);
+  });
 });
 
 // ---- checkPeerAuth body hash verification ----
@@ -560,6 +599,54 @@ describe('checkPeerAuth — body hash verification', () => {
     expect(response.status).toBe(403);
     const data = (await response.json()) as { error: string };
     expect(data.error).toBe('Unknown peer');
+  });
+
+  it('rejects oversized proxied context writes before calling the peer client', async () => {
+    let writeCalls = 0;
+    const req = new Request(
+      'http://localhost/api/discovery/peers/peer-1/context/file',
+      {
+        method: 'PUT',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          path: 'test/CLAUDE.md',
+          content: 'x'.repeat(1024 * 1024 + 64),
+        }),
+      },
+    );
+
+    const ctx = makeContext({
+      trustStore: {
+        getPeer: () => ({
+          instanceId: 'peer-1',
+          status: 'trusted',
+          sharedSecret: 'secret',
+          host: '127.0.0.1',
+          port: 6001,
+        }),
+        updatePeerLastSeen: () => {},
+      } as any,
+      createPeerClient: () => ({
+        getAgents: async () => [],
+        getStats: async () => ({}),
+        streamLogs: async () => new Response(''),
+        getContextLayers: async () => ({}),
+        listContextFiles: async () => [],
+        writeContextFile: async () => {
+          writeCalls += 1;
+          return { ok: true };
+        },
+      }),
+    });
+
+    const res = await handleDiscoveryRequest(req, new URL(req.url), ctx);
+    expect(res).not.toBeNull();
+    const response = res as Response;
+    expect(response.status).toBe(413);
+    expect((await response.json()) as { error: string }).toEqual({
+      error: 'Request body too large',
+    });
+    expect(writeCalls).toBe(0);
   });
 
   it('uses an injected peer client override when provided', async () => {

--- a/src/discovery/routes.ts
+++ b/src/discovery/routes.ts
@@ -32,6 +32,7 @@ import type {
   RemotePeerAgents,
   StoredPeer,
 } from './types.js';
+import { readJsonBody, RequestBodyTooLargeError } from '../request-body.js';
 
 export interface DiscoveryRouteContext {
   instanceId: string;
@@ -61,6 +62,8 @@ const pairRateLimiter = new Map<string, { count: number; resetAt: number }>();
 const PAIR_RATE_LIMIT = 10;
 const PAIR_RATE_WINDOW_MS = 60_000;
 const RATE_LIMITER_MAX_ENTRIES = 10_000;
+const MAX_DISCOVERY_JSON_BODY_BYTES = 64 * 1024;
+const MAX_DISCOVERY_CONTEXT_WRITE_BODY_BYTES = 1024 * 1024;
 
 function checkRateLimit(
   ip: string,
@@ -389,8 +392,14 @@ async function handlePairRequest(
 
   let body: PairRequestBody;
   try {
-    body = (await req.json()) as PairRequestBody;
-  } catch {
+    body = await readJsonBody<PairRequestBody>(
+      req,
+      MAX_DISCOVERY_JSON_BODY_BYTES,
+    );
+  } catch (err) {
+    if (err instanceof RequestBodyTooLargeError) {
+      return json({ error: 'Request body too large' }, 413);
+    }
     return json({ error: 'Invalid JSON body' }, 400);
   }
 
@@ -473,8 +482,11 @@ async function handleCompletePairing(
     };
   };
   try {
-    body = (await req.json()) as typeof body;
-  } catch {
+    body = await readJsonBody<typeof body>(req, MAX_DISCOVERY_JSON_BODY_BYTES);
+  } catch (err) {
+    if (err instanceof RequestBodyTooLargeError) {
+      return json({ error: 'Request body too large' }, 413);
+    }
     return json({ error: 'Invalid JSON body' }, 400);
   }
 
@@ -538,8 +550,11 @@ async function handleUpdateDiscoveryState(
 
   let body: { enabled?: unknown };
   try {
-    body = (await req.json()) as typeof body;
-  } catch {
+    body = await readJsonBody<typeof body>(req, MAX_DISCOVERY_JSON_BODY_BYTES);
+  } catch (err) {
+    if (err instanceof RequestBodyTooLargeError) {
+      return json({ error: 'Request body too large' }, 413);
+    }
     return json({ error: 'Invalid JSON body' }, 400);
   }
 
@@ -1010,8 +1025,14 @@ async function handleProxyContextWrite(
 
   let body: { path: string; content: string };
   try {
-    body = (await req.json()) as typeof body;
-  } catch {
+    body = await readJsonBody<typeof body>(
+      req,
+      MAX_DISCOVERY_CONTEXT_WRITE_BODY_BYTES,
+    );
+  } catch (err) {
+    if (err instanceof RequestBodyTooLargeError) {
+      return json({ error: 'Request body too large' }, 413);
+    }
     return json({ error: 'Invalid JSON body' }, 400);
   }
 
@@ -1105,8 +1126,11 @@ async function handleContextPush(
 
   let body: { path: string };
   try {
-    body = (await req.json()) as typeof body;
-  } catch {
+    body = await readJsonBody<typeof body>(req, MAX_DISCOVERY_JSON_BODY_BYTES);
+  } catch (err) {
+    if (err instanceof RequestBodyTooLargeError) {
+      return json({ error: 'Request body too large' }, 413);
+    }
     return json({ error: 'Invalid JSON body' }, 400);
   }
 
@@ -1149,8 +1173,11 @@ async function handleContextPull(
 
   let body: { path: string };
   try {
-    body = (await req.json()) as typeof body;
-  } catch {
+    body = await readJsonBody<typeof body>(req, MAX_DISCOVERY_JSON_BODY_BYTES);
+  } catch (err) {
+    if (err instanceof RequestBodyTooLargeError) {
+      return json({ error: 'Request body too large' }, 413);
+    }
     return json({ error: 'Invalid JSON body' }, 400);
   }
 

--- a/src/request-body.ts
+++ b/src/request-body.ts
@@ -1,0 +1,70 @@
+const textDecoder = new TextDecoder();
+
+export class RequestBodyTooLargeError extends Error {
+  constructor(readonly limitBytes: number) {
+    super(`Request body exceeded ${limitBytes} bytes`);
+  }
+}
+
+function parseContentLengthHeader(value: string | null): number | null {
+  if (!value) return null;
+  const parsed = Number.parseInt(value, 10);
+  if (!Number.isFinite(parsed) || parsed < 0) return null;
+  return parsed;
+}
+
+export async function readRequestBody(
+  req: Request,
+  maxBodyBytes: number,
+): Promise<string> {
+  const contentLength = parseContentLengthHeader(
+    req.headers.get('content-length'),
+  );
+  if (contentLength !== null && contentLength > maxBodyBytes) {
+    throw new RequestBodyTooLargeError(maxBodyBytes);
+  }
+
+  if (!req.body) return '';
+
+  const reader = req.body.getReader();
+  const chunks: Uint8Array[] = [];
+  let totalBytes = 0;
+
+  try {
+    while (true) {
+      const { done, value } = await reader.read();
+      if (done) break;
+      if (!value) continue;
+
+      totalBytes += value.byteLength;
+      if (totalBytes > maxBodyBytes) {
+        try {
+          await reader.cancel('Request body exceeded size limit');
+        } catch {
+          // Ignore cancellation failures; callers only need the limit signal.
+        }
+        throw new RequestBodyTooLargeError(maxBodyBytes);
+      }
+
+      chunks.push(value);
+    }
+  } finally {
+    reader.releaseLock();
+  }
+
+  const body = new Uint8Array(totalBytes);
+  let offset = 0;
+  for (const chunk of chunks) {
+    body.set(chunk, offset);
+    offset += chunk.byteLength;
+  }
+
+  return textDecoder.decode(body);
+}
+
+export async function readJsonBody<T>(
+  req: Request,
+  maxBodyBytes: number,
+): Promise<T> {
+  return JSON.parse(await readRequestBody(req, maxBodyBytes)) as T;
+}

--- a/src/web/routes.test.ts
+++ b/src/web/routes.test.ts
@@ -663,6 +663,29 @@ describe('web routes unit tests', () => {
     expect(writes).toEqual([{ path: 'groups/main', content: '# updated' }]);
   });
 
+  it('rejects oversized context file writes before mutating state', async () => {
+    let writeCalls = 0;
+    const largeContent = 'x'.repeat(1024 * 1024 + 64);
+    const res = await handle(
+      new Request('http://localhost/api/context/file', {
+        method: 'PUT',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ path: 'groups/main', content: largeContent }),
+      }),
+      makeState({
+        writeContextFile: () => {
+          writeCalls += 1;
+        },
+      }),
+    );
+
+    expect(res.status).toBe(413);
+    expect((await jsonBody(res)) as { error: string }).toEqual({
+      error: 'Request body too large',
+    });
+    expect(writeCalls).toBe(0);
+  });
+
   it('rejects unsupported methods for context writes', async () => {
     const res = await handle(
       new Request('http://localhost/api/context/file', { method: 'GET' }),

--- a/src/web/routes.ts
+++ b/src/web/routes.ts
@@ -39,10 +39,12 @@ import {
   renderAgentsContent,
 } from './agents-page.js';
 import { sanitizeTelegramAvatarUrl } from '../telegram-avatar.js';
+import { readJsonBody, RequestBodyTooLargeError } from '../request-body.js';
 
 /** Optional discovery context — set by the orchestrator when discovery is enabled. */
 let discoveryContext: DiscoveryRouteContext | null = null;
 let networkPageState: (() => NetworkPageState) | null = null;
+const MAX_WEB_JSON_BODY_BYTES = 1024 * 1024;
 
 /** Called by the orchestrator to wire up discovery routes. */
 export function setDiscoveryContext(
@@ -438,8 +440,14 @@ async function handleCreateTask(
 ): Promise<Response> {
   let body: Record<string, unknown>;
   try {
-    body = (await req.json()) as Record<string, unknown>;
-  } catch {
+    body = await readJsonBody<Record<string, unknown>>(
+      req,
+      MAX_WEB_JSON_BODY_BYTES,
+    );
+  } catch (err) {
+    if (err instanceof RequestBodyTooLargeError) {
+      return json({ error: 'Request body too large' }, 413);
+    }
     return json({ error: 'Invalid JSON body' }, 400);
   }
 
@@ -549,8 +557,14 @@ async function handleUpdateTask(
 
   let body: Record<string, unknown>;
   try {
-    body = (await req.json()) as Record<string, unknown>;
-  } catch {
+    body = await readJsonBody<Record<string, unknown>>(
+      req,
+      MAX_WEB_JSON_BODY_BYTES,
+    );
+  } catch (err) {
+    if (err instanceof RequestBodyTooLargeError) {
+      return json({ error: 'Request body too large' }, 413);
+    }
     return json({ error: 'Invalid JSON body' }, 400);
   }
 
@@ -786,8 +800,14 @@ async function handleWriteContextFile(
 ): Promise<Response> {
   let body: Record<string, unknown>;
   try {
-    body = (await req.json()) as Record<string, unknown>;
-  } catch {
+    body = await readJsonBody<Record<string, unknown>>(
+      req,
+      MAX_WEB_JSON_BODY_BYTES,
+    );
+  } catch (err) {
+    if (err instanceof RequestBodyTooLargeError) {
+      return json({ error: 'Request body too large' }, 413);
+    }
     return json({ error: 'Invalid JSON body' }, 400);
   }
 
@@ -942,8 +962,14 @@ async function handleSetAgentAvatar(
 
   let body: Record<string, unknown>;
   try {
-    body = (await req.json()) as Record<string, unknown>;
-  } catch {
+    body = await readJsonBody<Record<string, unknown>>(
+      req,
+      MAX_WEB_JSON_BODY_BYTES,
+    );
+  } catch (err) {
+    if (err instanceof RequestBodyTooLargeError) {
+      return json({ error: 'Request body too large' }, 413);
+    }
     return json({ error: 'Invalid JSON body' }, 400);
   }
 
@@ -1024,8 +1050,14 @@ async function handleSendMessage(
 
   let body: Record<string, unknown>;
   try {
-    body = (await req.json()) as Record<string, unknown>;
-  } catch {
+    body = await readJsonBody<Record<string, unknown>>(
+      req,
+      MAX_WEB_JSON_BODY_BYTES,
+    );
+  } catch (err) {
+    if (err instanceof RequestBodyTooLargeError) {
+      return json({ error: 'Request body too large' }, 413);
+    }
     return json({ error: 'Invalid JSON body' }, 400);
   }
 


### PR DESCRIPTION
## Summary

- add a shared capped request-body reader so JSON endpoints can reject oversized payloads before buffering them into memory
- enforce byte limits across authenticated Web UI JSON routes and discovery pairing/context-write routes, returning `413` on overflow
- add regression coverage for oversized discovery pair requests and oversized local/remote context writes

## Testing

- `bun test src/web/routes.test.ts src/discovery/routes.test.ts`
- `bun run tsc --noEmit`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * API endpoints now enforce request body size limits and reject oversized requests with HTTP 413 status code
  * Discovery endpoints limited to 64 KiB; web endpoints to 1 MiB

* **Tests**
  * Added tests verifying request body size limit enforcement across API endpoints

<!-- end of auto-generated comment: release notes by coderabbit.ai -->