### PR TITLE
fix(security): cap proxied peer log streams

### DIFF
--- a/src/discovery/routes.test.ts
+++ b/src/discovery/routes.test.ts
@@ -543,6 +543,79 @@ describe('checkPeerAuth — body hash verification', () => {
     expect(body).toContain('remote log');
   });
 
+  it('caps concurrent proxied peer log streams and releases slots on cancel', async () => {
+    let streamCalls = 0;
+    const ctx = makeContext({
+      trustStore: {
+        getPeer: () => ({
+          instanceId: 'peer-1',
+          status: 'trusted',
+          sharedSecret: 'secret',
+          host: '127.0.0.1',
+          port: 6001,
+        }),
+        updatePeerLastSeen: () => {},
+      } as any,
+      createPeerClient: () => ({
+        getAgents: async () => [],
+        getStats: async () => ({}),
+        streamLogs: async () => {
+          streamCalls += 1;
+          return new Response(new ReadableStream<Uint8Array>(), {
+            headers: { 'Content-Type': 'text/event-stream; charset=utf-8' },
+          });
+        },
+        getContextLayers: async () => ({}),
+        listContextFiles: async () => [],
+        writeContextFile: async () => ({ ok: true }),
+      }),
+    });
+
+    const responses: Response[] = [];
+    try {
+      for (let i = 0; i < 100; i += 1) {
+        const req = new Request(
+          'http://localhost/api/discovery/peers/peer-1/logs',
+          { method: 'GET' },
+        );
+        const res = await handleDiscoveryRequest(req, new URL(req.url), ctx);
+        expect(res).not.toBeNull();
+        responses.push(res as Response);
+      }
+
+      const cappedReq = new Request(
+        'http://localhost/api/discovery/peers/peer-1/logs',
+        { method: 'GET' },
+      );
+      const capped = (await handleDiscoveryRequest(
+        cappedReq,
+        new URL(cappedReq.url),
+        ctx,
+      )) as Response;
+
+      expect(capped.status).toBe(429);
+      expect(await capped.text()).toContain(
+        'Too many proxied log stream connections',
+      );
+      expect(streamCalls).toBe(100);
+    } finally {
+      await Promise.all(responses.map((response) => response.body?.cancel()));
+    }
+
+    const retryReq = new Request(
+      'http://localhost/api/discovery/peers/peer-1/logs',
+      { method: 'GET' },
+    );
+    const retry = (await handleDiscoveryRequest(
+      retryReq,
+      new URL(retryReq.url),
+      ctx,
+    )) as Response;
+    expect(retry.status).toBe(200);
+    await retry.body?.cancel();
+    expect(streamCalls).toBe(101);
+  });
+
   it('returns SSE error event when peer is not trusted for log stream', async () => {
     const req = new Request(
       'http://localhost/api/discovery/peers/unknown-peer/logs',

--- a/src/discovery/routes.ts
+++ b/src/discovery/routes.ts
@@ -67,6 +67,8 @@ const PAIR_RATE_WINDOW_MS = 60_000;
 const RATE_LIMITER_MAX_ENTRIES = 10_000;
 const MAX_DISCOVERY_JSON_BODY_BYTES = 64 * 1024;
 const MAX_DISCOVERY_CONTEXT_WRITE_BODY_BYTES = 1024 * 1024;
+const MAX_PROXIED_LOG_STREAM_CLIENTS = 100;
+let proxiedLogStreamClients = 0;
 
 function checkRateLimit(
   ip: string,
@@ -299,7 +301,7 @@ export function handleDiscoveryRequest(
     const instanceId = decodeURIComponent(
       pathname.slice('/api/discovery/peers/'.length, -'/logs'.length),
     );
-    return handleProxyLogStream(instanceId, ctx);
+    return handleProxyLogStream(instanceId, req, ctx);
   }
 
   // GET /api/discovery/peers/:id/context/layers
@@ -983,18 +985,64 @@ function sseError(message: string, status = 200): Response {
 
 async function handleProxyLogStream(
   instanceId: string,
+  req: Request,
   ctx: DiscoveryRouteContext,
 ): Promise<Response> {
   const result = getPeerClientResult(instanceId, ctx);
   if (!result.client) return sseError(result.error);
 
+  if (proxiedLogStreamClients >= MAX_PROXIED_LOG_STREAM_CLIENTS) {
+    return sseError('Too many proxied log stream connections', 429);
+  }
+
+  proxiedLogStreamClients += 1;
+  let reader: {
+    read: () => Promise<{ done: boolean; value?: Uint8Array }>;
+    cancel: () => Promise<unknown>;
+  } | null = null;
+  let closed = false;
+
+  const cleanup = (cancelUpstream: boolean) => {
+    if (closed) return;
+    closed = true;
+    if (proxiedLogStreamClients > 0) proxiedLogStreamClients -= 1;
+    if (cancelUpstream) {
+      reader?.cancel().catch(() => {});
+    }
+  };
+
   try {
     const response = await result.client.streamLogs();
     const contentType = response.headers.get('content-type') || '';
     if (!contentType.includes('text/event-stream') || !response.body) {
+      cleanup(true);
       return sseError('Remote peer returned non-SSE response');
     }
-    return new Response(response.body, {
+    reader = response.body.getReader();
+
+    const stream = new ReadableStream<Uint8Array>({
+      async pull(controller) {
+        try {
+          const chunk = await reader!.read();
+          if (chunk.done) {
+            cleanup(false);
+            controller.close();
+            return;
+          }
+          if (chunk.value) controller.enqueue(chunk.value);
+        } catch (err) {
+          cleanup(false);
+          controller.error(err);
+        }
+      },
+      cancel() {
+        cleanup(true);
+      },
+    });
+
+    req.signal.addEventListener('abort', () => cleanup(true), { once: true });
+
+    return new Response(stream, {
       headers: {
         'Content-Type': 'text/event-stream; charset=utf-8',
         'Cache-Control': 'no-cache, no-transform',
@@ -1002,6 +1050,7 @@ async function handleProxyLogStream(
       },
     });
   } catch (err) {
+    cleanup(true);
     const msg = err instanceof Error ? err.message : String(err);
     return sseError(`Proxy error: ${msg}`);
   }


### PR DESCRIPTION
## Summary

- Caps proxied trusted-peer log SSE streams at 100 concurrent clients before opening an upstream peer tunnel.
- Wraps remote SSE bodies with a local cleanup path that releases slots on completion, cancellation, request abort, and upstream errors.
- Adds regression coverage for cap enforcement and slot release after client cancellation.

Closes #595

## Test plan

- [x] `bun test src/discovery/routes.test.ts src/discovery/peer-client.test.ts`
- [x] `bunx tsc --noEmit`
- [x] `bun run format:check`
- [x] `bun test`
