### PR TITLE
fix(discord): acknowledge slash flows before queueing

### DIFF
--- a/.agents/skills/setup/scripts/08-setup-service.sh
+++ b/.agents/skills/setup/scripts/08-setup-service.sh
@@ -31,15 +31,46 @@ if [ -z "$PLATFORM" ]; then
   esac
 fi
 
-NODE_PATH=$(which bun || which node)
+BUN_PATH="$(command -v bun || true)"
+NODE_PATH="${BUN_PATH:-$(command -v node || true)}"
 PROJECT_PATH="$PROJECT_ROOT"
 HOME_PATH="$HOME"
 
 log "Setting up service: platform=$PLATFORM node=$NODE_PATH project=$PROJECT_PATH"
 
+if [ -z "$NODE_PATH" ]; then
+  log "No Bun or Node runtime found"
+  cat <<EOF
+=== OMNICLAW SETUP: SETUP_SERVICE ===
+SERVICE_TYPE: unknown
+NODE_PATH:
+PROJECT_PATH: $PROJECT_PATH
+STATUS: failed
+ERROR: runtime_not_found
+LOG: logs/setup.log
+=== END ===
+EOF
+  exit 1
+fi
+
 # Build first
 log "Building TypeScript"
-if ! bun run build >> "$LOG_FILE" 2>&1; then
+if [ -z "$BUN_PATH" ]; then
+  log "Bun not found; build requires Bun"
+  cat <<EOF
+=== OMNICLAW SETUP: SETUP_SERVICE ===
+SERVICE_TYPE: unknown
+NODE_PATH: $NODE_PATH
+PROJECT_PATH: $PROJECT_PATH
+STATUS: failed
+ERROR: bun_not_found
+LOG: logs/setup.log
+=== END ===
+EOF
+  exit 1
+fi
+
+if ! "$BUN_PATH" run build >> "$LOG_FILE" 2>&1; then
   log "Build failed"
   cat <<EOF
 === OMNICLAW SETUP: SETUP_SERVICE ===
@@ -145,7 +176,7 @@ WorkingDirectory=${PROJECT_PATH}
 Restart=always
 RestartSec=5
 Environment=HOME=${HOME_PATH}
-Environment=PATH=/usr/local/bin:/usr/bin:/bin:${HOME_PATH}/.local/bin
+Environment=PATH=${HOME_PATH}/.bun/bin:/usr/local/bin:/usr/bin:/bin:${HOME_PATH}/.local/bin
 StandardOutput=append:${PROJECT_PATH}/logs/omniclaw.stdout.log
 StandardError=append:${PROJECT_PATH}/logs/omniclaw.log
 

--- a/.agents/skills/setup/scripts/08-setup-service.sh
+++ b/.agents/skills/setup/scripts/08-setup-service.sh
@@ -105,6 +105,8 @@ case "$PLATFORM" in
     <string>com.omniclaw</string>
     <key>ProgramArguments</key>
     <array>
+        <string>/usr/bin/caffeinate</string>
+        <string>-dimsu</string>
         <string>${NODE_PATH}</string>
         <string>${PROJECT_PATH}/dist/index.js</string>
     </array>

--- a/container/Dockerfile.base
+++ b/container/Dockerfile.base
@@ -16,6 +16,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     git \
     wget \
     openssh-client \
+    libnss-wrapper \
     jq \
     ripgrep \
     build-essential \
@@ -142,14 +143,15 @@ RUN mkdir -p /workspace/group /workspace/global /workspace/server /workspace/ext
 # Pre-create /home/bun/.local so Docker bind mounts (e.g. opencode data at
 # /home/bun/.local/share/opencode) don't create it as root, which blocks
 # OpenCode from writing to /home/bun/.local/state/.
-# Make /etc/passwd writable so --user can add a dynamic entry at runtime.
 # Apple Container may run with the host uid/gid rather than the image's bun
