### PR TITLE
feat(security): add rate limiting to Web UI login endpoint

### DIFF
--- a/src/web/rate-limit.test.ts
+++ b/src/web/rate-limit.test.ts
@@ -1,0 +1,280 @@
+import { describe, it, expect, afterEach } from 'bun:test';
+
+import { createRateLimiter } from './rate-limit.js';
+import { startWebServer, type WebServerHandle } from './server.js';
+import type { WebStateProvider, QueueStats } from './types.js';
+import type { Agent } from '../types.js';
+
+// ---- Fixtures ----
+
+function makeAgent(overrides: Partial<Agent> = {}): Agent {
+  return {
+    id: 'test-agent',
+    name: 'Test Agent',
+    folder: 'test-agent',
+    backend: 'apple-container',
+    agentRuntime: 'claude-agent-sdk',
+    isAdmin: false,
+    createdAt: '2026-01-01T00:00:00.000Z',
+    ...overrides,
+  };
+}
+
+const defaultStats: QueueStats = {
+  activeContainers: 0,
+  idleContainers: 0,
+  maxActive: 8,
+  maxIdle: 4,
+};
+
+function makeState(
+  overrides: Partial<WebStateProvider> = {},
+): WebStateProvider {
+  return {
+    getAgents: () => ({ 'test-agent': makeAgent() }),
+    getChannelSubscriptions: () => ({}),
+    getTasks: () => [],
+    getTaskById: () => undefined,
+    getMessages: () => [],
+    getChats: () => [],
+    getQueueStats: () => defaultStats,
+    getQueueDetails: () => [],
+    getIpcEvents: () => [],
+    getTaskRunLogs: () => [],
+    getTaskRunPhaseEvents: () => [],
+    searchMessages: () => [],
+    createTask: () => {},
+    updateTask: () => {},
+    deleteTask: () => {},
+    calculateNextRun: () => null,
+    readContextFile: () => null,
+    writeContextFile: () => {},
+    updateAgentAvatar: () => {},
+    ...overrides,
+  };
+}
+
+// ---- Unit tests for rate limiter ----
+
+describe('RateLimiter', () => {
+  it('allows requests under the threshold', () => {
+    const limiter = createRateLimiter({ maxAttempts: 3, windowMs: 60_000 });
+    expect(limiter.isBlocked('1.2.3.4')).toBe(false);
+    limiter.recordFailure('1.2.3.4');
+    expect(limiter.isBlocked('1.2.3.4')).toBe(false);
+    limiter.recordFailure('1.2.3.4');
+    expect(limiter.isBlocked('1.2.3.4')).toBe(false);
+    limiter.dispose();
+  });
+
+  it('blocks after reaching the threshold', () => {
+    const limiter = createRateLimiter({ maxAttempts: 3, windowMs: 60_000 });
+    limiter.recordFailure('1.2.3.4');
+    limiter.recordFailure('1.2.3.4');
+    const blocked = limiter.recordFailure('1.2.3.4');
+    expect(blocked).toBe(true);
+    expect(limiter.isBlocked('1.2.3.4')).toBe(true);
+    limiter.dispose();
+  });
+
+  it('tracks IPs independently', () => {
+    const limiter = createRateLimiter({ maxAttempts: 2, windowMs: 60_000 });
+    limiter.recordFailure('1.1.1.1');
+    limiter.recordFailure('1.1.1.1');
+    expect(limiter.isBlocked('1.1.1.1')).toBe(true);
+    expect(limiter.isBlocked('2.2.2.2')).toBe(false);
+    expect(limiter.size).toBe(1);
+    limiter.dispose();
+  });
+
+  it('resets the counter for an IP', () => {
+    const limiter = createRateLimiter({ maxAttempts: 2, windowMs: 60_000 });
+    limiter.recordFailure('1.2.3.4');
+    limiter.recordFailure('1.2.3.4');
+    expect(limiter.isBlocked('1.2.3.4')).toBe(true);
+    limiter.reset('1.2.3.4');
+    expect(limiter.isBlocked('1.2.3.4')).toBe(false);
+    expect(limiter.size).toBe(0);
+    limiter.dispose();
+  });
+
+  it('returns a positive retryAfter for blocked IPs', () => {
+    const limiter = createRateLimiter({ maxAttempts: 1, windowMs: 30_000 });
+    limiter.recordFailure('1.2.3.4');
+    const seconds = limiter.retryAfter('1.2.3.4');
+    expect(seconds).toBeGreaterThan(0);
+    expect(seconds).toBeLessThanOrEqual(30);
+    limiter.dispose();
+  });
+
+  it('returns 0 retryAfter for non-blocked IPs', () => {
+    const limiter = createRateLimiter({ maxAttempts: 5, windowMs: 60_000 });
+    expect(limiter.retryAfter('1.2.3.4')).toBe(0);
+    limiter.recordFailure('1.2.3.4');
+    expect(limiter.retryAfter('1.2.3.4')).toBe(0);
+    limiter.dispose();
+  });
+
+  it('expires entries after the window elapses', () => {
+    // Use a very short window to test expiry
+    const limiter = createRateLimiter({ maxAttempts: 1, windowMs: 1 });
+    limiter.recordFailure('1.2.3.4');
+    expect(limiter.isBlocked('1.2.3.4')).toBe(true);
+
+    // Wait for the window to expire
+    const start = Date.now();
+    while (Date.now() - start < 5) {
+      // busy-wait a few ms
+    }
+    expect(limiter.isBlocked('1.2.3.4')).toBe(false);
+    limiter.dispose();
+  });
+
+  it('cleanup removes stale entries', () => {
+    const limiter = createRateLimiter({ maxAttempts: 1, windowMs: 1 });
+    limiter.recordFailure('1.2.3.4');
+    limiter.recordFailure('5.6.7.8');
+    expect(limiter.size).toBe(2);
+
+    const start = Date.now();
+    while (Date.now() - start < 5) {
+      // busy-wait
+    }
+    limiter.cleanup();
+    expect(limiter.size).toBe(0);
+    limiter.dispose();
+  });
+
+  it('uses default config when none provided', () => {
+    const limiter = createRateLimiter();
+    // Default is 5 attempts — should not block after 4 failures
+    for (let i = 0; i < 4; i++) {
+      limiter.recordFailure('1.2.3.4');
+    }
+    expect(limiter.isBlocked('1.2.3.4')).toBe(false);
+    limiter.recordFailure('1.2.3.4');
+    expect(limiter.isBlocked('1.2.3.4')).toBe(true);
+    limiter.dispose();
+  });
+});
+
+// ---- Integration tests for rate limiting on /login ----
+
+const TEST_PASSWORD = 'rate-limit-test-pwd';
+let handle: WebServerHandle | null = null;
+
+afterEach(async () => {
+  if (handle) {
+    await handle.stop();
+    handle = null;
+  }
+});
+
+function serverUrl(path: string): string {
+  return `http://localhost:${handle!.port}${path}`;
+}
+
+async function postLogin(password: string): Promise<Response> {
+  const form = new URLSearchParams();
+  form.set('password', password);
+  return fetch(serverUrl('/login'), {
+    method: 'POST',
+    body: form,
+    redirect: 'manual',
+  });
+}
+
+describe('login rate limiting', () => {
+  it('returns 429 after too many failed login attempts', async () => {
+    handle = startWebServer(
+      { port: 0, sessionPassword: TEST_PASSWORD },
+      makeState(),
+    );
+
+    // Exhaust the rate limit (default: 5 failures)
+    for (let i = 0; i < 5; i++) {
+      const res = await postLogin('wrong-password');
+      expect(res.status).toBe(401);
+      await res.text(); // drain body
+    }
+
+    // Next attempt should be rate-limited
+    const blocked = await postLogin('wrong-password');
+    expect(blocked.status).toBe(429);
+    const html = await blocked.text();
+    expect(html).toContain('Too many failed attempts');
+    expect(blocked.headers.get('Retry-After')).toBeTruthy();
+  });
+
+  it('blocks even correct password when rate-limited', async () => {
+    handle = startWebServer(
+      { port: 0, sessionPassword: TEST_PASSWORD },
+      makeState(),
+    );
+
+    // Exhaust the rate limit
+    for (let i = 0; i < 5; i++) {
+      const res = await postLogin('wrong');
+      await res.text();
+    }
+
+    // Correct password should still be rejected with 429
+    const blocked = await postLogin(TEST_PASSWORD);
+    expect(blocked.status).toBe(429);
+    await blocked.text();
+  });
+
+  it('resets rate limit after successful login', async () => {
+    handle = startWebServer(
+      { port: 0, sessionPassword: TEST_PASSWORD },
+      makeState(),
+    );
+
+    // 4 failures (under the threshold)
+    for (let i = 0; i < 4; i++) {
+      const res = await postLogin('wrong');
+      await res.text();
+    }
+
+    // Successful login resets the counter
+    const success = await postLogin(TEST_PASSWORD);
+    expect(success.status).toBe(302);
+    await success.text();
+
+    // Should be able to fail again without being blocked
+    const afterReset = await postLogin('wrong');
+    expect(afterReset.status).toBe(401);
+    await afterReset.text();
+  });
+
+  it('shows rate limit message on GET /login when blocked', async () => {
+    handle = startWebServer(
+      { port: 0, sessionPassword: TEST_PASSWORD },
+      makeState(),
+    );
+
+    // Exhaust the rate limit
+    for (let i = 0; i < 5; i++) {
+      const res = await postLogin('wrong');
+      await res.text();
+    }
+
+    // GET /login should also show the rate limit message
+    const getRes = await fetch(serverUrl('/login'));
+    expect(getRes.status).toBe(429);
+    const html = await getRes.text();
+    expect(html).toContain('Too many failed attempts');
+    expect(getRes.headers.get('Retry-After')).toBeTruthy();
+  });
+
+  it('does not rate limit when session auth is disabled', async () => {
+    handle = startWebServer({ port: 0 }, makeState());
+    // Without sessionPassword, /login is not handled by session auth, so the
+    // login limiter is bypassed instead of returning 429 after repeated posts.
+    for (let i = 0; i < 6; i++) {
+      const res = await postLogin('wrong-password');
+      expect(res.status).not.toBe(429);
+      await res.text();
+    }
+  });
+});

