### PR TITLE
fix(security): restrict discovery LAN admin trust

### DIFF
--- a/src/web/server.test.ts
+++ b/src/web/server.test.ts
@@ -551,6 +551,26 @@ describe('isTrustedLanDiscoveryAdminRequest', () => {
     ).toBe(true);
   });
 
+  it('rejects public peers even when the listener is bound to a private LAN IP', () => {
+    const req = Object.assign(
+      new Request('http://evil.example/api/discovery/requests', {
+        headers: { Host: 'evil.example' },
+      }),
+      {
+        socket: { remoteAddress: '8.8.8.8' },
+      },
+    ) as Request;
+
+    expect(
+      isTrustedLanDiscoveryAdminRequest(
+        req,
+        '/api/discovery/requests',
+        '192.168.1.10',
+        true,
+      ),
+    ).toBe(false);
+  });
+
   it('allows loopback-bound servers when the socket address is unavailable', () => {
     const req = new Request('http://evil.example/api/discovery/requests', {
       headers: { Host: 'evil.example' },

--- a/src/web/server.ts
+++ b/src/web/server.ts
@@ -999,11 +999,26 @@ export function isTrustedLanDiscoveryAdminRequest(
     req as unknown as { socket?: { remoteAddress?: string } }
   ).socket?.remoteAddress;
 
-  // Only trust the actual socket peer or the configured listener host. URL/Host
-  // are attacker-controlled and must not influence auth decisions.
+  // Auth bypass must key off the actual peer address. The listener hostname is
+  // the server's own bind target, not a property of the client request.
+  if (remoteAddress) {
+    return isLoopbackOrPrivateAddress(remoteAddress);
+  }
+
+  // Bun may not always expose a socket address in tests or some deployments.
+  // Preserve the loopback-only fallback for local-only listeners.
+  return isLoopbackAddress(listenerHostname);
+}
+
+function isLoopbackAddress(address?: string): boolean {
+  if (!address) return false;
+  const normalized = address.toLowerCase();
+
   return (
-    isLoopbackOrPrivateAddress(remoteAddress) ||
-    isLoopbackOrPrivateAddress(listenerHostname)
+    normalized === '::1' ||
+    normalized === '::ffff:127.0.0.1' ||
+    normalized === 'localhost' ||
+    normalized.startsWith('127.')
   );
 }
 
@@ -1011,9 +1026,7 @@ function isLoopbackOrPrivateAddress(address?: string): boolean {
   if (!address) return false;
   const normalized = address.toLowerCase();
 
-  if (normalized === '::1' || normalized === '::ffff:127.0.0.1') return true;
-  if (normalized === 'localhost') return true;
-  if (normalized.startsWith('127.')) return true;
+  if (isLoopbackAddress(normalized)) return true;
 
   const ipv4 = normalized.startsWith('::ffff:')
     ? normalized.slice('::ffff:'.length)


### PR DESCRIPTION
## Summary

- fix `isTrustedLanDiscoveryAdminRequest()` so discovery admin auth bypass is based on the actual client socket peer instead of the Web UI listener bind host
- keep a loopback-only fallback when no socket address is available to preserve local-only behavior without extending LAN trust to public clients
- add a regression test covering a public remote address against a private listener hostname

## Testing

- `bun test src/web/server.test.ts`
- `bun -e "import { isTrustedLanDiscoveryAdminRequest } from './src/web/server.ts'; const req = new Request('http://example.com/api/discovery/requests'); Object.assign(req,{socket:{remoteAddress:'8.8.8.8'}}); console.log(isTrustedLanDiscoveryAdminRequest(req,'/api/discovery/requests','192.168.1.10',true));"`

Closes #557


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Strengthened network discovery admin authentication by enforcing stricter peer address validation. Requests from public addresses are now properly rejected regardless of listener configuration.

* **Tests**
  * Added test coverage validating authentication rejection for requests originating from public network addresses.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->