### PR TITLE
test: cover WhatsApp auth flow branches

### DIFF
--- a/src/whatsapp-auth.test.ts
+++ b/src/whatsapp-auth.test.ts
@@ -1,0 +1,272 @@
+import { beforeEach, describe, expect, it, mock } from 'bun:test';
+
+import { DisconnectReason } from '@whiskeysockets/baileys';
+
+import {
+  askQuestion,
+  authenticate,
+  connectSocket,
+  getCliOptions,
+} from './whatsapp-auth.js';
+
+type Handler = (...args: any[]) => void;
+
+function createSocketHarness(pairingCode = '123-456') {
+  const handlers: Record<string, Handler> = {};
+  const requestPairingCode = mock(async (_phoneNumber: string) => pairingCode);
+
+  return {
+    handlers,
+    socket: {
+      requestPairingCode,
+      ev: {
+        on: mock((event: string, handler: Handler) => {
+          handlers[event] = handler;
+        }),
+      },
+    },
+    requestPairingCode,
+  };
+}
+
+function createConnectDeps(overrides: Record<string, unknown> = {}) {
+  const timers: Array<() => void | Promise<void>> = [];
+  const socketHarness = createSocketHarness();
+  const saveCreds = mock(() => {});
+  const writeFileSync = mock(() => {});
+  const unlinkSync = mock(() => {});
+  const exit = mock((_code: number) => {});
+  const log = mock(() => {});
+  const error = mock(() => {});
+  const warn = mock(() => {});
+
+  const deps = {
+    fs: { writeFileSync, unlinkSync },
+    makeWASocket: mock((_config: unknown) => socketHarness.socket),
+    fetchLatestWaWebVersion: mock(async () => ({ version: [1, 2, 3] })),
+    makeCacheableSignalKeyStore: mock((_keys: unknown, _logger: unknown) => ({})),
+    useMultiFileAuthState: mock(async () => ({
+      state: { creds: { registered: false }, keys: {} },
+      saveCreds,
+    })),
+    qrcodeGenerate: mock((_qr: string, _options: { small: boolean }) => {}),
+    exit,
+    setTimeout: mock((handler: () => void | Promise<void>, _delay: number) => {
+      timers.push(handler);
+      return 1 as unknown as Timer;
+    }),
+    console: { log, error },
+    logger: { warn } as unknown,
+  };
+
+  return {
+    deps: { ...deps, ...overrides } as Parameters<typeof connectSocket>[3],
+    timers,
+    socketHarness,
+    writeFileSync,
+    unlinkSync,
+    exit,
+    log,
+    error,
+    warn,
+    saveCreds,
+  };
+}
+
+describe('getCliOptions', () => {
+  it('parses pairing mode and phone number flags', () => {
+    expect(
+      getCliOptions(['bun', 'src/whatsapp-auth.ts', '--pairing-code', '--phone', '14155551234']),
+    ).toEqual({
+      usePairingCode: true,
+      phoneArg: '14155551234',
+    });
+  });
+
+  it('returns falsey defaults when flags are absent', () => {
+    expect(getCliOptions(['bun', 'src/whatsapp-auth.ts'])).toEqual({
+      usePairingCode: false,
+      phoneArg: undefined,
+    });
+  });
+});
+
+describe('askQuestion', () => {
+  it('trims the answer and closes the readline interface', async () => {
+    const close = mock(() => {});
+    const createInterface = mock(() => ({
+      question: (_prompt: string, callback: (answer: string) => void) => {
+        callback('  14155551234  ');
+      },
+      close,
+    }));
+
+    await expect(askQuestion('Phone?', createInterface as never)).resolves.toBe(
+      '14155551234',
+    );
+    expect(close).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe('authenticate', () => {
+  it('cleans stale files, prompts in pairing mode, and connects with the answer', async () => {
+    const mkdirSync = mock(() => {});
+    const unlinkSync = mock(() => {
+      throw new Error('missing');
+    });
+    const askQuestionMock = mock(async () => '14155551234');
+    const connectSocketMock = mock(async (_phoneNumber?: string) => {});
+    const log = mock(() => {});
+
+    await authenticate(
+      { usePairingCode: true },
+      {
+        fs: { mkdirSync, unlinkSync },
+        askQuestion: askQuestionMock,
+        connectSocket: connectSocketMock,
+        console: { log },
+      },
+    );
+
+    expect(mkdirSync).toHaveBeenCalledWith('./store/auth', { recursive: true });
+    expect(unlinkSync).toHaveBeenCalledTimes(2);
+    expect(askQuestionMock).toHaveBeenCalledTimes(1);
+    expect(connectSocketMock).toHaveBeenCalledWith('14155551234');
+  });
+});
+
+describe('connectSocket', () => {
+  let cliOptions: ReturnType<typeof getCliOptions>;
+
+  beforeEach(() => {
+    cliOptions = { usePairingCode: false };
+  });
+
+  it('exits early when credentials are already registered', async () => {
+    const harness = createConnectDeps({
+      useMultiFileAuthState: mock(async () => ({
+        state: { creds: { registered: true }, keys: {} },
+        saveCreds: mock(() => {}),
+      })),
+    });
+
+    await connectSocket(undefined, false, cliOptions, harness.deps);
+
+    expect(harness.writeFileSync).toHaveBeenCalledWith(
+      './store/auth-status.txt',
+      'already_authenticated',
+    );
+    expect(harness.exit).toHaveBeenCalledWith(0);
+    expect(harness.deps.makeWASocket).not.toHaveBeenCalled();
+  });
+
+  it('requests a pairing code and records it after the delayed startup timer', async () => {
+    const harness = createConnectDeps();
+
+    await connectSocket('14155551234', false, { usePairingCode: true }, harness.deps);
+
+    expect(harness.timers).toHaveLength(1);
+    await harness.timers[0]!();
+    expect(harness.socketHarness.requestPairingCode).toHaveBeenCalledWith('14155551234');
+    expect(harness.writeFileSync).toHaveBeenCalledWith(
+      './store/auth-status.txt',
+      'pairing_code:123-456',
+    );
+  });
+
+  it('writes QR payloads and renders them in the terminal', async () => {
+    const harness = createConnectDeps();
+
+    await connectSocket(undefined, false, cliOptions, harness.deps);
+    harness.socketHarness.handlers['connection.update']({ qr: 'qr-payload' });
+
+    expect(harness.writeFileSync).toHaveBeenCalledWith(
+      './store/qr-data.txt',
+      'qr-payload',
+    );
+    expect(harness.deps.qrcodeGenerate).toHaveBeenCalledWith('qr-payload', {
+      small: true,
+    });
+  });
+
+  it('marks logged-out disconnects as failures', async () => {
+    const harness = createConnectDeps();
+
+    await connectSocket(undefined, false, cliOptions, harness.deps);
+    harness.socketHarness.handlers['connection.update']({
+      connection: 'close',
+      lastDisconnect: {
+        error: { output: { statusCode: DisconnectReason.loggedOut } },
+      },
+    });
+
+    expect(harness.writeFileSync).toHaveBeenCalledWith(
+      './store/auth-status.txt',
+      'failed:logged_out',
+    );
+    expect(harness.exit).toHaveBeenCalledWith(1);
+  });
+
+  it('marks timed-out disconnects as qr timeouts', async () => {
+    const harness = createConnectDeps();
+
+    await connectSocket(undefined, false, cliOptions, harness.deps);
+    harness.socketHarness.handlers['connection.update']({
+      connection: 'close',
+      lastDisconnect: {
+        error: { output: { statusCode: DisconnectReason.timedOut } },
+      },
+    });
+
+    expect(harness.writeFileSync).toHaveBeenCalledWith(
+      './store/auth-status.txt',
+      'failed:qr_timeout',
+    );
+    expect(harness.exit).toHaveBeenCalledWith(1);
+  });
+
+  it('reconnects after stream error 515 instead of failing the flow', async () => {
+    const harness = createConnectDeps();
+
+    await connectSocket('14155551234', false, cliOptions, harness.deps);
+    harness.socketHarness.handlers['connection.update']({
+      connection: 'close',
+      lastDisconnect: { error: { output: { statusCode: 515 } } },
+    });
+    await Promise.resolve();
+    await Promise.resolve();
+
+    expect(harness.warn).toHaveBeenCalledTimes(1);
+    expect(harness.deps.makeWASocket).toHaveBeenCalledTimes(2);
+    expect(harness.exit).not.toHaveBeenCalled();
+  });
+
+  it('records successful authentication, removes the QR file, and exits after the success timer', async () => {
+    const harness = createConnectDeps();
+
+    await connectSocket(undefined, false, cliOptions, harness.deps);
+    harness.socketHarness.handlers['connection.update']({ connection: 'open' });
+
+    expect(harness.writeFileSync).toHaveBeenCalledWith(
+      './store/auth-status.txt',
+      'authenticated',
+    );
+    expect(harness.unlinkSync).toHaveBeenCalledWith('./store/qr-data.txt');
+    expect(harness.timers).toHaveLength(1);
+    harness.timers[0]!();
+    expect(harness.exit).toHaveBeenCalledWith(0);
+  });
+
+  it('records unknown close reasons as generic failures', async () => {
+    const harness = createConnectDeps();
+
+    await connectSocket(undefined, false, cliOptions, harness.deps);
+    harness.socketHarness.handlers['connection.update']({ connection: 'close' });
+
+    expect(harness.writeFileSync).toHaveBeenCalledWith(
+      './store/auth-status.txt',
+      'failed:unknown',
+    );
+    expect(harness.exit).toHaveBeenCalledWith(1);
+  });
+});

--- a/src/whatsapp-auth.test.ts
+++ b/src/whatsapp-auth.test.ts
@@ -1,5 +1,7 @@
 import { beforeEach, describe, expect, it, mock } from 'bun:test';
 
+import fs from 'fs';
+
 import { DisconnectReason } from '@whiskeysockets/baileys';
 
 import {
@@ -10,6 +12,7 @@ import {
 } from './whatsapp-auth.js';
 
 type Handler = (...args: any[]) => void;
+type ConnectSocketDeps = NonNullable<Parameters<typeof connectSocket>[3]>;
 
 function createSocketHarness(pairingCode = '123-456') {
   const handlers: Record<string, Handler> = {};
@@ -43,8 +46,13 @@ function createConnectDeps(overrides: Record<string, unknown> = {}) {
   const deps = {
     fs: { writeFileSync, unlinkSync },
     makeWASocket: mock((_config: unknown) => socketHarness.socket),
-    fetchLatestWaWebVersion: mock(async () => ({ version: [1, 2, 3] })),
-    makeCacheableSignalKeyStore: mock((_keys: unknown, _logger: unknown) => ({})),
+    fetchLatestWaWebVersion: mock(async () => ({
+      version: [1, 2, 3],
+      isLatest: true,
+    })),
+    makeCacheableSignalKeyStore: mock(
+      (_keys: unknown, _logger: unknown) => ({}),
+    ),
     useMultiFileAuthState: mock(async () => ({
       state: { creds: { registered: false }, keys: {} },
       saveCreds,
@@ -60,7 +68,7 @@ function createConnectDeps(overrides: Record<string, unknown> = {}) {
   };
 
   return {
-    deps: { ...deps, ...overrides } as Parameters<typeof connectSocket>[3],
+    deps: { ...deps, ...overrides } as unknown as ConnectSocketDeps,
     timers,
     socketHarness,
     writeFileSync,
@@ -76,7 +84,13 @@ function createConnectDeps(overrides: Record<string, unknown> = {}) {
 describe('getCliOptions', () => {
   it('parses pairing mode and phone number flags', () => {
     expect(
-      getCliOptions(['bun', 'src/whatsapp-auth.ts', '--pairing-code', '--phone', '14155551234']),
+      getCliOptions([
+        'bun',
+        'src/whatsapp-auth.ts',
+        '--pairing-code',
+        '--phone',
+        '14155551234',
+      ]),
     ).toEqual({
       usePairingCode: true,
       phoneArg: '14155551234',
@@ -110,7 +124,10 @@ describe('askQuestion', () => {
 
 describe('authenticate', () => {
   it('cleans stale files, prompts in pairing mode, and connects with the answer', async () => {
-    const mkdirSync = mock(() => {});
+    const mkdirSync = mock(
+      ((..._args: Parameters<typeof fs.mkdirSync>) =>
+        undefined) as typeof fs.mkdirSync,
+    );
     const unlinkSync = mock(() => {
       throw new Error('missing');
     });
@@ -163,11 +180,18 @@ describe('connectSocket', () => {
   it('requests a pairing code and records it after the delayed startup timer', async () => {
     const harness = createConnectDeps();
 
-    await connectSocket('14155551234', false, { usePairingCode: true }, harness.deps);
+    await connectSocket(
+      '14155551234',
+      false,
+      { usePairingCode: true },
+      harness.deps,
+    );
 
     expect(harness.timers).toHaveLength(1);
     await harness.timers[0]!();
-    expect(harness.socketHarness.requestPairingCode).toHaveBeenCalledWith('14155551234');
+    expect(harness.socketHarness.requestPairingCode).toHaveBeenCalledWith(
+      '14155551234',
+    );
     expect(harness.writeFileSync).toHaveBeenCalledWith(
       './store/auth-status.txt',
       'pairing_code:123-456',
@@ -261,7 +285,9 @@ describe('connectSocket', () => {
     const harness = createConnectDeps();
 
     await connectSocket(undefined, false, cliOptions, harness.deps);
-    harness.socketHarness.handlers['connection.update']({ connection: 'close' });
+    harness.socketHarness.handlers['connection.update']({
+      connection: 'close',
+    });
 
     expect(harness.writeFileSync).toHaveBeenCalledWith(
       './store/auth-status.txt',

--- a/src/whatsapp-auth.ts
+++ b/src/whatsapp-auth.ts
@@ -7,7 +7,6 @@
  * Usage: npx tsx src/whatsapp-auth.ts
  */
 import fs from 'fs';
-import path from 'path';
 import qrcode from 'qrcode-terminal';
 import readline from 'readline';
 
@@ -25,18 +24,78 @@ const AUTH_DIR = './store/auth';
 const QR_FILE = './store/qr-data.txt';
 const STATUS_FILE = './store/auth-status.txt';
 
-// Quiet logger for Baileys — suppress info/debug noise during auth
 const logger = createLogger({}, 'warn');
 
-// Check for --pairing-code flag and phone number
-const usePairingCode = process.argv.includes('--pairing-code');
-const phoneArg = process.argv.find((_, i, arr) => arr[i - 1] === '--phone');
+type CliOptions = {
+  usePairingCode: boolean;
+  phoneArg?: string;
+};
 
-function askQuestion(prompt: string): Promise<string> {
-  const rl = readline.createInterface({
+type AuthLogger = ReturnType<typeof createLogger>;
+
+type SocketLike = {
+  requestPairingCode: (phoneNumber: string) => Promise<string>;
+  ev: {
+    on: (event: string, handler: (...args: any[]) => void) => void;
+  };
+};
+
+type ConnectSocketDeps = {
+  fs: Pick<typeof fs, 'writeFileSync' | 'unlinkSync'>;
+  makeWASocket: (config: Parameters<typeof makeWASocket>[0]) => SocketLike;
+  fetchLatestWaWebVersion: typeof fetchLatestWaWebVersion;
+  makeCacheableSignalKeyStore: typeof makeCacheableSignalKeyStore;
+  useMultiFileAuthState: typeof useMultiFileAuthState;
+  qrcodeGenerate: (qr: string, options: { small: boolean }) => void;
+  exit: (code: number) => void;
+  setTimeout: typeof setTimeout;
+  console: Pick<typeof console, 'log' | 'error'>;
+  logger: AuthLogger;
+};
+
+type AuthenticateDeps = {
+  fs: Pick<typeof fs, 'mkdirSync' | 'unlinkSync'>;
+  askQuestion: (prompt: string) => Promise<string>;
+  connectSocket: (phoneNumber?: string) => Promise<void>;
+  console: Pick<typeof console, 'log'>;
+};
+
+const defaultConnectSocketDeps: ConnectSocketDeps = {
+  fs,
+  makeWASocket,
+  fetchLatestWaWebVersion,
+  makeCacheableSignalKeyStore,
+  useMultiFileAuthState,
+  qrcodeGenerate: qrcode.generate,
+  exit: (code) => process.exit(code),
+  setTimeout,
+  console,
+  logger,
+};
+
+const defaultAuthenticateDeps: AuthenticateDeps = {
+  fs,
+  askQuestion: (prompt) => askQuestion(prompt),
+  connectSocket: (phoneNumber) => connectSocket(phoneNumber),
+  console,
+};
+
+export function getCliOptions(argv = process.argv): CliOptions {
+  return {
+    usePairingCode: argv.includes('--pairing-code'),
+    phoneArg: argv.find((_, i, values) => values[i - 1] === '--phone'),
+  };
+}
+
+export function askQuestion(
+  prompt: string,
+  createInterface: typeof readline.createInterface = readline.createInterface,
+): Promise<string> {
+  const rl = createInterface({
     input: process.stdin,
     output: process.stdout,
   });
+
   return new Promise((resolve) => {
     rl.question(prompt, (answer) => {
       rl.close();
@@ -45,48 +104,49 @@ function askQuestion(prompt: string): Promise<string> {
   });
 }
 
-async function connectSocket(
+export async function connectSocket(
   phoneNumber?: string,
   isReconnect = false,
+  cliOptions = getCliOptions(),
+  deps: ConnectSocketDeps = defaultConnectSocketDeps,
 ): Promise<void> {
-  const { state, saveCreds } = await useMultiFileAuthState(AUTH_DIR);
+  const { state, saveCreds } = await deps.useMultiFileAuthState(AUTH_DIR);
 
   if (state.creds.registered && !isReconnect) {
-    fs.writeFileSync(STATUS_FILE, 'already_authenticated');
-    console.log('✓ Already authenticated with WhatsApp');
-    console.log(
+    deps.fs.writeFileSync(STATUS_FILE, 'already_authenticated');
+    deps.console.log('✓ Already authenticated with WhatsApp');
+    deps.console.log(
       '  To re-authenticate, delete the store/auth folder and run again.',
     );
-    process.exit(0);
+    deps.exit(0);
+    return;
   }
 
-  const { version } = await fetchLatestWaWebVersion({});
-  const sock = makeWASocket({
+  const { version } = await deps.fetchLatestWaWebVersion({});
+  const sock = deps.makeWASocket({
     version,
     auth: {
       creds: state.creds,
-      keys: makeCacheableSignalKeyStore(state.keys, logger),
+      keys: deps.makeCacheableSignalKeyStore(state.keys, deps.logger),
     },
     printQRInTerminal: false,
-    logger,
+    logger: deps.logger,
     browser: Browsers.macOS('Chrome'),
   });
 
-  if (usePairingCode && phoneNumber && !state.creds.me) {
-    // Request pairing code after a short delay for connection to initialize
-    // Only on first connect (not reconnect after 515)
-    setTimeout(async () => {
+  if (cliOptions.usePairingCode && phoneNumber && !state.creds.me) {
+    deps.setTimeout(async () => {
       try {
-        const code = await sock.requestPairingCode(phoneNumber!);
-        console.log(`\n🔗 Your pairing code: ${code}\n`);
-        console.log('  1. Open WhatsApp on your phone');
-        console.log('  2. Tap Settings → Linked Devices → Link a Device');
-        console.log('  3. Tap "Link with phone number instead"');
-        console.log(`  4. Enter this code: ${code}\n`);
-        fs.writeFileSync(STATUS_FILE, `pairing_code:${code}`);
+        const code = await sock.requestPairingCode(phoneNumber);
+        deps.console.log(`\n🔗 Your pairing code: ${code}\n`);
+        deps.console.log('  1. Open WhatsApp on your phone');
+        deps.console.log('  2. Tap Settings → Linked Devices → Link a Device');
+        deps.console.log('  3. Tap "Link with phone number instead"');
+        deps.console.log(`  4. Enter this code: ${code}\n`);
+        deps.fs.writeFileSync(STATUS_FILE, `pairing_code:${code}`);
       } catch (err: any) {
-        console.error('Failed to request pairing code:', err.message);
-        process.exit(1);
+        deps.console.error('Failed to request pairing code:', err.message);
+        deps.exit(1);
       }
     }, 3000);
   }
@@ -95,13 +155,12 @@ async function connectSocket(
     const { connection, lastDisconnect, qr } = update;
 
     if (qr) {
-      // Write raw QR data to file so the setup skill can render it
-      fs.writeFileSync(QR_FILE, qr);
-      console.log('Scan this QR code with WhatsApp:\n');
-      console.log('  1. Open WhatsApp on your phone');
-      console.log('  2. Tap Settings → Linked Devices → Link a Device');
-      console.log('  3. Point your camera at the QR code below\n');
-      qrcode.generate(qr, { small: true });
+      deps.fs.writeFileSync(QR_FILE, qr);
+      deps.console.log('Scan this QR code with WhatsApp:\n');
+      deps.console.log('  1. Open WhatsApp on your phone');
+      deps.console.log('  2. Tap Settings → Linked Devices → Link a Device');
+      deps.console.log('  3. Point your camera at the QR code below\n');
+      deps.qrcodeGenerate(qr, { small: true });
     }
 
     if (connection === 'close') {
@@ -110,70 +169,71 @@ async function connectSocket(
       )?.output?.statusCode;
 
       if (reason === DisconnectReason.loggedOut) {
-        fs.writeFileSync(STATUS_FILE, 'failed:logged_out');
-        console.log('\n✗ Logged out. Delete store/auth and try again.');
-        process.exit(1);
+        deps.fs.writeFileSync(STATUS_FILE, 'failed:logged_out');
+        deps.console.log('\n✗ Logged out. Delete store/auth and try again.');
+        deps.exit(1);
       } else if (reason === DisconnectReason.timedOut) {
-        fs.writeFileSync(STATUS_FILE, 'failed:qr_timeout');
-        console.log('\n✗ QR code timed out. Please try again.');
-        process.exit(1);
+        deps.fs.writeFileSync(STATUS_FILE, 'failed:qr_timeout');
+        deps.console.log('\n✗ QR code timed out. Please try again.');
+        deps.exit(1);
       } else if (reason === 515) {
-        // 515 = stream error, often happens after pairing succeeds but before
-        // registration completes. Reconnect to finish the handshake.
-        logger.warn(
+        deps.logger.warn(
           { statusCode: 515 },
           'Stream error after pairing — reconnecting',
         );
-        connectSocket(phoneNumber, true);
+        void connectSocket(phoneNumber, true, cliOptions, deps);
       } else {
-        fs.writeFileSync(STATUS_FILE, `failed:${reason || 'unknown'}`);
-        console.log('\n✗ Connection failed. Please try again.');
-        process.exit(1);
+        deps.fs.writeFileSync(STATUS_FILE, `failed:${reason || 'unknown'}`);
+        deps.console.log('\n✗ Connection failed. Please try again.');
+        deps.exit(1);
       }
     }
 
     if (connection === 'open') {
-      fs.writeFileSync(STATUS_FILE, 'authenticated');
-      // Clean up QR file now that we're connected
-      try {
-        fs.unlinkSync(QR_FILE);
-      } catch {}
-      console.log('\n✓ Successfully authenticated with WhatsApp!');
-      console.log('  Credentials saved to store/auth/');
-      console.log('  You can now start the OmniClaw service.\n');
+      deps.fs.writeFileSync(STATUS_FILE, 'authenticated');
 
-      // Give it a moment to save credentials, then exit
-      setTimeout(() => process.exit(0), 1000);
+      try {
+        deps.fs.unlinkSync(QR_FILE);
+      } catch {}
+
+      deps.console.log('\n✓ Successfully authenticated with WhatsApp!');
+      deps.console.log('  Credentials saved to store/auth/');
+      deps.console.log('  You can now start the OmniClaw service.\n');
+      deps.setTimeout(() => deps.exit(0), 1000);
     }
   });
 
   sock.ev.on('creds.update', saveCreds);
 }
 
-async function authenticate(): Promise<void> {
-  fs.mkdirSync(AUTH_DIR, { recursive: true });
+export async function authenticate(
+  cliOptions = getCliOptions(),
+  deps: AuthenticateDeps = defaultAuthenticateDeps,
+): Promise<void> {
+  deps.fs.mkdirSync(AUTH_DIR, { recursive: true });
 
-  // Clean up any stale QR/status files from previous runs
   try {
-    fs.unlinkSync(QR_FILE);
-  } catch {}
-  try {
-    fs.unlinkSync(STATUS_FILE);
+    deps.fs.unlinkSync(QR_FILE);
   } catch {}
 
-  let phoneNumber = phoneArg;
-  if (usePairingCode && !phoneNumber) {
-    phoneNumber = await askQuestion(
+  try {
+    deps.fs.unlinkSync(STATUS_FILE);
+  } catch {}
+
+  let phoneNumber = cliOptions.phoneArg;
+  if (cliOptions.usePairingCode && !phoneNumber) {
+    phoneNumber = await deps.askQuestion(
       'Enter your phone number (with country code, no + or spaces, e.g. 14155551234): ',
     );
   }
 
-  console.log('Starting WhatsApp authentication...\n');
-
-  await connectSocket(phoneNumber);
+  deps.console.log('Starting WhatsApp authentication...\n');
+  await deps.connectSocket(phoneNumber);
 }
 
-authenticate().catch((err) => {
-  console.error('Authentication failed:', err.message);
-  process.exit(1);
-});
+if (import.meta.main) {
+  authenticate().catch((err) => {
+    console.error('Authentication failed:', err.message);
+    process.exit(1);
+  });
+}

--- a/src/whatsapp-auth.ts
+++ b/src/whatsapp-auth.ts
@@ -36,7 +36,10 @@ type AuthLogger = ReturnType<typeof createLogger>;
 type SocketLike = {
   requestPairingCode: (phoneNumber: string) => Promise<string>;
   ev: {
-    on: (event: string, handler: (...args: any[]) => void) => void;
+    on: (
+      event: 'connection.update' | 'creds.update',
+      handler: (...args: any[]) => void,
+    ) => void;
   };
 };
 
@@ -62,7 +65,7 @@ type AuthenticateDeps = {
 
 const defaultConnectSocketDeps: ConnectSocketDeps = {
   fs,
-  makeWASocket,
+  makeWASocket: (config) => makeWASocket(config) as unknown as SocketLike,
   fetchLatestWaWebVersion,
   makeCacheableSignalKeyStore,
   useMultiFileAuthState,


### PR DESCRIPTION
## Summary
- add deterministic unit tests for `src/whatsapp-auth.ts`, covering CLI parsing, readline prompting, pairing-code scheduling, QR rendering, reconnect-on-515, success, and failure branches
- refactor the auth script to expose dependency-injectable helpers so the WhatsApp auth flow can be exercised without live Baileys sockets or process exits
- raise the suite by 12 tests from 1648 to 1660 total tests and keep `bun test` green in this branch

## Verification
- `bun test src/whatsapp-auth.test.ts`
- `bun test`

## Files Covered
- `src/whatsapp-auth.ts`
- `src/whatsapp-auth.test.ts`

## Remaining Coverage Gaps
- `src/simtest/index.ts` still lacks dedicated deterministic startup and shutdown tests
- `src/ipc.ts` still relies mostly on indirect coverage rather than focused helper-level tests


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added explicit CLI flag support for `--pairing-code` and `--phone` options to streamline authentication configuration.

* **Bug Fixes**
  * Improved error handling and reconnection logic during authentication failures.

* **Tests**
  * Added comprehensive test suite covering CLI parsing, authentication flows, QR code generation, and connection handling to ensure reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->