### PR TITLE
test(web): cover session expiry and network wifi rendering

### DIFF
--- a/src/web/network.test.ts
+++ b/src/web/network.test.ts
@@ -138,8 +138,16 @@ describe('renderNetworkContent', () => {
       runtime: makeRuntime({
         currentNetwork: { id: 'ssid:office<&>', label: 'Office <Wi-Fi>' },
         trustedNetworks: [
-          { id: 'ssid:home<&>', label: 'Home <Wi-Fi>' },
-          { id: 'ssid:lab', label: 'Lab Network' },
+          {
+            id: 'ssid:home<&>',
+            label: 'Home <Wi-Fi>',
+            trustedAt: '2026-03-01T00:00:00.000Z',
+          },
+          {
+            id: 'ssid:lab',
+            label: 'Lab Network',
+            trustedAt: '2026-03-02T00:00:00.000Z',
+          },
         ],
       }),
       peers: [],

--- a/src/web/network.test.ts
+++ b/src/web/network.test.ts
@@ -151,6 +151,8 @@ describe('renderNetworkContent', () => {
     );
     expect(html).toContain('<strong>Home &lt;Wi-Fi&gt;</strong>');
     expect(html).toContain('ssid:home&lt;&amp;&gt;');
+    expect(html).toContain('<strong>Lab Network</strong>');
+    expect(html).toContain('ssid:lab');
     expect(html).toContain('data-network-action="untrust-network"');
     expect(html).not.toContain('No trusted Wi-Fi networks yet.');
   });

--- a/src/web/network.test.ts
+++ b/src/web/network.test.ts
@@ -128,6 +128,32 @@ describe('renderNetworkContent', () => {
       'Discovery controls are unavailable in this environment.',
     );
   });
+
+  it('renders current and trusted Wi-Fi networks with escaped identifiers', () => {
+    const html = renderNetworkContent({
+      instanceId: 'local-id',
+      instanceName: 'Main Node',
+      discoveryAvailable: true,
+      discoveryEnabled: true,
+      runtime: makeRuntime({
+        currentNetwork: { id: 'ssid:office<&>', label: 'Office <Wi-Fi>' },
+        trustedNetworks: [
+          { id: 'ssid:home<&>', label: 'Home <Wi-Fi>' },
+          { id: 'ssid:lab', label: 'Lab Network' },
+        ],
+      }),
+      peers: [],
+      pendingRequests: [],
+    });
+
+    expect(html).toContain(
+      'Current Wi-Fi: <strong>Office &lt;Wi-Fi&gt;</strong>',
+    );
+    expect(html).toContain('<strong>Home &lt;Wi-Fi&gt;</strong>');
+    expect(html).toContain('ssid:home&lt;&amp;&gt;');
+    expect(html).toContain('data-network-action="untrust-network"');
+    expect(html).not.toContain('No trusted Wi-Fi networks yet.');
+  });
 });
 
 describe('renderPendingRequests', () => {

--- a/src/web/session-auth.test.ts
+++ b/src/web/session-auth.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, afterEach } from 'bun:test';
+import { describe, it, expect, afterEach, spyOn } from 'bun:test';
 
 import {
   createSessionStore,
@@ -112,6 +112,50 @@ describe('SessionStore', () => {
     // but we can verify purge runs without errors
     store.purge();
     expect(store.validate(token)).toBe(true);
+  });
+
+  it('invalidates expired sessions during validation and purge', () => {
+    const now = spyOn(Date, 'now');
+    try {
+      now.mockReturnValue(1_000);
+      const store = createSessionStore();
+      const token = store.create();
+      const purgeToken = store.create();
+      expect(store.size).toBe(2);
+
+      now.mockReturnValue(1_000 + 24 * 60 * 60 * 1000);
+      expect(store.validate(token)).toBe(false);
+      expect(store.size).toBe(1);
+
+      store.purge();
+      expect(store.validate(purgeToken)).toBe(false);
+      expect(store.size).toBe(0);
+    } finally {
+      now.mockRestore();
+    }
+  });
+
+  it('evicts the oldest session when the store reaches capacity', () => {
+    const now = spyOn(Date, 'now');
+    try {
+      const store = createSessionStore();
+      const tokens: string[] = [];
+
+      for (let i = 0; i < 100; i++) {
+        now.mockReturnValue(10_000 + i);
+        tokens.push(store.create());
+      }
+
+      now.mockReturnValue(20_000);
+      const newest = store.create();
+
+      expect(store.size).toBe(100);
+      expect(store.validate(tokens[0])).toBe(false);
+      expect(store.validate(tokens[1])).toBe(true);
+      expect(store.validate(newest)).toBe(true);
+    } finally {
+      now.mockRestore();
+    }
   });
 });
 

--- a/src/web/session-auth.test.ts
+++ b/src/web/session-auth.test.ts
@@ -123,6 +123,7 @@ describe('SessionStore', () => {
       const purgeToken = store.create();
       expect(store.size).toBe(2);
 
+      // Advance to exactly expiresAt to cover the <= expiry boundary.
       now.mockReturnValue(1_000 + 24 * 60 * 60 * 1000);
       expect(store.validate(token)).toBe(false);
       expect(store.size).toBe(1);
@@ -152,6 +153,29 @@ describe('SessionStore', () => {
       expect(store.size).toBe(100);
       expect(store.validate(tokens[0])).toBe(false);
       expect(store.validate(tokens[1])).toBe(true);
+      expect(store.validate(newest)).toBe(true);
+    } finally {
+      now.mockRestore();
+    }
+  });
+
+  it('purges expired sessions before evicting at capacity', () => {
+    const now = spyOn(Date, 'now');
+    try {
+      const store = createSessionStore();
+      const tokens: string[] = [];
+
+      for (let i = 0; i < 100; i++) {
+        now.mockReturnValue(10_000 + i);
+        tokens.push(store.create());
+      }
+
+      now.mockReturnValue(10_000 + 99 + 24 * 60 * 60 * 1000);
+      const newest = store.create();
+
+      expect(store.size).toBe(1);
+      expect(store.validate(tokens[0]!)).toBe(false);
+      expect(store.validate(tokens[99]!)).toBe(false);
       expect(store.validate(newest)).toBe(true);
     } finally {
       now.mockRestore();


### PR DESCRIPTION
## Summary

- Add deterministic `Date.now` tests for session expiry, purge, and max-session eviction.
- Add network page rendering coverage for current/trusted Wi-Fi state and escaped network identifiers.

## Test Count / Coverage

- Baseline tracked suite: `1904 pass, 0 fail`, coverage `88.79% funcs / 87.17% lines`.
- After changes tracked suite: `1907 pass, 0 fail`, coverage `88.97% funcs / 87.38% lines`.
- Files now fully covered by this PR: `src/web/session-auth.ts`, `src/web/network.ts`.

## Verification

- `bun test src/web/session-auth.test.ts src/web/network.test.ts`
- `bun test $(git ls-files '*test.ts')`
- `bun test --coverage $(git ls-files '*test.ts')`

## Note

The shared workspace contains unrelated pre-existing untracked test files, so plain `bun test` also picks them up and fails outside this PR. The tracked test suite passes cleanly.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added test coverage for network content rendering with proper identifier escaping.
  * Expanded session store test coverage for expired session handling and capacity eviction scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->