### PR TITLE
fix(security): stream WhatsApp media downloads with limits

### DIFF
--- a/src/channels/whatsapp.test.ts
+++ b/src/channels/whatsapp.test.ts
@@ -1,5 +1,6 @@
 import fs from 'fs';
 import path from 'path';
+import { Readable } from 'stream';
 import {
   afterEach,
   describe,
@@ -12,6 +13,7 @@ import {
 
 import { GROUPS_DIR } from '../config.js';
 import {
+  MAX_BINARY_DOWNLOAD_BYTES,
   formatImageMarker,
   formatPlaceholder,
   formatTextFileMarker,
@@ -941,6 +943,83 @@ describe('WhatsAppChannel.downloadWhatsAppMedia', () => {
       message: { imageMessage: {} },
     });
     expect(result).toBeNull();
+  });
+
+  it('downloads streamed media under the byte limit', async () => {
+    const channel = makeChannel();
+    const mediaDownloader = mock(async (_msg: any, type: string, opts: any) => {
+      expect(type).toBe('stream');
+      expect(opts?.options?.signal).toBeInstanceOf(AbortSignal);
+      return Readable.from([Buffer.from('hello')]);
+    });
+
+    setPrivate(channel, 'sock', { updateMediaMessage: mock() });
+    setPrivate(channel, 'mediaDownloader', mediaDownloader);
+
+    const result = await (channel as any).downloadWhatsAppMedia({
+      message: { imageMessage: {} },
+    });
+
+    expect(result?.toString()).toBe('hello');
+    expect(mediaDownloader).toHaveBeenCalledTimes(1);
+  });
+
+  it('returns null when streamed media exceeds the byte limit', async () => {
+    const channel = makeChannel();
+    const stream = Readable.from([Buffer.alloc(MAX_BINARY_DOWNLOAD_BYTES + 1)]);
+    const destroySpy = spyOn(stream, 'destroy');
+
+    setPrivate(channel, 'sock', { updateMediaMessage: mock() });
+    setPrivate(
+      channel,
+      'mediaDownloader',
+      mock(async () => stream),
+    );
+
+    const result = await (channel as any).downloadWhatsAppMedia({
+      message: { imageMessage: {} },
+    });
+
+    expect(result).toBeNull();
+    expect(destroySpy).toHaveBeenCalled();
+  });
+
+  it('returns null when the media download times out', async () => {
+    const channel = makeChannel();
+    const originalTimeout = (globalThis as any).AbortSignal.timeout;
+
+    (globalThis as any).AbortSignal.timeout = (ms: number) => {
+      const controller = new AbortController();
+      setTimeout(() => controller.abort(new Error(`timeout:${ms}`)), 0);
+      return controller.signal;
+    };
+
+    setPrivate(channel, 'sock', { updateMediaMessage: mock() });
+    setPrivate(
+      channel,
+      'mediaDownloader',
+      mock(
+        async (_msg: any, _type: string, opts: any) =>
+          await new Promise((_, reject) => {
+            const signal = opts?.options?.signal as AbortSignal | undefined;
+            signal?.addEventListener(
+              'abort',
+              () => reject(signal.reason ?? new Error('aborted')),
+              { once: true },
+            );
+          }),
+      ),
+    );
+
+    try {
+      const result = await (channel as any).downloadWhatsAppMedia({
+        message: { imageMessage: {} },
+      });
+
+      expect(result).toBeNull();
+    } finally {
+      (globalThis as any).AbortSignal.timeout = originalTimeout;
+    }
   });
 });
 

--- a/src/channels/whatsapp.ts
+++ b/src/channels/whatsapp.ts
@@ -34,6 +34,39 @@ import {
 } from '../types.js';
 
 const GROUP_SYNC_INTERVAL_MS = 24 * 60 * 60 * 1000; // 24 hours
