### PR TITLE
fix(ci): auto-close superseded dep bump PRs (#517)

### DIFF
--- a/.github/workflows/update-claude-sdk.yml
+++ b/.github/workflows/update-claude-sdk.yml
@@ -119,6 +119,20 @@ jobs:
             --head "$BRANCH" \
             --title "$TITLE" \
             --body-file "$BODY_FILE"
+
+          NEW_PR=$(gh pr list --repo omniaura/omniclaw --base main --head "$BRANCH" --json number --jq '.[0].number // ""')
+          if [ -z "$NEW_PR" ]; then
+            echo "::error::Could not find newly created PR for $BRANCH"
+            exit 1
+          fi
+
+          PREFIX="update/claude-sdk-"
+          OLD_PRS=$(gh pr list --repo omniaura/omniclaw --base main --state open --json number,headRefName \
+            --jq '.[] | select(.headRefName | startswith("'"$PREFIX"'")) | select(.number != '"$NEW_PR"') | .number')
+          for OLD_PR in $OLD_PRS; do
+            echo "Closing superseded PR #$OLD_PR (superseded by #$NEW_PR)"
+            gh pr close "$OLD_PR" --repo omniaura/omniclaw --comment "Superseded by #$NEW_PR"
+          done
         env:
           GH_TOKEN: ${{ steps.app-token.outputs.token != '' && steps.app-token.outputs.token || github.token }}
 

--- a/.github/workflows/update-container-deps.yml
+++ b/.github/workflows/update-container-deps.yml
@@ -160,6 +160,20 @@ jobs:
             --head "$BRANCH" \
             --title "$TITLE" \
             --body-file "$BODY_FILE"
+
+          NEW_PR=$(gh pr list --repo omniaura/omniclaw --base main --head "$BRANCH" --json number --jq '.[0].number // ""')
+          if [ -z "$NEW_PR" ]; then
+            echo "::error::Could not find newly created PR for $BRANCH"
+            exit 1
+          fi
+
+          PREFIX="update/${{ matrix.tool }}-"
+          OLD_PRS=$(gh pr list --repo omniaura/omniclaw --base main --state open --json number,headRefName \
+            --jq '.[] | select(.headRefName | startswith("'"$PREFIX"'")) | select(.number != '"$NEW_PR"') | .number')
+          for OLD_PR in $OLD_PRS; do
+            echo "Closing superseded PR #$OLD_PR (superseded by #$NEW_PR)"
+            gh pr close "$OLD_PR" --repo omniaura/omniclaw --comment "Superseded by #$NEW_PR"
+          done
         env:
           GH_TOKEN: ${{ steps.app-token.outputs.token != '' && steps.app-token.outputs.token || github.token }}
 

--- a/.github/workflows/update-opencode.yml
+++ b/.github/workflows/update-opencode.yml
@@ -179,6 +179,20 @@ jobs:
             --head "$BRANCH" \
             --title "${{ steps.check.outputs.commit_title }}" \
             --body-file "$BODY_FILE"
+
+          NEW_PR=$(gh pr list --repo omniaura/omniclaw --base main --head "$BRANCH" --json number --jq '.[0].number // ""')
+          if [ -z "$NEW_PR" ]; then
+            echo "::error::Could not find newly created PR for $BRANCH"
+            exit 1
+          fi
+
+          PREFIX="update/opencode-"
+          OLD_PRS=$(gh pr list --repo omniaura/omniclaw --base main --state open --json number,headRefName \
+            --jq '.[] | select(.headRefName | startswith("'"$PREFIX"'")) | select(.number != '"$NEW_PR"') | .number')
+          for OLD_PR in $OLD_PRS; do
+            echo "Closing superseded PR #$OLD_PR (superseded by #$NEW_PR)"
+            gh pr close "$OLD_PR" --repo omniaura/omniclaw --comment "Superseded by #$NEW_PR"
+          done
         env:
           GH_TOKEN: ${{ steps.app-token.outputs.token != '' && steps.app-token.outputs.token || github.token }}
 


### PR DESCRIPTION
## Summary

- Adds superseded-PR cleanup after dependency bump workflows create a new PR.
- Closes older open PRs with the same dependency branch prefix and comments `Superseded by #<new>`.
- Applies to Claude SDK, container dependency, and OpenCode bump workflows.

## Immediate Cleanup

- Verified #488, #492, #493, and #502 are already closed, so no manual close was needed.

## Verification

- `bunx prettier --check .github/workflows/update-claude-sdk.yml .github/workflows/update-container-deps.yml .github/workflows/update-opencode.yml`
- `git diff --check`
- `bun run typecheck`

Closes #517