-# group, so group-writable is not sufficient there.
-RUN chown -R bun:bun /workspace && chmod 777 /home/bun \
+# group, so these home directories must be writable by that mapped uid. Dynamic
+# passwd entries are handled with nss_wrapper at runtime, so /etc/passwd stays
+# root-owned and non-writable.
+RUN chown -R bun:bun /workspace && chmod 1777 /home/bun \
     && mkdir -p /home/bun/.local/state /home/bun/.local/share \
     && chown -R bun:bun /home/bun/.local \
-    && chmod 777 /home/bun/.local /home/bun/.local/state /home/bun/.local/share \
-    && chmod 666 /etc/passwd
+    && chmod 1777 /home/bun/.local /home/bun/.local/state /home/bun/.local/share \
+    && chmod 644 /etc/passwd
 
 # Pre-warm tsgo (native TypeScript checker) so `npx tsgo` / `bunx tsgo` works.
 # Host-mounted projects may have platform-specific binaries; npm global install

--- a/container/entrypoint.sh
+++ b/container/entrypoint.sh
@@ -3,10 +3,22 @@ set -e
 
 export HOME=/home/bun
 
-# When running as host uid (--user 501:20), there's no /etc/passwd entry.
+# When running as host uid (--user 501:20), there's no passwd entry.
 # Many tools (claude, git, ssh-keygen) need to resolve the current user.
 if ! id -un &>/dev/null 2>&1; then
