### PR TITLE
test: cover request body size enforcement

### DIFF
--- a/src/request-body.test.ts
+++ b/src/request-body.test.ts
@@ -1,0 +1,169 @@
+import { describe, expect, it } from 'bun:test';
+
+import {
+  readJsonBody,
+  readRequestBody,
+  RequestBodyTooLargeError,
+} from './request-body.js';
+
+type ReadResult = ReadableStreamReadResult<Uint8Array>;
+
+function createMockRequest(options: {
+  contentLength?: string | null;
+  body?: { getReader: () => ReadableStreamDefaultReader<Uint8Array> } | null;
+}): Request {
+  const headers = new Headers();
+  if (options.contentLength !== undefined && options.contentLength !== null) {
+    headers.set('content-length', options.contentLength);
+  }
+
+  return {
+    headers,
+    body:
+      (options.body as unknown as Request['body']) === undefined
+        ? null
+        : (options.body as unknown as Request['body']),
+  } as Request;
+}
+
+function createMockReader(options: {
+  reads: ReadResult[];
+  onCancel?: () => void | Promise<void>;
+  onReleaseLock?: () => void;
+}): ReadableStreamDefaultReader<Uint8Array> {
+  const queue = [...options.reads];
+
+  return {
+    read: async () => queue.shift() ?? { done: true, value: undefined },
+    cancel: async () => {
+      await options.onCancel?.();
+    },
+    releaseLock: () => {
+      options.onReleaseLock?.();
+    },
+  } as unknown as ReadableStreamDefaultReader<Uint8Array>;
+}
+
+describe('request-body helpers', () => {
+  it('returns an empty string when the request has no body', async () => {
+    const req = createMockRequest({ body: null });
+
+    await expect(readRequestBody(req, 32)).resolves.toBe('');
+  });
+
+  it('rejects oversized content-length headers before reading the stream', async () => {
+    let getReaderCalled = false;
+    const req = createMockRequest({
+      contentLength: '33',
+      body: {
+        getReader() {
+          getReaderCalled = true;
+          throw new Error('should not read body');
+        },
+      },
+    });
+
+    await expect(readRequestBody(req, 32)).rejects.toEqual(
+      expect.objectContaining({
+        limitBytes: 32,
+        message: 'Request body exceeded 32 bytes',
+      }),
+    );
+    expect(getReaderCalled).toBe(false);
+  });
+
+  it('treats malformed content-length headers as unknown and reads the body', async () => {
+    const reader = createMockReader({
+      reads: [
+        { done: false, value: new TextEncoder().encode('ok') },
+        { done: true, value: undefined },
+      ],
+    });
+    const req = createMockRequest({
+      contentLength: '-5',
+      body: { getReader: () => reader },
+    });
+
+    await expect(readRequestBody(req, 32)).resolves.toBe('ok');
+  });
+
+  it('concatenates streamed chunks and ignores empty reads', async () => {
+    let released = false;
+    const reader = createMockReader({
+      reads: [
+        { done: false, value: new TextEncoder().encode('{"ok":') },
+        { done: false, value: undefined },
+        { done: false, value: new TextEncoder().encode('true}') },
+        { done: true, value: undefined },
+      ],
+      onReleaseLock: () => {
+        released = true;
+      },
+    });
+    const req = createMockRequest({ body: { getReader: () => reader } });
+
+    await expect(readRequestBody(req, 64)).resolves.toBe('{"ok":true}');
+    expect(released).toBe(true);
+  });
+
+  it('cancels oversized streams, releases the lock, and throws a typed error', async () => {
+    let cancelled = false;
+    let released = false;
+    const reader = createMockReader({
+      reads: [
+        { done: false, value: new TextEncoder().encode('hello') },
+        { done: false, value: new TextEncoder().encode('!') },
+      ],
+      onCancel: () => {
+        cancelled = true;
+      },
+      onReleaseLock: () => {
+        released = true;
+      },
+    });
+    const req = createMockRequest({ body: { getReader: () => reader } });
+
+    await expect(readRequestBody(req, 5)).rejects.toBeInstanceOf(
+      RequestBodyTooLargeError,
+    );
+    expect(cancelled).toBe(true);
+    expect(released).toBe(true);
+  });
+
+  it('still throws the size-limit error when reader cancellation fails', async () => {
+    let released = false;
+    const reader = createMockReader({
+      reads: [{ done: false, value: new TextEncoder().encode('toolarge') }],
+      onCancel: async () => {
+        throw new Error('cancel failed');
+      },
+      onReleaseLock: () => {
+        released = true;
+      },
+    });
+    const req = createMockRequest({ body: { getReader: () => reader } });
+
+    await expect(readRequestBody(req, 4)).rejects.toEqual(
+      expect.objectContaining({
+        limitBytes: 4,
+        message: 'Request body exceeded 4 bytes',
+      }),
+    );
+    expect(released).toBe(true);
+  });
+
+  it('parses JSON after reading the complete request body', async () => {
+    const reader = createMockReader({
+      reads: [
+        { done: false, value: new TextEncoder().encode('{"count":') },
+        { done: false, value: new TextEncoder().encode('2}') },
+        { done: true, value: undefined },
+      ],
+    });
+    const req = createMockRequest({ body: { getReader: () => reader } });
+
+    await expect(readJsonBody<{ count: number }>(req, 32)).resolves.toEqual({
+      count: 2,
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- add deterministic unit tests for `src/request-body.ts`, covering empty bodies, malformed `content-length`, chunk concatenation, and JSON parsing
- exercise oversized body enforcement with monkey-patched readers so cancellation, lock release, and cancellation-failure paths stay covered
- raise the suite from 1626 tests across 90 files to 1633 tests across 91 files

## Testing
- `bun test src/request-body.test.ts`
- `bun test`

## Coverage Notes
- Newly covered: `src/request-body.ts`
- Remaining sibling-test gaps: `src/discovery/index.ts`, `src/index.ts`, `src/ipc.ts`, `src/migrations.ts`, `src/simtest/index.ts`, `src/web/index.ts`, `src/web/types.ts`, `src/whatsapp-auth.ts`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added comprehensive test coverage for request-body handling, validating scenarios including body validation, size limits, stream processing, and JSON parsing.

**Note:** This release includes internal test improvements with no user-visible feature changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->