### PR TITLE
Fix ARM64 container browser bootstrap

### DIFF
--- a/container/Dockerfile.base
+++ b/container/Dockerfile.base
@@ -83,16 +83,31 @@ RUN bun install -g @anthropic-ai/claude-code
 # `agent-browser install --with-deps` calls sudo internally which doesn't exist, so we
 # run `npx playwright install-deps` directly as root instead (no sudo needed).
 # The JS wrapper at /usr/local/bin/agent-browser uses Node's existsSync() which returns
-# false for paths under /root/.bun/ due to EACCES on access() in the container sandbox,
-# so we symlink the native binary directly to /usr/local/bin/agent-browser.
+# false for paths under /root/.bun/ due to EACCES on access() in the container sandbox.
+# Copy the native binary into /usr/local/bin and wrap it there instead of executing out of
+# /root/.bun directly. Linux ARM64 also cannot download Chrome for Testing, so those builds
+# must install system Chromium and force agent-browser to launch it explicitly.
 ARG AGENT_BROWSER_VERSION=0.24.1
 ENV PLAYWRIGHT_BROWSERS_PATH=/opt/pw-browsers
+COPY agent-browser-wrapper.sh /tmp/agent-browser-wrapper
 RUN echo 'trustedDependencies = ["agent-browser"]' >> /root/.bunfig.toml \
     && bun install -g "agent-browser@${AGENT_BROWSER_VERSION}" \
-    && agent-browser install \
+    && AGENT_BROWSER_BIN="$(find /root/.bun -name 'agent-browser-linux-*' -type f | head -1)" \
+    && test -n "$AGENT_BROWSER_BIN" \
+    && install -m 755 "$AGENT_BROWSER_BIN" /usr/local/bin/agent-browser-real \
+    && install -m 755 /tmp/agent-browser-wrapper /usr/local/bin/agent-browser \
+    && ARCH="$(dpkg --print-architecture)" \
+    && if [ "$ARCH" = "arm64" ]; then \
+         apt-get update \
+         && apt-get install -y --no-install-recommends chromium \
+         && rm -rf /var/lib/apt/lists/*; \
+       else \
+         agent-browser install; \
+       fi \
     && npx playwright install-deps \
-    && chmod -R 755 $PLAYWRIGHT_BROWSERS_PATH \
-    && ln -sf $(find /root/.bun -name 'agent-browser-linux-*' -type f | head -1) /usr/local/bin/agent-browser
+    && mkdir -p "$PLAYWRIGHT_BROWSERS_PATH" \
+    && chmod -R 755 "$PLAYWRIGHT_BROWSERS_PATH" \
+    && rm -f /tmp/agent-browser-wrapper
 
 # Install OpenCode CLI (alternative agent runtime)
 # Download directly from GitHub releases to avoid DNS issues with opencode.ai.

--- a/container/agent-browser-wrapper.sh
+++ b/container/agent-browser-wrapper.sh
@@ -1,0 +1,13 @@
+#!/bin/sh
+set -eu
+
+REAL_BIN="/usr/local/bin/agent-browser-real"
+SYSTEM_CHROMIUM="/usr/bin/chromium"
+
+# Chrome for Testing is not published for Linux ARM64, so force agent-browser
+# onto the distro Chromium package when present.
+if [ -x "$SYSTEM_CHROMIUM" ] && [ "$(uname -m)" = "aarch64" ]; then
+  exec "$REAL_BIN" --executable-path "$SYSTEM_CHROMIUM" "$@"
+fi
+
+exec "$REAL_BIN" "$@"


### PR DESCRIPTION
## Summary
- fix the ARM64 container build by skipping Chrome-for-Testing downloads and installing system Chromium instead
- copy the native agent-browser binary out of /root/.bun and wrap it from /usr/local/bin so the runtime no longer depends on root-owned paths
- keep the existing amd64 install path intact while preserving Playwright dependency setup

## Verification
- just build-all
- container run --rm --entrypoint /bin/sh omniclaw-agent-base:latest -c 'uname -m && ls -l /usr/local/bin/agent-browser /usr/local/bin/agent-browser-real && agent-browser --help >/tmp/agent-browser-help.txt && sed -n "1,20p" /tmp/agent-browser-help.txt'


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Optimized browser agent installation and initialization process with improved architecture-specific handling.
  * Enhanced ARM64 system support to utilize native system browser when available for better performance.
  * Refined cross-platform browser compatibility and setup reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->