### PR TITLE
fix(security): close DNS rebinding SSRF in remote image cache

### DIFF
--- a/src/web/image-cache.test.ts
+++ b/src/web/image-cache.test.ts
@@ -1,5 +1,6 @@
 import { randomUUID } from 'crypto';
 import fs from 'fs';
+import http from 'node:http';
 import path from 'path';
 
 import { describe, expect, it } from 'bun:test';
@@ -8,8 +9,10 @@ import { DATA_DIR } from '../config.js';
 import { logger } from '../logger.js';
 import {
   describeImageUrl,
+  fetchWithPinnedDns,
   readStreamWithCap,
   type RemoteImageFetch,
+  resolveAndValidateRemoteImageUrl,
   serveCachedRemoteImage,
   validateRemoteImageUrl,
 } from './image-cache.js';
@@ -400,5 +403,215 @@ describe('validateRemoteImageUrl', () => {
         lookupHostAddresses: async () => ['93.184.216.34'],
       }),
     ).resolves.toBeNull();
+  });
+});
+
+describe('resolveAndValidateRemoteImageUrl', () => {
+  it('returns resolved addresses for hostname-based urls', async () => {
+    const result = await resolveAndValidateRemoteImageUrl(
+      'https://cdn.example.com/avatar.png',
+      { lookupHostAddresses: async () => ['93.184.216.34', '2606:2800:220:1:248:1893:25c8:1946'] },
+    );
+    expect(result.error).toBeNull();
+    expect(result.resolvedAddresses).toEqual([
+      '93.184.216.34',
+      '2606:2800:220:1:248:1893:25c8:1946',
+    ]);
+  });
+
+  it('returns empty addresses for direct-IP urls', async () => {
+    const result = await resolveAndValidateRemoteImageUrl(
+      'https://93.184.216.34/avatar.png',
+    );
+    expect(result.error).toBeNull();
+    expect(result.resolvedAddresses).toEqual([]);
+  });
+
+  it('returns error and empty addresses for blocked urls', async () => {
+    const result = await resolveAndValidateRemoteImageUrl(
+      'http://127.0.0.1/avatar.png',
+    );
+    expect(result.error).toBe('private address is not allowed');
+    expect(result.resolvedAddresses).toEqual([]);
+  });
+
+  it('returns error when hostname resolves to private address', async () => {
+    const result = await resolveAndValidateRemoteImageUrl(
+      'https://evil.test/avatar.png',
+      { lookupHostAddresses: async () => ['10.0.0.1'] },
+    );
+    expect(result.error).toBe('resolved private address is not allowed');
+    expect(result.resolvedAddresses).toEqual([]);
+  });
+});
+
+describe('fetchWithPinnedDns', () => {
+  it('connects to the pinned address instead of resolving DNS', async () => {
+    const body = 'pinned-response-body';
+    let receivedHost: string | undefined;
+
+    const server = http.createServer((req, res) => {
+      receivedHost = req.headers.host;
+      res.writeHead(200, { 'content-type': 'text/plain' });
+      res.end(body);
+    });
+
+    await new Promise<void>((resolve) => server.listen(0, '127.0.0.1', resolve));
+    const port = (server.address() as { port: number }).port;
+
+    try {
+      // Fetch a URL with hostname "cdn.example.com" but pin to 127.0.0.1.
+      // Without pinning, this would attempt real DNS resolution for cdn.example.com.
+      const response = await fetchWithPinnedDns(
+        `http://cdn.example.com:${port}/avatar.png`,
+        '127.0.0.1',
+        5000,
+      );
+
+      expect(response.status).toBe(200);
+      const text = await response.text();
+      expect(text).toBe(body);
+      // The Host header should carry the original hostname.
+      expect(receivedHost).toBe(`cdn.example.com:${port}`);
+    } finally {
+      server.close();
+    }
+  });
+
+  it('rejects after timeout', async () => {
+    // Start a server that never responds
+    const server = http.createServer(() => {
+      // intentionally hang
+    });
+
+    await new Promise<void>((resolve) => server.listen(0, '127.0.0.1', resolve));
+    const port = (server.address() as { port: number }).port;
+
+    try {
+      await expect(
+        fetchWithPinnedDns(
+          `http://cdn.example.com:${port}/slow.png`,
+          '127.0.0.1',
+          100,
+        ),
+      ).rejects.toThrow(/timed out/i);
+    } finally {
+      server.close();
+    }
+  });
+});
+
+describe('serveCachedRemoteImage DNS rebinding prevention', () => {
+  it('uses pinned DNS when no fetchImpl is provided', async () => {
+    const testImageCacheDir = path.join(
+      DATA_DIR,
+      'image-cache-rebinding-test',
+      randomUUID(),
+    );
+
+    clearTestImageCache(testImageCacheDir);
+
+    // Start a local HTTP server that serves an image.
+    const body = Buffer.from('fake-png-data');
+    let receivedHost: string | undefined;
+    const server = http.createServer((req, res) => {
+      receivedHost = req.headers.host;
+      res.writeHead(200, { 'content-type': 'image/png' });
+      res.end(body);
+    });
+
+    await new Promise<void>((resolve) => server.listen(0, '127.0.0.1', resolve));
+    const port = (server.address() as { port: number }).port;
+
+    try {
+      // Use a public IP (93.184.216.34) that will pass validation, but the
+      // server actually listens on 127.0.0.1. We test fetchWithPinnedDns
+      // directly to verify the pinned path works end-to-end.
+      const response = await fetchWithPinnedDns(
+        `http://cdn.example.com:${port}/avatar.png`,
+        '127.0.0.1',
+        5000,
+      );
+
+      expect(response.status).toBe(200);
+      // Verify the Host header carries the original hostname, not the pinned IP.
+      expect(receivedHost).toBe(`cdn.example.com:${port}`);
+    } finally {
+      server.close();
+      clearTestImageCache(testImageCacheDir);
+    }
+  });
+
+  it('blocks fetch when DNS resolves to a private address', async () => {
+    const testImageCacheDir = path.join(
+      DATA_DIR,
+      'image-cache-rebinding-test',
+      randomUUID(),
+    );
+
+    clearTestImageCache(testImageCacheDir);
+
+    const originalWarn = logger.warn;
+    const records: Array<Record<string, unknown>> = [];
+    logger.warn = ((fieldsOrMsg: Record<string, unknown> | string) => {
+      if (typeof fieldsOrMsg !== 'string') {
+        records.push(fieldsOrMsg);
+      }
+    }) as unknown as typeof logger.warn;
+
+    try {
+      // DNS resolver returns a private address — should be blocked at
+      // validation time, never reaching any fetch.
+      const response = await serveCachedRemoteImage(
+        'rebind-key',
+        async () => 'http://evil.test/avatar.png',
+        {
+          cacheDir: testImageCacheDir,
+          lookupHostAddresses: async () => ['10.0.0.1'],
+        },
+      );
+
+      expect(response).toBeNull();
+      expect(records.some((r) => r.blockReason === 'resolved private address is not allowed')).toBe(true);
+    } finally {
+      clearTestImageCache(testImageCacheDir);
+      logger.warn = originalWarn;
+    }
+  });
+
+  it('passes lookupHostAddresses through to validation', async () => {
+    const testImageCacheDir = path.join(
+      DATA_DIR,
+      'image-cache-rebinding-test',
+      randomUUID(),
+    );
+
+    clearTestImageCache(testImageCacheDir);
+
+    const originalWarn = logger.warn;
+    logger.warn = (() => {}) as unknown as typeof logger.warn;
+
+    let lookupCalled = false;
+
+    try {
+      await serveCachedRemoteImage(
+        'lookup-passthrough-key',
+        async () => 'http://cdn.example.com/avatar.png',
+        {
+          cacheDir: testImageCacheDir,
+          lookupHostAddresses: async () => {
+            lookupCalled = true;
+            // Return a private address to trigger block (easiest way to verify
+            // that our custom resolver was actually used).
+            return ['192.168.1.1'];
+          },
+        },
+      );
+
+      expect(lookupCalled).toBe(true);
+    } finally {
+      clearTestImageCache(testImageCacheDir);
+      logger.warn = originalWarn;
+    }
   });
 });

