### PR TITLE
test(discovery): cover runtime controller edge cases

### DIFF
--- a/src/discovery/runtime.test.ts
+++ b/src/discovery/runtime.test.ts
@@ -1,6 +1,7 @@
-import { beforeEach, describe, expect, it, mock } from 'bun:test';
+import { beforeEach, describe, expect, it, mock, spyOn } from 'bun:test';
 
 import { setRouterState, _initTestDatabase } from '../db.js';
+import { logger } from '../logger.js';
 import { DiscoveryRuntimeController } from './runtime.js';
 
 describe('DiscoveryRuntimeController', () => {
@@ -57,5 +58,178 @@ describe('DiscoveryRuntimeController', () => {
 
     expect(snapshot.enabled).toBe(false);
     expect(snapshot.active).toBe(false);
+  });
+
+  it('prefers persisted settings over the initial enabled flag', async () => {
+    setRouterState(
+      'discovery_runtime_settings',
+      JSON.stringify({
+        enabled: false,
+        trustedNetworks: [
+          {
+            id: 'wifi:home',
+            label: 'Home WiFi',
+            trustedAt: '2026-03-01T00:00:00.000Z',
+          },
+        ],
+      }),
+    );
+
+    const controller = new DiscoveryRuntimeController({
+      initialEnabled: true,
+      detectCurrentNetwork: async () => ({
+        id: 'wifi:home',
+        label: 'Home WiFi',
+      }),
+    });
+
+    const snapshot = await controller.refresh();
+
+    expect(snapshot).toMatchObject({
+      enabled: false,
+      active: false,
+      currentNetwork: {
+        id: 'wifi:home',
+        label: 'Home WiFi',
+      },
+      trustedNetworks: [
+        {
+          id: 'wifi:home',
+          label: 'Home WiFi',
+          trustedAt: '2026-03-01T00:00:00.000Z',
+        },
+      ],
+    });
+  });
+
+  it('throws when trusting a network before one has been detected', () => {
+    const controller = new DiscoveryRuntimeController({
+      initialEnabled: true,
+      detectCurrentNetwork: async () => null,
+    });
+
+    expect(() => controller.trustCurrentNetwork()).toThrow(
+      'No current Wi-Fi network detected',
+    );
+  });
+
+  it('does not duplicate trusted networks and falls back to permissive mode when all trusts are removed', async () => {
+    const controller = new DiscoveryRuntimeController({
+      initialEnabled: true,
+      detectCurrentNetwork: async () => ({
+        id: 'wifi:home',
+        label: 'Home WiFi',
+      }),
+    });
+
+    await controller.refresh();
+
+    const firstTrust = controller.trustCurrentNetwork();
+    const secondTrust = controller.trustCurrentNetwork();
+
+    expect(firstTrust.trustedNetworks).toHaveLength(1);
+    expect(secondTrust.trustedNetworks).toHaveLength(1);
+    expect(controller.isRemoteAccessAllowed()).toBe(true);
+
+    const snapshot = controller.untrustNetwork('wifi:home');
+
+    expect(snapshot.trustedNetworks).toEqual([]);
+    expect(snapshot.active).toBe(true);
+
+    controller.trustCurrentNetwork();
+    const afterRemovingCurrent = controller.untrustNetwork('wifi:home');
+    expect(afterRemovingCurrent.active).toBe(true);
+    expect(controller.isRemoteAccessAllowed()).toBe(true);
+  });
+
+  it('warns and clears the current network when detection fails', async () => {
+    const detector = mock(async () => ({
+      id: 'wifi:home',
+      label: 'Home WiFi',
+    }));
+    const controller = new DiscoveryRuntimeController({
+      initialEnabled: true,
+      detectCurrentNetwork: detector,
+    });
+    const warnSpy = spyOn(logger, 'warn').mockImplementation(() => {});
+
+    await controller.refresh();
+    controller.trustCurrentNetwork();
+
+    detector.mockImplementation(async () => {
+      throw new Error('wifi scan failed');
+    });
+
+    const snapshot = await controller.refresh();
+
+    expect(snapshot.currentNetwork).toBeNull();
+    expect(snapshot.active).toBe(false);
+    expect(controller.isRemoteAccessAllowed()).toBe(false);
+    expect(
+      warnSpy.mock.calls.some(
+        ([fields, message]) =>
+          message === 'Failed to detect current network' &&
+          fields instanceof Object,
+      ),
+    ).toBe(true);
+    warnSpy.mockRestore();
+  });
+
+  it('notifies only when the active state changes', async () => {
+    const onActiveChange = mock(() => {});
+    const detector = mock(async () => ({
+      id: 'wifi:home',
+      label: 'Home WiFi',
+    }));
+    const controller = new DiscoveryRuntimeController({
+      initialEnabled: true,
+      detectCurrentNetwork: detector,
+      onActiveChange,
+    });
+
+    await controller.refresh();
+    await controller.refresh();
+    controller.trustCurrentNetwork();
+    controller.setEnabled(false);
+    controller.setEnabled(false);
+
+    expect(onActiveChange).toHaveBeenCalledTimes(2);
+    expect(onActiveChange).toHaveBeenNthCalledWith(
+      1,
+      true,
+      expect.objectContaining({
+        enabled: true,
+        active: true,
+      }),
+    );
+    expect(onActiveChange).toHaveBeenLastCalledWith(
+      false,
+      expect.objectContaining({
+        enabled: false,
+        active: false,
+      }),
+    );
+  });
+
+  it('starts polling only once and clears the interval on stop', () => {
+    const setIntervalSpy = spyOn(globalThis, 'setInterval');
+    const clearIntervalSpy = spyOn(globalThis, 'clearInterval');
+    const controller = new DiscoveryRuntimeController({
+      initialEnabled: true,
+      detectCurrentNetwork: async () => null,
+      pollIntervalMs: 4321,
+    });
+
+    controller.start();
+    controller.start();
+    controller.stop();
+    controller.stop();
+
+    expect(setIntervalSpy).toHaveBeenCalledTimes(1);
+    expect(setIntervalSpy).toHaveBeenCalledWith(expect.any(Function), 4321);
+    expect(clearIntervalSpy).toHaveBeenCalledTimes(1);
+
+    setIntervalSpy.mockRestore();
+    clearIntervalSpy.mockRestore();
   });
 });

