### PR TITLE
fix(discovery): cap trusted-peer JSON response bodies

### DIFF
--- a/src/discovery/peer-client.test.ts
+++ b/src/discovery/peer-client.test.ts
@@ -5,6 +5,7 @@ import { PeerClient, verifyPeerRequestSignature } from './peer-client.js';
 
 const originalFetch = globalThis.fetch;
 const MAX_PEER_PROXY_IMAGE_BYTES = 5 * 1024 * 1024;
+const MAX_PEER_JSON_RESPONSE_BYTES = 1024 * 1024;
 
 function sha256Hex(value: string): string {
   return createHash('sha256').update(value).digest('hex');
@@ -243,6 +244,63 @@ describe('PeerClient', () => {
     await expect(client.getChatIcon('chat/room')).rejects.toThrow(
       'Download exceeded 5242880 bytes',
     );
+  });
+
+  it('rejects authenticated JSON responses that exceed the content-length cap', async () => {
+    let cancelled = false;
+    globalThis.fetch = mock(() =>
+      Promise.resolve(
+        new Response(
+          new ReadableStream<Uint8Array>({
+            cancel() {
+              cancelled = true;
+            },
+          }),
+          {
+            headers: {
+              'content-length': String(MAX_PEER_JSON_RESPONSE_BYTES + 1),
+              'content-type': 'application/json',
+            },
+          },
+        ),
+      ),
+    ) as unknown as typeof globalThis.fetch;
+
+    const client = new PeerClient('peer.local', 3000, 'stats-cap', 'secret');
+
+    await expect(client.getStats()).rejects.toThrow(
+      'Peer JSON response exceeded 1048576 bytes',
+    );
+    expect(cancelled).toBe(true);
+  });
+
+  it('rejects streamed authenticated JSON responses that exceed the byte cap', async () => {
+    const firstChunk = new Uint8Array(768 * 1024);
+    const secondChunk = new Uint8Array(512 * 1024);
+    globalThis.fetch = mock(() =>
+      Promise.resolve(
+        new Response(
+          new ReadableStream<Uint8Array>({
+            start(controller) {
+              controller.enqueue(firstChunk);
+              controller.enqueue(secondChunk);
+              controller.close();
+            },
+          }),
+          {
+            headers: {
+              'content-type': 'application/json',
+            },
+          },
+        ),
+      ),
+    ) as unknown as typeof globalThis.fetch;
+
+    const client = new PeerClient('peer.local', 3000, 'layers-cap', 'secret');
+
+    await expect(
+      client.getContextLayers({ folder: 'groups/main' }),
+    ).rejects.toThrow('Download exceeded 1048576 bytes');
   });
 
   it('rejects oversized error bodies from content-length without buffering them', async () => {

--- a/src/discovery/peer-client.test.ts
+++ b/src/discovery/peer-client.test.ts
@@ -300,7 +300,7 @@ describe('PeerClient', () => {
 
     await expect(
       client.getContextLayers({ folder: 'groups/main' }),
-    ).rejects.toThrow('Download exceeded 1048576 bytes');
+    ).rejects.toThrow('Peer JSON response exceeded 1048576 bytes');
   });
 
   it('rejects oversized error bodies from content-length without buffering them', async () => {

--- a/src/discovery/peer-client.ts
+++ b/src/discovery/peer-client.ts
@@ -18,6 +18,7 @@ const DEFAULT_TIMEOUT_MS = 10_000;
 const MAX_PEER_PROXY_IMAGE_BYTES = 5 * 1024 * 1024;
 const MAX_PEER_ERROR_BODY_BYTES = 8 * 1024;
 const MAX_PEER_JSON_RESPONSE_BYTES = 1024 * 1024;
+const PEER_JSON_RESPONSE_LABEL = 'Peer JSON response';
 const textDecoder = new TextDecoder();
 
 export interface PeerClientLike {
@@ -61,7 +62,6 @@ export class PeerClient implements PeerClientLike {
     return readJsonResponseWithLimit<PeerInfoResponse>(
       res,
       MAX_PEER_JSON_RESPONSE_BYTES,
-      'Peer JSON response',
     );
   }
 
@@ -75,7 +75,6 @@ export class PeerClient implements PeerClientLike {
     return readJsonResponseWithLimit<PairResponse>(
       res,
       MAX_PEER_JSON_RESPONSE_BYTES,
-      'Peer JSON response',
     );
   }
 
@@ -94,7 +93,6 @@ export class PeerClient implements PeerClientLike {
     return readJsonResponseWithLimit<RemoteAgentSummary[]>(
       res,
       MAX_PEER_JSON_RESPONSE_BYTES,
-      'Peer JSON response',
     );
   }
 
@@ -139,11 +137,7 @@ export class PeerClient implements PeerClientLike {
   /** GET /api/stats — requires auth */
   async getStats(): Promise<unknown> {
     const res = await this.authenticatedFetch('/api/stats');
-    return readJsonResponseWithLimit(
-      res,
-      MAX_PEER_JSON_RESPONSE_BYTES,
-      'Peer JSON response',
-    );
+    return readJsonResponseWithLimit(res, MAX_PEER_JSON_RESPONSE_BYTES);
   }
 
   /** GET /api/logs/stream — requires auth */
@@ -155,11 +149,7 @@ export class PeerClient implements PeerClientLike {
   async getContextLayers(params: Record<string, string>): Promise<unknown> {
     const query = new URLSearchParams(params).toString();
     const res = await this.authenticatedFetch(`/api/context/layers?${query}`);
-    return readJsonResponseWithLimit(
-      res,
-      MAX_PEER_JSON_RESPONSE_BYTES,
-      'Peer JSON response',
-    );
+    return readJsonResponseWithLimit(res, MAX_PEER_JSON_RESPONSE_BYTES);
   }
 
   /** GET /api/context/files — requires auth */
@@ -168,7 +158,6 @@ export class PeerClient implements PeerClientLike {
     return readJsonResponseWithLimit<ContextFileEntry[]>(
       res,
       MAX_PEER_JSON_RESPONSE_BYTES,
-      'Peer JSON response',
     );
   }
 
@@ -185,7 +174,6 @@ export class PeerClient implements PeerClientLike {
     return readJsonResponseWithLimit<{ ok: boolean }>(
       res,
       MAX_PEER_JSON_RESPONSE_BYTES,
-      'Peer JSON response',
     );
   }
 
@@ -346,7 +334,7 @@ async function readErrorResponseWithLimit(
 async function readJsonResponseWithLimit<T>(
   response: Response,
   maxBytes: number,
-  label: string,
+  label = PEER_JSON_RESPONSE_LABEL,
 ): Promise<T> {
   const contentLength = Number.parseInt(
     response.headers.get('content-length') || '',
@@ -357,8 +345,15 @@ async function readJsonResponseWithLimit<T>(
     throw new Error(`${label} exceeded ${maxBytes} bytes`);
   }
 
-  const bytes = await readStreamWithByteLimit(response.body, maxBytes);
-  return JSON.parse(textDecoder.decode(bytes)) as T;
+  try {
+    const bytes = await readStreamWithByteLimit(response.body, maxBytes);
+    return JSON.parse(textDecoder.decode(bytes)) as T;
+  } catch (error) {
+    if (error instanceof Error && error.message.includes('Download exceeded')) {
+      throw new Error(`${label} exceeded ${maxBytes} bytes`);
+    }
+    throw error;
+  }
 }
 
 function sha256Hex(value: string): string {

--- a/src/discovery/peer-client.ts
+++ b/src/discovery/peer-client.ts
@@ -17,6 +17,8 @@ import type {
 const DEFAULT_TIMEOUT_MS = 10_000;
 const MAX_PEER_PROXY_IMAGE_BYTES = 5 * 1024 * 1024;
 const MAX_PEER_ERROR_BODY_BYTES = 8 * 1024;
+const MAX_PEER_JSON_RESPONSE_BYTES = 1024 * 1024;
+const textDecoder = new TextDecoder();
 
 export interface PeerClientLike {
   getAgents(): Promise<RemoteAgentSummary[]>;
@@ -56,7 +58,11 @@ export class PeerClient implements PeerClientLike {
   /** GET /api/discovery/info — no auth required */
   async getInfo(): Promise<PeerInfoResponse> {
     const res = await this.fetch('/api/discovery/info');
-    return res.json() as Promise<PeerInfoResponse>;
+    return readJsonResponseWithLimit<PeerInfoResponse>(
+      res,
+      MAX_PEER_JSON_RESPONSE_BYTES,
+      'Peer JSON response',
+    );
   }
 
   /** POST /api/discovery/pair — no auth required */
@@ -66,7 +72,11 @@ export class PeerClient implements PeerClientLike {
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify(body),
     });
-    return res.json() as Promise<PairResponse>;
+    return readJsonResponseWithLimit<PairResponse>(
+      res,
+      MAX_PEER_JSON_RESPONSE_BYTES,
+      'Peer JSON response',
+    );
   }
 
   /** POST /api/discovery/complete-pairing — sends approval callback */
@@ -81,7 +91,11 @@ export class PeerClient implements PeerClientLike {
   /** GET /api/agents — requires auth */
   async getAgents(): Promise<RemoteAgentSummary[]> {
     const res = await this.authenticatedFetch('/api/agents');
-    return res.json() as Promise<RemoteAgentSummary[]>;
+    return readJsonResponseWithLimit<RemoteAgentSummary[]>(
+      res,
+      MAX_PEER_JSON_RESPONSE_BYTES,
+      'Peer JSON response',
+    );
   }
 
   /** GET /api/agents/:id/avatar/image — requires auth, returns image bytes */
@@ -125,7 +139,11 @@ export class PeerClient implements PeerClientLike {
   /** GET /api/stats — requires auth */
   async getStats(): Promise<unknown> {
     const res = await this.authenticatedFetch('/api/stats');
-    return res.json();
+    return readJsonResponseWithLimit(
+      res,
+      MAX_PEER_JSON_RESPONSE_BYTES,
+      'Peer JSON response',
+    );
   }
 
   /** GET /api/logs/stream — requires auth */
@@ -137,13 +155,21 @@ export class PeerClient implements PeerClientLike {
   async getContextLayers(params: Record<string, string>): Promise<unknown> {
     const query = new URLSearchParams(params).toString();
     const res = await this.authenticatedFetch(`/api/context/layers?${query}`);
-    return res.json();
+    return readJsonResponseWithLimit(
+      res,
+      MAX_PEER_JSON_RESPONSE_BYTES,
+      'Peer JSON response',
+    );
   }
 
   /** GET /api/context/files — requires auth */
   async listContextFiles(): Promise<ContextFileEntry[]> {
     const res = await this.authenticatedFetch('/api/context/files');
-    return res.json() as Promise<ContextFileEntry[]>;
+    return readJsonResponseWithLimit<ContextFileEntry[]>(
+      res,
+      MAX_PEER_JSON_RESPONSE_BYTES,
+      'Peer JSON response',
+    );
   }
 
   /** PUT /api/context/file — requires auth */
@@ -156,7 +182,11 @@ export class PeerClient implements PeerClientLike {
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({ path: layerPath, content }),
     });
-    return res.json() as Promise<{ ok: boolean }>;
+    return readJsonResponseWithLimit<{ ok: boolean }>(
+      res,
+      MAX_PEER_JSON_RESPONSE_BYTES,
+      'Peer JSON response',
+    );
   }
 
   private async authenticatedFetch(
@@ -311,6 +341,24 @@ async function readErrorResponseWithLimit(
 
   text += decoder.decode();
   return truncated ? `${text}... [truncated]` : text;
+}
+
+async function readJsonResponseWithLimit<T>(
+  response: Response,
+  maxBytes: number,
+  label: string,
+): Promise<T> {
+  const contentLength = Number.parseInt(
+    response.headers.get('content-length') || '',
+    10,
+  );
+  if (Number.isFinite(contentLength) && contentLength > maxBytes) {
+    response.body?.cancel().catch(() => {});
+    throw new Error(`${label} exceeded ${maxBytes} bytes`);
+  }
+
+  const bytes = await readStreamWithByteLimit(response.body, maxBytes);
+  return JSON.parse(textDecoder.decode(bytes)) as T;
 }
 
 function sha256Hex(value: string): string {


### PR DESCRIPTION
## Summary
- cap trusted-peer JSON responses in `PeerClient` before parsing so paired remote instances cannot force unbounded `res.json()` buffering
- reject oversized `Content-Length` values up front and enforce the same 1 MiB ceiling while streaming response bodies
- add regression tests for both header-based and streamed overflow on authenticated discovery responses

## Testing
- `bun test src/discovery/peer-client.test.ts`
- `bun run typecheck`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Enforced a 1 MiB limit for JSON responses from peers to improve stability and prevent oversized downloads.
  * Peer responses that exceed the limit are now rejected and their downloads are terminated.

* **Tests**
  * Added tests verifying enforcement of the JSON response size limit for both streamed and non-streamed responses.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->