### PR TITLE
fix(security): cap execution broker payloads

### DIFF
--- a/src/backends/local-backend.test.ts
+++ b/src/backends/local-backend.test.ts
@@ -8,7 +8,10 @@ import {
   buildExecInvocationArgs,
   buildExecutionContainerArgs,
   buildVolumeMounts,
+  ExecBrokerOutputLimitError,
   LocalBackend,
+  parseExecRequest,
+  readExecBrokerText,
   resolveGitHubTokenForContainer,
 } from './local-backend.js';
 
@@ -797,6 +800,38 @@ describe('LocalBackend', () => {
         '-lc',
         'pwd',
       ]);
+    });
+  });
+
+  describe('execution broker parsing', () => {
+    const log = {
+      warn() {},
+    } as any;
+
+    it('rejects oversized execution request files before parsing JSON', () => {
+      const fixture = createFixture();
+      try {
+        fs.mkdirSync(fixture.ipcDir, { recursive: true });
+        const requestPath = path.join(fixture.ipcDir, 'oversized.json');
+        fs.writeFileSync(requestPath, 'x'.repeat(64 * 1024 + 1));
+
+        expect(parseExecRequest(requestPath, log)).toBeNull();
+      } finally {
+        fixture.cleanup();
+      }
+    });
+
+    it('limits execution broker stream capture', async () => {
+      const stream = new ReadableStream<Uint8Array>({
+        start(controller) {
+          controller.enqueue(new Uint8Array(1024 * 1024 + 1));
+          controller.close();
+        },
+      });
+
+      await expect(readExecBrokerText(stream, 'stdout')).rejects.toThrow(
+        ExecBrokerOutputLimitError,
+      );
     });
   });
 

--- a/src/backends/local-backend.test.ts
+++ b/src/backends/local-backend.test.ts
@@ -1,4 +1,4 @@
-import { afterEach, describe, expect, it } from 'bun:test';
+import { afterEach, describe, expect, it, mock, spyOn } from 'bun:test';
 import fs from 'node:fs';
 import path from 'node:path';
 
@@ -13,6 +13,7 @@ import {
   parseExecRequest,
   readExecBrokerText,
   resolveGitHubTokenForContainer,
+  runExecBrokerRequest,
 } from './local-backend.js';
 
 function uniqueId(): string {
@@ -821,6 +822,18 @@ describe('LocalBackend', () => {
       }
     });
 
