### PR TITLE
chore: shared-VM config nit cleanup

### DIFF
--- a/src/backends/local-backend.ts
+++ b/src/backends/local-backend.ts
@@ -1125,10 +1125,7 @@ function startExecBroker(
 }
 
 function isSharedVmEnabled(): boolean {
-  return (
-    (SHARED_CLAUDE_VM || process.env.SHARED_CLAUDE_VM === 'true') &&
-    LOCAL_RUNTIME !== 'docker'
-  );
+  return SHARED_CLAUDE_VM && LOCAL_RUNTIME !== 'docker';
 }
 
 export const SHARED_VM_NETWORK_ISOLATION_ERROR_CODE =

--- a/src/backends/shared-vm.ts
+++ b/src/backends/shared-vm.ts
@@ -6,7 +6,6 @@
  * so it doesn't need to be recreated when agents register/unregister.
  */
 
-import { $ } from 'bun';
 import fs from 'fs';
 import path from 'path';
 
@@ -69,7 +68,7 @@ export class SharedVmManager {
   /** Stop any orphaned shared VMs from previous runs. */
   async cleanupOrphans(): Promise<void> {
     try {
-      const lsResult = await $`container ls --format json`.quiet();
+      const lsResult = await Bun.$`${LOCAL_RUNTIME} ls --format json`.quiet();
       const containers: { status: string; configuration: { id: string } }[] =
         JSON.parse(lsResult.text() || '[]');
       const orphans = containers
@@ -168,7 +167,7 @@ export class SharedVmManager {
 
   private async isAlive(name: string): Promise<boolean> {
     try {
-      const lsResult = await $`container ls --format json`.quiet();
+      const lsResult = await Bun.$`${LOCAL_RUNTIME} ls --format json`.quiet();
       const containers: { status: string; configuration: { id: string } }[] =
         JSON.parse(lsResult.text() || '[]');
       return containers.some(

--- a/src/config.test.ts
+++ b/src/config.test.ts
@@ -294,6 +294,14 @@ describe('parseConfigEnv', () => {
     expect(parsed.CHANNEL_ROSTER_SCOPE).toBe('guild');
   });
 
+  it('treats blank shared VM memory as unset', () => {
+    const parsed = parseConfigEnv({
+      SHARED_CLAUDE_VM_MEMORY: '',
+    });
+
+    expect(parsed.SHARED_CLAUDE_VM_MEMORY).toBe('16G');
+  });
+
   it('throws a clear error for invalid numeric config', () => {
     expect(() =>
       parseConfigEnv({

--- a/src/config.ts
+++ b/src/config.ts
@@ -73,7 +73,10 @@ const configSchema = z
       parseBooleanString,
       z.boolean().default(false),
     ),
-    SHARED_CLAUDE_VM_MEMORY: z.string().default('16G'),
+    SHARED_CLAUDE_VM_MEMORY: z.preprocess(
+      optionalTrimmedString,
+      z.string().default('16G'),
+    ),
     EXEC_CONTAINER_MEMORY: z.string().optional(),
     CONTAINER_TIMEOUT: z.preprocess(
       parseIntegerString,


### PR DESCRIPTION
## Summary

- [x] Drop the redundant `process.env.SHARED_CLAUDE_VM` fallback in `isSharedVmEnabled()`.
- [x] Treat blank `SHARED_CLAUDE_VM_MEMORY` as unset so it falls back to `16G`.
- [x] Use `LOCAL_RUNTIME` instead of hardcoded `container` for shared-VM `ls` calls.

Refs #626.

## Tests

- `bun test src/config.test.ts src/backends/local-backend.test.ts`
- `bun run typecheck`
- `bun run format:check`