--- a/src/discovery/runtime.test.ts
+++ b/src/discovery/runtime.test.ts
@@ -153,26 +153,28 @@ describe('DiscoveryRuntimeController', () => {
     });
     const warnSpy = spyOn(logger, 'warn').mockImplementation(() => {});
 
-    await controller.refresh();
-    controller.trustCurrentNetwork();
+    try {
+      await controller.refresh();
+      controller.trustCurrentNetwork();
 
-    detector.mockImplementation(async () => {
-      throw new Error('wifi scan failed');
-    });
+      detector.mockImplementation(async () => {
+        throw new Error('wifi scan failed');
+      });
 
-    const snapshot = await controller.refresh();
+      const snapshot = await controller.refresh();
 
-    expect(snapshot.currentNetwork).toBeNull();
-    expect(snapshot.active).toBe(false);
-    expect(controller.isRemoteAccessAllowed()).toBe(false);
-    expect(
-      warnSpy.mock.calls.some(
-        ([fields, message]) =>
-          message === 'Failed to detect current network' &&
-          fields instanceof Object,
-      ),
-    ).toBe(true);
-    warnSpy.mockRestore();
+      expect(snapshot.currentNetwork).toBeNull();
+      expect(snapshot.active).toBe(false);
+      expect(controller.isRemoteAccessAllowed()).toBe(false);
+      expect(warnSpy).toHaveBeenCalledWith(
+        expect.objectContaining({
+          err: expect.any(Error),
+        }),
+        'Failed to detect current network',
+      );
+    } finally {
+      warnSpy.mockRestore();
+    }
   });
 
   it('notifies only when the active state changes', async () => {
@@ -220,16 +222,18 @@ describe('DiscoveryRuntimeController', () => {
       pollIntervalMs: 4321,
     });
 
-    controller.start();
-    controller.start();
-    controller.stop();
-    controller.stop();
+    try {
+      controller.start();
+      controller.start();
+      controller.stop();
+      controller.stop();
 
-    expect(setIntervalSpy).toHaveBeenCalledTimes(1);
-    expect(setIntervalSpy).toHaveBeenCalledWith(expect.any(Function), 4321);
-    expect(clearIntervalSpy).toHaveBeenCalledTimes(1);
-
-    setIntervalSpy.mockRestore();
-    clearIntervalSpy.mockRestore();
+      expect(setIntervalSpy).toHaveBeenCalledTimes(1);
+      expect(setIntervalSpy).toHaveBeenCalledWith(expect.any(Function), 4321);
+      expect(clearIntervalSpy).toHaveBeenCalledTimes(1);
+    } finally {
+      setIntervalSpy.mockRestore();
+      clearIntervalSpy.mockRestore();
+    }
   });
 });


### PR DESCRIPTION
## Summary
- add deterministic coverage for `DiscoveryRuntimeController` persistence, trust-list transitions, detection failures, and polling lifecycle behavior
- raise targeted coverage for `src/discovery/runtime.ts` from the previously reported 16.48% lines to 98.80% lines and 93.75% functions in the focused coverage run
- increase runtime controller tests from 3 to 9 cases while keeping the full clean-worktree suite green

## Testing
- `bun test src/discovery/runtime.test.ts`
- `bun test --coverage src/discovery/runtime.test.ts`
- `bun test`

## Notes
- remaining low-coverage gaps from the focused report are still concentrated in `src/discovery/trust-store.ts`, `src/discovery/pairing-crypto.ts`, `src/db.ts`, `src/config.ts`, and `src/logger.ts`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Enhanced test coverage for runtime discovery functionality, including network detection, trust management, state transitions, and polling behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->