### PR TITLE
fix(security): bind pair requests to source host to prevent hijack

### DIFF
--- a/src/discovery/index.ts
+++ b/src/discovery/index.ts
@@ -1,7 +1,7 @@
 export { startDiscovery } from './mdns.js';
 export { DiscoveryRuntimeController } from './runtime.js';
 export { detectCurrentNetwork } from './network-identity.js';
-export { TrustStore } from './trust-store.js';
+export { TrustStore, PairRequestHostMismatchError } from './trust-store.js';
 export { PeerClient } from './peer-client.js';
 export {
   handleDiscoveryRequest,

--- a/src/discovery/routes.test.ts
+++ b/src/discovery/routes.test.ts
@@ -6,6 +6,7 @@ import {
   handleDiscoveryRequest,
   type DiscoveryRouteContext,
 } from './routes.js';
+import { PairRequestHostMismatchError } from './trust-store.js';
 
 const realFetch = globalThis.fetch;
 
@@ -274,6 +275,43 @@ describe('handleDiscoveryRequest', () => {
       });
       expect((res as Response).status).toBe(400);
     }
+  });
+
+  it('returns 409 when pair request is bound to a different host (#489)', async () => {
+    const req = withSocketAddress(
+      new Request('http://localhost/api/discovery/pair', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          instanceId: 'victim-instance',
+          name: 'Attacker',
+          host: '10.0.0.99',
+          port: 9999,
+          callbackToken: 'attacker-callback',
+          keyAgreementPublicKey: 'attacker-pub',
+        }),
+      }),
+      '10.0.0.99',
+    );
+
+    const ctx = makeContext({
+      trustStore: {
+        isPeerTrusted: () => false,
+        createPairRequest: () => {
+          throw new PairRequestHostMismatchError(
+            'victim-instance',
+            '10.0.0.30',
+            '10.0.0.99',
+          );
+        },
+      } as any,
+    });
+
+    const res = await handleDiscoveryRequest(req, new URL(req.url), ctx);
+    expect(res).not.toBeNull();
+    expect((res as Response).status).toBe(409);
+    const body = (await (res as Response).json()) as { error: string };
+    expect(body.error).toContain('bound to a different host');
   });
 
   it('rejects oversized pair requests before creating trust-store state', async () => {

--- a/src/discovery/routes.ts
+++ b/src/discovery/routes.ts
@@ -19,7 +19,10 @@ import {
   encryptPairingSecret,
   generatePairingKeyPair,
 } from './pairing-crypto.js';
-import type { TrustStore } from './trust-store.js';
+import {
+  type TrustStore,
+  PairRequestHostMismatchError,
+} from './trust-store.js';
 import type { DiscoveryRuntimeController } from './runtime.js';
 import type {
   ContextFileEntry,
@@ -431,15 +434,26 @@ async function handlePairRequest(
     return json({ status: 'already_trusted' });
   }
 
-  // Create or update pair request
-  const request = ctx.trustStore.createPairRequest(
-    body.instanceId,
-    body.name,
-    ip,
-    body.port,
-    body.callbackToken,
-    body.keyAgreementPublicKey,
-  );
+  // Create or update pair request (host-bound to prevent hijack — #489)
+  let request;
+  try {
+    request = ctx.trustStore.createPairRequest(
+      body.instanceId,
+      body.name,
+      ip,
+      body.port,
+      body.callbackToken,
+      body.keyAgreementPublicKey,
+    );
+  } catch (err) {
+    if (err instanceof PairRequestHostMismatchError) {
+      return json(
+        { error: 'A pending request for this instance is bound to a different host' },
+        409,
+      );
+    }
+    throw err;
+  }
 
   // Broadcast SSE event for the web UI
   ctx.broadcast?.({

--- a/src/discovery/routes.ts
+++ b/src/discovery/routes.ts
@@ -448,7 +448,10 @@ async function handlePairRequest(
   } catch (err) {
     if (err instanceof PairRequestHostMismatchError) {
       return json(
-        { error: 'A pending request for this instance is bound to a different host' },
+        {
+          error:
+            'A pending request for this instance is bound to a different host',
+        },
         409,
       );
     }

--- a/src/discovery/trust-store.test.ts
+++ b/src/discovery/trust-store.test.ts
@@ -2,7 +2,7 @@ import { describe, expect, it } from 'bun:test';
 import { Database } from 'bun:sqlite';
 
 import { createSchema } from '../db.js';
-import { TrustStore } from './trust-store.js';
+import { TrustStore, PairRequestHostMismatchError } from './trust-store.js';
 
 function makeTrustStore() {
   const db = new Database(':memory:');
@@ -104,7 +104,7 @@ describe('TrustStore', () => {
     });
   });
 
-  it('reuses an existing pending request for the same peer', () => {
+  it('reuses an existing pending request for the same peer from the same host', () => {
     const { trustStore } = makeTrustStore();
 
     const first = trustStore.createPairRequest(
@@ -115,10 +115,11 @@ describe('TrustStore', () => {
       'callback-a',
       'pub-a',
     );
+    // Same host — allowed (e.g. key rotation after restart)
     const second = trustStore.createPairRequest(
       'peer-3',
       'Peer Three Updated',
-      '10.0.0.31',
+      '10.0.0.30',
       7005,
       'callback-b',
       'pub-b',
@@ -129,12 +130,79 @@ describe('TrustStore', () => {
     expect(trustStore.getRequestById(first.id)).toMatchObject({
       id: first.id,
       fromName: 'Peer Three Updated',
-      fromHost: '10.0.0.31',
+      fromHost: '10.0.0.30',
       fromPort: 7005,
       callbackToken: 'callback-b',
       keyAgreementPublicKey: 'pub-b',
       status: 'pending',
     });
+  });
+
+  it('rejects pair request update from a different host (#489)', () => {
+    const { trustStore } = makeTrustStore();
+
+    // Legitimate request from 10.0.0.30
+    trustStore.createPairRequest(
+      'peer-hijack',
+      'Legit Peer',
+      '10.0.0.30',
+      7004,
+      'legit-callback',
+      'legit-pub',
+    );
+
+    // Attacker on 10.0.0.99 tries to overwrite with their callback
+    expect(() =>
+      trustStore.createPairRequest(
+        'peer-hijack',
+        'Attacker',
+        '10.0.0.99',
+        9999,
+        'attacker-callback',
+        'attacker-pub',
+      ),
+    ).toThrow(PairRequestHostMismatchError);
+
+    // Original request remains untouched
+    const pending = trustStore.getPendingRequests();
+    expect(pending).toHaveLength(1);
+    expect(pending[0]).toMatchObject({
+      fromInstanceId: 'peer-hijack',
+      fromName: 'Legit Peer',
+      fromHost: '10.0.0.30',
+      callbackToken: 'legit-callback',
+      keyAgreementPublicKey: 'legit-pub',
+    });
+  });
+
+  it('allows new request after previous one is resolved (#489)', () => {
+    const { trustStore } = makeTrustStore();
+
+    const first = trustStore.createPairRequest(
+      'peer-resolved',
+      'First Host',
+      '10.0.0.30',
+      7004,
+      'callback-1',
+      'pub-1',
+    );
+
+    // Admin rejects the first request
+    trustStore.rejectPairRequest(first.id);
+
+    // Now a request from a different host for the same instanceId is fine
+    const second = trustStore.createPairRequest(
+      'peer-resolved',
+      'Second Host',
+      '10.0.0.99',
+      8080,
+      'callback-2',
+      'pub-2',
+    );
+
+    expect(second.id).not.toBe(first.id);
+    expect(second.fromHost).toBe('10.0.0.99');
+    expect(trustStore.getPendingRequests()).toHaveLength(1);
   });
 
   it('approves and rejects pair requests with strict pending-state checks', () => {

--- a/src/discovery/trust-store.ts
+++ b/src/discovery/trust-store.ts
@@ -70,6 +70,20 @@ function mapRowToPairRequest(row: PairRequestRow): PairRequest {
   };
 }
 
+/** Thrown when a pair request update is rejected due to host mismatch. */
+export class PairRequestHostMismatchError extends Error {
+  constructor(
+    public readonly fromInstanceId: string,
+    public readonly existingHost: string,
+    public readonly newHost: string,
+  ) {
+    super(
+      `Pair request from ${newHost} rejected: pending request for instance ${fromInstanceId} is bound to ${existingHost}`,
+    );
+    this.name = 'PairRequestHostMismatchError';
+  }
+}
+
 export class TrustStore {
   constructor(private db: Database) {}
 
@@ -218,14 +232,32 @@ export class TrustStore {
       .get(fromInstanceId) as PairRequestRow | null;
 
     if (existing) {
-      // Update existing request
+      // Bind pending requests to their original source host to prevent
+      // a LAN attacker from overwriting a legitimate request with
+      // attacker-controlled callback details (see issue #489).
+      if (existing.from_host !== fromHost) {
+        logger.warn(
+          {
+            fromInstanceId,
+            existingHost: existing.from_host,
+            newHost: fromHost,
+          },
+          'Rejected pair request update from different host',
+        );
+        throw new PairRequestHostMismatchError(
+          fromInstanceId,
+          existing.from_host,
+          fromHost,
+        );
+      }
+
+      // Same host — allow refresh (e.g. new keypair after restart)
       this.db
         .prepare(
-          'UPDATE pair_requests SET from_name = ?, from_host = ?, from_port = ?, callback_token = ?, key_agreement_public_key = ?, created_at = ? WHERE id = ?',
+          'UPDATE pair_requests SET from_name = ?, from_port = ?, callback_token = ?, key_agreement_public_key = ?, created_at = ? WHERE id = ?',
         )
         .run(
           fromName,
-          fromHost,
           fromPort,
           callbackToken,
           keyAgreementPublicKey ?? null,


### PR DESCRIPTION
## Summary

Fixes #489 — a P1 security vulnerability where a LAN attacker could hijack discovery pairing requests.

**The vulnerability**: `createPairRequest()` deduplicates pending requests by `from_instance_id` alone and blindly overwrites all fields (callback token, public key, host, port). An attacker on the same LAN could submit a forged request with a victim's `instanceId` but attacker-controlled callback details, overwriting the legitimate pending request. When an admin approved the request via the Web UI, the shared secret was sent to the attacker's endpoint.

**The fix**: Pair requests are now bound to their originating source IP. When an existing pending request exists for the same `instanceId`:
- If the new request comes from the **same host** → allowed (supports legitimate key rotation after restart)
- If from a **different host** → rejected with `PairRequestHostMismatchError` (HTTP 409)
- Once a request is **resolved** (approved/rejected) → new requests from any host are accepted normally

### Changes

- `trust-store.ts`: Added `PairRequestHostMismatchError` class; `createPairRequest()` now validates host match before updating existing pending requests
- `routes.ts`: `handlePairRequest()` catches `PairRequestHostMismatchError` and returns 409 Conflict
- `index.ts`: Export the new error class

### Test coverage

- 3 new trust-store tests: host-binding enforcement, rejection from different host, post-resolution new request
- 1 new route handler test: verifies 409 response on host mismatch
- All 1629 existing tests pass, `tsc --noEmit` clean

## Test plan

- [x] `bun test` — 1629 pass, 0 fail
- [x] `tsc --noEmit` — clean
- [ ] Verify legitimate pair requests from the same IP can still refresh
- [ ] Verify attacker from different IP gets 409 when overwriting pending request
- [ ] Verify new requests work after previous request is rejected/approved

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Pairing requests are now strictly bound to their originating host: attempts to update an existing pending pairing from a different host are rejected with an HTTP 409 and an error indicating the request is already bound to a different host. Resolved/rejected requests can be recreated from another host. Tests added to verify these behaviors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->