### PR TITLE
test: cover linked GitHub context and backend orchestration

### DIFF
--- a/src/backends/index.test.ts
+++ b/src/backends/index.test.ts
@@ -1,6 +1,11 @@
-import { describe, it, expect } from 'bun:test';
+import { afterEach, describe, expect, it, mock } from 'bun:test';
+
 import { getBackend } from './index.js';
 import { LocalBackend } from './local-backend.js';
+
+afterEach(() => {
+  mock.restore();
+});
 
 /**
  * Tests for backends/index.ts — the backend factory.
@@ -49,6 +54,221 @@ describe('backends/index', () => {
       expect(typeof backend.writeFile).toBe('function');
       expect(typeof backend.initialize).toBe('function');
       expect(typeof backend.shutdown).toBe('function');
+    });
+  });
+
+  describe('module-level orchestration', () => {
+    it('resolveBackend uses the entity backend type', async () => {
+      class FakeLocalBackend {
+        name = 'fake';
+        initialize = mock(async () => {});
+        shutdown = mock(async () => {});
+        runAgent = mock(async () => ({ type: 'done' }));
+        sendMessage = mock(() => true);
+        closeStdin = mock(() => {});
+        writeIpcData = mock(() => {});
+        readFile = mock(async () => null);
+        writeFile = mock(async () => {});
+      }
+
+      mock.module('./local-backend.js', () => ({
+        LocalBackend: FakeLocalBackend,
+      }));
+
+      const backendModule = await import(
+        `./index.ts?test=${Math.random().toString(36).slice(2)}`,
+      );
+
+      const backend = backendModule.resolveBackend({
+        id: 'agent-1',
+        jid: 'dc:1',
+        name: 'Agent',
+        trigger: '@Agent',
+        folder: 'agent',
+        isAdmin: false,
+        backend: 'docker',
+        agentRuntime: 'claude-agent-sdk',
+      });
+
+      expect(backend).toBeInstanceOf(FakeLocalBackend);
+    });
+
+    it('initializeBackends initializes only the default backend when no entities are provided', async () => {
+      const initializeCalls: string[] = [];
+      const loggerInfo = mock(() => {});
+
+      class FakeLocalBackend {
+        name = 'fake';
+        initialize = mock(async () => {
+          initializeCalls.push('initialize');
+        });
+        shutdown = mock(async () => {});
+        runAgent = mock(async () => ({ type: 'done' }));
+        sendMessage = mock(() => true);
+        closeStdin = mock(() => {});
+        writeIpcData = mock(() => {});
+        readFile = mock(async () => null);
+        writeFile = mock(async () => {});
+      }
+
+      mock.module('./local-backend.js', () => ({
+        LocalBackend: FakeLocalBackend,
+      }));
+      mock.module('../logger.js', () => ({
+        logger: { info: loggerInfo, warn: mock(() => {}) },
+      }));
+
+      const backendModule = await import(
+        `./index.ts?test=${Math.random().toString(36).slice(2)}`,
+      );
+
+      await backendModule.initializeBackends({});
+
+      expect(initializeCalls).toEqual(['initialize']);
+      expect(loggerInfo).toHaveBeenCalledWith(
+        { backends: ['apple-container'] },
+        'Initializing backends',
+      );
+    });
+
+    it('initializeBackends deduplicates repeated backend types', async () => {
+      const initializeCalls: string[] = [];
+
+      class FakeLocalBackend {
+        static nextName = 'apple-container';
+
+        name = FakeLocalBackend.nextName;
+        initialize = mock(async () => {
+          initializeCalls.push(this.name);
+        });
+        shutdown = mock(async () => {});
+        runAgent = mock(async () => ({ type: 'done' }));
+        sendMessage = mock(() => true);
+        closeStdin = mock(() => {});
+        writeIpcData = mock(() => {});
+        readFile = mock(async () => null);
+        writeFile = mock(async () => {});
+
+        constructor() {
+          FakeLocalBackend.nextName = 'docker';
+        }
+      }
+
+      mock.module('./local-backend.js', () => ({
+        LocalBackend: FakeLocalBackend,
+      }));
+      mock.module('../logger.js', () => ({
+        logger: { info: mock(() => {}), warn: mock(() => {}) },
+      }));
+
+      const backendModule = await import(
+        `./index.ts?test=${Math.random().toString(36).slice(2)}`,
+      );
+
+      await backendModule.initializeBackends({
+        a: {
+          id: 'agent-a',
+          jid: 'dc:a',
+          name: 'A',
+          trigger: '@A',
+          folder: 'a',
+          isAdmin: false,
+          backend: 'docker',
+          agentRuntime: 'claude-agent-sdk',
+        },
+        b: {
+          id: 'agent-b',
+          jid: 'dc:b',
+          name: 'B',
+          trigger: '@B',
+          folder: 'b',
+          isAdmin: false,
+          backend: 'docker',
+          agentRuntime: 'claude-agent-sdk',
+        },
+        c: {
+          jid: 'main@g.us',
+          name: 'Main',
+          folder: 'main',
+          trigger: '@Main',
+          backend: 'apple-container',
+        },
+      });
+
+      expect(initializeCalls).toHaveLength(2);
+      expect(new Set(initializeCalls)).toEqual(
+        new Set(['docker', 'apple-container']),
+      );
+    });
+
+    it('shutdownBackends warns and continues when a backend shutdown fails', async () => {
+      const shutdownCalls: string[] = [];
+      const loggerWarn = mock(() => {});
+
+      class FakeLocalBackend {
+        static nextName = 'apple-container';
+
+        name = FakeLocalBackend.nextName;
+        initialize = mock(async () => {});
+        shutdown = mock(async () => {
+          shutdownCalls.push(this.name);
+          if (this.name === 'docker') {
+            throw new Error('docker stop failed');
+          }
+        });
+        runAgent = mock(async () => ({ type: 'done' }));
+        sendMessage = mock(() => true);
+        closeStdin = mock(() => {});
+        writeIpcData = mock(() => {});
+        readFile = mock(async () => null);
+        writeFile = mock(async () => {});
+
+        constructor() {
+          FakeLocalBackend.nextName = 'docker';
+        }
+      }
+
+      mock.module('./local-backend.js', () => ({
+        LocalBackend: FakeLocalBackend,
+      }));
+      mock.module('../logger.js', () => ({
+        logger: { info: mock(() => {}), warn: loggerWarn },
+      }));
+
+      const backendModule = await import(
+        `./index.ts?test=${Math.random().toString(36).slice(2)}`,
+      );
+
+      await backendModule.initializeBackends({
+        a: {
+          jid: 'main@g.us',
+          name: 'Main',
+          folder: 'main',
+          trigger: '@Main',
+          backend: 'apple-container',
+        },
+        b: {
+          id: 'agent-b',
+          jid: 'dc:b',
+          name: 'B',
+          trigger: '@B',
+          folder: 'b',
+          isAdmin: false,
+          backend: 'docker',
+          agentRuntime: 'claude-agent-sdk',
+        },
+      });
+
+      await backendModule.shutdownBackends();
+
+      expect(shutdownCalls).toEqual(['apple-container', 'docker']);
+      expect(loggerWarn).toHaveBeenCalledWith(
+        {
+          backend: 'docker',
+          error: expect.any(Error),
+        },
+        'Error shutting down backend',
+      );
     });
   });
 });

--- a/src/github-linked.test.ts
+++ b/src/github-linked.test.ts
@@ -1,10 +1,15 @@
-import { describe, it, expect } from 'bun:test';
+import { afterEach, describe, expect, it, mock } from 'bun:test';
 
 import {
   extractGitHubLinks,
   fetchGitHubLinkedContext,
   type ParsedGitHubLink,
 } from './github-linked.js';
+
+afterEach(() => {
+  mock.restore();
+  delete process.env.GITHUB_TOKEN;
+});
 
 describe('github-linked', () => {
   describe('extractGitHubLinks', () => {
@@ -154,6 +159,276 @@ describe('github-linked', () => {
       const links = extractGitHubLinks(text);
       // extractGitHubLinks returns all, but fetchGitHubLinkedContext caps at 3
       expect(links).toHaveLength(5);
+    });
+
+    it('returns null when GitHub access is disabled even if links are present', async () => {
+      const result = await fetchGitHubLinkedContext([
+        { content: 'https://github.com/omniaura/omniclaw/pull/1' },
+      ]);
+
+      expect(result).toBeNull();
+    });
+
+    it('fetches, formats, and caches linked pull request context', async () => {
+      process.env.GITHUB_TOKEN = 'test-token';
+
+      const githubFetch = mock(async (path: string) => {
+        expect(path).toBe('/repos/omniaura/omniclaw/pulls/42');
+        return {
+          number: 42,
+          title: 'Fix scheduler loop',
+          body: 'Body',
+          state: 'open',
+          html_url: 'https://github.com/omniaura/omniclaw/pull/42',
+          draft: false,
+          user: { login: 'peyton' },
+          head: { ref: 'feature-branch' },
+          base: { ref: 'main' },
+        };
+      });
+      const fetchPrReviews = mock(async () => [{ state: 'APPROVED' }]);
+      const fetchPrReviewComments = mock(async () => [{ body: 'Looks good' }]);
+      const fetchCombinedStatus = mock(async () => 'green');
+      const formatPrMarkdown = mock(
+        () => '### PR #42: Fix scheduler loop\n- CI: green',
+      );
+
+      mock.module('./github.js', () => ({
+        githubFetch,
+        fetchPrReviews,
+        fetchPrReviewComments,
+        fetchCombinedStatus,
+        formatPrMarkdown,
+        truncate: (value: string) => value,
+      }));
+      mock.module('./logger.js', () => ({
+        logger: { info: mock(() => {}), warn: mock(() => {}) },
+      }));
+
+      const linked = await import(
+        `./github-linked.ts?test=${Math.random().toString(36).slice(2)}`,
+      );
+
+      const messages = [
+        { content: 'Review https://github.com/omniaura/omniclaw/pull/42' },
+      ];
+
+      const first = await linked.fetchGitHubLinkedContext(messages);
+      const second = await linked.fetchGitHubLinkedContext(messages);
+
+      expect(first).toBe(
+        '# Linked GitHub Context\n\n### PR #42: Fix scheduler loop\n- CI: green',
+      );
+      expect(second).toBe(first);
+      expect(githubFetch).toHaveBeenCalledTimes(1);
+      expect(fetchPrReviews).toHaveBeenCalledTimes(1);
+      expect(fetchPrReviewComments).toHaveBeenCalledTimes(1);
+      expect(fetchCombinedStatus).toHaveBeenCalledWith(
+        'omniaura',
+        'omniclaw',
+        'feature-branch',
+      );
+      expect(formatPrMarkdown).toHaveBeenCalledTimes(1);
+    });
+
+    it('formats linked issue context with comments and truncation', async () => {
+      process.env.GITHUB_TOKEN = 'test-token';
+
+      const githubFetch = mock(async (path: string) => {
+        if (path === '/repos/omniaura/omniclaw/issues/91') {
+          return {
+            number: 91,
+            title: 'Improve linked issue context',
+            body: 'Issue body',
+            user: { login: 'peyton' },
+            labels: [{ name: 'bug' }, { name: 'triage' }],
+            assignee: { login: 'ocpeyton' },
+          };
+        }
+
+        if (
+          path ===
+          '/repos/omniaura/omniclaw/issues/91/comments?per_page=10&sort=created&direction=desc'
+        ) {
+          return [
+            {
+              user: { login: 'reviewer' },
+              body: 'First comment',
+              created_at: '2026-04-01T00:00:00Z',
+            },
+            {
+              user: null,
+              body: 'Second comment',
+              created_at: '2026-04-01T00:01:00Z',
+            },
+          ];
+        }
+
+        throw new Error(`Unexpected path: ${path}`);
+      });
+
+      mock.module('./github.js', () => ({
+        githubFetch,
+        fetchPrReviews: mock(async () => []),
+        fetchPrReviewComments: mock(async () => []),
+        fetchCombinedStatus: mock(async () => null),
+        formatPrMarkdown: mock(() => ''),
+        truncate: (value: string, max: number) => value.slice(0, max),
+      }));
+      mock.module('./logger.js', () => ({
+        logger: { info: mock(() => {}), warn: mock(() => {}) },
+      }));
+
+      const linked = await import(
+        `./github-linked.ts?test=${Math.random().toString(36).slice(2)}`,
+      );
+
+      const result = await linked.fetchGitHubLinkedContext([
+        { content: 'See https://github.com/omniaura/omniclaw/issues/91' },
+      ]);
+
+      expect(result).toContain('### Issue #91: Improve linked issue context');
+      expect(result).toContain(
+        '- Author: peyton | Labels: bug, triage | Assignee: ocpeyton',
+      );
+      expect(result).toContain('- Description: Issue body');
+      expect(result).toContain('- Comments (2):');
+      expect(result).toContain('  - reviewer: First comment');
+      expect(result).toContain('  - ?: Second comment');
+    });
+
+    it('treats linked issues with pull_request metadata as pull requests', async () => {
+      process.env.GITHUB_TOKEN = 'test-token';
+
+      const githubFetch = mock(async (path: string) => {
+        if (path === '/repos/omniaura/omniclaw/issues/123') {
+          return {
+            number: 123,
+            title: 'Shadow PR issue',
+            body: 'Issue view',
+            pull_request: { url: 'https://api.github.com/repos/x/y/pulls/123' },
+          };
+        }
+
+        if (path === '/repos/omniaura/omniclaw/pulls/123') {
+          return {
+            number: 123,
+            title: 'Actual PR',
+            body: 'PR body',
+            state: 'open',
+            html_url: 'https://github.com/omniaura/omniclaw/pull/123',
+            draft: false,
+            user: { login: 'peyton' },
+            head: { ref: 'pr-branch' },
+            base: { ref: 'main' },
+          };
+        }
+
+        throw new Error(`Unexpected path: ${path}`);
+      });
+      const fetchPrReviews = mock(async () => []);
+      const fetchPrReviewComments = mock(async () => []);
+      const fetchCombinedStatus = mock(async () => 'pending');
+
+      mock.module('./github.js', () => ({
+        githubFetch,
+        fetchPrReviews,
+        fetchPrReviewComments,
+        fetchCombinedStatus,
+        formatPrMarkdown: mock(() => 'PR markdown'),
+        truncate: (value: string) => value,
+      }));
+      mock.module('./logger.js', () => ({
+        logger: { info: mock(() => {}), warn: mock(() => {}) },
+      }));
+
+      const linked = await import(
+        `./github-linked.ts?test=${Math.random().toString(36).slice(2)}`,
+      );
+
+      const result = await linked.fetchGitHubLinkedContext([
+        { content: 'https://github.com/omniaura/omniclaw/issues/123' },
+      ]);
+
+      expect(result).toContain('PR markdown');
+      expect(fetchPrReviews).toHaveBeenCalledWith('omniaura', 'omniclaw', 123);
+      expect(fetchPrReviewComments).toHaveBeenCalledWith(
+        'omniaura',
+        'omniclaw',
+        123,
+      );
+      expect(fetchCombinedStatus).toHaveBeenCalledWith(
+        'omniaura',
+        'omniclaw',
+        'pr-branch',
+      );
+    });
+
+    it('caps linked fetches and logs rejected items while keeping successful sections', async () => {
+      process.env.GITHUB_TOKEN = 'test-token';
+
+      const warnSpy = mock(() => {});
+      const infoSpy = mock(() => {});
+
+      mock.module('./github.js', () => ({
+        githubFetch: mock(async (path: string) => {
+          const prNumber = Number(path.split('/').pop());
+          return {
+            number: prNumber,
+            title: `PR ${prNumber}`,
+            body: `Body ${prNumber}`,
+            state: 'open',
+            html_url: `https://github.com/omniaura/omniclaw/pull/${prNumber}`,
+            draft: false,
+            user: { login: 'peyton' },
+            head: { ref: `branch-${prNumber}` },
+            base: { ref: 'main' },
+          };
+        }),
+        fetchPrReviews: mock(async (_owner: string, _repo: string, number: number) => {
+          if (number === 2) {
+            throw new Error('reviews exploded');
+          }
+          return [];
+        }),
+        fetchPrReviewComments: mock(async () => []),
+        fetchCombinedStatus: mock(async () => 'green'),
+        formatPrMarkdown: mock((pr: { number: number }) => `PR-${pr.number}`),
+        truncate: (value: string) => value,
+      }));
+      mock.module('./logger.js', () => ({
+        logger: { info: infoSpy, warn: warnSpy },
+      }));
+
+      const linked = await import(
+        `./github-linked.ts?test=${Math.random().toString(36).slice(2)}`,
+      );
+
+      const result = await linked.fetchGitHubLinkedContext([
+        {
+          content: [
+            'https://github.com/omniaura/omniclaw/pull/1',
+            'https://github.com/omniaura/omniclaw/pull/2',
+            'https://github.com/omniaura/omniclaw/pull/3',
+            'https://github.com/omniaura/omniclaw/pull/4',
+          ].join(' '),
+        },
+      ]);
+
+      expect(result).toContain('PR-1');
+      expect(result).toContain('PR-3');
+      expect(result).not.toContain('PR-4');
+      expect(warnSpy).toHaveBeenCalledWith(
+        {
+          err: expect.any(Error),
+          link: 'https://github.com/omniaura/omniclaw/pull/2',
+        },
+        'Failed to fetch linked GitHub context',
+      );
+      expect(infoSpy).toHaveBeenCalledWith(
+        { total: 4, capped: 3 },
+        'Capped linked GitHub context items',
+      );
     });
   });
 });


### PR DESCRIPTION
## Summary
- Add deterministic, module-mocked tests for `src/github-linked.ts` covering PR fetches, issue formatting, PR-backed issue fallback, cache reuse, capped fetches, and rejected fetch logging.
- Add backend factory orchestration tests for `src/backends/index.ts` covering `resolveBackend`, default backend initialization, backend deduplication, and shutdown warning behavior.

## Verification
- `bun test src/github-linked.test.ts`
- `bun test src/backends/index.test.ts`
- `bun test` currently remains red on the current `origin/main` baseline in this repo snapshot (`1357 pass`, `271 fail`, `10 errors`), so full-suite green verification is not available from this branch.

## Coverage Notes
- `src/backends/index.ts`: functions `25.00% -> 83.33%`, lines `37.50% -> 92.86%`
- `src/github-linked.ts`: functions `25.00% -> 69.23%`, lines `24.49% -> 62.42%`
- Targeted test count increased from `23` to `32` across the touched files:
  - `src/backends/index.test.ts`: `6 -> 10`
  - `src/github-linked.test.ts`: `17 -> 22`

## Remaining Gaps
- `src/github-linked.ts` still has untested issue-formatting edge branches and lower-level fetch helpers.
- Large discovery and channel modules remain the biggest repo-level coverage gaps, especially `src/discovery/routes.ts`, `src/discovery/trust-store.ts`, `src/discovery/runtime.ts`, and `src/index.ts`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Enhanced test coverage for backend initialization/shutdown and GitHub context fetching to ensure reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->