### PR TITLE
feat(web): add password-based session authentication

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -143,6 +143,7 @@ const configSchema = z
     ),
     WEB_UI_USER: z.preprocess(optionalTrimmedString, z.string().optional()),
     WEB_UI_PASS: z.preprocess(optionalTrimmedString, z.string().optional()),
+    WEB_PASSWORD: z.preprocess(optionalTrimmedString, z.string().optional()),
     WEB_UI_HOST: z.string().default('127.0.0.1'),
     WEB_UI_CORS_ORIGIN: z.preprocess(
       optionalTrimmedString,
@@ -408,6 +409,8 @@ export const DISCOVERY_TRUST_LAN_ADMIN = CONFIG.DISCOVERY_TRUST_LAN_ADMIN;
 export const WEB_UI_PORT = CONFIG.WEB_UI_PORT;
 export const WEB_UI_USER = CONFIG.WEB_UI_USER;
 export const WEB_UI_PASS = CONFIG.WEB_UI_PASS;
+// Session-based password auth: when set, the web UI shows a login page instead of Basic Auth.
+export const WEB_PASSWORD = CONFIG.WEB_PASSWORD;
 // Bind hostname: defaults to loopback (127.0.0.1) for security.
 // Set WEB_UI_HOST=0.0.0.0 to expose on all interfaces (e.g. behind a reverse proxy).
 export const WEB_UI_HOST = CONFIG.WEB_UI_HOST;

--- a/src/index.ts
+++ b/src/index.ts
@@ -45,6 +45,7 @@ import {
   TELEGRAM_BOT_TOKENS,
   WEB_UI_CORS_ORIGIN,
   WEB_UI_HOST,
+  WEB_PASSWORD,
   WEB_UI_PASS,
   WEB_UI_PORT,
   WEB_UI_USER,
@@ -2582,23 +2583,24 @@ async function main(): Promise<void> {
     const isPublic = WEB_UI_HOST !== '127.0.0.1' && WEB_UI_HOST !== 'localhost';
     const allowUnauthedPublicWebUiForTrustedLan =
       isPublic && DISCOVERY_TRUST_LAN_ADMIN;
+    const hasAuth = (WEB_UI_USER && WEB_UI_PASS) || WEB_PASSWORD;
     if (
       isPublic &&
       !allowUnauthedPublicWebUiForTrustedLan &&
-      (!WEB_UI_USER || !WEB_UI_PASS)
+      !hasAuth
     ) {
       logger.error(
-        'WEB_UI_HOST is set to a public interface but WEB_UI_USER and/or WEB_UI_PASS are missing. ' +
-          'Refusing to start unauthenticated Web UI. Set both credentials or unset WEB_UI_PORT.',
+        'WEB_UI_HOST is set to a public interface but no auth is configured. ' +
+          'Set WEB_PASSWORD, or both WEB_UI_USER and WEB_UI_PASS, or unset WEB_UI_PORT.',
       );
       process.exit(1);
     }
     if (
       allowUnauthedPublicWebUiForTrustedLan &&
-      (!WEB_UI_USER || !WEB_UI_PASS)
+      !hasAuth
     ) {
       logger.warn(
-        'Starting Web UI on a non-loopback interface without WEB_UI_USER/WEB_UI_PASS because DISCOVERY_TRUST_LAN_ADMIN=true. Only do this on a trusted private LAN.',
+        'Starting Web UI on a non-loopback interface without auth because DISCOVERY_TRUST_LAN_ADMIN=true. Only do this on a trusted private LAN.',
       );
     }
     const webAuth =
@@ -2610,6 +2612,7 @@ async function main(): Promise<void> {
       {
         port: WEB_UI_PORT,
         auth: webAuth,
+        sessionPassword: WEB_PASSWORD,
         hostname: WEB_UI_HOST,
         corsOrigin: WEB_UI_CORS_ORIGIN,
         trustLanDiscoveryAdmin: DISCOVERY_TRUST_LAN_ADMIN,

--- a/src/index.ts
+++ b/src/index.ts
@@ -2584,21 +2584,14 @@ async function main(): Promise<void> {
     const allowUnauthedPublicWebUiForTrustedLan =
       isPublic && DISCOVERY_TRUST_LAN_ADMIN;
     const hasAuth = (WEB_UI_USER && WEB_UI_PASS) || WEB_PASSWORD;
-    if (
-      isPublic &&
-      !allowUnauthedPublicWebUiForTrustedLan &&
-      !hasAuth
-    ) {
+    if (isPublic && !allowUnauthedPublicWebUiForTrustedLan && !hasAuth) {
       logger.error(
         'WEB_UI_HOST is set to a public interface but no auth is configured. ' +
           'Set WEB_PASSWORD, or both WEB_UI_USER and WEB_UI_PASS, or unset WEB_UI_PORT.',
       );
       process.exit(1);
     }
-    if (
-      allowUnauthedPublicWebUiForTrustedLan &&
-      !hasAuth
-    ) {
+    if (allowUnauthedPublicWebUiForTrustedLan && !hasAuth) {
       logger.warn(
         'Starting Web UI on a non-loopback interface without auth because DISCOVERY_TRUST_LAN_ADMIN=true. Only do this on a trusted private LAN.',
       );

--- a/src/web/server.ts
+++ b/src/web/server.ts
@@ -169,7 +169,14 @@ export function startWebServer(
   state: WebStateProvider,
   trustStore?: TrustStore,
 ): WebServerHandle {
-  const { port, auth, sessionPassword, hostname, corsOrigin, trustLanDiscoveryAdmin } = config;
+  const {
+    port,
+    auth,
+    sessionPassword,
+    hostname,
+    corsOrigin,
+    trustLanDiscoveryAdmin,
+  } = config;
   const sessionStore = sessionPassword ? createSessionStore() : null;
   const bindHostname = hostname || '127.0.0.1';
   const sseClients = new Set<SseClient>();
@@ -253,9 +260,7 @@ export function startWebServer(
         }
       }
       if (url.pathname === '/logout') {
-        const sessionToken = parseSessionCookie(
-          req.headers.get('Cookie'),
-        );
+        const sessionToken = parseSessionCookie(req.headers.get('Cookie'));
         if (sessionToken) sessionStore.revoke(sessionToken);
         return new Response(null, {
           status: 302,

--- a/src/web/server.ts
+++ b/src/web/server.ts
@@ -12,6 +12,16 @@ import type { ScheduledTask } from '../types.js';
 import { escapeHtml, renderPagePatch } from './shared.js';
 import type { WebServerConfig, WebStateProvider, WsEvent } from './types.js';
 import {
+  createSessionStore,
+  parseSessionCookie,
+  makeSessionCookie,
+  makeClearSessionCookie,
+  verifyPassword,
+  isAuthExemptPath,
+  renderLoginPage,
+  type SessionStore,
+} from './session-auth.js';
+import {
   renderAgentDetailContent,
   buildAgentDetailData,
 } from './agent-detail.js';
@@ -159,7 +169,8 @@ export function startWebServer(
   state: WebStateProvider,
   trustStore?: TrustStore,
 ): WebServerHandle {
-  const { port, auth, hostname, corsOrigin, trustLanDiscoveryAdmin } = config;
+  const { port, auth, sessionPassword, hostname, corsOrigin, trustLanDiscoveryAdmin } = config;
+  const sessionStore = sessionPassword ? createSessionStore() : null;
   const bindHostname = hostname || '127.0.0.1';
   const sseClients = new Set<SseClient>();
   const recentLogs: string[] = [];
@@ -209,7 +220,66 @@ export function startWebServer(
           headers: corsOrigin ? makeCorsHeaders(corsOrigin) : {},
         });
       }
-      // Peer is authenticated — skip Basic Auth, fall through to routing
+      // Peer is authenticated — skip auth, fall through to routing
+    } else if (sessionStore && sessionPassword) {
+      // --- Session-based auth (WEB_PASSWORD) ---
+      // Handle login/logout before checking session
+      if (url.pathname === '/login') {
+        if (req.method === 'GET') {
+          return new Response(renderLoginPage(), {
+            headers: { 'Content-Type': 'text/html; charset=utf-8' },
+          });
+        }
+        if (req.method === 'POST') {
+          const formData = await req.formData().catch(() => null);
+          const password = formData?.get('password');
+          if (
+            typeof password === 'string' &&
+            verifyPassword(password, sessionPassword)
+          ) {
+            const token = sessionStore.create();
+            return new Response(null, {
+              status: 302,
+              headers: {
+                Location: '/',
+                'Set-Cookie': makeSessionCookie(token),
+              },
+            });
+          }
+          return new Response(renderLoginPage('Invalid password'), {
+            status: 401,
+            headers: { 'Content-Type': 'text/html; charset=utf-8' },
+          });
+        }
+      }
+      if (url.pathname === '/logout') {
+        const sessionToken = parseSessionCookie(
+          req.headers.get('Cookie'),
+        );
+        if (sessionToken) sessionStore.revoke(sessionToken);
+        return new Response(null, {
+          status: 302,
+          headers: {
+            Location: '/login',
+            'Set-Cookie': makeClearSessionCookie(),
+          },
+        });
+      }
+      // Check session cookie for all other routes
+      const sessionToken = parseSessionCookie(req.headers.get('Cookie'));
+      if (!sessionToken || !sessionStore.validate(sessionToken)) {
+        // API routes return 401 JSON; page routes redirect to login
+        if (url.pathname.startsWith('/api/')) {
+          return new Response(JSON.stringify({ error: 'Unauthorized' }), {
+            status: 401,
+            headers: { 'Content-Type': 'application/json' },
+          });
+        }
+        return new Response(null, {
+          status: 302,
+          headers: { Location: '/login' },
+        });
+      }
     } else if (auth && !checkBasicAuth(req, auth)) {
       // --- Basic auth for HTTP ---
       return new Response('Unauthorized', {
@@ -218,6 +288,7 @@ export function startWebServer(
       });
     } else if (
       !auth &&
+      !sessionPassword &&
       url.pathname.startsWith('/api/discovery/') &&
       !isUnauthDiscoveryRoute(url.pathname) &&
       !isTrustedLanDiscoveryAdminRequest(
@@ -234,7 +305,7 @@ export function startWebServer(
       return new Response(
         JSON.stringify({
           error:
-            'Discovery admin routes require authentication (set WEB_UI_USER/WEB_UI_PASS or access from a private network)',
+            'Discovery admin routes require authentication (set WEB_PASSWORD or WEB_UI_USER/WEB_UI_PASS or access from a private network)',
         }),
         {
           status: 403,

--- a/src/web/session-auth.test.ts
+++ b/src/web/session-auth.test.ts
@@ -1,0 +1,432 @@
+import { describe, it, expect, afterEach } from 'bun:test';
+
+import {
+  createSessionStore,
+  parseSessionCookie,
+  makeSessionCookie,
+  makeClearSessionCookie,
+  verifyPassword,
+  isAuthExemptPath,
+  renderLoginPage,
+} from './session-auth.js';
+import { startWebServer, type WebServerHandle } from './server.js';
+import type { WebStateProvider, QueueStats } from './types.js';
+import type { Agent, ChannelSubscription, ScheduledTask } from '../types.js';
+
+// ---- Fixtures ----
+
+function makeAgent(overrides: Partial<Agent> = {}): Agent {
+  return {
+    id: 'test-agent',
+    name: 'Test Agent',
+    folder: 'test-agent',
+    backend: 'apple-container',
+    agentRuntime: 'claude-agent-sdk',
+    isAdmin: false,
+    createdAt: '2026-01-01T00:00:00.000Z',
+    ...overrides,
+  };
+}
+
+const defaultStats: QueueStats = {
+  activeContainers: 0,
+  idleContainers: 0,
+  maxActive: 8,
+  maxIdle: 4,
+};
+
+function makeState(
+  overrides: Partial<WebStateProvider> = {},
+): WebStateProvider {
+  return {
+    getAgents: () => ({ 'test-agent': makeAgent() }),
+    getChannelSubscriptions: () => ({}),
+    getTasks: () => [],
+    getTaskById: () => undefined,
+    getMessages: () => [],
+    getChats: () => [],
+    getQueueStats: () => defaultStats,
+    getQueueDetails: () => [],
+    getIpcEvents: () => [],
+    getTaskRunLogs: () => [],
+    getTaskRunPhaseEvents: () => [],
+    searchMessages: () => [],
+    createTask: () => {},
+    updateTask: () => {},
+    deleteTask: () => {},
+    calculateNextRun: () => null,
+    readContextFile: () => null,
+    writeContextFile: () => {},
+    updateAgentAvatar: () => {},
+    ...overrides,
+  };
+}
+
+// ---- Unit tests for session store ----
+
+describe('SessionStore', () => {
+  it('creates and validates sessions', () => {
+    const store = createSessionStore();
+    const token = store.create();
+    expect(token).toBeString();
+    expect(token.length).toBe(64); // 32 bytes hex
+    expect(store.validate(token)).toBe(true);
+    expect(store.size).toBe(1);
+  });
+
+  it('rejects invalid tokens', () => {
+    const store = createSessionStore();
+    expect(store.validate('')).toBe(false);
+    expect(store.validate('nonexistent-token')).toBe(false);
+  });
+
+  it('revokes sessions', () => {
+    const store = createSessionStore();
+    const token = store.create();
+    expect(store.validate(token)).toBe(true);
+    store.revoke(token);
+    expect(store.validate(token)).toBe(false);
+    expect(store.size).toBe(0);
+  });
+
+  it('handles multiple sessions', () => {
+    const store = createSessionStore();
+    const t1 = store.create();
+    const t2 = store.create();
+    const t3 = store.create();
+    expect(store.size).toBe(3);
+    expect(store.validate(t1)).toBe(true);
+    expect(store.validate(t2)).toBe(true);
+    expect(store.validate(t3)).toBe(true);
+    store.revoke(t2);
+    expect(store.validate(t1)).toBe(true);
+    expect(store.validate(t2)).toBe(false);
+    expect(store.validate(t3)).toBe(true);
+  });
+
+  it('purges expired sessions', () => {
+    const store = createSessionStore();
+    const token = store.create();
+    expect(store.validate(token)).toBe(true);
+    // Manually expire by manipulating time isn't feasible here,
+    // but we can verify purge runs without errors
+    store.purge();
+    expect(store.validate(token)).toBe(true);
+  });
+});
+
+// ---- Unit tests for cookie helpers ----
+
+describe('parseSessionCookie', () => {
+  it('returns null for missing header', () => {
+    expect(parseSessionCookie(null)).toBeNull();
+  });
+
+  it('returns null for empty header', () => {
+    expect(parseSessionCookie('')).toBeNull();
+  });
+
+  it('extracts session token from single cookie', () => {
+    expect(parseSessionCookie('omniclaw_session=abc123')).toBe('abc123');
+  });
+
+  it('extracts session token from multiple cookies', () => {
+    expect(
+      parseSessionCookie('other=val; omniclaw_session=xyz789; foo=bar'),
+    ).toBe('xyz789');
+  });
+
+  it('returns null when session cookie is missing', () => {
+    expect(parseSessionCookie('other=val; foo=bar')).toBeNull();
+  });
+});
+
+describe('makeSessionCookie', () => {
+  it('builds a proper Set-Cookie header', () => {
+    const cookie = makeSessionCookie('token123');
+    expect(cookie).toContain('omniclaw_session=token123');
+    expect(cookie).toContain('HttpOnly');
+    expect(cookie).toContain('SameSite=Strict');
+    expect(cookie).toContain('Path=/');
+    expect(cookie).toContain('Max-Age=');
+  });
+});
+
+describe('makeClearSessionCookie', () => {
+  it('clears the session cookie', () => {
+    const cookie = makeClearSessionCookie();
+    expect(cookie).toContain('omniclaw_session=');
+    expect(cookie).toContain('Max-Age=0');
+  });
+});
+
+// ---- Unit tests for password verification ----
+
+describe('verifyPassword', () => {
+  it('returns true for matching passwords', () => {
+    expect(verifyPassword('secret', 'secret')).toBe(true);
+  });
+
+  it('returns false for non-matching passwords', () => {
+    expect(verifyPassword('wrong', 'secret')).toBe(false);
+  });
+
+  it('returns false for different length passwords', () => {
+    expect(verifyPassword('short', 'muchlongerpassword')).toBe(false);
+  });
+
+  it('handles empty strings', () => {
+    expect(verifyPassword('', '')).toBe(true);
+    expect(verifyPassword('', 'notempty')).toBe(false);
+  });
+});
+
+// ---- Unit tests for path exemption ----
+
+describe('isAuthExemptPath', () => {
+  it('exempts login and logout', () => {
+    expect(isAuthExemptPath('/login')).toBe(true);
+    expect(isAuthExemptPath('/logout')).toBe(true);
+  });
+
+  it('does not exempt other paths', () => {
+    expect(isAuthExemptPath('/')).toBe(false);
+    expect(isAuthExemptPath('/api/agents')).toBe(false);
+    expect(isAuthExemptPath('/agents')).toBe(false);
+  });
+});
+
+// ---- Unit tests for login page rendering ----
+
+describe('renderLoginPage', () => {
+  it('renders a login form', () => {
+    const html = renderLoginPage();
+    expect(html).toContain('<form');
+    expect(html).toContain('action="/login"');
+    expect(html).toContain('type="password"');
+    expect(html).toContain('Sign In');
+    expect(html).toContain('omniclaw');
+  });
+
+  it('renders an error message when provided', () => {
+    const html = renderLoginPage('Invalid password');
+    expect(html).toContain('Invalid password');
+    expect(html).toContain('login-error');
+  });
+
+  it('escapes HTML in error messages', () => {
+    const html = renderLoginPage('<script>alert(1)</script>');
+    expect(html).not.toContain('<script>alert(1)</script>');
+    expect(html).toContain('&lt;script&gt;');
+  });
+});
+
+// ---- Integration tests for session auth middleware ----
+
+const TEST_PASSWORD = 'test-secret-password';
+let handle: WebServerHandle | null = null;
+
+afterEach(async () => {
+  if (handle) {
+    await handle.stop();
+    handle = null;
+  }
+});
+
+function serverUrl(path: string): string {
+  return `http://localhost:${handle!.port}${path}`;
+}
+
+describe('session auth middleware', () => {
+  it('redirects unauthenticated page requests to /login', async () => {
+    handle = startWebServer(
+      { port: 0, sessionPassword: TEST_PASSWORD },
+      makeState(),
+    );
+    const res = await fetch(serverUrl('/'), { redirect: 'manual' });
+    expect(res.status).toBe(302);
+    expect(res.headers.get('Location')).toBe('/login');
+  });
+
+  it('returns 401 JSON for unauthenticated API requests', async () => {
+    handle = startWebServer(
+      { port: 0, sessionPassword: TEST_PASSWORD },
+      makeState(),
+    );
+    const res = await fetch(serverUrl('/api/agents'));
+    expect(res.status).toBe(401);
+    const body = (await res.json()) as { error: string };
+    expect(body.error).toBe('Unauthorized');
+  });
+
+  it('serves the login page on GET /login', async () => {
+    handle = startWebServer(
+      { port: 0, sessionPassword: TEST_PASSWORD },
+      makeState(),
+    );
+    const res = await fetch(serverUrl('/login'));
+    expect(res.status).toBe(200);
+    const html = await res.text();
+    expect(html).toContain('Sign In');
+    expect(html).toContain('action="/login"');
+  });
+
+  it('rejects wrong password on POST /login', async () => {
+    handle = startWebServer(
+      { port: 0, sessionPassword: TEST_PASSWORD },
+      makeState(),
+    );
+    const form = new FormData();
+    form.set('password', 'wrong-password');
+    const res = await fetch(serverUrl('/login'), {
+      method: 'POST',
+      body: form,
+      redirect: 'manual',
+    });
+    expect(res.status).toBe(401);
+    const html = await res.text();
+    expect(html).toContain('Invalid password');
+  });
+
+  it('sets session cookie on correct password', async () => {
+    handle = startWebServer(
+      { port: 0, sessionPassword: TEST_PASSWORD },
+      makeState(),
+    );
+    const form = new FormData();
+    form.set('password', TEST_PASSWORD);
+    const res = await fetch(serverUrl('/login'), {
+      method: 'POST',
+      body: form,
+      redirect: 'manual',
+    });
+    expect(res.status).toBe(302);
+    expect(res.headers.get('Location')).toBe('/');
+    const setCookie = res.headers.get('Set-Cookie');
+    expect(setCookie).toContain('omniclaw_session=');
+    expect(setCookie).toContain('HttpOnly');
+  });
+
+  it('allows authenticated requests with session cookie', async () => {
+    handle = startWebServer(
+      { port: 0, sessionPassword: TEST_PASSWORD },
+      makeState(),
+    );
+
+    // Login to get a session cookie
+    const form = new FormData();
+    form.set('password', TEST_PASSWORD);
+    const loginRes = await fetch(serverUrl('/login'), {
+      method: 'POST',
+      body: form,
+      redirect: 'manual',
+    });
+    const setCookie = loginRes.headers.get('Set-Cookie')!;
+    const cookieValue = setCookie.split(';')[0]; // omniclaw_session=<token>
+
+    // Access a protected route with the session cookie
+    const res = await fetch(serverUrl('/api/health'), {
+      headers: { Cookie: cookieValue },
+    });
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body).toHaveProperty('agents');
+  });
+
+  it('logout clears session and redirects to login', async () => {
+    handle = startWebServer(
+      { port: 0, sessionPassword: TEST_PASSWORD },
+      makeState(),
+    );
+
+    // Login first
+    const form = new FormData();
+    form.set('password', TEST_PASSWORD);
+    const loginRes = await fetch(serverUrl('/login'), {
+      method: 'POST',
+      body: form,
+      redirect: 'manual',
+    });
+    const setCookie = loginRes.headers.get('Set-Cookie')!;
+    const cookieValue = setCookie.split(';')[0];
+
+    // Logout
+    const logoutRes = await fetch(serverUrl('/logout'), {
+      headers: { Cookie: cookieValue },
+      redirect: 'manual',
+    });
+    expect(logoutRes.status).toBe(302);
+    expect(logoutRes.headers.get('Location')).toBe('/login');
+    expect(logoutRes.headers.get('Set-Cookie')).toContain('Max-Age=0');
+
+    // Session should now be invalid
+    const afterLogout = await fetch(serverUrl('/'), {
+      headers: { Cookie: cookieValue },
+      redirect: 'manual',
+    });
+    expect(afterLogout.status).toBe(302);
+    expect(afterLogout.headers.get('Location')).toBe('/login');
+  });
+
+  it('skips auth when sessionPassword is not configured', async () => {
+    handle = startWebServer({ port: 0 }, makeState());
+    const res = await fetch(serverUrl('/api/health'));
+    expect(res.status).toBe(200);
+  });
+
+  it('session auth takes precedence over Basic Auth when both configured', async () => {
+    handle = startWebServer(
+      {
+        port: 0,
+        auth: { username: 'admin', password: 'basic-secret' },
+        sessionPassword: TEST_PASSWORD,
+      },
+      makeState(),
+    );
+
+    // Basic Auth alone should NOT work when session auth is enabled
+    const basicRes = await fetch(serverUrl('/'), {
+      headers: { Authorization: `Basic ${btoa('admin:basic-secret')}` },
+      redirect: 'manual',
+    });
+    expect(basicRes.status).toBe(302);
+    expect(basicRes.headers.get('Location')).toBe('/login');
+
+    // Session auth should work
+    const form = new FormData();
+    form.set('password', TEST_PASSWORD);
+    const loginRes = await fetch(serverUrl('/login'), {
+      method: 'POST',
+      body: form,
+      redirect: 'manual',
+    });
+    expect(loginRes.status).toBe(302);
+    expect(loginRes.headers.get('Location')).toBe('/');
+  });
+
+  it('allows access to the full dashboard page when authenticated', async () => {
+    handle = startWebServer(
+      { port: 0, sessionPassword: TEST_PASSWORD },
+      makeState(),
+    );
+
+    // Login
+    const form = new FormData();
+    form.set('password', TEST_PASSWORD);
+    const loginRes = await fetch(serverUrl('/login'), {
+      method: 'POST',
+      body: form,
+      redirect: 'manual',
+    });
+    const cookieValue = loginRes.headers.get('Set-Cookie')!.split(';')[0];
+
+    // Access dashboard
+    const res = await fetch(serverUrl('/'), {
+      headers: { Cookie: cookieValue },
+    });
+    expect(res.status).toBe(200);
+    const html = await res.text();
+    expect(html).toContain('omniclaw');
+    expect(html).toContain('Dashboard');
+  });
+});

--- a/src/web/session-auth.ts
+++ b/src/web/session-auth.ts
@@ -1,0 +1,260 @@
+import { randomBytes, timingSafeEqual as cryptoTimingSafeEqual } from 'crypto';
+
+import { escapeHtml } from './shared.js';
+
+const SESSION_TTL_MS = 24 * 60 * 60 * 1000; // 24 hours
+const SESSION_TOKEN_BYTES = 32;
+const MAX_SESSIONS = 100;
+const COOKIE_NAME = 'omniclaw_session';
+
+export interface Session {
+  token: string;
+  createdAt: number;
+  expiresAt: number;
+}
+
+export interface SessionStore {
+  /** Create a new session and return its token. */
+  create(): string;
+  /** Validate a session token. Returns true if valid and not expired. */
+  validate(token: string): boolean;
+  /** Revoke a session by token. */
+  revoke(token: string): void;
+  /** Purge expired sessions. */
+  purge(): void;
+  /** Number of active sessions. */
+  readonly size: number;
+}
+
+/**
+ * Create an in-memory session store with automatic expiry.
+ */
+export function createSessionStore(): SessionStore {
+  const sessions = new Map<string, Session>();
+
+  function purge(): void {
+    const now = Date.now();
+    for (const [token, session] of sessions) {
+      if (session.expiresAt <= now) {
+        sessions.delete(token);
+      }
+    }
+  }
+
+  return {
+    create(): string {
+      // Purge expired sessions before creating new ones
+      purge();
+
+      // Evict oldest sessions if at capacity
+      if (sessions.size >= MAX_SESSIONS) {
+        const oldest = [...sessions.entries()].sort(
+          ([, a], [, b]) => a.createdAt - b.createdAt,
+        );
+        const toRemove = oldest.slice(
+          0,
+          sessions.size - MAX_SESSIONS + 1,
+        );
+        for (const [token] of toRemove) {
+          sessions.delete(token);
+        }
+      }
+
+      const token = randomBytes(SESSION_TOKEN_BYTES).toString('hex');
+      const now = Date.now();
+      sessions.set(token, {
+        token,
+        createdAt: now,
+        expiresAt: now + SESSION_TTL_MS,
+      });
+      return token;
+    },
+
+    validate(token: string): boolean {
+      if (!token || typeof token !== 'string') return false;
+      const session = sessions.get(token);
+      if (!session) return false;
+      if (session.expiresAt <= Date.now()) {
+        sessions.delete(token);
+        return false;
+      }
+      return true;
+    },
+
+    revoke(token: string): void {
+      sessions.delete(token);
+    },
+
+    purge,
+
+    get size(): number {
+      return sessions.size;
+    },
+  };
+}
+
+/**
+ * Parse the session token from a Cookie header.
+ */
+export function parseSessionCookie(cookieHeader: string | null): string | null {
+  if (!cookieHeader) return null;
+  const prefix = `${COOKIE_NAME}=`;
+  for (const part of cookieHeader.split(';')) {
+    const trimmed = part.trim();
+    if (trimmed.startsWith(prefix)) {
+      return trimmed.slice(prefix.length);
+    }
+  }
+  return null;
+}
+
+/**
+ * Build a Set-Cookie header value for session creation.
+ */
+export function makeSessionCookie(token: string): string {
+  return `${COOKIE_NAME}=${token}; HttpOnly; SameSite=Strict; Path=/; Max-Age=${Math.floor(SESSION_TTL_MS / 1000)}`;
+}
+
+/**
+ * Build a Set-Cookie header value that clears the session cookie.
+ */
+export function makeClearSessionCookie(): string {
+  return `${COOKIE_NAME}=; HttpOnly; SameSite=Strict; Path=/; Max-Age=0`;
+}
+
+/**
+ * Constant-time password comparison to prevent timing attacks.
+ */
+export function verifyPassword(input: string, expected: string): boolean {
+  if (typeof input !== 'string' || typeof expected !== 'string') return false;
+  const inputBuf = Buffer.from(input);
+  const expectedBuf = Buffer.from(expected);
+  if (inputBuf.length !== expectedBuf.length) return false;
+  return cryptoTimingSafeEqual(inputBuf, expectedBuf);
+}
+
+/**
+ * Check if a request path should bypass session auth.
+ */
+export function isAuthExemptPath(pathname: string): boolean {
+  return (
+    pathname === '/login' ||
+    pathname === '/logout'
+  );
+}
+
+/**
+ * Render the login page HTML.
+ */
+export function renderLoginPage(error?: string): string {
+  return (
+    `<!DOCTYPE html><html lang="en"><head>` +
+    `<meta charset="utf-8">` +
+    `<meta name="viewport" content="width=device-width, initial-scale=1">` +
+    `<title>OmniClaw \u2014 Login</title>` +
+    `<link rel="preconnect" href="https://fonts.googleapis.com">` +
+    `<link href="https://fonts.googleapis.com/css2?family=JetBrains+Mono:wght@400;500;600;700&display=swap" rel="stylesheet">` +
+    `<style>${loginCSS()}</style>` +
+    `</head><body>` +
+    `<div class="login-container">` +
+    `<div class="login-card">` +
+    `<div class="login-brand">omniclaw</div>` +
+    `<p class="login-subtitle">Agent Management Console</p>` +
+    (error
+      ? `<div class="login-error">${escapeHtml(error)}</div>`
+      : '') +
+    `<form method="POST" action="/login" class="login-form">` +
+    `<label for="password" class="login-label">Password</label>` +
+    `<input type="password" id="password" name="password" class="login-input" placeholder="Enter password" autofocus required>` +
+    `<button type="submit" class="login-button">Sign In</button>` +
+    `</form>` +
+    `</div>` +
+    `</div>` +
+    `</body></html>`
+  );
+}
+
+function loginCSS(): string {
+  return `
+    * { margin: 0; padding: 0; box-sizing: border-box; }
+    body {
+      font-family: 'JetBrains Mono', monospace;
+      background: #0a0a0f;
+      color: #e0e0e0;
+      min-height: 100vh;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+    }
+    .login-container {
+      width: 100%;
+      max-width: 400px;
+      padding: 1rem;
+    }
+    .login-card {
+      background: #13131a;
+      border: 1px solid #2a2a3a;
+      border-radius: 12px;
+      padding: 2.5rem 2rem;
+      text-align: center;
+    }
+    .login-brand {
+      font-size: 1.8rem;
+      font-weight: 700;
+      color: #a78bfa;
+      letter-spacing: 0.05em;
+      margin-bottom: 0.25rem;
+    }
+    .login-subtitle {
+      color: #888;
+      font-size: 0.8rem;
+      margin-bottom: 2rem;
+    }
+    .login-error {
+      background: rgba(239, 68, 68, 0.1);
+      border: 1px solid rgba(239, 68, 68, 0.3);
+      color: #f87171;
+      padding: 0.6rem 1rem;
+      border-radius: 6px;
+      font-size: 0.8rem;
+      margin-bottom: 1.5rem;
+    }
+    .login-form { text-align: left; }
+    .login-label {
+      display: block;
+      font-size: 0.75rem;
+      color: #999;
+      margin-bottom: 0.4rem;
+      text-transform: uppercase;
+      letter-spacing: 0.05em;
+    }
+    .login-input {
+      width: 100%;
+      padding: 0.75rem 1rem;
+      background: #1a1a24;
+      border: 1px solid #2a2a3a;
+      border-radius: 8px;
+      color: #e0e0e0;
+      font-family: inherit;
+      font-size: 0.9rem;
+      outline: none;
+      transition: border-color 0.15s;
+    }
+    .login-input:focus { border-color: #a78bfa; }
+    .login-button {
+      width: 100%;
+      margin-top: 1.25rem;
+      padding: 0.75rem;
+      background: #a78bfa;
+      color: #0a0a0f;
+      border: none;
+      border-radius: 8px;
+      font-family: inherit;
+      font-size: 0.9rem;
+      font-weight: 600;
+      cursor: pointer;
+      transition: background 0.15s;
+    }
+    .login-button:hover { background: #8b5cf6; }
+  `;
+}

--- a/src/web/session-auth.ts
+++ b/src/web/session-auth.ts
@@ -51,10 +51,7 @@ export function createSessionStore(): SessionStore {
         const oldest = [...sessions.entries()].sort(
           ([, a], [, b]) => a.createdAt - b.createdAt,
         );
-        const toRemove = oldest.slice(
-          0,
-          sessions.size - MAX_SESSIONS + 1,
-        );
+        const toRemove = oldest.slice(0, sessions.size - MAX_SESSIONS + 1);
         for (const [token] of toRemove) {
           sessions.delete(token);
         }
@@ -137,10 +134,7 @@ export function verifyPassword(input: string, expected: string): boolean {
  * Check if a request path should bypass session auth.
  */
 export function isAuthExemptPath(pathname: string): boolean {
-  return (
-    pathname === '/login' ||
-    pathname === '/logout'
-  );
+  return pathname === '/login' || pathname === '/logout';
 }
 
 /**
@@ -160,9 +154,7 @@ export function renderLoginPage(error?: string): string {
     `<div class="login-card">` +
     `<div class="login-brand">omniclaw</div>` +
     `<p class="login-subtitle">Agent Management Console</p>` +
-    (error
-      ? `<div class="login-error">${escapeHtml(error)}</div>`
-      : '') +
+    (error ? `<div class="login-error">${escapeHtml(error)}</div>` : '') +
     `<form method="POST" action="/login" class="login-form">` +
     `<label for="password" class="login-label">Password</label>` +
     `<input type="password" id="password" name="password" class="login-input" placeholder="Enter password" autofocus required>` +

--- a/src/web/types.ts
+++ b/src/web/types.ts
@@ -134,6 +134,8 @@ export interface WebServerConfig {
   port: number;
   /** Basic auth credentials. If unset, HTTP auth is disabled. */
   auth?: { username: string; password: string };
+  /** Session-based password. When set, serves a login page and uses cookie sessions. Takes precedence over Basic Auth. */
+  sessionPassword?: string;
   /** Bind hostname. Defaults to '127.0.0.1' (loopback only). */
   hostname?: string;
   /** Allowed CORS origin. If unset, no CORS headers are sent. */


### PR DESCRIPTION
## Summary

Adds session-based password authentication to the Web UI, replacing the browser-native Basic Auth popup with a proper login page and cookie-based sessions.

- New `WEB_PASSWORD` env var enables session auth with a styled login page at `/login`
- HttpOnly session cookies (24-hour TTL, timing-safe password comparison, LRU eviction at 100 sessions)
- `/logout` endpoint clears the session and redirects to login
- API routes return 401 JSON; page routes redirect to `/login` when unauthenticated
- Session auth takes precedence over Basic Auth when both are configured
- Auth is skipped entirely when neither `WEB_PASSWORD` nor `WEB_UI_USER`/`WEB_UI_PASS` is set (dev/localhost mode)

Closes #532

## Test plan

- [x] 31 new tests (unit + integration) covering session store, cookie parsing, password verification, login page rendering, full login/logout flow
- [x] All 466 web tests pass (0 regressions)
- [x] Full suite: 1773 tests pass
- [x] TypeScript compiles cleanly (`tsc --noEmit`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added session-based password authentication for the web UI as an alternative to Basic Auth.
  * Added login page and logout functionality.
  * Introduced `WEB_PASSWORD` configuration option for simpler credential management.

* **Tests**
  * Added comprehensive test coverage for session authentication behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->