### PR TITLE
[codex] fix macOS container runtime setup

### DIFF
--- a/.agents/skills/setup/scripts/08-setup-service.sh
+++ b/.agents/skills/setup/scripts/08-setup-service.sh
@@ -31,7 +31,7 @@ if [ -z "$PLATFORM" ]; then
   esac
 fi
 
-NODE_PATH=$(which node)
+NODE_PATH=$(which bun || which node)
 PROJECT_PATH="$PROJECT_ROOT"
 HOME_PATH="$HOME"
 
@@ -86,7 +86,7 @@ case "$PLATFORM" in
     <key>EnvironmentVariables</key>
     <dict>
         <key>PATH</key>
-        <string>/usr/local/bin:/usr/bin:/bin:${HOME_PATH}/.local/bin</string>
+        <string>${HOME_PATH}/.bun/bin:/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin:${HOME_PATH}/.local/bin</string>
         <key>HOME</key>
         <string>${HOME_PATH}</string>
     </dict>

--- a/container/.dockerignore
+++ b/container/.dockerignore
@@ -1,6 +1,7 @@
 *
 !Dockerfile
 !Dockerfile.base
+!agent-browser-wrapper.sh
 !entrypoint.sh
 !exec-shim.sh
 !agent-runner/

--- a/container/Dockerfile.base
+++ b/container/Dockerfile.base
@@ -142,11 +142,14 @@ RUN mkdir -p /workspace/group /workspace/global /workspace/server /workspace/ext
 # Pre-create /home/bun/.local so Docker bind mounts (e.g. opencode data at
 # /home/bun/.local/share/opencode) don't create it as root, which blocks
 # OpenCode from writing to /home/bun/.local/state/.
-# Make /etc/passwd group-writable so --user can add a dynamic entry at runtime
+# Make /etc/passwd writable so --user can add a dynamic entry at runtime.
+# Apple Container may run with the host uid/gid rather than the image's bun
+# group, so group-writable is not sufficient there.
 RUN chown -R bun:bun /workspace && chmod 777 /home/bun \
     && mkdir -p /home/bun/.local/state /home/bun/.local/share \
     && chown -R bun:bun /home/bun/.local \
-    && chmod 664 /etc/passwd
+    && chmod 777 /home/bun/.local /home/bun/.local/state /home/bun/.local/share \
+    && chmod 666 /etc/passwd
 
 # Pre-warm tsgo (native TypeScript checker) so `npx tsgo` / `bunx tsgo` works.
 # Host-mounted projects may have platform-specific binaries; npm global install

--- a/container/entrypoint.sh
+++ b/container/entrypoint.sh
@@ -1,10 +1,12 @@
 #!/bin/bash.real
 set -e
 
+export HOME=/home/bun
+
 # When running as host uid (--user 501:20), there's no /etc/passwd entry.
 # Many tools (claude, git, ssh-keygen) need to resolve the current user.
 if ! id -un &>/dev/null 2>&1; then
-  echo "omniclaw:x:$(id -u):$(id -g):OmniClaw Agent:${HOME:-/home/bun}:/bin/bash" >> /etc/passwd
+  echo "omniclaw:x:$(id -u):$(id -g):OmniClaw Agent:${HOME}:/bin/bash" >> /etc/passwd
 fi
 
 # Source environment variables from mounted env file
@@ -49,7 +51,7 @@ if [ -n "$GITHUB_TOKEN" ]; then
 fi
 
 # SSH key setup: deterministic from SSH_KEY_SEED, workspace-persisted, or random
-mkdir -p ~/.ssh
+mkdir -p "$HOME/.ssh"
 AGENT_FOLDER=$(basename /workspace/group)
 
 generate_deterministic_key() {
@@ -93,52 +95,52 @@ const home = process.env.HOME || '/home/bun';
 // Use ssh-keygen to convert PKCS#8 PEM to OpenSSH format
 fs.writeFileSync(home + '/.ssh/id_ed25519.pem', privPem, { mode: 0o600 });
 fs.writeFileSync(home + '/.ssh/id_ed25519.pub', sshPub + '\n', { mode: 0o644 });
-" && ssh-keygen -p -N "" -m pem -f ~/.ssh/id_ed25519.pem -q 2>/dev/null && mv ~/.ssh/id_ed25519.pem ~/.ssh/id_ed25519 || {
+  " && ssh-keygen -p -N "" -m pem -f "$HOME/.ssh/id_ed25519.pem" -q 2>/dev/null && mv "$HOME/.ssh/id_ed25519.pem" "$HOME/.ssh/id_ed25519" || {
     # Fallback: ssh-keygen conversion failed, try direct approach
-    rm -f ~/.ssh/id_ed25519.pem
+    rm -f "$HOME/.ssh/id_ed25519.pem"
     return 1
   }
-  chmod 600 ~/.ssh/id_ed25519
+  chmod 600 "$HOME/.ssh/id_ed25519"
 }
 
 if [ -n "$SSH_KEY_SEED" ]; then
   if generate_deterministic_key; then
     # Persist to workspace
     mkdir -p /workspace/group/.ssh
-    cp ~/.ssh/id_ed25519 /workspace/group/.ssh/id_ed25519
-    cp ~/.ssh/id_ed25519.pub /workspace/group/.ssh/id_ed25519.pub
+    cp "$HOME/.ssh/id_ed25519" /workspace/group/.ssh/id_ed25519
+    cp "$HOME/.ssh/id_ed25519.pub" /workspace/group/.ssh/id_ed25519.pub
     chmod 600 /workspace/group/.ssh/id_ed25519
   elif [ -f /workspace/group/.ssh/id_ed25519 ]; then
     # Deterministic generation failed, fall back to persisted key
