### PR TITLE
fix(security): cap trusted peer error bodies

### DIFF
--- a/src/discovery/peer-client.test.ts
+++ b/src/discovery/peer-client.test.ts
@@ -11,6 +11,7 @@ function sha256Hex(value: string): string {
 }
 
 afterEach(() => {
+  mock.restore();
   globalThis.fetch = originalFetch;
 });
 
@@ -242,6 +243,68 @@ describe('PeerClient', () => {
     await expect(client.getChatIcon('chat/room')).rejects.toThrow(
       'Download exceeded 5242880 bytes',
     );
+  });
+
+  it('rejects oversized error bodies from content-length without buffering them', async () => {
+    let cancelled = false;
+    globalThis.fetch = mock(() =>
+      Promise.resolve(
+        new Response(
+          new ReadableStream<Uint8Array>({
+            cancel() {
+              cancelled = true;
+            },
+          }),
+          {
+            status: 502,
+            statusText: 'Bad Gateway',
+            headers: {
+              'content-length': '9000',
+            },
+          },
+        ),
+      ),
+    ) as unknown as typeof globalThis.fetch;
+
+    const client = new PeerClient('peer.local', 3000, 'peer-1');
+
+    await expect(client.getInfo()).rejects.toThrow(
+      'Peer API error: 502 Bad Gateway - [response body omitted: exceeds 8192 byte limit]',
+    );
+    expect(cancelled).toBe(true);
+  });
+
+  it('truncates streamed error bodies that exceed the byte cap', async () => {
+    const chunk = 'x'.repeat(4096);
+    globalThis.fetch = mock(() =>
+      Promise.resolve(
+        new Response(
+          new ReadableStream<Uint8Array>({
+            start(controller) {
+              controller.enqueue(new TextEncoder().encode(chunk));
+              controller.enqueue(new TextEncoder().encode(chunk));
+              controller.enqueue(new TextEncoder().encode('tail'));
+              controller.close();
+            },
+          }),
+          {
+            status: 500,
+            statusText: 'Internal Server Error',
+          },
+        ),
+      ),
+    ) as unknown as typeof globalThis.fetch;
+
+    const client = new PeerClient('peer.local', 3000, 'peer-1');
+
+    try {
+      await client.getInfo();
+      throw new Error('expected getInfo to throw');
+    } catch (error) {
+      expect(error).toBeInstanceOf(Error);
+      expect((error as Error).message).toContain('... [truncated]');
+      expect((error as Error).message).not.toContain('tail');
+    }
   });
 
   it('rejects authenticated requests when the client is not paired', async () => {

--- a/src/discovery/peer-client.ts
+++ b/src/discovery/peer-client.ts
@@ -16,6 +16,7 @@ import type {
 
 const DEFAULT_TIMEOUT_MS = 10_000;
 const MAX_PEER_PROXY_IMAGE_BYTES = 5 * 1024 * 1024;
+const MAX_PEER_ERROR_BODY_BYTES = 8 * 1024;
 
 export interface PeerClientLike {
   getAgents(): Promise<RemoteAgentSummary[]>;
@@ -214,7 +215,10 @@ export class PeerClient implements PeerClientLike {
       });
 
       if (!res.ok && !allowedStatuses.includes(res.status)) {
-        const body = await res.text().catch(() => '');
+        const body = await readErrorResponseWithLimit(
+          res,
+          MAX_PEER_ERROR_BODY_BYTES,
+        );
         throw new Error(
           `Peer API error: ${res.status} ${res.statusText} - ${body}`,
         );
@@ -250,6 +254,63 @@ async function readBinaryResponseWithLimit(
   const copy = new Uint8Array(bytes.byteLength);
   copy.set(bytes);
   return copy.buffer;
+}
+
+async function readErrorResponseWithLimit(
+  response: Response,
+  maxBytes: number,
+): Promise<string> {
+  const contentLength = Number.parseInt(
+    response.headers.get('content-length') || '',
+    10,
+  );
+  if (Number.isFinite(contentLength) && contentLength > maxBytes) {
+    response.body?.cancel().catch(() => {});
+    return `[response body omitted: exceeds ${maxBytes} byte limit]`;
+  }
+
+  if (!response.body) {
+    return response.text().catch(() => '');
+  }
+
+  const reader = response.body.getReader();
+  const decoder = new TextDecoder();
+  let totalBytes = 0;
+  let text = '';
+  let truncated = false;
+
+  try {
+    while (true) {
+      const { done, value } = await reader.read();
+      if (done) break;
+      if (!value) continue;
+
+      const remainingBytes = maxBytes - totalBytes;
+      if (remainingBytes <= 0) {
+        truncated = true;
+        await reader.cancel('Error body exceeded byte limit');
+        break;
+      }
+
+      const chunk =
+        value.byteLength > remainingBytes
+          ? value.subarray(0, remainingBytes)
+          : value;
+      text += decoder.decode(chunk, { stream: true });
+      totalBytes += chunk.byteLength;
+
+      if (chunk.byteLength !== value.byteLength) {
+        truncated = true;
+        await reader.cancel('Error body exceeded byte limit');
+        break;
+      }
+    }
+  } finally {
+    reader.releaseLock();
+  }
+
+  text += decoder.decode();
+  return truncated ? `${text}... [truncated]` : text;
 }
 
 function sha256Hex(value: string): string {


### PR DESCRIPTION
## Summary

- cap trusted-peer error response bodies in `PeerClient.fetch()` so proxy failures cannot buffer unbounded remote text
- reject oversized declared error bodies immediately and truncate streamed error text after an 8 KiB cap
- add focused coverage for both the `Content-Length` short-circuit and streamed truncation paths

## Testing

- `bun test src/discovery/peer-client.test.ts src/discovery/routes.test.ts`
- `bun run typecheck`
- `bun run format:check`

Closes #523
