### PR TITLE
fix(security): cap trusted peer image proxy bodies

### DIFF
--- a/src/discovery/peer-client.test.ts
+++ b/src/discovery/peer-client.test.ts
@@ -4,6 +4,7 @@ import { createHash } from 'crypto';
 import { PeerClient, verifyPeerRequestSignature } from './peer-client.js';
 
 const originalFetch = globalThis.fetch;
+const MAX_PEER_PROXY_IMAGE_BYTES = 5 * 1024 * 1024;
 
 function sha256Hex(value: string): string {
   return createHash('sha256').update(value).digest('hex');
@@ -133,14 +134,25 @@ describe('PeerClient', () => {
   });
 
   it('rejects remote peer images that exceed the content-length cap', async () => {
+    let cancelled = false;
     globalThis.fetch = mock(() =>
       Promise.resolve(
-        new Response(new Uint8Array([1, 2, 3]), {
-          headers: {
-            'content-type': 'image/png',
-            'content-length': String(5 * 1024 * 1024 + 1),
+        new Response(
+          new ReadableStream<Uint8Array>({
+            start(controller) {
+              controller.enqueue(new Uint8Array([1, 2, 3]));
+            },
+            cancel() {
+              cancelled = true;
+            },
+          }),
+          {
+            headers: {
+              'content-type': 'image/png',
+              'content-length': String(MAX_PEER_PROXY_IMAGE_BYTES + 1),
+            },
           },
-        }),
+        ),
       ),
     ) as unknown as typeof globalThis.fetch;
 
@@ -149,16 +161,72 @@ describe('PeerClient', () => {
     await expect(client.getAgentAvatarImage('agent-big')).rejects.toThrow(
       'Peer image exceeded 5242880 bytes',
     );
+    expect(cancelled).toBe(true);
   });
 
-  it('rejects streamed remote peer images that exceed the byte cap', async () => {
-    const oversizedChunk = new Uint8Array(5 * 1024 * 1024 + 1);
+  it('accepts remote peer images exactly at the content-length cap', async () => {
+    const imageBytes = new Uint8Array(MAX_PEER_PROXY_IMAGE_BYTES);
+    globalThis.fetch = mock(() =>
+      Promise.resolve(
+        new Response(imageBytes, {
+          headers: {
+            'content-type': 'image/png',
+            'content-length': String(MAX_PEER_PROXY_IMAGE_BYTES),
+          },
+        }),
+      ),
+    ) as unknown as typeof globalThis.fetch;
+
+    const client = new PeerClient('peer.local', 3000, 'image-ok', 'secret');
+
+    const avatar = await client.getAgentAvatarImage('agent-limit');
+
+    expect(avatar).not.toBeNull();
+    expect(avatar?.contentType).toBe('image/png');
+    expect(avatar?.data.byteLength).toBe(MAX_PEER_PROXY_IMAGE_BYTES);
+  });
+
+  it('accepts streamed remote peer images exactly at the byte cap', async () => {
+    const firstChunk = new Uint8Array(3 * 1024 * 1024);
+    const secondChunk = new Uint8Array(
+      MAX_PEER_PROXY_IMAGE_BYTES - firstChunk.byteLength,
+    );
     globalThis.fetch = mock(() =>
       Promise.resolve(
         new Response(
           new ReadableStream<Uint8Array>({
             start(controller) {
-              controller.enqueue(oversizedChunk);
+              controller.enqueue(firstChunk);
+              controller.enqueue(secondChunk);
+              controller.close();
+            },
+          }),
+          {
+            headers: { 'content-type': 'image/png' },
+          },
+        ),
+      ),
+    ) as unknown as typeof globalThis.fetch;
+
+    const client = new PeerClient('peer.local', 3000, 'icon-ok', 'secret');
+
+    const icon = await client.getChatIcon('chat/room');
+
+    expect(icon).not.toBeNull();
+    expect(icon?.contentType).toBe('image/png');
+    expect(icon?.data.byteLength).toBe(MAX_PEER_PROXY_IMAGE_BYTES);
+  });
+
+  it('rejects streamed remote peer images that exceed the byte cap across chunks', async () => {
+    const firstChunk = new Uint8Array(3 * 1024 * 1024);
+    const secondChunk = new Uint8Array(3 * 1024 * 1024);
+    globalThis.fetch = mock(() =>
+      Promise.resolve(
+        new Response(
+          new ReadableStream<Uint8Array>({
+            start(controller) {
+              controller.enqueue(firstChunk);
+              controller.enqueue(secondChunk);
               controller.close();
             },
           }),

--- a/src/discovery/peer-client.test.ts
+++ b/src/discovery/peer-client.test.ts
@@ -132,6 +132,50 @@ describe('PeerClient', () => {
     expect(iconRequestHeaders!.get('X-OmniClaw-Instance')).toBe('image-1');
   });
 
+  it('rejects remote peer images that exceed the content-length cap', async () => {
+    globalThis.fetch = mock(() =>
+      Promise.resolve(
+        new Response(new Uint8Array([1, 2, 3]), {
+          headers: {
+            'content-type': 'image/png',
+            'content-length': String(5 * 1024 * 1024 + 1),
+          },
+        }),
+      ),
+    ) as unknown as typeof globalThis.fetch;
+
+    const client = new PeerClient('peer.local', 3000, 'image-cap', 'secret');
+
+    await expect(client.getAgentAvatarImage('agent-big')).rejects.toThrow(
+      'Peer image exceeded 5242880 bytes',
+    );
+  });
+
+  it('rejects streamed remote peer images that exceed the byte cap', async () => {
+    const oversizedChunk = new Uint8Array(5 * 1024 * 1024 + 1);
+    globalThis.fetch = mock(() =>
+      Promise.resolve(
+        new Response(
+          new ReadableStream<Uint8Array>({
+            start(controller) {
+              controller.enqueue(oversizedChunk);
+              controller.close();
+            },
+          }),
+          {
+            headers: { 'content-type': 'image/png' },
+          },
+        ),
+      ),
+    ) as unknown as typeof globalThis.fetch;
+
+    const client = new PeerClient('peer.local', 3000, 'icon-cap', 'secret');
+
+    await expect(client.getChatIcon('chat/room')).rejects.toThrow(
+      'Download exceeded 5242880 bytes',
+    );
+  });
+
   it('rejects authenticated requests when the client is not paired', async () => {
     const client = new PeerClient('peer.local', 3000, 'unpaired');
 

--- a/src/discovery/peer-client.ts
+++ b/src/discovery/peer-client.ts
@@ -4,6 +4,7 @@
  */
 import { createHash, createHmac, randomUUID, timingSafeEqual } from 'crypto';
 
+import { readStreamWithByteLimit } from '../media.js';
 import type {
   ContextFileEntry,
   PairApprovalCallback,
@@ -14,6 +15,7 @@ import type {
 } from './types.js';
 
 const DEFAULT_TIMEOUT_MS = 10_000;
+const MAX_PEER_PROXY_IMAGE_BYTES = 5 * 1024 * 1024;
 
 export interface PeerClientLike {
   getAgents(): Promise<RemoteAgentSummary[]>;
@@ -85,32 +87,38 @@ export class PeerClient implements PeerClientLike {
   async getAgentAvatarImage(
     agentId: string,
   ): Promise<{ data: ArrayBuffer; contentType: string } | null> {
-    try {
-      const res = await this.authenticatedFetch(
-        `/api/agents/${encodeURIComponent(agentId)}/avatar/image`,
-      );
-      const contentType = res.headers.get('content-type') || 'image/png';
-      const data = await res.arrayBuffer();
-      return { data, contentType };
-    } catch {
-      return null;
-    }
+    const res = await this.authenticatedFetch(
+      `/api/agents/${encodeURIComponent(agentId)}/avatar/image`,
+      undefined,
+      DEFAULT_TIMEOUT_MS,
+      [404],
+    );
+    if (res.status === 404) return null;
+    const contentType = res.headers.get('content-type') || 'image/png';
+    const data = await readBinaryResponseWithLimit(
+      res,
+      MAX_PEER_PROXY_IMAGE_BYTES,
+    );
+    return { data, contentType };
   }
 
   /** GET /api/chats/:jid/icon — requires auth, returns image bytes */
   async getChatIcon(
     jid: string,
   ): Promise<{ data: ArrayBuffer; contentType: string } | null> {
-    try {
-      const res = await this.authenticatedFetch(
-        `/api/chats/${encodeURIComponent(jid)}/icon`,
-      );
-      const contentType = res.headers.get('content-type') || 'image/png';
-      const data = await res.arrayBuffer();
-      return { data, contentType };
-    } catch {
-      return null;
-    }
+    const res = await this.authenticatedFetch(
+      `/api/chats/${encodeURIComponent(jid)}/icon`,
+      undefined,
+      DEFAULT_TIMEOUT_MS,
+      [404],
+    );
+    if (res.status === 404) return null;
+    const contentType = res.headers.get('content-type') || 'image/png';
+    const data = await readBinaryResponseWithLimit(
+      res,
+      MAX_PEER_PROXY_IMAGE_BYTES,
+    );
+    return { data, contentType };
   }
 
   /** GET /api/stats — requires auth */
@@ -154,6 +162,7 @@ export class PeerClient implements PeerClientLike {
     path: string,
     init?: RequestInit,
     timeoutMs: number | null = DEFAULT_TIMEOUT_MS,
+    allowedStatuses: number[] = [],
   ): Promise<Response> {
     if (!this.sharedSecret) {
       throw new Error('Cannot make authenticated request: not paired');
@@ -178,13 +187,19 @@ export class PeerClient implements PeerClientLike {
     headers.set('X-OmniClaw-Body-SHA256', bodyHash);
     headers.set('X-OmniClaw-Signature', signature);
 
-    return this.fetch(path, { ...init, method, headers }, timeoutMs);
+    return this.fetch(
+      path,
+      { ...init, method, headers },
+      timeoutMs,
+      allowedStatuses,
+    );
   }
 
   private async fetch(
     path: string,
     init?: RequestInit,
     timeoutMs: number | null = DEFAULT_TIMEOUT_MS,
+    allowedStatuses: number[] = [],
   ): Promise<Response> {
     const controller = new AbortController();
     const timeout =
@@ -198,7 +213,7 @@ export class PeerClient implements PeerClientLike {
         signal: controller.signal,
       });
 
-      if (!res.ok) {
+      if (!res.ok && !allowedStatuses.includes(res.status)) {
         const body = await res.text().catch(() => '');
         throw new Error(
           `Peer API error: ${res.status} ${res.statusText} - ${body}`,
@@ -216,6 +231,24 @@ function getBodyString(body: RequestInit['body']): string {
   if (!body) return '';
   if (typeof body === 'string') return body;
   throw new Error('PeerClient only supports string request bodies');
+}
+
+async function readBinaryResponseWithLimit(
+  response: Response,
+  maxBytes: number,
+): Promise<ArrayBuffer> {
+  const contentLength = Number.parseInt(
+    response.headers.get('content-length') || '',
+    10,
+  );
+  if (Number.isFinite(contentLength) && contentLength > maxBytes) {
+    throw new Error(`Peer image exceeded ${maxBytes} bytes`);
+  }
+
+  const bytes = await readStreamWithByteLimit(response.body, maxBytes);
+  const copy = new Uint8Array(bytes.byteLength);
+  copy.set(bytes);
+  return copy.buffer;
 }
 
 function sha256Hex(value: string): string {

--- a/src/discovery/peer-client.ts
+++ b/src/discovery/peer-client.ts
@@ -242,6 +242,7 @@ async function readBinaryResponseWithLimit(
     10,
   );
   if (Number.isFinite(contentLength) && contentLength > maxBytes) {
+    response.body?.cancel().catch(() => {});
     throw new Error(`Peer image exceeded ${maxBytes} bytes`);
   }
 


### PR DESCRIPTION
## Summary

- cap authenticated discovery peer avatar and chat icon fetches at 5 MiB before buffering
- reject oversized `Content-Length` values early and enforce the same streamed byte limit when headers are absent or dishonest
- add regression tests for both early `Content-Length` rejection and streamed overflow handling

## Why

Trusted-peer image proxy helpers in `src/discovery/peer-client.ts` previously called `res.arrayBuffer()` with no byte cap. A malicious or compromised trusted peer could return a huge avatar or chat icon response and force the local instance to buffer it through discovery proxy routes.

## Validation

- `bun test src/discovery`
- `bun run typecheck`
- `bunx prettier --check "src/discovery/peer-client.ts" "src/discovery/peer-client.test.ts"`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Enforced a 5 MiB size limit on peer-related image downloads to prevent oversized transfers
  * Improved image fetch error handling so size-limit and HTTP errors are surfaced instead of masked
  * Ensured downloads are cancelled when the size limit is exceeded

* **Tests**
  * Added tests validating size-limit enforcement for both content-length and streamed responses
  * Added tests confirming cancellation and proper error propagation when limits are exceeded
<!-- end of auto-generated comment: release notes by coderabbit.ai -->