--- a/src/web/rate-limit.ts
+++ b/src/web/rate-limit.ts
@@ -1,0 +1,116 @@
+/**
+ * IP-based rate limiting for the login endpoint.
+ *
+ * Tracks failed login attempts per source IP using a fixed window.
+ * After exceeding the threshold, subsequent attempts receive HTTP 429.
+ * A successful login resets the counter for that IP.
+ */
+
+const DEFAULT_MAX_ATTEMPTS = 5;
+const DEFAULT_WINDOW_MS = 60_000; // 1 minute
+const CLEANUP_INTERVAL_MS = 5 * 60_000; // 5 minutes
+
+export interface RateLimitEntry {
+  count: number;
+  windowStart: number;
+}
+
+export interface RateLimitConfig {
+  /** Maximum failed attempts before blocking. Default: 5. */
+  maxAttempts?: number;
+  /** Fixed window duration in milliseconds. Default: 60 000 (1 minute). */
+  windowMs?: number;
+}
+
+export interface RateLimiter {
+  /** Record a failed login attempt. Returns true if the IP is now blocked. */
+  recordFailure(ip: string): boolean;
+  /** Check whether an IP is currently blocked. */
+  isBlocked(ip: string): boolean;
+  /** Reset the counter for an IP (call on successful login). */
+  reset(ip: string): void;
+  /** Seconds until the current window expires for a blocked IP. Returns 0 if not blocked. */
+  retryAfter(ip: string): number;
+  /** Remove stale entries. */
+  cleanup(): void;
+  /** Stop the background cleanup timer. */
+  dispose(): void;
+  /** Number of tracked IPs (for testing). */
+  readonly size: number;
+}
+
+/**
+ * Create an in-memory rate limiter for login attempts.
+ */
+export function createRateLimiter(config?: RateLimitConfig): RateLimiter {
+  const maxAttempts = config?.maxAttempts ?? DEFAULT_MAX_ATTEMPTS;
+  const windowMs = config?.windowMs ?? DEFAULT_WINDOW_MS;
+  const entries = new Map<string, RateLimitEntry>();
+
+  const cleanupTimer = setInterval(() => cleanup(), CLEANUP_INTERVAL_MS);
+  // Allow the process to exit without waiting for the timer.
+  if (typeof cleanupTimer === 'object' && 'unref' in cleanupTimer) {
+    cleanupTimer.unref();
+  }
+
+  function getEntry(ip: string, now: number): RateLimitEntry | null {
+    const entry = entries.get(ip);
+    if (!entry) return null;
+    // Window expired — remove and treat as fresh.
+    if (now - entry.windowStart >= windowMs) {
+      entries.delete(ip);
+      return null;
+    }
+    return entry;
+  }
+
+  function cleanup(): void {
+    const now = Date.now();
+    for (const [ip, entry] of entries) {
+      if (now - entry.windowStart >= windowMs) {
+        entries.delete(ip);
+      }
+    }
+  }
+
+  return {
+    recordFailure(ip: string): boolean {
+      const now = Date.now();
+      const existing = getEntry(ip, now);
+      if (existing) {
+        existing.count++;
+        return existing.count >= maxAttempts;
+      }
+      entries.set(ip, { count: 1, windowStart: now });
+      return 1 >= maxAttempts;
+    },
+
+    isBlocked(ip: string): boolean {
+      const now = Date.now();
+      const entry = getEntry(ip, now);
+      return entry !== null && entry.count >= maxAttempts;
+    },
+
+    reset(ip: string): void {
+      entries.delete(ip);
+    },
+
+    retryAfter(ip: string): number {
+      const now = Date.now();
+      const entry = getEntry(ip, now);
+      if (!entry || entry.count < maxAttempts) return 0;
+      const remaining = windowMs - (now - entry.windowStart);
+      return Math.max(1, Math.ceil(remaining / 1000));
+    },
+
+    cleanup,
+
+    dispose(): void {
+      clearInterval(cleanupTimer);
+    },
+
+    get size(): number {
+      return entries.size;
+    },
+  };
+}

