### PR TITLE
feat(web): add conversation export (JSON and plain text)

### DIFF
--- a/src/web/routes.test.ts
+++ b/src/web/routes.test.ts
@@ -1210,3 +1210,151 @@ describe('POST /api/agents/{id}/message', () => {
     expect(body.error).toContain('DB write failed');
   });
 });
+
+describe('conversation export', () => {
+  const sampleMessages = [
+    {
+      id: 'msg-1',
+      chat_jid: 'dc:123',
+      sender: 'user',
+      sender_name: 'Alice',
+      content: 'Hello there',
+      timestamp: '2026-03-01T10:00:00.000Z',
+    },
+    {
+      id: 'msg-2',
+      chat_jid: 'dc:123',
+      sender: 'bot',
+      sender_name: 'Agent',
+      content: 'Hi! How can I help?',
+      timestamp: '2026-03-01T10:00:05.000Z',
+    },
+  ];
+
+  const sampleChats = [
+    {
+      jid: 'dc:123',
+      name: 'Test Chat',
+      last_message_time: '2026-03-01T10:00:05.000Z',
+    },
+  ];
+
+  it('returns JSON export with Content-Disposition header', async () => {
+    const state = makeState({
+      getMessages: () => sampleMessages,
+      getChats: () => sampleChats,
+    });
+    const res = await handle(
+      new Request('http://localhost/api/messages/dc%3A123/export?format=json'),
+      state,
+    );
+    expect(res.status).toBe(200);
+    expect(res.headers.get('content-type')).toContain('application/json');
+    expect(res.headers.get('content-disposition')).toContain('attachment');
+    expect(res.headers.get('content-disposition')).toContain(
+      'Test_Chat-export.json',
+    );
+
+    const body = JSON.parse(await res.text());
+    expect(body.chat_jid).toBe('dc:123');
+    expect(body.chat_name).toBe('Test Chat');
+    expect(body.message_count).toBe(2);
+    expect(body.messages).toHaveLength(2);
+    expect(body.messages[0].sender_name).toBe('Alice');
+    expect(body.exported_at).toBeTruthy();
+  });
+
+  it('returns text export with proper formatting', async () => {
+    const state = makeState({
+      getMessages: () => sampleMessages,
+      getChats: () => sampleChats,
+    });
+    const res = await handle(
+      new Request('http://localhost/api/messages/dc%3A123/export?format=text'),
+      state,
+    );
+    expect(res.status).toBe(200);
+    expect(res.headers.get('content-type')).toContain('text/plain');
+    expect(res.headers.get('content-disposition')).toContain(
+      'Test_Chat-export.txt',
+    );
+
+    const text = await res.text();
+    expect(text).toContain('# Conversation: Test Chat');
+    expect(text).toContain('# JID: dc:123');
+    expect(text).toContain('# Messages: 2');
+    expect(text).toContain('Alice:');
+    expect(text).toContain('Hello there');
+    expect(text).toContain('Agent:');
+    expect(text).toContain('Hi! How can I help?');
+  });
+
+  it('defaults to JSON format when no format specified', async () => {
+    const state = makeState({
+      getMessages: () => sampleMessages,
+      getChats: () => sampleChats,
+    });
+    const res = await handle(
+      new Request('http://localhost/api/messages/dc%3A123/export'),
+      state,
+    );
+    expect(res.status).toBe(200);
+    expect(res.headers.get('content-type')).toContain('application/json');
+  });
+
+  it('rejects invalid format parameter', async () => {
+    const state = makeState();
+    const res = await handle(
+      new Request('http://localhost/api/messages/dc%3A123/export?format=csv'),
+      state,
+    );
+    expect(res.status).toBe(400);
+    const body = (await res.json()) as any;
+    expect(body.error).toContain('Invalid format');
+  });
+
+  it('handles empty messages gracefully', async () => {
+    const state = makeState({
+      getMessages: () => [],
+      getChats: () => sampleChats,
+    });
+    const res = await handle(
+      new Request('http://localhost/api/messages/dc%3A123/export?format=json'),
+      state,
+    );
+    expect(res.status).toBe(200);
+    const body = JSON.parse(await res.text());
+    expect(body.message_count).toBe(0);
+    expect(body.messages).toHaveLength(0);
+  });
+
+  it('falls back to JID when chat name not found', async () => {
+    const state = makeState({
+      getMessages: () => sampleMessages,
+      getChats: () => [],
+    });
+    const res = await handle(
+      new Request('http://localhost/api/messages/dc%3A123/export?format=json'),
+      state,
+    );
+    expect(res.status).toBe(200);
+    const body = JSON.parse(await res.text());
+    expect(body.chat_name).toBe('dc:123');
+  });
+
+  it('sanitizes chat name in filename', async () => {
+    const state = makeState({
+      getMessages: () => [],
+      getChats: () => [
+        { jid: 'dc:123', name: 'My Chat / Special!', last_message_time: '' },
+      ],
+    });
+    const res = await handle(
+      new Request('http://localhost/api/messages/dc%3A123/export?format=json'),
+      state,
+    );
+    const disposition = res.headers.get('content-disposition') || '';
+    expect(disposition).toContain('My_Chat___Special_-export.json');
+    expect(disposition).not.toContain('/');
+  });
+});