+const WHATSAPP_MEDIA_DOWNLOAD_TIMEOUT_MS = 15_000;
+
+type WhatsAppMediaStream = AsyncIterable<Buffer | Uint8Array> & {
+  destroy?: (error?: Error) => void;
+};
+
+async function readWhatsAppMediaStream(
+  stream: WhatsAppMediaStream,
+  maxBytes: number,
+): Promise<Buffer> {
+  const chunks: Buffer[] = [];
+  let totalBytes = 0;
+
+  try {
+    for await (const chunk of stream) {
+      const bytes = Buffer.from(chunk);
+      totalBytes += bytes.length;
+
+      if (totalBytes > maxBytes) {
+        const error = new Error(`Download exceeded ${maxBytes} bytes`);
+        stream.destroy?.(error);
+        throw error;
+      }
+
+      chunks.push(bytes);
+    }
+  } catch (error) {
+    stream.destroy?.(error instanceof Error ? error : undefined);
+    throw error;
+  }
+
+  return Buffer.concat(chunks);
+}
 
 // Circuit breaker: force process restart if too many reconnects in a short window.
 // Fixes 408 timeout loops after Mac sleep or network drops where reconnect →
@@ -54,6 +87,7 @@ export class WhatsAppChannel implements Channel {
   prefixAssistantName = true;
 
   private sock!: WASocket;
+  private mediaDownloader = downloadMediaMessage;
   private connected = false;
   private lidToPhoneMap: Record<string, string> = {};
   private outgoingQueue: Array<{ jid: string; text: string }> = [];
@@ -668,26 +702,36 @@ export class WhatsAppChannel implements Channel {
    */
   private async downloadWhatsAppMedia(msg: any): Promise<Buffer | null> {
     try {
-      const buffer = (await downloadMediaMessage(
+      const stream = (await this.mediaDownloader(
         msg,
-        'buffer',
-        {},
+        'stream',
+        {
+          options: {
+            signal: AbortSignal.timeout(WHATSAPP_MEDIA_DOWNLOAD_TIMEOUT_MS),
+          },
+        },
         {
           logger: { ...console, child: () => console } as any,
           reuploadRequest: this.sock.updateMediaMessage,
         },
-      )) as Buffer;
+      )) as WhatsAppMediaStream;
+
+      const buffer = await readWhatsAppMediaStream(
+        stream,
+        MAX_BINARY_DOWNLOAD_BYTES,
+      );
+
       if (!buffer || buffer.length === 0) return null;
-      if (buffer.length > MAX_BINARY_DOWNLOAD_BYTES) {
-        logger.warn(
-          { bytes: buffer.length, max: MAX_BINARY_DOWNLOAD_BYTES },
-          'WhatsApp media exceeds size limit — discarding',
-        );
-        return null;
-      }
       return buffer;
     } catch (err) {
-      logger.warn({ err }, 'Failed to download WhatsApp media');
+      logger.warn(
+        {
+          err,
+          maxBytes: MAX_BINARY_DOWNLOAD_BYTES,
+          timeoutMs: WHATSAPP_MEDIA_DOWNLOAD_TIMEOUT_MS,
+        },
+        'Failed to download WhatsApp media',
+      );
       return null;
     }
   }


### PR DESCRIPTION
## Summary
- switch inbound WhatsApp media downloads to Baileys stream mode instead of buffering the full attachment first
- enforce the existing binary size cap while reading the decrypted media stream and abort stalled downloads after 15 seconds
- add regression coverage for successful bounded downloads, oversize rejection, and timeout handling

## Testing
- `bun test src/channels/whatsapp.test.ts`
- `bun run typecheck`

## Security
- fixes #576


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Tests**
  * Added tests for media download streaming behavior, size enforcement, and timeout handling.

* **Improvements**
  * Enhanced WhatsApp media downloads with streaming support and robust size enforcement.
  * Added timeout protection for media download operations.
  * Improved error logging for media download failures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->