### PR TITLE
ci: auto-fix formatting on PR branches

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,14 +5,37 @@ on:
     branches: [main]
   workflow_dispatch:
 
+permissions:
+  contents: write
+
 jobs:
   format:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+        with:
+          ref: ${{ github.head_ref }}
+          token: ${{ secrets.GITHUB_TOKEN }}
       - uses: oven-sh/setup-bun@v2
       - run: bun install
-      - run: bun run format:check
+      - name: Check formatting
+        id: fmt-check
+        run: bun run format:check
+        continue-on-error: true
+      - name: Auto-fix formatting
+        if: steps.fmt-check.outcome == 'failure'
+        run: |
+          bun run format
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git add -A
+          git diff --cached --quiet || git commit -m "style: auto-format with prettier"
+          git push
+      - name: Fail if formatting was wrong
+        if: steps.fmt-check.outcome == 'failure'
+        run: |
+          echo "::notice::Formatting was auto-fixed and pushed. A new CI run will start."
+          exit 1
 
   typecheck:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary
- When `format:check` fails, auto-runs prettier and pushes the fix back to the PR branch
- Job still exits non-zero so a fresh CI run triggers on the auto-fix commit
- Adds `contents: write` permission and checks out `head_ref` with token for push access

## Test plan
- [ ] Open a PR with unformatted code — CI should auto-commit the fix and re-trigger
- [ ] Open a PR with correct formatting — CI should pass without extra commits

Closes #524

🤖 Generated with [Claude Code](https://claude.com/claude-code)