--- a/src/web/routes.ts
+++ b/src/web/routes.ts
@@ -192,6 +192,8 @@ export function handleRequest(
   if (pathname === '/api/chats') return handleGetChats(state);
   if (pathname === '/api/messages/search')
     return handleSearchMessages(url, state);
+  if (pathname.endsWith('/export') && pathname.startsWith('/api/messages/'))
+    return handleExportMessages(url, state);
   if (pathname.startsWith('/api/messages/'))
     return handleGetMessages(url, state);
   if (pathname === '/api/stats') return handleGetStats(state);
@@ -721,6 +723,80 @@ function handleGetMessages(url: URL, state: WebStateProvider): Response {
   );
   const messages = state.getMessages(chatJid, since, limit);
   return json(messages);
+}
+
+const MAX_EXPORT_LIMIT = 5000;
+
+function handleExportMessages(url: URL, state: WebStateProvider): Response {
+  // /api/messages/{chatJid}/export?format=json|text&limit=5000
+  const pathWithoutExport = url.pathname.slice(
+    '/api/messages/'.length,
+    -'/export'.length,
+  );
+  let chatJid: string;
+  try {
+    chatJid = decodeURIComponent(pathWithoutExport);
+  } catch {
+    return json({ error: 'Invalid chatJid encoding' }, 400);
+  }
+  if (!chatJid) return json({ error: 'Missing chatJid' }, 400);
+
+  const format = url.searchParams.get('format') || 'json';
+  if (format !== 'json' && format !== 'text')
+    return json({ error: 'Invalid format. Use "json" or "text".' }, 400);
+
+  const limit = Math.min(
+    Math.max(1, parseInt(url.searchParams.get('limit') || '5000', 10) || 5000),
+    MAX_EXPORT_LIMIT,
+  );
+  const messages = state.getMessages(
+    chatJid,
+    '1970-01-01T00:00:00.000Z',
+    limit,
+  );
+
+  const chats = state.getChats();
+  const chatName = chats.find((c) => c.jid === chatJid)?.name || chatJid;
+  const safeName = chatName.replace(/[^a-zA-Z0-9_-]/g, '_');
+
+  if (format === 'text') {
+    const lines: string[] = [];
+    lines.push(`# Conversation: ${chatName}`);
+    lines.push(`# JID: ${chatJid}`);
+    lines.push(`# Exported: ${new Date().toISOString()}`);
+    lines.push(`# Messages: ${messages.length}`);
+    lines.push('');
+
+    for (const msg of messages) {
+      const time = new Date(msg.timestamp).toLocaleString();
+      const sender = msg.sender_name || msg.sender || 'Unknown';
+      lines.push(`[${time}] ${sender}:`);
+      lines.push(msg.content || '');
+      lines.push('');
+    }
+
+    return new Response(lines.join('\n'), {
+      headers: {
+        'Content-Type': 'text/plain; charset=utf-8',
+        'Content-Disposition': `attachment; filename="${safeName}-export.txt"`,
+      },
+    });
+  }
+
+  // JSON format
+  const payload = {
+    chat_jid: chatJid,
+    chat_name: chatName,
+    exported_at: new Date().toISOString(),
+    message_count: messages.length,
+    messages,
+  };
+  return new Response(JSON.stringify(payload, null, 2), {
+    headers: {
+      'Content-Type': 'application/json; charset=utf-8',
+      'Content-Disposition': `attachment; filename="${safeName}-export.json"`,
+    },
+  });
 }
 
 function handleGetStats(state: WebStateProvider): Response {

--- a/webui/src/components/conversations/MessageList.tsx
+++ b/webui/src/components/conversations/MessageList.tsx
@@ -1,5 +1,12 @@
-import { createEffect, createMemo, For, on, Show } from 'solid-js';
-import type { MessageInfo } from '~/lib/api';
+import {
+  createEffect,
+  createMemo,
+  createSignal,
+  For,
+  on,
+  Show,
+} from 'solid-js';
+import { api, type MessageInfo } from '~/lib/api';
 import type { LiveMessage } from '~/lib/stores/messages';
 
 const MAX_TEXT_LENGTH = 2000;
@@ -83,6 +90,9 @@ export default function MessageList(props: {
               </span>
             </Show>
           </span>
+          <Show when={allMessages().length > 0}>
+            <ExportDropdown chatJid={props.chatJid!} />
+          </Show>
         </div>
 
         <Show when={props.hasMore}>
@@ -165,5 +175,49 @@ export default function MessageList(props: {
         </Show>
       </Show>
     </main>
+  );
+}
+
+function ExportDropdown(props: { chatJid: string }) {
+  const [open, setOpen] = createSignal(false);
+
+  function download(format: 'json' | 'text') {
+    const url = api.getExportUrl(props.chatJid, format);
+    const a = document.createElement('a');
+    a.href = url;
+    a.download = '';
+    document.body.appendChild(a);
+    a.click();
+    document.body.removeChild(a);
+    setOpen(false);
+  }
+
+  return (
+    <div class="relative">
+      <button
+        class="px-2 py-0.5 text-[10px] rounded bg-surface-2 border border-border text-text-dim hover:text-text hover:border-accent/40 transition-colors"
+        title="Export conversation"
+        onClick={() => setOpen(!open())}
+        onBlur={() => setTimeout(() => setOpen(false), 150)}
+      >
+        Export
+      </button>
+      <Show when={open()}>
+        <div class="absolute right-0 top-full mt-1 bg-surface border border-border rounded shadow-lg z-10 min-w-[120px]">
+          <button
+            class="w-full text-left px-3 py-1.5 text-[11px] text-text hover:bg-surface-2 transition-colors"
+            onMouseDown={() => download('json')}
+          >
+            JSON
+          </button>
+          <button
+            class="w-full text-left px-3 py-1.5 text-[11px] text-text hover:bg-surface-2 transition-colors border-t border-border"
+            onMouseDown={() => download('text')}
+          >
+            Plain text
+          </button>
+        </div>
+      </Show>
+    </div>
   );
 }

--- a/webui/src/lib/api.ts
+++ b/webui/src/lib/api.ts
@@ -403,6 +403,10 @@ export const api = {
       { channel, content, sender_name: senderName },
     ),
 
+  // Export
+  getExportUrl: (chatJid: string, format: 'json' | 'text' = 'json') =>
+    `/api/messages/${encodeURIComponent(chatJid)}/export?format=${format}`,
+
   // Icons
   getChatIconUrl: (chatJid: string) =>
     `/api/chats/${encodeURIComponent(chatJid)}/icon`,

--- a/webui/src/routes/api/messages/[chatJid]/export.ts
+++ b/webui/src/routes/api/messages/[chatJid]/export.ts
@@ -1,0 +1,78 @@
+import type { APIEvent } from '@solidjs/start/server';
+import { getState } from '~/lib/server-state';
+
+const MAX_EXPORT_LIMIT = 5000;
+
+export function GET({ params, request }: APIEvent) {
+  const state = getState();
+  const chatJid = params.chatJid;
+  if (!chatJid)
+    return Response.json({ error: 'Missing chatJid' }, { status: 400 });
+
+  const url = new URL(request.url);
+  const format = url.searchParams.get('format') || 'json';
+  if (format !== 'json' && format !== 'text')
+    return Response.json(
+      { error: 'Invalid format. Use "json" or "text".' },
+      { status: 400 },
+    );
+
+  const limit = Math.min(
+    Math.max(1, parseInt(url.searchParams.get('limit') || '5000', 10) || 5000),
+    MAX_EXPORT_LIMIT,
+  );
+  const messages = state.getMessages(
+    chatJid,
+    '1970-01-01T00:00:00.000Z',
+    limit,
+  );
+
+  const chats = state.getChats() as Array<{
+    jid: string;
+    name: string;
+    last_message_time: string;
+  }>;
+  const chatName =
+    chats.find((c: { jid: string }) => c.jid === chatJid)?.name || chatJid;
+
+  if (format === 'text') {
+    const lines: string[] = [];
+    lines.push(`# Conversation: ${chatName}`);
+    lines.push(`# JID: ${chatJid}`);
+    lines.push(`# Exported: ${new Date().toISOString()}`);
+    lines.push(`# Messages: ${messages.length}`);
+    lines.push('');
+
+    for (const msg of messages) {
+      const time = new Date(msg.timestamp).toLocaleString();
+      const sender = msg.sender_name || msg.sender || 'Unknown';
+      lines.push(`[${time}] ${sender}:`);
+      lines.push(msg.content || '');
+      lines.push('');
+    }
+
+    const safeName = chatName.replace(/[^a-zA-Z0-9_-]/g, '_');
+    return new Response(lines.join('\n'), {
+      headers: {
+        'Content-Type': 'text/plain; charset=utf-8',
+        'Content-Disposition': `attachment; filename="${safeName}-export.txt"`,
+      },
+    });
+  }
+
+  // JSON format
+  const payload = {
+    chat_jid: chatJid,
+    chat_name: chatName,
+    exported_at: new Date().toISOString(),
+    message_count: messages.length,
+    messages,
+  };
+  const safeName = chatName.replace(/[^a-zA-Z0-9_-]/g, '_');
+  return new Response(JSON.stringify(payload, null, 2), {
+    headers: {
+      'Content-Type': 'application/json; charset=utf-8',
+      'Content-Disposition': `attachment; filename="${safeName}-export.json"`,
+    },
+  });
+}


### PR DESCRIPTION
## Summary

- Add conversation export feature to the web UI — download conversation history as JSON or plain text
- New `Export` dropdown button appears in the conversation message header when viewing a chat
- JSON format includes structured metadata (chat name, JID, export timestamp, message count)
- Plain text format includes human-readable headers and `[timestamp] sender: message` layout
- Both formats trigger browser download with sanitized filenames

## Changes

- `webui/src/routes/api/messages/[chatJid]/export.ts` — new SolidStart API route
- `src/web/routes.ts` — legacy route handler for `/api/messages/:chatJid/export`
- `webui/src/components/conversations/MessageList.tsx` — export dropdown UI
- `webui/src/lib/api.ts` — `getExportUrl()` helper
- `src/web/routes.test.ts` — 7 new tests (JSON/text format, edge cases, filename sanitization)

## Test plan

- [x] All 1742 tests pass (7 new export tests)
- [x] TypeScript type check passes (`tsc --noEmit`)
- [ ] Manual: open conversations page, select a chat, click Export → JSON
- [ ] Manual: open conversations page, select a chat, click Export → Plain text
- [ ] Verify downloaded files have correct content and filenames

Closes part of #505.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Users can now export conversations in JSON or text formats. Exports include chat metadata, message content, and timestamps with auto-generated, properly formatted filenames.

* **Tests**
  * Added comprehensive test coverage for the export feature, validating response formats, error handling, and filename sanitization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->