-  echo "omniclaw:x:$(id -u):$(id -g):OmniClaw Agent:${HOME}:/bin/bash" >> /etc/passwd
+  NSS_WRAPPER_PASSWD="$(mktemp)"
+  NSS_WRAPPER_GROUP="$(mktemp)"
+  cp /etc/passwd "$NSS_WRAPPER_PASSWD"
+  cp /etc/group "$NSS_WRAPPER_GROUP"
+  echo "omniclaw:x:$(id -u):$(id -g):OmniClaw Agent:${HOME}:/bin/bash" >> "$NSS_WRAPPER_PASSWD"
+  echo "omniclaw:x:$(id -g):" >> "$NSS_WRAPPER_GROUP"
+  export NSS_WRAPPER_PASSWD NSS_WRAPPER_GROUP
+  for NSS_WRAPPER_LIB in /usr/lib/*/libnss_wrapper.so /usr/lib/libnss_wrapper.so; do
+    if [ -f "$NSS_WRAPPER_LIB" ]; then
+      export LD_PRELOAD="${LD_PRELOAD:+$LD_PRELOAD:}$NSS_WRAPPER_LIB"
+      break
+    fi
+  done
 fi
 
 # Source environment variables from mounted env file
@@ -95,11 +107,16 @@ const home = process.env.HOME || '/home/bun';
 // Use ssh-keygen to convert PKCS#8 PEM to OpenSSH format
 fs.writeFileSync(home + '/.ssh/id_ed25519.pem', privPem, { mode: 0o600 });
 fs.writeFileSync(home + '/.ssh/id_ed25519.pub', sshPub + '\n', { mode: 0o644 });
-  " && ssh-keygen -p -N "" -m pem -f "$HOME/.ssh/id_ed25519.pem" -q 2>/dev/null && mv "$HOME/.ssh/id_ed25519.pem" "$HOME/.ssh/id_ed25519" || {
+  "
+  if ! ssh-keygen -p -N "" -m pem -f "$HOME/.ssh/id_ed25519.pem" -q 2>/dev/null; then
     # Fallback: ssh-keygen conversion failed, try direct approach
     rm -f "$HOME/.ssh/id_ed25519.pem"
     return 1
-  }
+  fi
+  if ! mv "$HOME/.ssh/id_ed25519.pem" "$HOME/.ssh/id_ed25519"; then
+    rm -f "$HOME/.ssh/id_ed25519.pem"
+    return 1
+  fi
   chmod 600 "$HOME/.ssh/id_ed25519"
 }
 
@@ -122,7 +139,7 @@ if [ -n "$SSH_KEY_SEED" ]; then
     cp "$HOME/.ssh/id_ed25519.pub" /workspace/group/.ssh/id_ed25519.pub
     chmod 600 /workspace/group/.ssh/id_ed25519
     PUBKEY=$(cat "$HOME/.ssh/id_ed25519.pub")
-    echo "{\"type\":\"ssh_pubkey\",\"pubkey\":\"$PUBKEY\"}" > /workspace/ipc/messages/ssh_pubkey_$(date +%s%N).json
+    echo "{\"type\":\"ssh_pubkey\",\"pubkey\":\"$PUBKEY\"}" > "/workspace/ipc/messages/ssh_pubkey_$(date +%s%N).json"
   fi
 elif [ -f /workspace/group/.ssh/id_ed25519 ]; then
   # Persistent key from previous container run
@@ -138,7 +155,7 @@ else
   chmod 600 /workspace/group/.ssh/id_ed25519
   # Notify host via IPC that a new key was generated
   PUBKEY=$(cat "$HOME/.ssh/id_ed25519.pub")
-  echo "{\"type\":\"ssh_pubkey\",\"pubkey\":\"$PUBKEY\"}" > /workspace/ipc/messages/ssh_pubkey_$(date +%s%N).json
+  echo "{\"type\":\"ssh_pubkey\",\"pubkey\":\"$PUBKEY\"}" > "/workspace/ipc/messages/ssh_pubkey_$(date +%s%N).json"
 fi
 ssh-keyscan github.com gitlab.com >> "$HOME/.ssh/known_hosts" 2>/dev/null || true
 

--- a/src/channels/discord.test.ts
+++ b/src/channels/discord.test.ts
@@ -230,13 +230,13 @@ describe('Discord download guards', () => {
 
 describe('Discord slash flows', () => {
   it('acknowledges the interaction before queueing the synthetic message', async () => {
-    let replied = false;
+    let deferred = false;
     let queued = false;
     const channel = new DiscordChannel({
       token: 'test-token-not-used',
       botId: 'PRIMARY',
       onSyntheticMessage: () => {
-        expect(replied).toBe(true);
+        expect(deferred).toBe(true);
         queued = true;
       },
     });
@@ -285,9 +285,10 @@ describe('Discord slash flows', () => {
         getInteger: (name: string) => (name === 'duration_minutes' ? 60 : null),
         getBoolean: () => null,
       },
-      reply: mock(async () => {
-        replied = true;
+      deferReply: mock(async () => {
+        deferred = true;
       }),
+      editReply: mock(async () => {}),
       followUp: mock(async () => {}),
     };
 
@@ -297,9 +298,9 @@ describe('Discord slash flows', () => {
       }
     ).handleSlashCommand(interaction);
 
-    expect(interaction.reply).toHaveBeenCalledWith({
+    expect(interaction.deferReply).toHaveBeenCalledWith({ ephemeral: true });
+    expect(interaction.editReply).toHaveBeenCalledWith({
       content: 'Queued "/mergemaster" for Clayton.',
-      ephemeral: true,
     });
     expect(queued).toBe(true);
     expect(interaction.followUp).not.toHaveBeenCalled();
@@ -358,7 +359,8 @@ describe('Discord slash flows', () => {
         getInteger: (name: string) => (name === 'duration_minutes' ? 60 : null),
         getBoolean: () => null,
       },
-      reply: mock(async () => {}),
+      deferReply: mock(async () => {}),
+      editReply: mock(async () => {}),
       followUp: mock(async () => {}),
     };
 
@@ -368,10 +370,11 @@ describe('Discord slash flows', () => {
       }
     ).handleSlashCommand(interaction);
 
-    expect(interaction.reply).toHaveBeenCalledTimes(1);
-    expect(interaction.reply).toHaveBeenCalledWith({
+    expect(interaction.deferReply).toHaveBeenCalledTimes(1);
+    expect(interaction.deferReply).toHaveBeenCalledWith({ ephemeral: true });
+    expect(interaction.editReply).toHaveBeenCalledTimes(1);
+    expect(interaction.editReply).toHaveBeenCalledWith({
       content: 'Queued "/mergemaster" for Clayton.',
-      ephemeral: true,
     });
     expect(interaction.followUp).toHaveBeenCalledTimes(1);
     expect(interaction.followUp).toHaveBeenCalledWith({

--- a/src/channels/discord.test.ts
+++ b/src/channels/discord.test.ts
@@ -1,4 +1,4 @@
-import { afterEach, describe, expect, it, mock } from 'bun:test';
+import { afterEach, beforeEach, describe, expect, it, mock } from 'bun:test';
 
 import {
   jidToChannelId,
@@ -6,6 +6,11 @@ import {
   getAttachmentWorkspaceFolder,
   isImageAttachment,
 } from './discord.js';
+import {
+  _initTestDatabase,
+  setAgent,
+  setChannelSubscription,
+} from '../db.js';
 import {
   downloadBinaryAttachment,
   downloadTextAttachment,
@@ -17,6 +22,10 @@ const originalFetch = globalThis.fetch;
 
 afterEach(() => {
   globalThis.fetch = originalFetch;
+});
+
+beforeEach(() => {
+  _initTestDatabase();
 });
 
 function createStream(
@@ -220,6 +229,83 @@ describe('Discord download guards', () => {
     await expect(
       downloadTextAttachment('https://cdn.discordapp.test/file.txt'),
     ).rejects.toThrow('Download exceeded 102400 bytes');
+  });
+});
+
+describe('Discord slash flows', () => {
+  it('acknowledges the interaction before queueing the synthetic message', async () => {
+    let replied = false;
+    let queued = false;
+    const channel = new DiscordChannel({
+      token: 'test-token-not-used',
+      botId: 'PRIMARY',
+      onSyntheticMessage: () => {
+        expect(replied).toBe(true);
+        queued = true;
+      },
+    });
+
+    setAgent({
+      id: 'clayton-discord',
+      name: 'Clayton',
+      folder: 'clayton-discord',
+      backend: 'apple-container',
+      agentRuntime: 'claude-agent-sdk',
+      isAdmin: false,
+      createdAt: '2026-05-01T00:00:00.000Z',
+    });
+    setChannelSubscription({
+      channelJid: 'dc:1474995286903361772',
+      agentId: 'clayton-discord',
+      trigger: '@Clayton',
+      requiresTrigger: true,
+      priority: 0,
+      isPrimary: true,
+      discordBotId: 'PRIMARY',
+      discordGuildId: '753336633083953213',
+      createdAt: '2026-05-01T00:00:00.000Z',
+    });
+
+    const interaction = {
+      id: '1499999999999999999',
+      commandName: 'mergemaster',
+      channelId: '1474995286903361772',
+      guildId: '753336633083953213',
+      inGuild: () => true,
+      member: { displayName: 'Future Trees' },
+      user: {
+        id: '217828620029132802',
+        globalName: 'Future Trees',
+        username: 'futuretrees',
+      },
+      channel: { name: 'agentflow' },
+      options: {
+        getString: (name: string) =>
+          name === 'repo'
+            ? 'omniclaw'
+            : name === 'goal'
+              ? 'clear the queue'
+              : null,
+        getInteger: (name: string) =>
+          name === 'duration_minutes' ? 60 : null,
+        getBoolean: () => null,
+      },
+      reply: mock(async () => {
+        replied = true;
+      }),
+      followUp: mock(async () => {}),
+    };
+
+    await (channel as unknown as {
+      handleSlashCommand: (input: typeof interaction) => Promise<void>;
+    }).handleSlashCommand(interaction);
+
+    expect(interaction.reply).toHaveBeenCalledWith({
+      content: 'Queued "/mergemaster" for Clayton.',
+      ephemeral: true,
+    });
+    expect(queued).toBe(true);
+    expect(interaction.followUp).not.toHaveBeenCalled();
   });
 });
 

--- a/src/channels/discord.test.ts
+++ b/src/channels/discord.test.ts
@@ -1,4 +1,5 @@
 import { afterEach, beforeEach, describe, expect, it, mock } from 'bun:test';
+import { MessageFlags } from 'discord.js';
 
 import {
   jidToChannelId,
@@ -298,7 +299,9 @@ describe('Discord slash flows', () => {
       }
     ).handleSlashCommand(interaction);
 
-    expect(interaction.deferReply).toHaveBeenCalledWith({ ephemeral: true });
+    expect(interaction.deferReply).toHaveBeenCalledWith({
+      flags: MessageFlags.Ephemeral,
+    });
     expect(interaction.editReply).toHaveBeenCalledWith({
       content: 'Queued "/mergemaster" for Clayton.',
     });
@@ -371,7 +374,9 @@ describe('Discord slash flows', () => {
     ).handleSlashCommand(interaction);
 
     expect(interaction.deferReply).toHaveBeenCalledTimes(1);
-    expect(interaction.deferReply).toHaveBeenCalledWith({ ephemeral: true });
+    expect(interaction.deferReply).toHaveBeenCalledWith({
+      flags: MessageFlags.Ephemeral,
+    });
     expect(interaction.editReply).toHaveBeenCalledTimes(1);
     expect(interaction.editReply).toHaveBeenCalledWith({
       content: 'Queued "/mergemaster" for Clayton.',

--- a/src/channels/discord.test.ts
+++ b/src/channels/discord.test.ts
@@ -304,6 +304,82 @@ describe('Discord slash flows', () => {
     expect(queued).toBe(true);
     expect(interaction.followUp).not.toHaveBeenCalled();
   });
+
+  it('sends follow-up when queueing fails after acknowledgement', async () => {
+    const channel = new DiscordChannel({
+      token: 'test-token-not-used',
+      botId: 'PRIMARY',
+      onSyntheticMessage: () => {
+        throw new Error('queue failed');
+      },
+    });
+
+    setAgent({
+      id: 'clayton-discord',
+      name: 'Clayton',
+      folder: 'clayton-discord',
+      backend: 'apple-container',
+      agentRuntime: 'claude-agent-sdk',
+      isAdmin: false,
+      createdAt: '2026-05-01T00:00:00.000Z',
+    });
+    setChannelSubscription({
+      channelJid: 'dc:1474995286903361772',
+      agentId: 'clayton-discord',
+      trigger: '@Clayton',
+      requiresTrigger: true,
+      priority: 0,
+      isPrimary: true,
+      discordBotId: 'PRIMARY',
+      discordGuildId: '753336633083953213',
+      createdAt: '2026-05-01T00:00:00.000Z',
+    });
+
+    const interaction = {
+      id: '1499999999999999999',
+      commandName: 'mergemaster',
+      channelId: '1474995286903361772',
+      guildId: '753336633083953213',
+      inGuild: () => true,
+      member: { displayName: 'Future Trees' },
+      user: {
+        id: '217828620029132802',
+        globalName: 'Future Trees',
+        username: 'futuretrees',
+      },
+      channel: { name: 'agentflow' },
+      options: {
+        getString: (name: string) =>
+          name === 'repo'
+            ? 'omniclaw'
+            : name === 'goal'
+              ? 'clear the queue'
+              : null,
+        getInteger: (name: string) => (name === 'duration_minutes' ? 60 : null),
+        getBoolean: () => null,
+      },
+      reply: mock(async () => {}),
+      followUp: mock(async () => {}),
+    };
+
+    await (
+      channel as unknown as {
+        handleSlashCommand: (input: typeof interaction) => Promise<void>;
+      }
+    ).handleSlashCommand(interaction);
+
+    expect(interaction.reply).toHaveBeenCalledTimes(1);
+    expect(interaction.reply).toHaveBeenCalledWith({
+      content: 'Queued "/mergemaster" for Clayton.',
+      ephemeral: true,
+    });
+    expect(interaction.followUp).toHaveBeenCalledTimes(1);
+    expect(interaction.followUp).toHaveBeenCalledWith({
+      content:
+        'I acknowledged the command, but failed to queue it. Check OmniClaw logs for details.',
+      ephemeral: true,
+    });
+  });
 });
 
 // --- shouldAutoRespond ---

--- a/src/channels/discord.test.ts
+++ b/src/channels/discord.test.ts
@@ -6,11 +6,7 @@ import {
   getAttachmentWorkspaceFolder,
   isImageAttachment,
 } from './discord.js';
-import {
-  _initTestDatabase,
-  setAgent,
-  setChannelSubscription,
-} from '../db.js';
+import { _initTestDatabase, setAgent, setChannelSubscription } from '../db.js';
 import {
   downloadBinaryAttachment,
   downloadTextAttachment,
@@ -286,8 +282,7 @@ describe('Discord slash flows', () => {
             : name === 'goal'
               ? 'clear the queue'
               : null,
-        getInteger: (name: string) =>
-          name === 'duration_minutes' ? 60 : null,
+        getInteger: (name: string) => (name === 'duration_minutes' ? 60 : null),
         getBoolean: () => null,
       },
       reply: mock(async () => {
@@ -296,9 +291,11 @@ describe('Discord slash flows', () => {
       followUp: mock(async () => {}),
     };
 
-    await (channel as unknown as {
-      handleSlashCommand: (input: typeof interaction) => Promise<void>;
-    }).handleSlashCommand(interaction);
+    await (
+      channel as unknown as {
+        handleSlashCommand: (input: typeof interaction) => Promise<void>;
+      }
+    ).handleSlashCommand(interaction);
 
     expect(interaction.reply).toHaveBeenCalledWith({
       content: 'Queued "/mergemaster" for Clayton.',

--- a/src/channels/discord.ts
+++ b/src/channels/discord.ts
@@ -9,6 +9,7 @@ import {
   GatewayIntentBits,
   type Message,
   type MessageReaction,
+  MessageFlags,
   type PartialMessageReaction,
   Partials,
   type PartialUser,
@@ -271,8 +272,28 @@ export class DiscordChannel implements Channel {
 
       this.client.on(Events.InteractionCreate, (interaction) => {
         if (!interaction.isChatInputCommand()) return;
+        logger.info(
+          {
+            botId: this.botId,
+            command: interaction.commandName,
+            interactionId: interaction.id,
+            guildId: interaction.guildId,
+            channelId: interaction.channelId,
+          },
+          'Discord slash interaction received',
+        );
         this.handleSlashCommand(interaction).catch((err) =>
-          logger.error({ err }, 'Error handling Discord slash command'),
+          logger.error(
+            {
+              err,
+              botId: this.botId,
+              command: interaction.commandName,
+              interactionId: interaction.id,
+              guildId: interaction.guildId,
+              channelId: interaction.channelId,
+            },
+            'Error handling Discord slash command',
+          ),
         );
       });
 
@@ -1163,7 +1184,35 @@ export class DiscordChannel implements Channel {
   private async handleSlashCommand(
     interaction: ChatInputCommandInteraction,
   ): Promise<void> {
-    await interaction.deferReply({ ephemeral: true });
+    const receivedAt = Date.now();
+    try {
+      await interaction.deferReply({ flags: MessageFlags.Ephemeral });
+      logger.info(
+        {
+          botId: this.botId,
+          command: interaction.commandName,
+          interactionId: interaction.id,
+          guildId: interaction.guildId,
+          channelId: interaction.channelId,
+          ackDurationMs: Date.now() - receivedAt,
+        },
+        'Discord slash interaction deferred',
+      );
+    } catch (err) {
+      logger.error(
+        {
+          err,
+          botId: this.botId,
+          command: interaction.commandName,
+          interactionId: interaction.id,
+          guildId: interaction.guildId,
+          channelId: interaction.channelId,
+          ackDurationMs: Date.now() - receivedAt,
+        },
+        'Failed to defer Discord slash interaction',
+      );
+      throw err;
+    }
 
     if (!interaction.inGuild()) {
       await interaction.editReply({

--- a/src/channels/discord.ts
+++ b/src/channels/discord.ts
@@ -1163,10 +1163,11 @@ export class DiscordChannel implements Channel {
   private async handleSlashCommand(
     interaction: ChatInputCommandInteraction,
   ): Promise<void> {
+    await interaction.deferReply({ ephemeral: true });
+
     if (!interaction.inGuild()) {
-      await interaction.reply({
+      await interaction.editReply({
         content: 'Slash flows are only available in registered guild channels.',
-        ephemeral: true,
       });
       return;
     }
@@ -1174,9 +1175,8 @@ export class DiscordChannel implements Channel {
     const chatJid = `dc:${interaction.channelId}`;
     const group = this.resolveGroupForChannel(chatJid);
     if (!group) {
-      await interaction.reply({
+      await interaction.editReply({
         content: 'This channel is not registered to an OmniClaw agent yet.',
-        ephemeral: true,
       });
       return;
     }
@@ -1186,17 +1186,15 @@ export class DiscordChannel implements Channel {
       if (
         !interaction.memberPermissions?.has(PermissionFlagsBits.ManageChannels)
       ) {
-        await interaction.reply({
+        await interaction.editReply({
           content:
             'You need the **Manage Channels** permission to use session commands.',
-          ephemeral: true,
         });
         return;
       }
       if (!this.opts.onSessionCommand) {
-        await interaction.reply({
+        await interaction.editReply({
           content: 'Session commands are not configured.',
-          ephemeral: true,
         });
         return;
       }
@@ -1208,7 +1206,7 @@ export class DiscordChannel implements Channel {
         group,
         sessionId,
       );
-      await interaction.reply({ content: result.message, ephemeral: true });
+      await interaction.editReply({ content: result.message });
       return;
     }
 
@@ -1216,10 +1214,9 @@ export class DiscordChannel implements Channel {
       (candidate) => candidate.name === interaction.commandName,
     );
     if (!command) {
-      await interaction.reply({
+      await interaction.editReply({
         content:
           'That slash flow is not configured for this channel. Add it to this workspace and restart or re-sync the bot.',
-        ephemeral: true,
       });
       return;
     }
@@ -1257,9 +1254,8 @@ export class DiscordChannel implements Channel {
         ? interaction.channel.name || chatJid
         : chatJid;
 
-    await interaction.reply({
+    await interaction.editReply({
       content: `Queued "/${command.name}" for ${group.name}.`,
-      ephemeral: true,
     });
 
     try {

--- a/src/channels/discord.ts
+++ b/src/channels/discord.ts
@@ -1257,30 +1257,57 @@ export class DiscordChannel implements Channel {
         ? interaction.channel.name || chatJid
         : chatJid;
 
-    storeChatMetadata(
-      chatJid,
-      timestamp,
-      chatName,
-      interaction.guildId || undefined,
-    );
-    this.opts.onSyntheticMessage?.({
-      id: `slash-${interaction.id}`,
-      chat_jid: chatJid,
-      sender: `discord:${interaction.user.id}`,
-      sender_name: senderName,
-      content: group.trigger
-        ? `${group.trigger} ${renderedPrompt}`
-        : renderedPrompt,
-      timestamp,
-      is_from_me: false,
-      sender_platform: 'discord',
-      sender_user_id: interaction.user.id,
-    });
-
     await interaction.reply({
       content: `Queued "/${command.name}" for ${group.name}.`,
       ephemeral: true,
     });
+
+    try {
+      storeChatMetadata(
+        chatJid,
+        timestamp,
+        chatName,
+        interaction.guildId || undefined,
+      );
+      this.opts.onSyntheticMessage?.({
+        id: `slash-${interaction.id}`,
+        chat_jid: chatJid,
+        sender: `discord:${interaction.user.id}`,
+        sender_name: senderName,
+        content: group.trigger
+          ? `${group.trigger} ${renderedPrompt}`
+          : renderedPrompt,
+        timestamp,
+        is_from_me: false,
+        sender_platform: 'discord',
+        sender_user_id: interaction.user.id,
+      });
+      logger.info(
+        {
+          command: command.name,
+          chatJid,
+          group: group.folder,
+          interactionId: interaction.id,
+        },
+        'Discord slash flow queued',
+      );
+    } catch (err) {
+      logger.error(
+        {
+          err,
+          command: command.name,
+          chatJid,
+          group: group.folder,
+          interactionId: interaction.id,
+        },
+        'Failed to queue Discord slash flow',
+      );
+      await interaction.followUp({
+        content:
+          'I acknowledged the command, but failed to queue it. Check OmniClaw logs for details.',
+        ephemeral: true,
+      });
+    }
   }
 }
 

--- a/src/channels/discord.ts
+++ b/src/channels/discord.ts
@@ -192,7 +192,7 @@ export interface DiscordChannelOpts {
   botId: string;
   token: string;
   multiBotMode?: boolean;
-  onSyntheticMessage?: (message: NewMessage) => void;
+  onSyntheticMessage?: (message: NewMessage) => void | Promise<void>;
   registeredGroups?: () => Record<string, RegisteredGroup>;
   onReaction?: (
     chatJid: string,
@@ -1269,7 +1269,7 @@ export class DiscordChannel implements Channel {
         chatName,
         interaction.guildId || undefined,
       );
-      this.opts.onSyntheticMessage?.({
+      await this.opts.onSyntheticMessage?.({
         id: `slash-${interaction.id}`,
         chat_jid: chatJid,
         sender: `discord:${interaction.user.id}`,

--- a/src/config.ts
+++ b/src/config.ts
@@ -58,6 +58,10 @@ const configSchema = z
       parseBooleanString,
       z.boolean().default(false),
     ),
+    STARTUP_CONFIRMATIONS: z.preprocess(
+      parseBooleanString,
+      z.boolean().default(true),
+    ),
     LOCAL_RUNTIME: z.string().default('container'),
     CONTAINER_IMAGE: z.string().default('omniclaw-agent:latest'),
     CONTAINER_MEMORY: z.string().default('4G'),
@@ -333,6 +337,7 @@ export const DATA_DIR = path.resolve(PROJECT_ROOT, 'data');
 export const MAIN_GROUP_FOLDER = 'main';
 
 export const LOCAL_RUNTIME = CONFIG.LOCAL_RUNTIME;
+export const STARTUP_CONFIRMATIONS = CONFIG.STARTUP_CONFIRMATIONS;
 export const CONTAINER_IMAGE = CONFIG.CONTAINER_IMAGE;
 export const CONTAINER_MEMORY = CONFIG.CONTAINER_MEMORY;
 export const SPLIT_EXECUTION = CONFIG.SPLIT_EXECUTION;

--- a/src/index.ts
+++ b/src/index.ts
@@ -42,6 +42,7 @@ import {
   SESSION_MAX_AGE,
   SLACK_BOTS,
   SLACK_DEFAULT_BOT_ID,
+  STARTUP_CONFIRMATIONS,
   TELEGRAM_BOT_TOKENS,
   WEB_UI_CORS_ORIGIN,
   WEB_UI_HOST,
@@ -2281,6 +2282,11 @@ function recoverPendingMessages(): void {
 }
 
 function queueStartupConfirmationMessages(): void {
+  if (!STARTUP_CONFIRMATIONS) {
+    logger.info('Startup confirmation prompts disabled');
+    return;
+  }
+
   if (
     !hasPriorRuntimeState({
       lastTimestamp,


### PR DESCRIPTION
## Summary
- acknowledge Discord slash flow interactions before queueing synthetic messages
- log successful slash flow queueing and surface follow-up failures after acknowledgement
- add a regression test covering /mergemaster acknowledgement order

## Tests
- bun test src/channels/discord.test.ts src/discord-command-flows.test.ts
- bun run build


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Slash commands now provide immediate acknowledgment to users before processing.
  * Added error handling with user-friendly messaging if command processing fails.

* **Tests**
  * Enhanced test setup with database initialization for improved test reliability.
  * Added comprehensive validation for slash command acknowledgment flow.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->