### PR TITLE
fix(config): default idle container pool to zero

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -24,6 +24,11 @@ DISCOVERY_TRUST_LAN_ADMIN=false
 # SPLIT_EXECUTION=false
 # EXEC_CONTAINER_MEMORY=8G
 
+# Container lifecycle
+# Defaults to 0 so idle message containers exit and future messages resume the session.
+# Increase to keep a warm idle pool for lower first-token latency.
+# MAX_IDLE_CONTAINERS=0
+
 # GitHub webhook listener
 # Set a shared secret when exposing /webhooks/github.
 # GITHUB_WEBHOOK_SECRET=

--- a/docs/SPEC.md
+++ b/docs/SPEC.md
@@ -225,6 +225,7 @@ Configuration constants are in `src/config.ts`. All values can be overridden via
 | `IDLE_TIMEOUT`              | `1800000`                       | Keep container alive after last result (30min) |
 | `SESSION_MAX_AGE`           | `14400000`                      | Rotate sessions after 4 hours                  |
 | `MAX_CONCURRENT_CONTAINERS` | `8`                             | Global container concurrency limit             |
+| `MAX_IDLE_CONTAINERS`       | `0`                             | Warm idle container pool size                  |
 | `MAX_TASK_CONTAINERS`       | `MAX_CONCURRENT_CONTAINERS - 1` | Containers reserved for scheduled tasks        |
 | `CONTAINER_IMAGE`           | `omniclaw-agent:latest`         | Container image name                           |
 | `CONTAINER_MEMORY`          | `4G`                            | Container memory limit                         |

--- a/src/config.test.ts
+++ b/src/config.test.ts
@@ -275,7 +275,7 @@ describe('parseConfigEnv', () => {
     const parsed = parseConfigEnv({});
 
     expect(parsed.CONTAINER_TIMEOUT).toBe(7200000);
-    expect(parsed.MAX_IDLE_CONTAINERS).toBe(4);
+    expect(parsed.MAX_IDLE_CONTAINERS).toBe(0);
     expect(parsed.DISCOVERY_ENABLED).toBe(false);
     expect(parsed.WEB_UI_PORT).toBeUndefined();
   });

--- a/src/config.ts
+++ b/src/config.ts
@@ -114,7 +114,7 @@ const configSchema = z
     ),
     MAX_IDLE_CONTAINERS: z.preprocess(
       parseIntegerString,
-      z.number().int().nonnegative().default(4),
+      z.number().int().nonnegative().default(0),
     ),
     MAX_TASK_CONTAINERS: z.preprocess(
       parseIntegerString,
@@ -364,7 +364,7 @@ export const MAX_ACTIVE_CONTAINERS = Math.max(
   1,
   CONFIG.MAX_ACTIVE_CONTAINERS ?? CONFIG.MAX_CONCURRENT_CONTAINERS ?? 8,
 );
-/** Max warm containers sitting idle, waiting for the next message. */
+/** Max warm containers sitting idle, waiting for the next message. Defaults to 0 to prefer session resume over resident containers. */
 export const MAX_IDLE_CONTAINERS = Math.max(0, CONFIG.MAX_IDLE_CONTAINERS);
 /** Backward-compat alias. */
 export const MAX_CONCURRENT_CONTAINERS = MAX_ACTIVE_CONTAINERS;


### PR DESCRIPTION
## Summary

- Default `MAX_IDLE_CONTAINERS` to `0` so message containers exit after idle instead of staying warm by default.
- Document the opt-in warm idle pool in `.env.example` and `docs/SPEC.md`.
- Update config default coverage for the new lifecycle default.

## Tests

- `bun test src/config.test.ts src/group-queue.test.ts`
- `bun run typecheck`
- `bun run format:check`

Closes #149.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Configuration**
  * Changed the default idle container pool size from 4 to 0, shifting system behavior to prioritize session resumption over maintaining idle containers in a warm-ready state.

* **Documentation**  
  * Added comprehensive configuration guidance for container lifecycle management and updated technical specifications to document the idle container pool setting and its default behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->