-    cp /workspace/group/.ssh/id_ed25519 ~/.ssh/id_ed25519
-    chmod 600 ~/.ssh/id_ed25519
+    cp /workspace/group/.ssh/id_ed25519 "$HOME/.ssh/id_ed25519"
+    chmod 600 "$HOME/.ssh/id_ed25519"
   else
     # Last resort: random key
-    ssh-keygen -t ed25519 -N "" -f ~/.ssh/id_ed25519 -q
+    ssh-keygen -t ed25519 -N "" -f "$HOME/.ssh/id_ed25519" -q
     mkdir -p /workspace/group/.ssh
-    cp ~/.ssh/id_ed25519 /workspace/group/.ssh/id_ed25519
-    cp ~/.ssh/id_ed25519.pub /workspace/group/.ssh/id_ed25519.pub
+    cp "$HOME/.ssh/id_ed25519" /workspace/group/.ssh/id_ed25519
+    cp "$HOME/.ssh/id_ed25519.pub" /workspace/group/.ssh/id_ed25519.pub
     chmod 600 /workspace/group/.ssh/id_ed25519
-    PUBKEY=$(cat ~/.ssh/id_ed25519.pub)
+    PUBKEY=$(cat "$HOME/.ssh/id_ed25519.pub")
     echo "{\"type\":\"ssh_pubkey\",\"pubkey\":\"$PUBKEY\"}" > /workspace/ipc/messages/ssh_pubkey_$(date +%s%N).json
   fi
 elif [ -f /workspace/group/.ssh/id_ed25519 ]; then
   # Persistent key from previous container run
-  cp /workspace/group/.ssh/id_ed25519 ~/.ssh/id_ed25519
-  chmod 600 ~/.ssh/id_ed25519
+  cp /workspace/group/.ssh/id_ed25519 "$HOME/.ssh/id_ed25519"
+  chmod 600 "$HOME/.ssh/id_ed25519"
 else
   # Generate a new random key for this agent
-  ssh-keygen -t ed25519 -N "" -f ~/.ssh/id_ed25519 -q
+  ssh-keygen -t ed25519 -N "" -f "$HOME/.ssh/id_ed25519" -q
   # Persist to workspace so it survives container restarts
   mkdir -p /workspace/group/.ssh
-  cp ~/.ssh/id_ed25519 /workspace/group/.ssh/id_ed25519
-  cp ~/.ssh/id_ed25519.pub /workspace/group/.ssh/id_ed25519.pub
+  cp "$HOME/.ssh/id_ed25519" /workspace/group/.ssh/id_ed25519
+  cp "$HOME/.ssh/id_ed25519.pub" /workspace/group/.ssh/id_ed25519.pub
   chmod 600 /workspace/group/.ssh/id_ed25519
   # Notify host via IPC that a new key was generated
-  PUBKEY=$(cat ~/.ssh/id_ed25519.pub)
+  PUBKEY=$(cat "$HOME/.ssh/id_ed25519.pub")
   echo "{\"type\":\"ssh_pubkey\",\"pubkey\":\"$PUBKEY\"}" > /workspace/ipc/messages/ssh_pubkey_$(date +%s%N).json
 fi
-ssh-keyscan github.com gitlab.com >> ~/.ssh/known_hosts 2>/dev/null || true
+ssh-keyscan github.com gitlab.com >> "$HOME/.ssh/known_hosts" 2>/dev/null || true
 
 # Buffer stdin then run agent.
 # If /tmp/input.json already exists, skip the stdin buffering step.


### PR DESCRIPTION
## Summary

Fixes the macOS/Apple Container runtime issues found while migrating OmniClaw to the Mac mini.

- Launch the built host service with Bun when Bun is available, while preserving the existing Node fallback.
- Include `agent-browser-wrapper.sh` in the container build context so fresh image builds do not fail.
- Make the agent container work when Apple Container runs processes as the host uid/gid instead of the image `bun` user/group.
- Force the container entrypoint to use `/home/bun` consistently so SSH/OpenCode state is written to the intended writable home directory.

## Root Cause

The migrated Mac mini exposed three runtime assumptions that are not true for Apple Container installs:

- the launchd service could find Node first and then fail on a Bun-targeted bundle;
- the Docker ignore file excluded a wrapper that `Dockerfile.base` copies;
- host uid containers could not write `/etc/passwd`, `~/.ssh`, or OpenCode state under `/home/bun/.local`.

## Compatibility

The service script still falls back to Node when Bun is unavailable. The container permission changes only affect container-internal writable setup paths used by host-uid execution; they do not change mounted workspace paths, routing, or agent selection. Docker users should keep the same runtime behavior, with the added benefit that arbitrary `--user` ids can resolve a home directory and write runtime state.

## Validation

- `bash -n .agents/skills/setup/scripts/08-setup-service.sh container/entrypoint.sh container/build.sh`
- `bun install`
- `bun run typecheck`
- `bun run build`
- Remote Mac mini: rebuilt `omniclaw-agent:latest` successfully with Apple Container.
- Remote Mac mini: triggered OCPeyton after rebuild; fresh log showed `Forcing OpenCode model: openai/gpt-5.5`, OpenCode connected, and the task completed with `last_outcome_state=done`.

## Notes

`bun test` was attempted after dependency install but does not currently pass in this local sandbox because existing tests write under `/Users/peyton/.config/omniclaw` and open local web-server routes; those failures are outside this patch. A targeted Prettier check is not applicable to these shell/Docker ignore files because Prettier has no parser for them.