--- a/src/web/image-cache.test.ts
+++ b/src/web/image-cache.test.ts
@@ -410,7 +410,12 @@ describe('resolveAndValidateRemoteImageUrl', () => {
   it('returns resolved addresses for hostname-based urls', async () => {
     const result = await resolveAndValidateRemoteImageUrl(
       'https://cdn.example.com/avatar.png',
-      { lookupHostAddresses: async () => ['93.184.216.34', '2606:2800:220:1:248:1893:25c8:1946'] },
+      {
+        lookupHostAddresses: async () => [
+          '93.184.216.34',
+          '2606:2800:220:1:248:1893:25c8:1946',
+        ],
+      },
     );
     expect(result.error).toBeNull();
     expect(result.resolvedAddresses).toEqual([
@@ -456,7 +461,9 @@ describe('fetchWithPinnedDns', () => {
       res.end(body);
     });
 
-    await new Promise<void>((resolve) => server.listen(0, '127.0.0.1', resolve));
+    await new Promise<void>((resolve) =>
+      server.listen(0, '127.0.0.1', resolve),
+    );
     const port = (server.address() as { port: number }).port;
 
     try {
@@ -484,7 +491,9 @@ describe('fetchWithPinnedDns', () => {
       // intentionally hang
     });
 
-    await new Promise<void>((resolve) => server.listen(0, '127.0.0.1', resolve));
+    await new Promise<void>((resolve) =>
+      server.listen(0, '127.0.0.1', resolve),
+    );
     const port = (server.address() as { port: number }).port;
 
     try {
@@ -520,7 +529,9 @@ describe('serveCachedRemoteImage DNS rebinding prevention', () => {
       res.end(body);
     });
 
-    await new Promise<void>((resolve) => server.listen(0, '127.0.0.1', resolve));
+    await new Promise<void>((resolve) =>
+      server.listen(0, '127.0.0.1', resolve),
+    );
     const port = (server.address() as { port: number }).port;
 
     try {
@@ -572,7 +583,11 @@ describe('serveCachedRemoteImage DNS rebinding prevention', () => {
       );
 
       expect(response).toBeNull();
-      expect(records.some((r) => r.blockReason === 'resolved private address is not allowed')).toBe(true);
+      expect(
+        records.some(
+          (r) => r.blockReason === 'resolved private address is not allowed',
+        ),
+      ).toBe(true);
     } finally {
       clearTestImageCache(testImageCacheDir);
       logger.warn = originalWarn;

--- a/src/web/image-cache.test.ts
+++ b/src/web/image-cache.test.ts
@@ -404,6 +404,14 @@ describe('validateRemoteImageUrl', () => {
       }),
     ).resolves.toBeNull();
   });
+
+  it('rejects hostnames that resolve no addresses', async () => {
+    await expect(
+      validateRemoteImageUrl('https://cdn.example.com/avatar.png', {
+        lookupHostAddresses: async () => [],
+      }),
+    ).resolves.toBe('no addresses resolved');
+  });
 });
 
 describe('resolveAndValidateRemoteImageUrl', () => {
@@ -511,7 +519,7 @@ describe('fetchWithPinnedDns', () => {
 });
 
 describe('serveCachedRemoteImage DNS rebinding prevention', () => {
-  it('uses pinned DNS when no fetchImpl is provided', async () => {
+  it('uses pinned DNS for hostname URLs even when fetchImpl is provided', async () => {
     const testImageCacheDir = path.join(
       DATA_DIR,
       'image-cache-rebinding-test',
@@ -535,16 +543,24 @@ describe('serveCachedRemoteImage DNS rebinding prevention', () => {
     const port = (server.address() as { port: number }).port;
 
     try {
-      // Use a public IP (93.184.216.34) that will pass validation, but the
-      // server actually listens on 127.0.0.1. We test fetchWithPinnedDns
-      // directly to verify the pinned path works end-to-end.
-      const response = await fetchWithPinnedDns(
-        `http://cdn.example.com:${port}/avatar.png`,
-        '127.0.0.1',
-        5000,
+      const response = await serveCachedRemoteImage(
+        'pinned-hostname-key',
+        async () => `http://cdn.example.com:${port}/avatar.png`,
+        {
+          cacheDir: testImageCacheDir,
+          lookupHostAddresses: async () => ['93.184.216.34'],
+          fetchImpl: (async () => {
+            throw new Error('fetchImpl must not be used for hostname URLs');
+          }) as RemoteImageFetch,
+          fetchWithPinnedDnsImpl: (url, pinnedAddress, timeoutMs) => {
+            expect(pinnedAddress).toBe('93.184.216.34');
+            return fetchWithPinnedDns(url, '127.0.0.1', timeoutMs);
+          },
+        },
       );
 
-      expect(response.status).toBe(200);
+      expect(response).not.toBeNull();
+      expect(response!.status).toBe(200);
       // Verify the Host header carries the original hostname, not the pinned IP.
       expect(receivedHost).toBe(`cdn.example.com:${port}`);
     } finally {

--- a/src/web/image-cache.ts
+++ b/src/web/image-cache.ts
@@ -1,6 +1,8 @@
 import { createHash } from 'crypto';
 import { lookup } from 'dns/promises';
 import fs from 'fs';
+import http from 'node:http';
+import https from 'node:https';
 import { isIP } from 'net';
 import path from 'path';
 
@@ -30,6 +32,8 @@ export interface RemoteImageCacheOptions {
   fetchImpl?: RemoteImageFetch;
   /** Maximum bytes to read from the upstream response. Defaults to 5 MiB. */
   maxBytes?: number;
+  /** Override DNS resolution (primarily for tests). */
+  lookupHostAddresses?: (hostname: string) => Promise<string[]>;
 }
 
 export interface RemoteImageUrlValidationOptions {
@@ -100,35 +104,46 @@ function isBlockedPrivateAddress(address: string): boolean {
   return false;
 }
 
-export async function validateRemoteImageUrl(
+export interface RemoteImageUrlValidationResult {
+  error: string | null;
+  /** Pre-resolved IP addresses. Empty for direct-IP URLs. */
+  resolvedAddresses: string[];
+}
+
+/**
+ * Validate a remote image URL and resolve its hostname to IP addresses.
+ * Returns both the validation result and the resolved addresses so callers
+ * can pin DNS for the subsequent fetch (preventing DNS rebinding).
+ */
+export async function resolveAndValidateRemoteImageUrl(
   url: string,
   options: RemoteImageUrlValidationOptions = {},
-): Promise<string | null> {
+): Promise<RemoteImageUrlValidationResult> {
   let parsed: URL;
   try {
     parsed = new URL(url);
   } catch {
-    return 'invalid url';
+    return { error: 'invalid url', resolvedAddresses: [] };
   }
 
   if (parsed.protocol !== 'https:' && parsed.protocol !== 'http:') {
-    return 'unsupported protocol';
+    return { error: 'unsupported protocol', resolvedAddresses: [] };
   }
 
   if (parsed.username || parsed.password) {
-    return 'embedded credentials are not allowed';
+    return { error: 'embedded credentials are not allowed', resolvedAddresses: [] };
   }
 
   const hostname = parsed.hostname.toLowerCase().replace(/^\[|\]$/g, '');
   if (hostname === 'localhost' || hostname.endsWith('.localhost')) {
-    return 'loopback host is not allowed';
+    return { error: 'loopback host is not allowed', resolvedAddresses: [] };
   }
 
   if (isIP(hostname) && isBlockedPrivateAddress(hostname)) {
-    return 'private address is not allowed';
+    return { error: 'private address is not allowed', resolvedAddresses: [] };
   }
 
-  if (isIP(hostname)) return null;
+  if (isIP(hostname)) return { error: null, resolvedAddresses: [] };
 
   const resolveHostAddresses =
     options.lookupHostAddresses ?? lookupHostAddresses;
@@ -136,13 +151,24 @@ export async function validateRemoteImageUrl(
   try {
     const addresses = await resolveHostAddresses(hostname);
     if (addresses.some((address) => isBlockedPrivateAddress(address))) {
-      return 'resolved private address is not allowed';
+      return { error: 'resolved private address is not allowed', resolvedAddresses: [] };
     }
+    return { error: null, resolvedAddresses: addresses };
   } catch {
-    return 'dns lookup failed - cannot verify host safety';
+    return { error: 'dns lookup failed - cannot verify host safety', resolvedAddresses: [] };
   }
+}
 
-  return null;
+/**
+ * Validate a remote image URL. Returns an error string or null if valid.
+ * Backward-compatible wrapper around resolveAndValidateRemoteImageUrl.
+ */
+export async function validateRemoteImageUrl(
+  url: string,
+  options: RemoteImageUrlValidationOptions = {},
+): Promise<string | null> {
+  const result = await resolveAndValidateRemoteImageUrl(url, options);
+  return result.error;
 }
 
 export function describeImageUrl(url: string): string {
@@ -233,14 +259,122 @@ export async function readStreamWithCap(
   return Buffer.concat(chunks, totalBytes);
 }
 
+/**
+ * Fetch a URL with DNS pinned to a pre-resolved address, preventing DNS
+ * rebinding. Uses Node's http/https modules with a custom `lookup` that
+ * always returns the validated address instead of re-resolving.
+ */
+export async function fetchWithPinnedDns(
+  url: string,
+  pinnedAddress: string,
+  timeoutMs: number,
+): Promise<Response> {
+  const parsed = new URL(url);
+  const isSecure = parsed.protocol === 'https:';
+  const requestFn = isSecure ? https.request : http.request;
+  const defaultPort = isSecure ? 443 : 80;
+  const port = parsed.port ? Number.parseInt(parsed.port, 10) : defaultPort;
+  const family = pinnedAddress.includes(':') ? 6 : 4;
+
+  return new Promise<Response>((resolve, reject) => {
+    let settled = false;
+    const settle = (fn: () => void) => {
+      if (!settled) {
+        settled = true;
+        fn();
+      }
+    };
+
+    const timer = setTimeout(() => {
+      req.destroy();
+      settle(() =>
+        reject(new Error(`Image fetch timed out after ${timeoutMs}ms`)),
+      );
+    }, timeoutMs);
+
+    const req = requestFn(
+      {
+        method: 'GET',
+        hostname: parsed.hostname,
+        port,
+        path: `${parsed.pathname}${parsed.search}`,
+        // Pin DNS: always return the pre-validated address.
+        // Bun's http client calls lookup with { all: true } and expects
+        // an array result; Node.js uses the simple (err, address, family) form.
+        lookup: (
+          _hostname: string,
+          _opts: unknown,
+          cb?: Function,
+        ) => {
+          const callback = typeof _opts === 'function' ? _opts : cb!;
+          const opts =
+            typeof _opts === 'object' && _opts !== null
+              ? (_opts as Record<string, unknown>)
+              : {};
+          if (opts.all) {
+            callback(null, [{ address: pinnedAddress, family }]);
+          } else {
+            callback(null, pinnedAddress, family);
+          }
+        },
+        ...(isSecure
+          ? { servername: parsed.hostname, rejectUnauthorized: true }
+          : {}),
+      },
+      (res: http.IncomingMessage) => {
+        const body = new ReadableStream<Uint8Array>({
+          start(controller) {
+            res.on('data', (chunk: Buffer) => {
+              controller.enqueue(new Uint8Array(chunk));
+            });
+            res.on('end', () => {
+              clearTimeout(timer);
+              controller.close();
+            });
+            res.on('error', (err) => {
+              clearTimeout(timer);
+              controller.error(err);
+            });
+          },
+          cancel() {
+            res.destroy();
+          },
+        });
+
+        const headers = new Headers();
+        for (const [key, val] of Object.entries(res.headers)) {
+          if (val === undefined) continue;
+          const values = Array.isArray(val) ? val : [val];
+          for (const v of values) headers.append(key, v);
+        }
+
+        settle(() =>
+          resolve(
+            new Response(body, {
+              status: res.statusCode ?? 200,
+              statusText: res.statusMessage ?? '',
+              headers,
+            }),
+          ),
+        );
+      },
+    );
+
+    req.on('error', (err: Error) => {
+      clearTimeout(timer);
+      settle(() => reject(err));
+    });
+
+    req.end();
+  });
+}
+
 export async function serveCachedRemoteImage(
   cacheKey: string,
   resolveUrl: () => Promise<string | null>,
   options: RemoteImageCacheOptions = {},
 ): Promise<Response | null> {
   const cacheDir = options.cacheDir ?? IMAGE_CACHE_DIR;
-  const fetchImpl: RemoteImageFetch =
-    options.fetchImpl ?? ((input, init) => fetch(input, init));
   const maxBytes = options.maxBytes ?? DEFAULT_MAX_IMAGE_BYTES;
   fs.mkdirSync(cacheDir, { recursive: true });
   const { dataPath, metaPath } = getCachePaths(cacheDir, cacheKey);
@@ -257,13 +391,15 @@ export async function serveCachedRemoteImage(
   const url = await resolveUrl();
   if (!url) return null;
 
-  const blockReason = await validateRemoteImageUrl(url);
-  if (blockReason) {
+  const validation = await resolveAndValidateRemoteImageUrl(url, {
+    lookupHostAddresses: options.lookupHostAddresses,
+  });
+  if (validation.error) {
     logger.warn(
       {
         cacheKey,
         imageUrl: describeImageUrl(url),
-        blockReason,
+        blockReason: validation.error,
       },
       'Blocked remote image fetch',
     );
@@ -271,13 +407,27 @@ export async function serveCachedRemoteImage(
   }
 
   try {
-    // This still has a DNS rebinding/TOCTOU gap because fetch() resolves the
-    // hostname again. The write-time validation in routes.ts prevents
-    // persistence of malicious custom avatar URLs, and this fetch-time check
-    // adds a second guard for stored remote image URLs.
-    const upstream = await fetchImpl(url, {
-      signal: AbortSignal.timeout(REMOTE_IMAGE_FETCH_TIMEOUT_MS),
-    });
+    let upstream: Response;
+    if (options.fetchImpl) {
+      // Caller-provided fetch (tests, custom transports).
+      upstream = await options.fetchImpl(url, {
+        signal: AbortSignal.timeout(REMOTE_IMAGE_FETCH_TIMEOUT_MS),
+      });
+    } else if (validation.resolvedAddresses.length > 0) {
+      // Hostname URL: connect to the pre-validated IP, preventing DNS
+      // rebinding between validation and fetch.
+      upstream = await fetchWithPinnedDns(
+        url,
+        validation.resolvedAddresses[0],
+        REMOTE_IMAGE_FETCH_TIMEOUT_MS,
+      );
+    } else {
+      // Direct-IP URL: already validated above, safe to fetch directly.
+      upstream = await fetch(url, {
+        signal: AbortSignal.timeout(REMOTE_IMAGE_FETCH_TIMEOUT_MS),
+      });
+    }
+
     if (!upstream.ok) {
       logger.warn(
         {

--- a/src/web/image-cache.ts
+++ b/src/web/image-cache.ts
@@ -131,7 +131,10 @@ export async function resolveAndValidateRemoteImageUrl(
   }
 
   if (parsed.username || parsed.password) {
-    return { error: 'embedded credentials are not allowed', resolvedAddresses: [] };
+    return {
+      error: 'embedded credentials are not allowed',
+      resolvedAddresses: [],
+    };
   }
 
   const hostname = parsed.hostname.toLowerCase().replace(/^\[|\]$/g, '');
@@ -151,11 +154,17 @@ export async function resolveAndValidateRemoteImageUrl(
   try {
     const addresses = await resolveHostAddresses(hostname);
     if (addresses.some((address) => isBlockedPrivateAddress(address))) {
-      return { error: 'resolved private address is not allowed', resolvedAddresses: [] };
+      return {
+        error: 'resolved private address is not allowed',
+        resolvedAddresses: [],
+      };
     }
     return { error: null, resolvedAddresses: addresses };
   } catch {
-    return { error: 'dns lookup failed - cannot verify host safety', resolvedAddresses: [] };
+    return {
+      error: 'dns lookup failed - cannot verify host safety',
+      resolvedAddresses: [],
+    };
   }
 }
 
@@ -301,11 +310,7 @@ export async function fetchWithPinnedDns(
         // Pin DNS: always return the pre-validated address.
         // Bun's http client calls lookup with { all: true } and expects
         // an array result; Node.js uses the simple (err, address, family) form.
-        lookup: (
-          _hostname: string,
-          _opts: unknown,
-          cb?: Function,
-        ) => {
+        lookup: (_hostname: string, _opts: unknown, cb?: Function) => {
           const callback = typeof _opts === 'function' ? _opts : cb!;
           const opts =
             typeof _opts === 'object' && _opts !== null

--- a/src/web/image-cache.ts
+++ b/src/web/image-cache.ts
@@ -27,9 +27,17 @@ export type RemoteImageFetch = (
   init?: RequestInit,
 ) => Promise<Response>;
 
+export type PinnedRemoteImageFetch = (
+  url: string,
+  pinnedAddress: string,
+  timeoutMs: number,
+) => Promise<Response>;
+
 export interface RemoteImageCacheOptions {
   cacheDir?: string;
   fetchImpl?: RemoteImageFetch;
+  /** Override pinned DNS fetch (primarily for tests). */
+  fetchWithPinnedDnsImpl?: PinnedRemoteImageFetch;
   /** Maximum bytes to read from the upstream response. Defaults to 5 MiB. */
   maxBytes?: number;
   /** Override DNS resolution (primarily for tests). */
@@ -153,6 +161,9 @@ export async function resolveAndValidateRemoteImageUrl(
 
   try {
     const addresses = await resolveHostAddresses(hostname);
+    if (addresses.length === 0) {
+      return { error: 'no addresses resolved', resolvedAddresses: [] };
+    }
     if (addresses.some((address) => isBlockedPrivateAddress(address))) {
       return {
         error: 'resolved private address is not allowed',
@@ -413,19 +424,21 @@ export async function serveCachedRemoteImage(
 
   try {
     let upstream: Response;
-    if (options.fetchImpl) {
-      // Caller-provided fetch (tests, custom transports).
-      upstream = await options.fetchImpl(url, {
-        signal: AbortSignal.timeout(REMOTE_IMAGE_FETCH_TIMEOUT_MS),
-      });
-    } else if (validation.resolvedAddresses.length > 0) {
+    if (validation.resolvedAddresses.length > 0) {
       // Hostname URL: connect to the pre-validated IP, preventing DNS
       // rebinding between validation and fetch.
-      upstream = await fetchWithPinnedDns(
+      const pinnedFetch = options.fetchWithPinnedDnsImpl ?? fetchWithPinnedDns;
+      upstream = await pinnedFetch(
         url,
         validation.resolvedAddresses[0],
         REMOTE_IMAGE_FETCH_TIMEOUT_MS,
       );
+    } else if (options.fetchImpl) {
+      // Caller-provided fetch is only safe for direct-IP URLs, where there is
+      // no hostname to re-resolve after validation.
+      upstream = await options.fetchImpl(url, {
+        signal: AbortSignal.timeout(REMOTE_IMAGE_FETCH_TIMEOUT_MS),
+      });
     } else {
       // Direct-IP URL: already validated above, safe to fetch directly.
       upstream = await fetch(url, {


### PR DESCRIPTION
## Summary

Closes the DNS rebinding / TOCTOU SSRF vulnerability described in #587.

`serveCachedRemoteImage` previously called `validateRemoteImageUrl` (which resolves DNS and checks the addresses are public), then passed the original hostname URL to `fetch()` — which re-resolves DNS independently. An attacker-controlled domain could pass validation while pointing to a public IP, then rebind to `127.0.0.1`, RFC1918, or cloud metadata endpoints before the fetch executes.

### Fix

- New `resolveAndValidateRemoteImageUrl` resolves DNS once and returns both the validation result and the resolved IP addresses
- New `fetchWithPinnedDns` uses `node:http`/`node:https` with a custom `lookup` callback that always returns the pre-validated address — the TCP connection goes to the exact IP we checked, with no DNS re-resolution
- `serveCachedRemoteImage` routes hostname URLs through pinned fetch, direct-IP URLs through standard `fetch`, and test-injected `fetchImpl` when provided
- `validateRemoteImageUrl` kept as a backward-compatible wrapper (used in `routes.ts` write-time validation)

### New exports

| Function | Purpose |
|---|---|
| `resolveAndValidateRemoteImageUrl` | Validates + returns resolved addresses |
| `fetchWithPinnedDns` | HTTP(S) fetch pinned to a specific IP |
| `RemoteImageUrlValidationResult` | Return type for the above |

### Tests (9 new, 32 total for this file)

- `resolveAndValidateRemoteImageUrl` returns addresses for hostnames, empty for direct IPs, error for blocked
- `fetchWithPinnedDns` connects to pinned address with correct Host header
- `fetchWithPinnedDns` times out correctly
- `serveCachedRemoteImage` blocks when DNS resolves to private address
- `serveCachedRemoteImage` passes `lookupHostAddresses` through to validation

### Test results

- 1799 pass, 0 fail across 95 files
- `tsc --noEmit` clean

## Test plan

- [x] `bun test src/web/image-cache.test.ts` — 32 pass, 0 fail
- [x] `bun test` — 1799 pass, 0 fail
- [x] `bunx tsc --noEmit` — clean
- [ ] CI green on PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Remote image validation now includes DNS pre-resolution and returns resolved addresses; requests to private/loopback addresses are blocked.
  * Remote image fetches can use a pinned IP for the connection while preserving the original hostname in the request; request timeouts supported.

* **Tests**
  * Added unit and integration tests for DNS validation, pinned-IP fetching behavior, header preservation, blocking cases, and timeout handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->