### PR TITLE
chore(whatsapp): remove sender identity instrumentation

### DIFF
--- a/src/channels/whatsapp.ts
+++ b/src/channels/whatsapp.ts
@@ -481,18 +481,6 @@ export class WhatsAppChannel implements Channel {
               await this.buildSenderIdentity(rawSender);
             const senderName = msg.pushName?.trim() || '';
 
-            if (!senderName) {
-              logger.warn(
-                {
-                  op: 'senderIdentity',
-                  counter: 'sender_name_empty',
-                  platform: 'whatsapp',
-                  sender,
-                },
-                'WhatsApp message has empty sender_name',
-              );
-            }
-
             // Prepend reply context so the agent knows what's being replied to
             const contextInfo = msg.message?.extendedTextMessage?.contextInfo;
             if (contextInfo?.quotedMessage || contextInfo?.stanzaId) {


### PR DESCRIPTION
## Summary

- Removes the WhatsApp Phase 0 `sender_name_empty` instrumentation log from the adapter.
- Leaves canonical WhatsApp sender construction unchanged.
- Defers the router fallback follow-up because the direct router fallback is already gone and remaining sender fallbacks are in web export/render paths.

## Verification

- `bun test src/channels/whatsapp.test.ts src/sender-identity.test.ts`
- `bun run typecheck`
- `bunx prettier --check src/channels/whatsapp.ts`

Refs #211
