### PR TITLE
test(ipc): cover watcher quarantine and subscription paths

### DIFF
--- a/src/ipc-messages.test.ts
+++ b/src/ipc-messages.test.ts
@@ -253,6 +253,50 @@ describe('processMessageIpc: react_to_message', () => {
     });
   });
 
+  it('writes an error response when addReaction is not supported', async () => {
+    deps.findChannel = () => ({}) as Channel;
+
+    const result = await processMsg({
+      type: 'react_to_message',
+      chatJid: 'other@g.us',
+      messageId: 'msg-334',
+      emoji: '👍',
+      requestId: 'req-334',
+    });
+
+    expect(result).toEqual({ action: 'handled' });
+    expect(readResponse('main', 'req-334')).toEqual({
+      type: 'react_to_message_response',
+      requestId: 'req-334',
+      ok: false,
+      error: 'Channel does not support adding reactions.',
+    });
+  });
+
+  it('writes an error response when removeReaction is not supported', async () => {
+    deps.findChannel = () =>
+      ({
+        addReaction: async () => {},
+      }) as Partial<Channel> as Channel;
+
+    const result = await processMsg({
+      type: 'react_to_message',
+      chatJid: 'other@g.us',
+      messageId: 'msg-335',
+      emoji: '👍',
+      remove: true,
+      requestId: 'req-335',
+    });
+
+    expect(result).toEqual({ action: 'handled' });
+    expect(readResponse('main', 'req-335')).toEqual({
+      type: 'react_to_message_response',
+      requestId: 'req-335',
+      ok: false,
+      error: 'Channel does not support removing reactions.',
+    });
+  });
+
   it('blocks when reaction requestId sanitizes to empty string', async () => {
     const result = await processMsg({
       type: 'react_to_message',

--- a/src/ipc-processing.test.ts
+++ b/src/ipc-processing.test.ts
@@ -58,6 +58,13 @@ let sentMessages: Array<{ jid: string; text: string }>;
 let notifiedGroups: Array<{ jid: string; text: string }>;
 let syncCalled: boolean;
 let taskSnapshots: Array<{ groupFolder: string; isMain: boolean }>;
+let groupSnapshots: Array<{
+  groupFolder: string;
+  isMain: boolean;
+  availableCount: number;
+  registeredJids: string[];
+}>;
+let subscriptionChangedCalls: number;
 let deps: IpcDeps;
 
 beforeEach(() => {
@@ -73,6 +80,8 @@ beforeEach(() => {
   notifiedGroups = [];
   syncCalled = false;
   taskSnapshots = [];
+  groupSnapshots = [];
+  subscriptionChangedCalls = 0;
 
   setRegisteredGroup('main@g.us', MAIN_GROUP);
   setRegisteredGroup('other@g.us', OTHER_GROUP);
@@ -99,9 +108,24 @@ beforeEach(() => {
       syncCalled = true;
     },
     getAvailableGroups: () => [],
-    writeGroupsSnapshot: () => {},
+    writeGroupsSnapshot: (
+      groupFolder,
+      isMain,
+      availableGroups,
+      registeredJids,
+    ) => {
+      groupSnapshots.push({
+        groupFolder,
+        isMain,
+        availableCount: availableGroups.length,
+        registeredJids: Array.from(registeredJids).sort(),
+      });
+    },
     writeTasksSnapshot: (groupFolder, isMain) => {
       taskSnapshots.push({ groupFolder, isMain });
+    },
+    onSubscriptionChanged: () => {
+      subscriptionChangedCalls += 1;
     },
   };
 });
@@ -137,6 +161,14 @@ describe('processTaskIpc: refresh_groups', () => {
     await processTaskIpc({ type: 'refresh_groups' }, 'main', true, deps);
 
     expect(syncCalled).toBe(true);
+    expect(groupSnapshots).toEqual([
+      {
+        groupFolder: 'main',
+        isMain: true,
+        availableCount: 0,
+        registeredJids: ['main@g.us', 'other@g.us', 'third@g.us'],
+      },
+    ]);
   });
 
   it('non-main group cannot trigger refresh', async () => {
@@ -148,6 +180,27 @@ describe('processTaskIpc: refresh_groups', () => {
     );
 
     expect(syncCalled).toBe(false);
+    expect(groupSnapshots).toHaveLength(0);
+  });
+});
+
+describe('processTaskIpc: schedule_task invalid config', () => {
+  it('rejects invalid schedule values that cannot compute next_run', async () => {
+    await processTaskIpc(
+      {
+        type: 'schedule_task',
+        prompt: 'Broken schedule',
+        schedule_type: 'interval',
+        schedule_value: 'not-a-number',
+        targetJid: 'main@g.us',
+      },
+      'main',
+      true,
+      deps,
+    );
+
+    expect(getAllTasks()).toHaveLength(0);
+    expect(taskSnapshots).toHaveLength(0);
   });
 });
 
@@ -270,6 +323,28 @@ describe('processTaskIpc: register_group with discord', () => {
 });
 
 describe('processTaskIpc: channel subscriptions', () => {
+  it('subscribe_channel uses target defaults and notifies subscription observers', async () => {
+    await processTaskIpc(
+      {
+        type: 'subscribe_channel',
+        channel_jid: 'dc:555',
+        target_agent: 'third-group',
+      },
+      'main',
+      true,
+      deps,
+    );
+
+    const subs = getSubscriptionsForChannel('dc:555');
+    expect(subs).toHaveLength(1);
+    expect(subs[0]).toMatchObject({
+      agentId: 'third-group',
+      trigger: '@Andy',
+      requiresTrigger: true,
+    });
+    expect(subscriptionChangedCalls).toBe(1);
+  });
+
   it('subscribe_channel adds a second agent to same channel', async () => {
     setChannelSubscription({
       channelJid: 'dc:777',
@@ -295,6 +370,91 @@ describe('processTaskIpc: channel subscriptions', () => {
       'other-group',
       'third-group',
     ]);
+    expect(subscriptionChangedCalls).toBe(1);
+  });
+
+  it('subscribe_channel preserves primary metadata on upsert', async () => {
+    setChannelSubscription({
+      channelJid: 'dc:778',
+      agentId: 'third-group',
+      trigger: '@Legacy',
+      requiresTrigger: false,
+      priority: 100,
+      isPrimary: true,
+      createdAt: '2024-02-02T00:00:00.000Z',
+    });
+
+    await processTaskIpc(
+      {
+        type: 'subscribe_channel',
+        channel_jid: 'dc:778',
+        target_agent: 'third-group',
+        trigger: '@NewThird',
+        discord_bot_id: 'OPENCODE',
+        discord_guild_id: '123456789012345678',
+      },
+      'main',
+      true,
+      deps,
+    );
+
+    const [sub] = getSubscriptionsForChannel('dc:778');
+    expect(sub).toMatchObject({
+      agentId: 'third-group',
+      trigger: '@NewThird',
+      requiresTrigger: true,
+      isPrimary: true,
+      discordBotId: 'OPENCODE',
+      discordGuildId: '123456789012345678',
+      createdAt: '2024-02-02T00:00:00.000Z',
+    });
+  });
+
+  it('non-main group cannot subscribe channels', async () => {
+    await processTaskIpc(
+      {
+        type: 'subscribe_channel',
+        channel_jid: 'dc:779',
+        target_agent: 'third-group',
+      },
+      'other-group',
+      false,
+      deps,
+    );
+
+    expect(getSubscriptionsForChannel('dc:779')).toHaveLength(0);
+    expect(subscriptionChangedCalls).toBe(0);
+  });
+
+  it('subscribe_channel ignores missing required fields', async () => {
+    await processTaskIpc(
+      {
+        type: 'subscribe_channel',
+        channel_jid: 'dc:780',
+      } as any,
+      'main',
+      true,
+      deps,
+    );
+
+    expect(getSubscriptionsForChannel('dc:780')).toHaveLength(0);
+    expect(subscriptionChangedCalls).toBe(0);
+  });
+
+  it('subscribe_channel ignores unknown target agents', async () => {
+    await processTaskIpc(
+      {
+        type: 'subscribe_channel',
+        channel_jid: 'dc:781',
+        target_agent: 'missing-agent',
+      },
+      'main',
+      true,
+      deps,
+    );
+
+    expect(getSubscriptionsForChannel('dc:781')).toHaveLength(0);
+    expect(subscriptionChangedCalls).toBe(0);
   });
 
   it('unsubscribe_channel removes targeted subscription', async () => {
@@ -329,6 +489,58 @@ describe('processTaskIpc: channel subscriptions', () => {
     const subs = getSubscriptionsForChannel('dc:888');
     expect(subs).toHaveLength(1);
     expect(subs[0].agentId).toBe('other-group');
+    expect(subscriptionChangedCalls).toBe(1);
+  });
+
+  it('non-main group cannot unsubscribe channels', async () => {
+    setChannelSubscription({
+      channelJid: 'dc:889',
+      agentId: 'third-group',
+      trigger: '@Third',
+      requiresTrigger: true,
+      priority: 100,
+      isPrimary: false,
+      createdAt: '2024-01-01T00:00:00.000Z',
+    });
+
+    await processTaskIpc(
+      {
+        type: 'unsubscribe_channel',
+        channel_jid: 'dc:889',
+        target_agent: 'third-group',
+      },
+      'other-group',
+      false,
+      deps,
+    );
+
+    expect(getSubscriptionsForChannel('dc:889')).toHaveLength(1);
+    expect(subscriptionChangedCalls).toBe(0);
+  });
+
+  it('unsubscribe_channel ignores missing required fields', async () => {
+    setChannelSubscription({
+      channelJid: 'dc:890',
+      agentId: 'third-group',
+      trigger: '@Third',
+      requiresTrigger: true,
+      priority: 100,
+      isPrimary: false,
+      createdAt: '2024-01-01T00:00:00.000Z',
+    });
+
+    await processTaskIpc(
+      {
+        type: 'unsubscribe_channel',
+        channel_jid: 'dc:890',
+      } as any,
+      'main',
+      true,
+      deps,
+    );
+
+    expect(getSubscriptionsForChannel('dc:890')).toHaveLength(1);
+    expect(subscriptionChangedCalls).toBe(0);
   });
 });
 

--- a/src/ipc-watcher.test.ts
+++ b/src/ipc-watcher.test.ts
@@ -232,7 +232,6 @@ describe('startIpcWatcher', () => {
 
     startIpcWatcher(deps);
     expect(scheduledDelays).toEqual([IPC_POLL_INTERVAL]);
-
     fs.rmSync(
       path.join(IPC_BASE_DIR, 'main', 'messages', malformedMessageFile),
       {

--- a/src/ipc-watcher.test.ts
+++ b/src/ipc-watcher.test.ts
@@ -17,6 +17,8 @@ const MAIN_GROUP: RegisteredGroup = {
 
 const flushMicrotasks = async () => {
   await Promise.resolve();
+  await Promise.resolve();
+  await Promise.resolve();
 };
 
 describe('startIpcWatcher', () => {
@@ -51,6 +53,9 @@ describe('startIpcWatcher', () => {
       'errors',
       malformedRuntimeFolder,
     );
+    const malformedMessageFile = `malformed-${id}.json`;
+    const malformedTaskFile = `malformed-task-${id}.json`;
+    const failingTaskFile = `failing-task-${id}.json`;
 
     fs.rmSync(path.join(IPC_BASE_DIR, staleRuntimeFolder), {
       recursive: true,
@@ -74,6 +79,12 @@ describe('startIpcWatcher', () => {
       recursive: true,
     });
     fs.mkdirSync(path.join(IPC_BASE_DIR, malformedRuntimeFolder, 'messages'), {
+      recursive: true,
+    });
+    fs.mkdirSync(path.join(IPC_BASE_DIR, 'main', 'messages'), {
+      recursive: true,
+    });
+    fs.mkdirSync(path.join(IPC_BASE_DIR, 'main', 'tasks'), {
       recursive: true,
     });
 
@@ -105,6 +116,18 @@ describe('startIpcWatcher', () => {
         chatJid: 'main@g.us',
         text: 'malformed runtime should never be processed',
       }),
+    );
+    fs.writeFileSync(
+      path.join(IPC_BASE_DIR, 'main', 'messages', malformedMessageFile),
+      '{"type":',
+    );
+    fs.writeFileSync(
+      path.join(IPC_BASE_DIR, 'main', 'tasks', malformedTaskFile),
+      '{"type":',
+    );
+    fs.writeFileSync(
+      path.join(IPC_BASE_DIR, 'main', 'tasks', failingTaskFile),
+      JSON.stringify({ type: 'refresh_groups' }),
     );
 
     const otherGroup: RegisteredGroup = {
@@ -152,7 +175,9 @@ describe('startIpcWatcher', () => {
       registeredGroups: () => groups,
       registerGroup: () => {},
       updateGroup: () => {},
-      syncGroupMetadata: async () => {},
+      syncGroupMetadata: async () => {
+        throw new Error('sync exploded');
+      },
       getAvailableGroups: () => [],
       writeGroupsSnapshot: () => {},
       activeRuntimeFolders: () => new Set<string>(),
@@ -186,9 +211,48 @@ describe('startIpcWatcher', () => {
     );
     expect(fs.existsSync(rogueErrorDir)).toBe(true);
     expect(fs.existsSync(malformedRuntimeErrorDir)).toBe(true);
+    expect(fs.existsSync(path.join(IPC_BASE_DIR, rogueFolder))).toBe(false);
+    const quarantinedFiles = fs.readdirSync(path.join(IPC_BASE_DIR, 'errors'));
+    expect(
+      quarantinedFiles.some(
+        (file) => file.includes(`main-`) && file.endsWith(malformedMessageFile),
+      ),
+    ).toBe(true);
+    expect(
+      quarantinedFiles.some(
+        (file) => file.includes(`main-`) && file.endsWith(malformedTaskFile),
+      ),
+    ).toBe(true);
+    expect(
+      quarantinedFiles.some(
+        (file) => file.includes(`main-`) && file.endsWith(failingTaskFile),
+      ),
+    ).toBe(true);
     expect(scheduledDelays).toEqual([IPC_POLL_INTERVAL]);
 
     startIpcWatcher(deps);
     expect(scheduledDelays).toEqual([IPC_POLL_INTERVAL]);
+
+    fs.rmSync(
+      path.join(IPC_BASE_DIR, 'main', 'messages', malformedMessageFile),
+      {
+        force: true,
+      },
+    );
+    fs.rmSync(path.join(IPC_BASE_DIR, 'main', 'tasks', malformedTaskFile), {
+      force: true,
+    });
+    fs.rmSync(path.join(IPC_BASE_DIR, 'main', 'tasks', failingTaskFile), {
+      force: true,
+    });
+    for (const file of quarantinedFiles) {
+      if (
+        file.endsWith(malformedMessageFile) ||
+        file.endsWith(malformedTaskFile) ||
+        file.endsWith(failingTaskFile)
+      ) {
+        fs.rmSync(path.join(IPC_BASE_DIR, 'errors', file), { force: true });
+      }
+    }
   });
 });


### PR DESCRIPTION
## Summary
- add focused `src/ipc.ts` regression coverage for malformed watcher inputs, quarantined IPC files, and failing task processing paths
- cover IPC channel subscription and refresh edge cases, including observer notifications, missing-field rejection, and invalid schedule handling
- cover unsupported reaction add/remove flows so response-file behavior stays deterministic across channel adapters

## Verification
- `bun test src/ipc-messages.test.ts src/ipc-processing.test.ts src/ipc-watcher.test.ts`
- `bun test`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Enhanced test coverage for message reaction handling error scenarios.
  * Expanded test suite for group subscription and scheduling functionality.
  * Improved error handling and file quarantine testing for IPC watcher processes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->