### PR TITLE
test(ipc): cover watcher and event edge cases

### DIFF
--- a/src/ipc-messages.test.ts
+++ b/src/ipc-messages.test.ts
@@ -44,6 +44,10 @@ let reactions: Array<{
 let deps: IpcDeps;
 let tmpDir: string;
 
+const flushMicrotasks = async () => {
+  await Promise.resolve();
+};
+
 beforeEach(() => {
   groups = {
     'main@g.us': MAIN_GROUP,
@@ -181,6 +185,24 @@ describe('processMessageIpc: react_to_message', () => {
     expect(readResponse('main', 'req-111')).toEqual({
       type: 'react_to_message_response',
       requestId: 'req-111',
+      ok: true,
+      result: 'Reaction added.',
+    });
+  });
+
+  it('sanitizes requestId before writing the response file', async () => {
+    const result = await processMsg({
+      type: 'react_to_message',
+      chatJid: 'other@g.us',
+      messageId: 'msg-112',
+      emoji: '👍',
+      requestId: 'req/../112!?',
+    });
+
+    expect(result).toEqual({ action: 'handled' });
+    expect(readResponse('main', 'req112')).toEqual({
+      type: 'react_to_message_response',
+      requestId: 'req112',
       ok: true,
       result: 'Reaction added.',
     });
@@ -552,6 +574,141 @@ describe('processMessageIpc: ssh_pubkey', () => {
 // =============================================================================
 
 describe('processMessageIpc: message', () => {
+  it('emits a message_sent IPC event asynchronously', async () => {
+    const events: Array<{
+      kind: string;
+      sourceGroup: string;
+      summary: string;
+      details?: Record<string, unknown>;
+    }> = [];
+    deps.onIpcEvent = (kind, sourceGroup, summary, details) => {
+      events.push({ kind, sourceGroup, summary, details });
+    };
+
+    const result = await processMsg(
+      {
+        type: 'message',
+        chatJid: 'third@g.us',
+        text: 'Cross-group hello',
+      },
+      'other-group',
+      false,
+    );
+
+    expect(result).toEqual({ action: 'handled' });
+
+    await flushMicrotasks();
+
+    expect(events).toEqual([
+      {
+        kind: 'message_sent',
+        sourceGroup: 'other-group',
+        summary: 'Message sent to third@g.us',
+        details: { chatJid: 'third@g.us' },
+      },
+    ]);
+  });
+
+  it('emits a message_blocked IPC event for unauthorized targets', async () => {
+    const events: Array<{
+      kind: string;
+      sourceGroup: string;
+      summary: string;
+      details?: Record<string, unknown>;
+    }> = [];
+    deps.onIpcEvent = (kind, sourceGroup, summary, details) => {
+      events.push({ kind, sourceGroup, summary, details });
+    };
+
+    const result = await processMsg(
+      {
+        type: 'message',
+        chatJid: 'unknown@g.us',
+        text: 'Should be blocked',
+      },
+      'other-group',
+      false,
+    );
+
+    expect(result).toEqual({
+      action: 'blocked',
+      reason: 'target not registered',
+    });
+
+    await flushMicrotasks();
+
+    expect(events).toEqual([
+      {
+        kind: 'message_blocked',
+        sourceGroup: 'other-group',
+        summary: 'Blocked: target unknown@g.us not registered',
+        details: { chatJid: 'unknown@g.us' },
+      },
+    ]);
+  });
+
+  it('emits a message_suppressed IPC event for internal-only content', async () => {
+    const events: Array<{
+      kind: string;
+      sourceGroup: string;
+      summary: string;
+      details?: Record<string, unknown>;
+    }> = [];
+    deps.onIpcEvent = (kind, sourceGroup, summary, details) => {
+      events.push({ kind, sourceGroup, summary, details });
+    };
+
+    const result = await processMsg(
+      {
+        type: 'message',
+        chatJid: 'other@g.us',
+        text: '<internal>All internal reasoning</internal>',
+      },
+      'main',
+      true,
+    );
+
+    expect(result).toEqual({ action: 'suppressed', reason: 'internal-only' });
+
+    await flushMicrotasks();
+
+    expect(events).toEqual([
+      {
+        kind: 'message_suppressed',
+        sourceGroup: 'main',
+        summary: 'Message suppressed (internal-only)',
+        details: { chatJid: 'other@g.us' },
+      },
+    ]);
+  });
+
+  it('swallows IPC event observer failures without affecting message delivery', async () => {
+    let observerCalls = 0;
+    deps.onIpcEvent = () => {
+      observerCalls += 1;
+      throw new Error('observer failed');
+    };
+
+    const result = await processMsg(
+      {
+        type: 'message',
+        chatJid: 'third@g.us',
+        text: 'Still delivered',
+      },
+      'other-group',
+      false,
+    );
+
+    expect(result).toEqual({ action: 'handled' });
+    expect(sentMessages).toEqual([
+      { jid: 'third@g.us', text: 'Still delivered' },
+    ]);
+
+    await flushMicrotasks();
+
+    expect(observerCalls).toBe(1);
+  });
+
   it('passes discord_bot_id to sendMessage for multi-bot routing', async () => {
     deps.sendMessage = async (jid, text, discordBotId) => {
       sendCalls.push({ jid, text, discordBotId });

--- a/src/ipc-watcher.test.ts
+++ b/src/ipc-watcher.test.ts
@@ -44,7 +44,13 @@ describe('startIpcWatcher', () => {
     const ownerFolder = `runtime-owner-${id}`;
     staleRuntimeFolder = `${ownerFolder}${DISPATCH_RUNTIME_SEP}0123456789abcdef`;
     const rogueFolder = `rogue-source-${id}`;
+    const malformedRuntimeFolder = `${ownerFolder}${DISPATCH_RUNTIME_SEP}not-a-digest`;
     rogueErrorDir = path.join(IPC_BASE_DIR, 'errors', rogueFolder);
+    const malformedRuntimeErrorDir = path.join(
+      IPC_BASE_DIR,
+      'errors',
+      malformedRuntimeFolder,
+    );
 
     fs.rmSync(path.join(IPC_BASE_DIR, staleRuntimeFolder), {
       recursive: true,
@@ -54,12 +60,20 @@ describe('startIpcWatcher', () => {
       recursive: true,
       force: true,
     });
+    fs.rmSync(path.join(IPC_BASE_DIR, malformedRuntimeFolder), {
+      recursive: true,
+      force: true,
+    });
     fs.rmSync(rogueErrorDir, { recursive: true, force: true });
+    fs.rmSync(malformedRuntimeErrorDir, { recursive: true, force: true });
 
     fs.mkdirSync(path.join(IPC_BASE_DIR, staleRuntimeFolder, 'messages'), {
       recursive: true,
     });
     fs.mkdirSync(path.join(IPC_BASE_DIR, rogueFolder, 'messages'), {
+      recursive: true,
+    });
+    fs.mkdirSync(path.join(IPC_BASE_DIR, malformedRuntimeFolder, 'messages'), {
       recursive: true,
     });
 
@@ -77,6 +91,14 @@ describe('startIpcWatcher', () => {
         type: 'message',
         chatJid: 'main@g.us',
         text: 'should never be processed',
+      }),
+    );
+    fs.writeFileSync(
+      path.join(IPC_BASE_DIR, malformedRuntimeFolder, 'messages', 'message.json'),
+      JSON.stringify({
+        type: 'message',
+        chatJid: 'main@g.us',
+        text: 'malformed runtime should never be processed',
       }),
     );
 
@@ -158,6 +180,10 @@ describe('startIpcWatcher', () => {
       false,
     );
     expect(fs.existsSync(rogueErrorDir)).toBe(true);
+    expect(fs.existsSync(malformedRuntimeErrorDir)).toBe(true);
+    expect(scheduledDelays).toEqual([IPC_POLL_INTERVAL]);
+
+    startIpcWatcher(deps);
     expect(scheduledDelays).toEqual([IPC_POLL_INTERVAL]);
   });
 });

--- a/src/ipc-watcher.test.ts
+++ b/src/ipc-watcher.test.ts
@@ -94,7 +94,12 @@ describe('startIpcWatcher', () => {
       }),
     );
     fs.writeFileSync(
-      path.join(IPC_BASE_DIR, malformedRuntimeFolder, 'messages', 'message.json'),
+      path.join(
+        IPC_BASE_DIR,
+        malformedRuntimeFolder,
+        'messages',
+        'message.json',
+      ),
       JSON.stringify({
         type: 'message',
         chatJid: 'main@g.us',


### PR DESCRIPTION
## Summary
- Add deterministic IPC tests for sanitized response request IDs and async `onIpcEvent` delivery/error handling in `src/ipc-messages.test.ts`.
- Extend the watcher simulation to quarantine malformed runtime dispatch folders and prove duplicate `startIpcWatcher()` calls do not schedule an extra poll.
- Raise coverage around `src/ipc.ts` control-flow edges without changing production code.

## Testing
- `bun test`

## Test Count
- Before: 1655 tests across 91 files
- After: 1660 tests across 91 files

## Files Covered
- `src/ipc.ts`

## Remaining Coverage Gaps
- `src/backends/local-backend.isolated.ts`
- `src/discovery/types.ts`
- `src/migrations.ts`
- `src/task-scheduler-loop.harness.ts`
- `src/web/types.ts`
- `src/whatsapp-auth.ts`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added tests for IPC message events covering successful delivery, blocked messages, suppressed content, and observer error handling (observer errors do not affect delivery).
  * Added a helper to wait for async IPC emissions and a test ensuring request IDs are sanitized before use.
  * Enhanced IPC watcher tests to detect malformed runtime folders, verify error quarantine creation, and strengthen polling/scheduling assertions including repeated watcher start.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->