### PR TITLE
fix(security): cap Web UI login request bodies

### DIFF
--- a/src/web/server.ts
+++ b/src/web/server.ts
@@ -4,6 +4,10 @@ import { ServerSentEventGenerator } from '@starfederation/datastar-sdk/web';
 
 import { logger } from '../logger.js';
 import {
+  readRequestBody,
+  RequestBodyTooLargeError,
+} from '../request-body.js';
+import {
   handleRequest,
   getRemotePeers,
   createRemotePeerResolver,
@@ -61,6 +65,7 @@ const PORT_ZERO_RETRY_ATTEMPTS = 10;
 const PORT_ZERO_FALLBACK_START = 40000;
 const PORT_ZERO_FALLBACK_SPAN = 20000;
 const MAX_PEER_AUTH_BODY_BYTES = 1024 * 1024;
+const MAX_LOGIN_BODY_BYTES = 1024 * 1024;
 
 interface RequestBodyHashResult {
   hash: string;
@@ -238,8 +243,23 @@ export function startWebServer(
           });
         }
         if (req.method === 'POST') {
-          const formData = await req.formData().catch(() => null);
-          const password = formData?.get('password');
+          let rawBody: string;
+          try {
+            rawBody = await readRequestBody(req, MAX_LOGIN_BODY_BYTES);
+          } catch (err) {
+            if (err instanceof RequestBodyTooLargeError) {
+              return new Response('Request body too large', {
+                status: 413,
+                headers: { 'Content-Type': 'text/plain' },
+              });
+            }
+            return new Response(renderLoginPage('Invalid request'), {
+              status: 400,
+              headers: { 'Content-Type': 'text/html; charset=utf-8' },
+            });
+          }
+          const params = new URLSearchParams(rawBody);
+          const password = params.get('password');
           if (
             typeof password === 'string' &&
             verifyPassword(password, sessionPassword)

--- a/src/web/server.ts
+++ b/src/web/server.ts
@@ -3,10 +3,7 @@ import { createHash } from 'crypto';
 import { ServerSentEventGenerator } from '@starfederation/datastar-sdk/web';
 
 import { logger } from '../logger.js';
-import {
-  readRequestBody,
-  RequestBodyTooLargeError,
-} from '../request-body.js';
+import { readRequestBody, RequestBodyTooLargeError } from '../request-body.js';
 import {
   handleRequest,
   getRemotePeers,

--- a/src/web/session-auth.test.ts
+++ b/src/web/session-auth.test.ts
@@ -276,7 +276,7 @@ describe('session auth middleware', () => {
       { port: 0, sessionPassword: TEST_PASSWORD },
       makeState(),
     );
-    const form = new FormData();
+    const form = new URLSearchParams();
     form.set('password', 'wrong-password');
     const res = await fetch(serverUrl('/login'), {
       method: 'POST',
@@ -293,7 +293,7 @@ describe('session auth middleware', () => {
       { port: 0, sessionPassword: TEST_PASSWORD },
       makeState(),
     );
-    const form = new FormData();
+    const form = new URLSearchParams();
     form.set('password', TEST_PASSWORD);
     const res = await fetch(serverUrl('/login'), {
       method: 'POST',
@@ -314,7 +314,7 @@ describe('session auth middleware', () => {
     );
 
     // Login to get a session cookie
-    const form = new FormData();
+    const form = new URLSearchParams();
     form.set('password', TEST_PASSWORD);
     const loginRes = await fetch(serverUrl('/login'), {
       method: 'POST',
@@ -340,7 +340,7 @@ describe('session auth middleware', () => {
     );
 
     // Login first
-    const form = new FormData();
+    const form = new URLSearchParams();
     form.set('password', TEST_PASSWORD);
     const loginRes = await fetch(serverUrl('/login'), {
       method: 'POST',
@@ -393,7 +393,7 @@ describe('session auth middleware', () => {
     expect(basicRes.headers.get('Location')).toBe('/login');
 
     // Session auth should work
-    const form = new FormData();
+    const form = new URLSearchParams();
     form.set('password', TEST_PASSWORD);
     const loginRes = await fetch(serverUrl('/login'), {
       method: 'POST',
@@ -411,7 +411,7 @@ describe('session auth middleware', () => {
     );
 
     // Login
-    const form = new FormData();
+    const form = new URLSearchParams();
     form.set('password', TEST_PASSWORD);
     const loginRes = await fetch(serverUrl('/login'), {
       method: 'POST',
@@ -428,5 +428,94 @@ describe('session auth middleware', () => {
     const html = await res.text();
     expect(html).toContain('omniclaw');
     expect(html).toContain('Dashboard');
+  });
+});
+
+// ---- Login body cap tests (#548) ----
+
+describe('login body size cap', () => {
+  it('rejects oversized Content-Length with 413', async () => {
+    handle = startWebServer(
+      { port: 0, sessionPassword: TEST_PASSWORD },
+      makeState(),
+    );
+
+    const oversized = 'password=' + 'A'.repeat(1024 * 1024 + 64);
+    const res = await fetch(serverUrl('/login'), {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/x-www-form-urlencoded',
+        'Content-Length': String(oversized.length),
+      },
+      body: oversized,
+      redirect: 'manual',
+    });
+    expect(res.status).toBe(413);
+  });
+
+  it('accepts normal-sized login bodies', async () => {
+    handle = startWebServer(
+      { port: 0, sessionPassword: TEST_PASSWORD },
+      makeState(),
+    );
+
+    const body = `password=${encodeURIComponent(TEST_PASSWORD)}`;
+    const res = await fetch(serverUrl('/login'), {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+      body,
+      redirect: 'manual',
+    });
+    expect(res.status).toBe(302);
+    expect(res.headers.get('Location')).toBe('/');
+  });
+
+  it('returns 401 for wrong password via urlencoded body', async () => {
+    handle = startWebServer(
+      { port: 0, sessionPassword: TEST_PASSWORD },
+      makeState(),
+    );
+
+    const body = 'password=wrong-password';
+    const res = await fetch(serverUrl('/login'), {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+      body,
+      redirect: 'manual',
+    });
+    expect(res.status).toBe(401);
+    const html = await res.text();
+    expect(html).toContain('Invalid password');
+  });
+
+  it('handles missing password field gracefully', async () => {
+    handle = startWebServer(
+      { port: 0, sessionPassword: TEST_PASSWORD },
+      makeState(),
+    );
+
+    const body = 'username=admin';
+    const res = await fetch(serverUrl('/login'), {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+      body,
+      redirect: 'manual',
+    });
+    expect(res.status).toBe(401);
+  });
+
+  it('handles empty body gracefully', async () => {
+    handle = startWebServer(
+      { port: 0, sessionPassword: TEST_PASSWORD },
+      makeState(),
+    );
+
+    const res = await fetch(serverUrl('/login'), {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+      body: '',
+      redirect: 'manual',
+    });
+    expect(res.status).toBe(401);
   });
 });


### PR DESCRIPTION
## Summary

Caps the `POST /login` request body to prevent pre-auth memory/CPU denial-of-service.

- Replaces unbounded `req.formData()` with the shared `readRequestBody()` bounded reader (1 MiB cap, matching other Web UI write endpoints)
- Parses the bounded body as `URLSearchParams` to extract the password field
- Returns HTTP 413 for oversized payloads before any form parsing
- Updates existing session-auth tests to use `URLSearchParams` (matches actual browser form submission encoding)
- 5 new regression tests: oversized body rejection, normal login, wrong password, missing password field, empty body

Closes #548

## Test plan

- [x] 5 new tests covering body cap enforcement and edge cases
- [x] All 36 session-auth tests pass (0 regressions)
- [x] Full suite: 1780 tests pass, 0 failures
- [x] TypeScript compiles cleanly (`tsc --noEmit`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Added request body size validation for login submissions with HTTP 413 response for oversized payloads
  * Improved error handling for malformed login requests with appropriate HTTP status codes and messages

<!-- end of auto-generated comment: release notes by coderabbit.ai -->