### PR TITLE
feat(container): log system/task_progress SDK messages

### DIFF
--- a/container/agent-runner/src/index.ts
+++ b/container/agent-runner/src/index.ts
@@ -1310,6 +1310,22 @@ async function runQuery(
           }
         }
       }
+    } else if (
+      message.type === 'system' &&
+      (message as { subtype?: string }).subtype === 'task_progress'
+    ) {
+      const tp = message as {
+        description?: string;
+        last_tool_name?: string;
+        usage?: { total_tokens?: number; tool_uses?: number; duration_ms?: number };
+      };
+      const desc = tp.description || '';
+      const tool = tp.last_tool_name ? ` [${tp.last_tool_name}]` : '';
+      const tokens = tp.usage?.total_tokens ?? 0;
+      const toolUses = tp.usage?.tool_uses ?? 0;
+      log(
+        `[msg #${messageCount}] type=${msgType}${tool} tokens=${tokens} tools=${toolUses} :: ${desc}`,
+      );
     } else {
       log(`[msg #${messageCount}] type=${msgType}`);
     }

--- a/container/agent-runner/src/index.ts
+++ b/container/agent-runner/src/index.ts
@@ -1317,7 +1317,11 @@ async function runQuery(
       const tp = message as {
         description?: string;
         last_tool_name?: string;
-        usage?: { total_tokens?: number; tool_uses?: number; duration_ms?: number };
+        usage?: {
+          total_tokens?: number;
+          tool_uses?: number;
+          duration_ms?: number;
+        };
       };
       const desc = tp.description || '';
       const tool = tp.last_tool_name ? ` [${tp.last_tool_name}]` : '';


### PR DESCRIPTION
## Summary
- The Claude Agent SDK emits `system/task_progress` events (`SDKTaskProgressMessage`) with `description`, `last_tool_name`, and usage stats. Previously these fell through to the generic else in the message loop and only the type name was logged.
- Adds a dedicated branch that extracts and logs the payload for observability.

## Test plan
- [ ] Rebuild container (`container builder stop && container builder rm && container builder start && ./container/build.sh`)
- [ ] Trigger an agent run that produces task_progress messages
- [ ] Verify logs show `type=system/task_progress [ToolName] tokens=N tools=N :: description`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Enhanced task progress tracking with richer, real-time visibility into agent operations.
  * Progress logs now include optional active tool names and descriptive task messages.
  * Execution metrics such as token usage and tool-use counts are surfaced for better monitoring.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->