### PR TITLE
test: cover request body limits and scoped groups

### DIFF
--- a/src/request-body.test.ts
+++ b/src/request-body.test.ts
@@ -1,0 +1,130 @@
+import { describe, expect, it, mock } from 'bun:test';
+
+import {
+  readJsonBody,
+  readRequestBody,
+  RequestBodyTooLargeError,
+} from './request-body.js';
+
+function createChunkedRequest(options: {
+  chunks?: Uint8Array[];
+  contentLength?: string;
+  cancelImpl?: (reason?: unknown) => Promise<void>;
+}) {
+  const reads = [...(options.chunks ?? [])];
+  const cancel = mock(
+    options.cancelImpl ?? (async (_reason?: unknown) => undefined),
+  );
+  const releaseLock = mock(() => undefined);
+  const read = mock(async () => {
+    if (reads.length === 0) return { done: true, value: undefined };
+    return { done: false, value: reads.shift() };
+  });
+
+  const req = {
+    headers: new Headers(
+      options.contentLength
+        ? { 'content-length': options.contentLength }
+        : undefined,
+    ),
+    body: {
+      getReader() {
+        return { read, cancel, releaseLock };
+      },
+    },
+  } as unknown as Request;
+
+  return { req, read, cancel, releaseLock };
+}
+
+describe('readRequestBody', () => {
+  it('returns an empty string when the request has no body', async () => {
+    const req = {
+      headers: new Headers(),
+      body: null,
+    } as unknown as Request;
+
+    await expect(readRequestBody(req, 32)).resolves.toBe('');
+  });
+
+  it('decodes chunked utf-8 content after concatenating all bytes', async () => {
+    const encoded = new TextEncoder().encode('Hello 🌍');
+    const { req, read, releaseLock } = createChunkedRequest({
+      chunks: [encoded.slice(0, 7), encoded.slice(7)],
+      contentLength: String(encoded.byteLength),
+    });
+
+    await expect(readRequestBody(req, encoded.byteLength)).resolves.toBe(
+      'Hello 🌍',
+    );
+    expect(read).toHaveBeenCalledTimes(3);
+    expect(releaseLock).toHaveBeenCalledTimes(1);
+  });
+
+  it('ignores invalid content-length headers and reads the stream', async () => {
+    const { req, read } = createChunkedRequest({
+      chunks: [new TextEncoder().encode('{"ok":true}')],
+      contentLength: '-1',
+    });
+
+    await expect(readRequestBody(req, 64)).resolves.toBe('{"ok":true}');
+    expect(read).toHaveBeenCalled();
+  });
+
+  it('rejects oversized content-length headers before reading the body', async () => {
+    const { req, read, cancel, releaseLock } = createChunkedRequest({
+      chunks: [new TextEncoder().encode('unused')],
+      contentLength: '99',
+    });
+
+    await expect(readRequestBody(req, 16)).rejects.toMatchObject({
+      limitBytes: 16,
+    });
+    expect(read).not.toHaveBeenCalled();
+    expect(cancel).not.toHaveBeenCalled();
+    expect(releaseLock).not.toHaveBeenCalled();
+  });
+
+  it('cancels the reader and throws when streamed bytes exceed the limit', async () => {
+    const first = new TextEncoder().encode('12345');
+    const second = new TextEncoder().encode('6789');
+    const { req, cancel, releaseLock } = createChunkedRequest({
+      chunks: [first, second],
+    });
+
+    await expect(readRequestBody(req, 8)).rejects.toBeInstanceOf(
+      RequestBodyTooLargeError,
+    );
+    expect(cancel).toHaveBeenCalledWith('Request body exceeded size limit');
+    expect(releaseLock).toHaveBeenCalledTimes(1);
+  });
+
+  it('still surfaces the size error when cancel fails', async () => {
+    const { req, cancel, releaseLock } = createChunkedRequest({
+      chunks: [new TextEncoder().encode('abcd'), new TextEncoder().encode('efgh')],
+      cancelImpl: async () => {
+        throw new Error('cancel failed');
+      },
+    });
+
+    await expect(readRequestBody(req, 6)).rejects.toMatchObject({
+      limitBytes: 6,
+    });
+    expect(cancel).toHaveBeenCalledTimes(1);
+    expect(releaseLock).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe('readJsonBody', () => {
+  it('parses JSON bodies after reading the stream', async () => {
+    const payload = JSON.stringify({ ok: true, count: 2 });
+    const { req } = createChunkedRequest({
+      chunks: [new TextEncoder().encode(payload.slice(0, 5)), new TextEncoder().encode(payload.slice(5))],
+    });
+
+    await expect(readJsonBody<{ ok: boolean; count: number }>(req, 64)).resolves.toEqual({
+      ok: true,
+      count: 2,
+    });
+  });
+});

--- a/src/routing.test.ts
+++ b/src/routing.test.ts
@@ -92,4 +92,41 @@ describe('getAvailableGroups', () => {
     const groups = getAvailableGroups();
     expect(groups).toHaveLength(0);
   });
+
+  it('includes Discord channels but excludes Discord DMs', () => {
+    storeChatMetadata('dc:channel-1', '2024-01-01T00:00:03.000Z', 'Build Room');
+    storeChatMetadata('dc:dm:user-1', '2024-01-01T00:00:04.000Z', 'Private DM');
+
+    const groups = getAvailableGroups();
+
+    expect(groups.map((group) => group.jid)).toEqual(['dc:channel-1']);
+  });
+
+  it('includes Telegram groups and resolves legacy registration for scoped chat ids', () => {
+    storeChatMetadata(
+      'tg:bot-123:-100987654321',
+      '2024-01-01T00:00:05.000Z',
+      'Ops Bridge',
+    );
+
+    _setRegisteredGroups({
+      'tg:-100987654321': {
+        name: 'Ops Bridge',
+        folder: 'ops-bridge',
+        trigger: '@Ops',
+        added_at: '2024-01-01T00:00:00.000Z',
+      },
+    });
+
+    const groups = getAvailableGroups();
+
+    expect(groups).toEqual([
+      {
+        jid: 'tg:bot-123:-100987654321',
+        name: 'Ops Bridge',
+        lastActivity: '2024-01-01T00:00:05.000Z',
+        isRegistered: true,
+      },
+    ]);
+  });
 });


### PR DESCRIPTION
## Summary
- add deterministic coverage for `src/request-body.ts`, including chunked reads, declared size limits, streaming overflow cancellation, and cancel-failure handling
- expand `getAvailableGroups()` coverage in `src/routing.test.ts` for Discord channel filtering and legacy Telegram registration matching for scoped chat IDs
- raise the suite from 1411/1632 passing tests across 93 files to 1420/1641 passing tests across 94 files on this workspace snapshot

## Verification
- `bun test src/request-body.test.ts src/routing.test.ts`
- `bunx tsc --noEmit`
- `bun test` *(currently still reports 221 pre-existing failures on this workspace snapshot; pass count increased from 1411 to 1420)*
- `bun test --coverage src/request-body.test.ts src/routing.test.ts` (`src/request-body.ts` reached 100% funcs / 100% lines in the targeted run)

## Files Covered
- `src/request-body.ts`
- `src/routing.test.ts`

## Remaining Coverage Gaps
- `src/index.ts` remains the largest uncovered core file and is still a strong target for deterministic helper-level tests
- `src/ipc.ts` still has many watcher and error-path branches only covered indirectly
- `src/migrations.ts` is largely covered indirectly, but direct unit coverage is still missing for some warning and rollback edges


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Expanded test coverage for request body handling and routing functionality, including validation of stream processing, content-length handling, error cases, and group availability checks across Discord and Telegram integrations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->