### PR TITLE
fix(ci): only swallow auto-merge-settings errors in dep bump workflows (#496)

### DIFF
--- a/.github/workflows/auto-merge-deps.yml
+++ b/.github/workflows/auto-merge-deps.yml
@@ -60,11 +60,27 @@ jobs:
             exit 0
           fi
 
+          enable_auto_merge() {
+            local pr="$1"
+            local err_file
+            err_file=$(mktemp)
+            if gh pr merge "$pr" --repo omniaura/omniclaw --auto --squash 2>"$err_file"; then
+              echo "  ✓ Auto-merge enabled for PR #$pr"
+            elif grep -Eiq 'auto-merge.*(not enabled|not allowed|disabled)|Pull request Auto merge is not allowed' "$err_file"; then
+              echo "::warning::Could not enable auto-merge for PR #$pr (is auto-merge enabled in repo settings?)"
+              cat "$err_file"
+            else
+              echo "::error::Failed to enable auto-merge for PR #$pr"
+              cat "$err_file" >&2
+              rm -f "$err_file"
+              return 1
+            fi
+            rm -f "$err_file"
+          }
+
           for PR in $PRS; do
             echo "Enabling auto-merge for PR #$PR..."
-            gh pr merge "$PR" --repo omniaura/omniclaw --auto --squash \
-              && echo "  ✓ Auto-merge enabled for PR #$PR" \
-              || echo "::warning::Could not enable auto-merge for PR #$PR"
+            enable_auto_merge "$PR"
           done
         env:
           GH_TOKEN: ${{ steps.app-token.outputs.token != '' && steps.app-token.outputs.token || github.token }}

--- a/.github/workflows/update-claude-sdk.yml
+++ b/.github/workflows/update-claude-sdk.yml
@@ -127,10 +127,26 @@ jobs:
         run: |
           BRANCH="update/claude-sdk-${{ steps.latest.outputs.version }}"
           PR=$(gh pr list --repo omniaura/omniclaw --base main --head "$BRANCH" --json number --jq '.[0].number // ""')
+          enable_auto_merge() {
+            local pr="$1"
+            local err_file
+            err_file=$(mktemp)
+            if gh pr merge "$pr" --repo omniaura/omniclaw --auto --squash 2>"$err_file"; then
+              echo "Auto-merge enabled for PR #$pr"
+            elif grep -Eiq 'auto-merge.*(not enabled|not allowed|disabled)|Pull request Auto merge is not allowed' "$err_file"; then
+              echo "::warning::Could not enable auto-merge for PR #$pr (is auto-merge enabled in repo settings?)"
+              cat "$err_file"
+            else
+              echo "::error::Failed to enable auto-merge for PR #$pr"
+              cat "$err_file" >&2
+              rm -f "$err_file"
+              return 1
+            fi
+            rm -f "$err_file"
+          }
+
           if [ -n "$PR" ]; then
-            gh pr merge "$PR" --repo omniaura/omniclaw --auto --squash \
-              && echo "Auto-merge enabled for PR #$PR" \
-              || echo "::warning::Could not enable auto-merge for PR #$PR (is auto-merge enabled in repo settings?)"
+            enable_auto_merge "$PR"
           fi
         env:
           GH_TOKEN: ${{ steps.app-token.outputs.token != '' && steps.app-token.outputs.token || github.token }}

--- a/.github/workflows/update-container-deps.yml
+++ b/.github/workflows/update-container-deps.yml
@@ -168,10 +168,26 @@ jobs:
         run: |
           BRANCH="update/${{ matrix.tool }}-${{ steps.latest.outputs.version }}"
           PR=$(gh pr list --repo omniaura/omniclaw --base main --head "$BRANCH" --json number --jq '.[0].number // ""')
+          enable_auto_merge() {
+            local pr="$1"
+            local err_file
+            err_file=$(mktemp)
+            if gh pr merge "$pr" --repo omniaura/omniclaw --auto --squash 2>"$err_file"; then
+              echo "Auto-merge enabled for PR #$pr"
+            elif grep -Eiq 'auto-merge.*(not enabled|not allowed|disabled)|Pull request Auto merge is not allowed' "$err_file"; then
+              echo "::warning::Could not enable auto-merge for PR #$pr (is auto-merge enabled in repo settings?)"
+              cat "$err_file"
+            else
+              echo "::error::Failed to enable auto-merge for PR #$pr"
+              cat "$err_file" >&2
+              rm -f "$err_file"
+              return 1
+            fi
+            rm -f "$err_file"
+          }
+
           if [ -n "$PR" ]; then
-            gh pr merge "$PR" --repo omniaura/omniclaw --auto --squash \
-              && echo "Auto-merge enabled for PR #$PR" \
-              || echo "::warning::Could not enable auto-merge for PR #$PR (is auto-merge enabled in repo settings?)"
+            enable_auto_merge "$PR"
           fi
         env:
           GH_TOKEN: ${{ steps.app-token.outputs.token != '' && steps.app-token.outputs.token || github.token }}

--- a/.github/workflows/update-opencode.yml
+++ b/.github/workflows/update-opencode.yml
@@ -187,10 +187,26 @@ jobs:
         run: |
           BRANCH="update/opencode-${{ steps.check.outputs.branch_suffix }}"
           PR=$(gh pr list --repo omniaura/omniclaw --base main --head "$BRANCH" --json number --jq '.[0].number // ""')
+          enable_auto_merge() {
+            local pr="$1"
+            local err_file
+            err_file=$(mktemp)
+            if gh pr merge "$pr" --repo omniaura/omniclaw --auto --squash 2>"$err_file"; then
+              echo "Auto-merge enabled for PR #$pr"
+            elif grep -Eiq 'auto-merge.*(not enabled|not allowed|disabled)|Pull request Auto merge is not allowed' "$err_file"; then
+              echo "::warning::Could not enable auto-merge for PR #$pr (is auto-merge enabled in repo settings?)"
+              cat "$err_file"
+            else
+              echo "::error::Failed to enable auto-merge for PR #$pr"
+              cat "$err_file" >&2
+              rm -f "$err_file"
+              return 1
+            fi
+            rm -f "$err_file"
+          }
+
           if [ -n "$PR" ]; then
-            gh pr merge "$PR" --repo omniaura/omniclaw --auto --squash \
-              && echo "Auto-merge enabled for PR #$PR" \
-              || echo "::warning::Could not enable auto-merge for PR #$PR (is auto-merge enabled in repo settings?)"
+            enable_auto_merge "$PR"
           fi
         env:
           GH_TOKEN: ${{ steps.app-token.outputs.token != '' && steps.app-token.outputs.token || github.token }}


### PR DESCRIPTION
## Summary

- Updates dependency auto-merge workflows to capture `gh pr merge --auto --squash` stderr.
- Downgrades only the known repository auto-merge-settings failure to a warning.
- Fails the workflow on unexpected `gh pr merge` errors instead of masking them.

## Verification

- `bunx prettier --check .github/workflows/auto-merge-deps.yml .github/workflows/update-claude-sdk.yml .github/workflows/update-container-deps.yml .github/workflows/update-opencode.yml`
- `git diff --check`
- `bun run typecheck`

Closes #496