--- a/src/web/server.ts
+++ b/src/web/server.ts
@@ -22,6 +22,7 @@ import {
   renderLoginPage,
   type SessionStore,
 } from './session-auth.js';
+import { createRateLimiter, type RateLimiter } from './rate-limit.js';
 import {
   renderAgentDetailContent,
   buildAgentDetailData,
@@ -180,6 +181,7 @@ export function startWebServer(
     trustLanDiscoveryAdmin,
   } = config;
   const sessionStore = sessionPassword ? createSessionStore() : null;
+  const loginRateLimiter = sessionPassword ? createRateLimiter() : null;
   const bindHostname = hostname || '127.0.0.1';
   const sseClients = new Set<SseClient>();
   const recentLogs: string[] = [];
@@ -196,7 +198,7 @@ export function startWebServer(
   // Store the promise so the first proxied request can await it.
   const solidReady = solidMode ? initSolidHandler(state) : null;
 
-  const fetchHandler = async (req: Request) => {
+  const fetchHandler = async (req: Request, bunServer: Bun.Server<unknown>) => {
     const url = new URL(req.url);
     const resolveRemotePeers = createRemotePeerResolver(getRemotePeers);
     if (url.pathname === '/ws') {
@@ -234,12 +236,48 @@ export function startWebServer(
       // --- Session-based auth (WEB_PASSWORD) ---
       // Handle login/logout before checking session
       if (url.pathname === '/login') {
+        const clientIp =
+          bunServer.requestIP(req)?.address ?? 'unknown';
+
         if (req.method === 'GET') {
-          return new Response(renderLoginPage(), {
-            headers: { 'Content-Type': 'text/html; charset=utf-8' },
-          });
+          const blocked = loginRateLimiter?.isBlocked(clientIp);
+          return new Response(
+            renderLoginPage(
+              blocked
+                ? 'Too many failed attempts. Please try again later.'
+                : undefined,
+            ),
+            {
+              status: blocked ? 429 : 200,
+              headers: {
+                'Content-Type': 'text/html; charset=utf-8',
+                ...(blocked
+                  ? {
+                      'Retry-After': String(
+                        loginRateLimiter!.retryAfter(clientIp),
+                      ),
+                    }
+                  : {}),
+              },
+            },
+          );
         }
         if (req.method === 'POST') {
+          // Reject if rate-limited before doing any password work.
+          if (loginRateLimiter?.isBlocked(clientIp)) {
+            const retryAfter = loginRateLimiter.retryAfter(clientIp);
+            return new Response(
+              renderLoginPage('Too many failed attempts. Please try again later.'),
+              {
+                status: 429,
+                headers: {
+                  'Content-Type': 'text/html; charset=utf-8',
+                  'Retry-After': String(retryAfter),
+                },
+              },
+            );
+          }
+
           let rawBody: string;
           try {
             rawBody = await readRequestBody(req, MAX_LOGIN_BODY_BYTES);
@@ -262,6 +300,8 @@ export function startWebServer(
             typeof password === 'string' &&
             verifyPassword(password, sessionPassword)
           ) {
+            // Successful login — clear any failure history for this IP.
+            loginRateLimiter?.reset(clientIp);
             const token = sessionStore.create();
             return new Response(null, {
               status: 302,
@@ -271,6 +311,9 @@ export function startWebServer(
               },
             });
           }
+
+          // Failed login — record the attempt.
+          loginRateLimiter?.recordFailure(clientIp);
           return new Response(renderLoginPage('Invalid password'), {
             status: 401,
             headers: { 'Content-Type': 'text/html; charset=utf-8' },
@@ -872,6 +915,7 @@ export function startWebServer(
     },
     async stop() {
       clearInterval(snapshotTicker);
+      loginRateLimiter?.dispose();
       for (const client of sseClients) {
         client.close();
       }

--- a/src/web/server.ts
+++ b/src/web/server.ts
@@ -236,8 +236,7 @@ export function startWebServer(
       // --- Session-based auth (WEB_PASSWORD) ---
       // Handle login/logout before checking session
       if (url.pathname === '/login') {
-        const clientIp =
-          bunServer.requestIP(req)?.address ?? 'unknown';
+        const clientIp = bunServer.requestIP(req)?.address ?? 'unknown';
 
         if (req.method === 'GET') {
           const blocked = loginRateLimiter?.isBlocked(clientIp);
@@ -267,7 +266,9 @@ export function startWebServer(
           if (loginRateLimiter?.isBlocked(clientIp)) {
             const retryAfter = loginRateLimiter.retryAfter(clientIp);
             return new Response(
-              renderLoginPage('Too many failed attempts. Please try again later.'),
+              renderLoginPage(
+                'Too many failed attempts. Please try again later.',
+              ),
               {
                 status: 429,
                 headers: {


### PR DESCRIPTION
## Summary

- Adds fixed-window IP rate limiting for failed `/login` attempts when session auth is enabled.
- Returns `429` with `Retry-After` after repeated failures and resets the limiter after a successful login.
- Keeps the limiter disabled when session auth is off; `/login` is exercised directly in that regression test.

## Review Notes

- Rebased onto current `main` after PR #614.
- Addressed CodeRabbit's limiter naming concern by documenting the implementation as fixed-window instead of claiming sliding-window behavior.
- Addressed the disabled-auth test concern by repeatedly posting to `/login` and asserting it does not return `429`.

Closes #540