+    it('returns null when an execution request file cannot be statted', () => {
+      const fixture = createFixture();
+      try {
+        fs.mkdirSync(fixture.ipcDir, { recursive: true });
+        const requestPath = path.join(fixture.ipcDir, 'missing.json');
+
+        expect(parseExecRequest(requestPath, log)).toBeNull();
+      } finally {
+        fixture.cleanup();
+      }
+    });
+
     it('limits execution broker stream capture', async () => {
       const stream = new ReadableStream<Uint8Array>({
         start(controller) {
@@ -832,6 +845,80 @@ describe('LocalBackend', () => {
       await expect(readExecBrokerText(stream, 'stdout')).rejects.toThrow(
         ExecBrokerOutputLimitError,
       );
+    });
+
+    it('limits cumulative execution broker stream capture', async () => {
+      const stream = new ReadableStream<Uint8Array>({
+        start(controller) {
+          for (let i = 0; i < 1024; i++) {
+            controller.enqueue(new Uint8Array(1024));
+          }
+          controller.enqueue(new Uint8Array(1));
+          controller.close();
+        },
+      });
+
+      await expect(readExecBrokerText(stream, 'stderr')).rejects.toThrow(
+        ExecBrokerOutputLimitError,
+      );
+    });
+
+    it('writes a synthetic broker response when output exceeds the limit', async () => {
+      const fixture = createFixture();
+      const spawnSpy = spyOn(Bun, 'spawn').mockImplementation((() => ({
+        stdout: new ReadableStream<Uint8Array>({
+          start(controller) {
+            controller.enqueue(new Uint8Array(1024 * 1024 + 1));
+            controller.close();
+          },
+        }),
+        stderr: new ReadableStream<Uint8Array>({
+          start(controller) {
+            controller.close();
+          },
+        }),
+        exited: Promise.resolve(0),
+        kill: mock(() => {}),
+      })) as unknown as typeof Bun.spawn);
+
+      try {
+        const responseDir = path.join(fixture.ipcDir, 'exec-responses');
+        fs.mkdirSync(responseDir, { recursive: true });
+
+        await runExecBrokerRequest(
+          {
+            id: 'exec-req-limit',
+            cwd: '/workspace/group',
+            args: ['-lc', 'printf ok'],
+            env: {},
+          },
+          'exec-sidecar',
+          responseDir,
+          { debug() {} } as any,
+        );
+
+        expect(
+          fs.readFileSync(
+            path.join(responseDir, 'exec-req-limit.stdout'),
+            'utf8',
+          ),
+        ).toBe('');
+        expect(
+          fs.readFileSync(
+            path.join(responseDir, 'exec-req-limit.stderr'),
+            'utf8',
+          ),
+        ).toContain('Execution broker stdout exceeded');
+        expect(
+          fs.readFileSync(
+            path.join(responseDir, 'exec-req-limit.exitcode'),
+            'utf8',
+          ),
+        ).toBe('125');
+      } finally {
+        spawnSpy.mockRestore();
+        fixture.cleanup();
+      }
     });
   });
 

--- a/src/backends/local-backend.ts
+++ b/src/backends/local-backend.ts
@@ -581,6 +581,8 @@ export interface ExecRequest {
 const EXEC_BROKER_REQUEST_DIR = '/workspace/ipc/exec-requests';
 const EXEC_BROKER_RESPONSE_DIR = '/workspace/ipc/exec-responses';
 const EXEC_BROKER_POLL_INTERVAL_MS = 50;
+const MAX_EXEC_BROKER_REQUEST_BYTES = 64 * 1024;
+const MAX_EXEC_BROKER_OUTPUT_BYTES = 1024 * 1024;
 const SAFE_EXEC_REQUEST_ID = /^[A-Za-z0-9_-]+$/;
 const SAFE_ENV_KEY = /^[A-Za-z_][A-Za-z0-9_]*$/;
 
@@ -849,10 +851,56 @@ async function spawnExecutionContainer(
   };
 }
 
-function parseExecRequest(
+export class ExecBrokerOutputLimitError extends Error {
+  constructor(label: string) {
+    super(
+      `Execution broker ${label} exceeded ${MAX_EXEC_BROKER_OUTPUT_BYTES} bytes`,
+    );
+    this.name = 'ExecBrokerOutputLimitError';
+  }
+}
+
+export async function readExecBrokerText(
+  stream: ReadableStream<Uint8Array> | number | null | undefined,
+  label: string,
+): Promise<string> {
+  if (typeof stream === 'number' || !stream) return '';
+
+  const reader = stream.getReader();
+  const decoder = new TextDecoder();
+  let bytes = 0;
+  let text = '';
+
+  try {
+    while (true) {
+      const { value, done } = await reader.read();
+      if (done) break;
+      bytes += value.byteLength;
+      if (bytes > MAX_EXEC_BROKER_OUTPUT_BYTES) {
+        throw new ExecBrokerOutputLimitError(label);
+      }
+      text += decoder.decode(value, { stream: true });
+    }
+    text += decoder.decode();
+    return text;
+  } finally {
+    reader.releaseLock();
+  }
+}
+
+export function parseExecRequest(
   requestPath: string,
   log: typeof logger,
 ): ExecRequest | null {
+  const { size } = fs.statSync(requestPath);
+  if (size > MAX_EXEC_BROKER_REQUEST_BYTES) {
+    log.warn(
+      { requestPath, size, maxBytes: MAX_EXEC_BROKER_REQUEST_BYTES },
+      'Rejected oversized execution request',
+    );
+    return null;
+  }
+
   const raw = fs.readFileSync(requestPath, 'utf-8');
   const parsed = JSON.parse(raw) as Partial<ExecRequest>;
 
@@ -937,19 +985,25 @@ async function runExecBrokerRequest(
     },
   );
 
-  const stdoutPromise =
-    typeof proc.stdout === 'number' || !proc.stdout
-      ? Promise.resolve('')
-      : new Response(proc.stdout).text();
-  const stderrPromise =
-    typeof proc.stderr === 'number' || !proc.stderr
-      ? Promise.resolve('')
-      : new Response(proc.stderr).text();
-  const [stdout, stderr, exitCode] = await Promise.all([
-    stdoutPromise,
-    stderrPromise,
-    proc.exited,
-  ]);
+  let stdout = '';
+  let stderr = '';
+  let exitCode = 125;
+  try {
+    [stdout, stderr, exitCode] = await Promise.all([
+      readExecBrokerText(proc.stdout, 'stdout'),
+      readExecBrokerText(proc.stderr, 'stderr'),
+      proc.exited,
+    ]);
+  } catch (err) {
+    proc.kill();
+    await proc.exited.catch(() => undefined);
+    writeExecBrokerResponse(responseDir, request.id, {
+      stdout: '',
+      stderr: err instanceof Error ? err.message : 'Execution broker failed',
+      exitCode,
+    });
+    return;
+  }
 
   writeExecBrokerResponse(responseDir, request.id, {
     stdout,

--- a/src/backends/local-backend.ts
+++ b/src/backends/local-backend.ts
@@ -892,7 +892,13 @@ export function parseExecRequest(
   requestPath: string,
   log: typeof logger,
 ): ExecRequest | null {
-  const { size } = fs.statSync(requestPath);
+  let size: number;
+  try {
+    size = fs.statSync(requestPath).size;
+  } catch (err) {
+    log.warn({ requestPath, err }, 'Rejected unreadable execution request');
+    return null;
+  }
   if (size > MAX_EXEC_BROKER_REQUEST_BYTES) {
     log.warn(
       { requestPath, size, maxBytes: MAX_EXEC_BROKER_REQUEST_BYTES },
@@ -967,7 +973,7 @@ function writeExecBrokerResponse(
   fs.renameSync(`${exitCodePath}.tmp`, exitCodePath);
 }
 
-async function runExecBrokerRequest(
+export async function runExecBrokerRequest(
   request: ExecRequest,
   execContainerName: string,
   responseDir: string,
@@ -987,6 +993,7 @@ async function runExecBrokerRequest(
 
   let stdout = '';
   let stderr = '';
+  // 125 means the broker synthesized a response before the child returned one.
   let exitCode = 125;
   try {
     [stdout, stderr, exitCode] = await Promise.all([
@@ -996,7 +1003,17 @@ async function runExecBrokerRequest(
     ]);
   } catch (err) {
     proc.kill();
-    await proc.exited.catch(() => undefined);
+    const exitedAfterTerm = await Promise.race([
+      proc.exited.then(
+        () => true,
+        () => true,
+      ),
+      Bun.sleep(1000).then(() => false),
+    ]);
+    if (!exitedAfterTerm) {
+      proc.kill('SIGKILL');
+      await proc.exited.catch(() => undefined);
+    }
     writeExecBrokerResponse(responseDir, request.id, {
       stdout: '',
       stderr: err instanceof Error ? err.message : 'Execution broker failed',


### PR DESCRIPTION
## Summary

- Cap split-execution broker request files at 64 KiB before JSON parsing.
- Cap captured stdout/stderr at 1 MiB per stream and stop the exec process when exceeded.
- Add regression coverage for oversized broker requests and output streams.

## Security Impact

The execution broker processes IPC request files and subprocess output from agent-controlled execution flows. Without local caps, a compromised or buggy agent could force the orchestrator to allocate excessive memory by writing a huge request file or producing unbounded stdout/stderr.

## Tests

- `bun test src/backends/local-backend.test.ts`
- `bun run typecheck`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added execution broker parsing test suite validating size limit constraints and error handling.

* **Bug Fixes**
  * Implemented output size limits for execution broker to prevent excessive resource consumption.
  * Enhanced error handling with proper exit codes when output limits are exceeded.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->