### PR TITLE
feat: load declarative agent topology

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -43,3 +43,8 @@ DISCOVERY_TRUST_LAN_ADMIN=false
 # GITHUB_WEBHOOK_PATH=/webhooks/github
 # Max bytes accepted before rejecting a webhook with HTTP 413.
 # GITHUB_WEBHOOK_MAX_BODY_BYTES=262144
+
+# Declarative agent topology
+# Defaults to agents.yaml in the project root. Set to another relative or absolute
+# path to load agent/channel registrations from versioned config at startup.
+# AGENTS_CONFIG_PATH=agents.yaml

--- a/.env.example
+++ b/.env.example
@@ -45,6 +45,7 @@ DISCOVERY_TRUST_LAN_ADMIN=false
 # GITHUB_WEBHOOK_MAX_BODY_BYTES=262144
 
 # Declarative agent topology
-# Defaults to agents.yaml in the project root. Set to another relative or absolute
-# path to load agent/channel registrations from versioned config at startup.
+# Defaults to agents.yaml in the project root. Loading is opt-in by file
+# existence. Set to another relative or absolute path to load agent/channel
+# registrations from versioned config at startup.
 # AGENTS_CONFIG_PATH=agents.yaml

--- a/README.md
+++ b/README.md
@@ -157,7 +157,7 @@ agents:
         discordGuildId: '789'
 ```
 
-Set `AGENTS_CONFIG_PATH` to load a different file. Startup upserts configured registrations through the same path as IPC `register_group`; it does not delete DB rows that are absent from the file.
+Set `AGENTS_CONFIG_PATH` to load a different file. Loading is opt-in by file existence; if the configured file does not exist, startup skips declarative topology. Startup upserts configured registrations through the same path as IPC `register_group`; it does not delete DB rows that are absent from the file. The config uses camelCase keys only. Heartbeat blocks are not accepted yet because scheduler wiring is separate runtime state.
 
 ### Layered context
 

--- a/README.md
+++ b/README.md
@@ -133,6 +133,32 @@ OmniClaw now routes channels to agents. An agent has:
 
 Multiple chats can map to the same agent, and one server can host multiple agents.
 
+### Declarative topology
+
+OmniClaw can load agent/channel registrations from `agents.yaml` at startup. SQLite remains the runtime state store for messages, sessions, task runs, and the imported routing rows; the YAML file is the versionable source for agent topology.
+
+```yaml
+agents:
+  main:
+    name: Omni
+    backend: apple-container
+    channels:
+      - jid: '123@s.whatsapp.net'
+        trigger: '@Omni'
+
+  omniclaw-discord:
+    name: OCPeyton
+    backend: docker
+    agentRuntime: opencode
+    description: Infrastructure and OmniClaw development agent
+    channels:
+      - jid: 'dc:123456'
+        trigger: '@OCPeyton'
+        discordGuildId: '789'
+```
+
+Set `AGENTS_CONFIG_PATH` to load a different file. Startup upserts configured registrations through the same path as IPC `register_group`; it does not delete DB rows that are absent from the file.
+
 ### Layered context
 
 Context is no longer just a single per-group file. OmniClaw supports layered `CLAUDE.md` context at multiple scopes:

--- a/bun.lock
+++ b/bun.lock
@@ -18,6 +18,7 @@
         "grammy": "^1.40.0",
         "qrcode-terminal": "^0.12.0",
         "telegramify-markdown": "^1.3.2",
+        "yaml": "^2.8.4",
         "zod": "^4.3.6",
       },
       "devDependencies": {
@@ -838,6 +839,8 @@
     "wrappy": ["wrappy@1.0.2", "", {}, "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ=="],
 
     "ws": ["ws@8.19.0", "", { "peerDependencies": { "bufferutil": "^4.0.1", "utf-8-validate": ">=5.0.2" }, "optionalPeers": ["bufferutil", "utf-8-validate"] }, "sha512-blAT2mjOEIi0ZzruJfIhb3nps74PRWTCz1IjglWEEpQl5XS/UNama6u2/rjFkDDouqr4L67ry+1aGIALViWjDg=="],
+
+    "yaml": ["yaml@2.8.4", "", { "bin": { "yaml": "bin.mjs" } }, "sha512-ml/JPOj9fOQK8RNnWojA67GbZ0ApXAUlN2UQclwv2eVgTgn7O9gg9o7paZWKMp4g0H3nTLtS9LVzhkpOFIKzog=="],
 
     "zod": ["zod@4.3.6", "", {}, "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg=="],
 

--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
     "grammy": "^1.40.0",
     "qrcode-terminal": "^0.12.0",
     "telegramify-markdown": "^1.3.2",
+    "yaml": "^2.8.4",
     "zod": "^4.3.6"
   },
   "devDependencies": {

--- a/src/agent-topology.test.ts
+++ b/src/agent-topology.test.ts
@@ -1,0 +1,156 @@
+import fs from 'fs';
+import os from 'os';
+import path from 'path';
+import { afterEach, describe, expect, it } from 'vitest';
+
+import {
+  applyDeclarativeAgentTopology,
+  loadDeclarativeAgentTopology,
+} from './agent-topology.js';
+import type { RegisteredGroup } from './types.js';
+
+const tempDirs: string[] = [];
+
+afterEach(() => {
+  for (const dir of tempDirs.splice(0)) {
+    fs.rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+function writeTopology(source: string): string {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'omniclaw-topology-'));
+  tempDirs.push(dir);
+  const filePath = path.join(dir, 'agents.yaml');
+  fs.writeFileSync(filePath, source);
+  return filePath;
+}
+
+describe('loadDeclarativeAgentTopology', () => {
+  it('returns no registrations when the topology file is absent', () => {
+    const filePath = path.join(os.tmpdir(), 'missing-agents.yaml');
+
+    expect(loadDeclarativeAgentTopology(filePath)).toEqual([]);
+  });
+
+  it('maps agents.yaml channels to registered groups', () => {
+    const filePath = writeTopology(`
+agents:
+  omniclaw-discord:
+    name: OCPeyton
+    backend: docker
+    agentRuntime: opencode
+    description: Infrastructure agent
+    serverFolder: servers/omniaura
+    channels:
+      - jid: "dc:123456"
+        name: omniclaw
+        trigger: "@OCPeyton"
+        requiresTrigger: true
+        discordGuildId: "789"
+        channelFolder: servers/omniaura/omniclaw
+`);
+
+    const registrations = loadDeclarativeAgentTopology(filePath);
+
+    expect(registrations).toHaveLength(1);
+    expect(registrations[0].jid).toBe('dc:123456');
+    expect(registrations[0].group).toMatchObject({
+      name: 'omniclaw',
+      folder: 'omniclaw-discord',
+      trigger: '@OCPeyton',
+      backend: 'docker',
+      agentRuntime: 'opencode',
+      description: 'Infrastructure agent',
+      discordGuildId: '789',
+      serverFolder: 'servers/omniaura',
+      channelFolder: 'servers/omniaura/omniclaw',
+    });
+    expect(registrations[0].group.added_at).toMatch(/^\d{4}-\d{2}-\d{2}T/);
+  });
+
+  it('preserves existing added_at timestamps for stable upserts', () => {
+    const filePath = writeTopology(`
+agents:
+  main:
+    channels:
+      - jid: "123@s.whatsapp.net"
+        trigger: "@Omni"
+`);
+    const existing: Record<string, RegisteredGroup> = {
+      '123@s.whatsapp.net': {
+        name: 'Old name',
+        folder: 'main',
+        trigger: '@Old',
+        added_at: '2026-01-01T00:00:00.000Z',
+      },
+    };
+
+    const registrations = loadDeclarativeAgentTopology(filePath, existing);
+
+    expect(registrations[0].group.added_at).toBe('2026-01-01T00:00:00.000Z');
+    expect(registrations[0].group.trigger).toBe('@Omni');
+  });
+
+  it('rejects unsafe folder names', () => {
+    const filePath = writeTopology(`
+agents:
+  ../main:
+    channels:
+      - jid: "123@s.whatsapp.net"
+        trigger: "@Omni"
+`);
+
+    expect(() => loadDeclarativeAgentTopology(filePath)).toThrow(
+      /Invalid key in record/,
+    );
+  });
+
+  it('rejects duplicate channel jids', () => {
+    const filePath = writeTopology(`
+agents:
+  main:
+    channels:
+      - jid: "dc:123"
+        trigger: "@Omni"
+  other:
+    channels:
+      - jid: "dc:123"
+        trigger: "@Other"
+`);
+
+    expect(() => loadDeclarativeAgentTopology(filePath)).toThrow(
+      /duplicate channel jid dc:123/,
+    );
+  });
+});
+
+describe('applyDeclarativeAgentTopology', () => {
+  it('registers each loaded topology channel', () => {
+    const filePath = writeTopology(`
+agents:
+  main:
+    name: Omni
+    channels:
+      - jid: "123@s.whatsapp.net"
+        trigger: "@Omni"
+      - jid: "dc:456"
+        trigger: "@Omni"
+`);
+    const registered: Array<{ jid: string; group: RegisteredGroup }> = [];
+
+    const count = applyDeclarativeAgentTopology({
+      filePath,
+      existingGroups: {},
+      registerGroup: (jid, group) => registered.push({ jid, group }),
+    });
+
+    expect(count).toBe(2);
+    expect(registered.map((entry) => entry.jid)).toEqual([
+      '123@s.whatsapp.net',
+      'dc:456',
+    ]);
+    expect(registered.every((entry) => entry.group.folder === 'main')).toBe(
+      true,
+    );
+  });
+});

--- a/src/agent-topology.test.ts
+++ b/src/agent-topology.test.ts
@@ -41,6 +41,14 @@ agents:
     agentRuntime: opencode
     description: Infrastructure agent
     serverFolder: servers/omniaura
+    containerConfig:
+      timeout: 300000
+      memory: 4096
+      networkMode: full
+      additionalMounts:
+        - hostPath: /tmp/project
+          containerPath: project
+          readonly: true
     channels:
       - jid: "dc:123456"
         name: omniclaw
@@ -64,6 +72,18 @@ agents:
       discordGuildId: '789',
       serverFolder: 'servers/omniaura',
       channelFolder: 'servers/omniaura/omniclaw',
+      containerConfig: {
+        timeout: 300000,
+        memory: 4096,
+        networkMode: 'full',
+        additionalMounts: [
+          {
+            hostPath: '/tmp/project',
+            containerPath: 'project',
+            readonly: true,
+          },
+        ],
+      },
     });
     expect(registrations[0].group.added_at).toMatch(/^\d{4}-\d{2}-\d{2}T/);
   });
@@ -105,6 +125,98 @@ agents:
     );
   });
 
+  it('rejects uppercase folder names', () => {
+    const filePath = writeTopology(`
+agents:
+  Main:
+    channels:
+      - jid: "123@s.whatsapp.net"
+        trigger: "@Omni"
+`);
+
+    expect(() => loadDeclarativeAgentTopology(filePath)).toThrow(
+      /Invalid key in record/,
+    );
+  });
+
+  it('rejects heartbeat blocks until scheduler wiring exists', () => {
+    const filePath = writeTopology(`
+agents:
+  main:
+    heartbeat:
+      enabled: true
+      interval: "1800000"
+    channels:
+      - jid: "123@s.whatsapp.net"
+        trigger: "@Omni"
+`);
+
+    expect(() => loadDeclarativeAgentTopology(filePath)).toThrow(
+      /Unrecognized key: "heartbeat"/,
+    );
+  });
+
+  it('rejects snake_case aliases', () => {
+    const filePath = writeTopology(`
+agents:
+  main:
+    agent_runtime: opencode
+    channels:
+      - jid: "dc:123"
+        trigger: "@Omni"
+        discord_guild_id: "456"
+`);
+
+    expect(() => loadDeclarativeAgentTopology(filePath)).toThrow(
+      /Unrecognized key/,
+    );
+  });
+
+  it('rejects unknown agent keys', () => {
+    const filePath = writeTopology(`
+agents:
+  main:
+    chanels:
+      - jid: "dc:123"
+        trigger: "@Omni"
+`);
+
+    expect(() => loadDeclarativeAgentTopology(filePath)).toThrow(
+      /Unrecognized key: "chanels"/,
+    );
+  });
+
+  it('rejects unknown containerConfig keys', () => {
+    const filePath = writeTopology(`
+agents:
+  main:
+    containerConfig:
+      memmory: 4096
+    channels:
+      - jid: "dc:123"
+        trigger: "@Omni"
+`);
+
+    expect(() => loadDeclarativeAgentTopology(filePath)).toThrow(
+      /Unrecognized key: "memmory"/,
+    );
+  });
+
+  it('prefixes YAML parse errors clearly', () => {
+    const filePath = writeTopology(`
+agents:
+  main:
+    channels:
+      - jid: "dc:123"
+        trigger: "@Omni"
+       badIndent: true
+`);
+
+    expect(() => loadDeclarativeAgentTopology(filePath)).toThrow(
+      /Invalid agent topology YAML:/,
+    );
+  });
+
   it('rejects duplicate channel jids', () => {
     const filePath = writeTopology(`
 agents:
@@ -125,6 +237,20 @@ agents:
 });
 
 describe('applyDeclarativeAgentTopology', () => {
+  it('returns 0 and does not register groups when the topology file is absent', () => {
+    const filePath = path.join(os.tmpdir(), 'missing-agents.yaml');
+    const registered: Array<{ jid: string; group: RegisteredGroup }> = [];
+
+    const count = applyDeclarativeAgentTopology({
+      filePath,
+      existingGroups: {},
+      registerGroup: (jid, group) => registered.push({ jid, group }),
+    });
+
+    expect(count).toBe(0);
+    expect(registered).toEqual([]);
+  });
+
   it('registers each loaded topology channel', () => {
     const filePath = writeTopology(`
 agents:
@@ -152,5 +278,35 @@ agents:
     expect(registered.every((entry) => entry.group.folder === 'main')).toBe(
       true,
     );
+  });
+
+  it('does not delete existing groups that are absent from topology', () => {
+    const filePath = writeTopology(`
+agents:
+  main:
+    channels:
+      - jid: "123@s.whatsapp.net"
+        trigger: "@Omni"
+`);
+    const existingGroups: Record<string, RegisteredGroup> = {
+      'stale@s.whatsapp.net': {
+        name: 'Stale',
+        folder: 'stale',
+        trigger: '@Stale',
+        added_at: '2026-01-01T00:00:00.000Z',
+      },
+    };
+    const registered: Array<{ jid: string; group: RegisteredGroup }> = [];
+
+    const count = applyDeclarativeAgentTopology({
+      filePath,
+      existingGroups,
+      registerGroup: (jid, group) => registered.push({ jid, group }),
+    });
+
+    expect(count).toBe(1);
+    expect(registered.map((entry) => entry.jid)).toEqual([
+      '123@s.whatsapp.net',
+    ]);
   });
 });

--- a/src/agent-topology.ts
+++ b/src/agent-topology.ts
@@ -1,0 +1,172 @@
+import fs from 'fs';
+import { parseDocument } from 'yaml';
+import { z } from 'zod';
+
+import { logger } from './logger.js';
+import type { BackendType, ContainerConfig, RegisteredGroup } from './types.js';
+
+const folderSchema = z
+  .string()
+  .regex(/^[a-z0-9][a-z0-9_-]*$/i, 'must be a safe folder name');
+
+const backendSchema = z.enum(['apple-container', 'docker']);
+const agentRuntimeSchema = z.enum(['claude-agent-sdk', 'opencode', 'codex']);
+const containerConfigSchema = z
+  .object({})
+  .passthrough()
+  .transform((value) => value as ContainerConfig);
+
+const channelSchema = z
+  .object({
+    jid: z.string().min(1),
+    name: z.string().min(1).optional(),
+    trigger: z.string().min(1),
+    requiresTrigger: z.boolean().optional(),
+    discordBotId: z.string().min(1).optional(),
+    discord_bot_id: z.string().min(1).optional(),
+    discordGuildId: z.string().min(1).optional(),
+    discord_guild_id: z.string().min(1).optional(),
+    serverFolder: z.string().min(1).optional(),
+    server_folder: z.string().min(1).optional(),
+    channelFolder: z.string().min(1).optional(),
+    channel_folder: z.string().min(1).optional(),
+    categoryFolder: z.string().min(1).optional(),
+    category_folder: z.string().min(1).optional(),
+    autoRespondToQuestions: z.boolean().optional(),
+    auto_respond_to_questions: z.boolean().optional(),
+    autoRespondKeywords: z.array(z.string().min(1)).optional(),
+    auto_respond_keywords: z.array(z.string().min(1)).optional(),
+  })
+  .strict();
+
+const agentSchema = z
+  .object({
+    name: z.string().min(1).optional(),
+    folder: folderSchema.optional(),
+    backend: backendSchema.optional(),
+    agentRuntime: agentRuntimeSchema.optional(),
+    agent_runtime: agentRuntimeSchema.optional(),
+    description: z.string().min(1).optional(),
+    containerConfig: containerConfigSchema.optional(),
+    container_config: containerConfigSchema.optional(),
+    serverFolder: z.string().min(1).optional(),
+    server_folder: z.string().min(1).optional(),
+    agentContextFolder: z.string().min(1).optional(),
+    agent_context_folder: z.string().min(1).optional(),
+    heartbeat: z.object({}).passthrough().optional(),
+    channels: z.array(channelSchema).min(1),
+  })
+  .strict();
+
+const topologySchema = z
+  .object({
+    agents: z.record(folderSchema, agentSchema).default({}),
+  })
+  .strict();
+
+export interface TopologyRegistration {
+  jid: string;
+  group: RegisteredGroup;
+}
+
+function formatTopologyError(error: z.ZodError): string {
+  return error.issues
+    .map((issue) => {
+      const path = issue.path.length > 0 ? issue.path.join('.') : 'agents.yaml';
+      return `${path}: ${issue.message}`;
+    })
+    .join('\n');
+}
+
+function readYamlFile(filePath: string): unknown {
+  const source = fs.readFileSync(filePath, 'utf8');
+  const document = parseDocument(source, { prettyErrors: true });
+  if (document.errors.length > 0) {
+    const details = document.errors.map((error) => error.message).join('\n');
+    throw new Error(`Invalid agent topology YAML:\n${details}`);
+  }
+  return document.toJSON();
+}
+
+export function loadDeclarativeAgentTopology(
+  filePath: string,
+  existingGroups: Record<string, RegisteredGroup> = {},
+): TopologyRegistration[] {
+  if (!fs.existsSync(filePath)) return [];
+
+  const parsed = topologySchema.safeParse(readYamlFile(filePath));
+  if (!parsed.success) {
+    throw new Error(
+      `Invalid agent topology config ${filePath}:\n${formatTopologyError(parsed.error)}`,
+    );
+  }
+
+  const registrations: TopologyRegistration[] = [];
+  const seenJids = new Set<string>();
+
+  for (const [agentId, agent] of Object.entries(parsed.data.agents)) {
+    const folder = agent.folder || agentId;
+    const agentName = agent.name || agentId;
+
+    for (const channel of agent.channels) {
+      if (seenJids.has(channel.jid)) {
+        throw new Error(
+          `Invalid agent topology config ${filePath}: duplicate channel jid ${channel.jid}`,
+        );
+      }
+      seenJids.add(channel.jid);
+
+      const existing = existingGroups[channel.jid];
+      const group: RegisteredGroup = {
+        name: channel.name || agentName,
+        folder,
+        trigger: channel.trigger,
+        added_at: existing?.added_at || new Date().toISOString(),
+        containerConfig: agent.containerConfig || agent.container_config,
+        requiresTrigger: channel.requiresTrigger,
+        discordBotId: channel.discordBotId || channel.discord_bot_id,
+        discordGuildId: channel.discordGuildId || channel.discord_guild_id,
+        serverFolder:
+          channel.serverFolder ||
+          channel.server_folder ||
+          agent.serverFolder ||
+          agent.server_folder,
+        backend: agent.backend as BackendType | undefined,
+        agentRuntime: agent.agentRuntime || agent.agent_runtime,
+        description: agent.description,
+        autoRespondToQuestions:
+          channel.autoRespondToQuestions ?? channel.auto_respond_to_questions,
+        autoRespondKeywords:
+          channel.autoRespondKeywords || channel.auto_respond_keywords,
+        channelFolder: channel.channelFolder || channel.channel_folder,
+        categoryFolder: channel.categoryFolder || channel.category_folder,
+        agentContextFolder:
+          agent.agentContextFolder || agent.agent_context_folder,
+      };
+      registrations.push({ jid: channel.jid, group });
+    }
+  }
+
+  return registrations;
+}
+
+export function applyDeclarativeAgentTopology(options: {
+  filePath: string;
+  existingGroups: Record<string, RegisteredGroup>;
+  registerGroup: (jid: string, group: RegisteredGroup) => void;
+}): number {
+  const registrations = loadDeclarativeAgentTopology(
+    options.filePath,
+    options.existingGroups,
+  );
+  for (const registration of registrations) {
+    options.registerGroup(registration.jid, registration.group);
+  }
+  if (registrations.length > 0) {
+    logger.info(
+      { filePath: options.filePath, registrationCount: registrations.length },
+      'Declarative agent topology applied',
+    );
+  }
+  return registrations.length;
+}

--- a/src/agent-topology.ts
+++ b/src/agent-topology.ts
@@ -7,13 +7,30 @@ import type { BackendType, ContainerConfig, RegisteredGroup } from './types.js';
 
 const folderSchema = z
   .string()
-  .regex(/^[a-z0-9][a-z0-9_-]*$/i, 'must be a safe folder name');
+  .regex(/^[a-z0-9][a-z0-9_-]*$/, 'must be a lowercase safe folder name');
 
 const backendSchema = z.enum(['apple-container', 'docker']);
 const agentRuntimeSchema = z.enum(['claude-agent-sdk', 'opencode', 'codex']);
+const additionalMountSchema = z
+  .object({
+    hostPath: z.string().min(1),
+    containerPath: z.string().min(1).optional(),
+    readonly: z.boolean().optional(),
+  })
+  .strict();
 const containerConfigSchema = z
-  .object({})
-  .passthrough()
+  .object({
+    additionalMounts: z.array(additionalMountSchema).optional(),
+    timeout: z.number().int().positive().optional(),
+    memory: z.number().int().positive().optional(),
+    networkMode: z.enum(['full', 'none']).optional(),
+    mcpServers: z
+      .record(z.string(), z.record(z.string(), z.unknown()))
+      .optional(),
+    allowGcpCredentials: z.boolean().optional(),
+    streamIntermediates: z.boolean().optional(),
+  })
+  .strict()
   .transform((value) => value as ContainerConfig);
 
 const channelSchema = z
@@ -23,19 +40,12 @@ const channelSchema = z
     trigger: z.string().min(1),
     requiresTrigger: z.boolean().optional(),
     discordBotId: z.string().min(1).optional(),
-    discord_bot_id: z.string().min(1).optional(),
     discordGuildId: z.string().min(1).optional(),
-    discord_guild_id: z.string().min(1).optional(),
     serverFolder: z.string().min(1).optional(),
-    server_folder: z.string().min(1).optional(),
     channelFolder: z.string().min(1).optional(),
-    channel_folder: z.string().min(1).optional(),
     categoryFolder: z.string().min(1).optional(),
-    category_folder: z.string().min(1).optional(),
     autoRespondToQuestions: z.boolean().optional(),
-    auto_respond_to_questions: z.boolean().optional(),
     autoRespondKeywords: z.array(z.string().min(1)).optional(),
-    auto_respond_keywords: z.array(z.string().min(1)).optional(),
   })
   .strict();
 
@@ -45,15 +55,10 @@ const agentSchema = z
     folder: folderSchema.optional(),
     backend: backendSchema.optional(),
     agentRuntime: agentRuntimeSchema.optional(),
-    agent_runtime: agentRuntimeSchema.optional(),
     description: z.string().min(1).optional(),
     containerConfig: containerConfigSchema.optional(),
-    container_config: containerConfigSchema.optional(),
     serverFolder: z.string().min(1).optional(),
-    server_folder: z.string().min(1).optional(),
     agentContextFolder: z.string().min(1).optional(),
-    agent_context_folder: z.string().min(1).optional(),
-    heartbeat: z.object({}).passthrough().optional(),
     channels: z.array(channelSchema).min(1),
   })
   .strict();
@@ -122,26 +127,19 @@ export function loadDeclarativeAgentTopology(
         folder,
         trigger: channel.trigger,
         added_at: existing?.added_at || new Date().toISOString(),
-        containerConfig: agent.containerConfig || agent.container_config,
+        containerConfig: agent.containerConfig,
         requiresTrigger: channel.requiresTrigger,
-        discordBotId: channel.discordBotId || channel.discord_bot_id,
-        discordGuildId: channel.discordGuildId || channel.discord_guild_id,
-        serverFolder:
-          channel.serverFolder ||
-          channel.server_folder ||
-          agent.serverFolder ||
-          agent.server_folder,
+        discordBotId: channel.discordBotId,
+        discordGuildId: channel.discordGuildId,
+        serverFolder: channel.serverFolder || agent.serverFolder,
         backend: agent.backend as BackendType | undefined,
-        agentRuntime: agent.agentRuntime || agent.agent_runtime,
+        agentRuntime: agent.agentRuntime,
         description: agent.description,
-        autoRespondToQuestions:
-          channel.autoRespondToQuestions ?? channel.auto_respond_to_questions,
-        autoRespondKeywords:
-          channel.autoRespondKeywords || channel.auto_respond_keywords,
-        channelFolder: channel.channelFolder || channel.channel_folder,
-        categoryFolder: channel.categoryFolder || channel.category_folder,
-        agentContextFolder:
-          agent.agentContextFolder || agent.agent_context_folder,
+        autoRespondToQuestions: channel.autoRespondToQuestions,
+        autoRespondKeywords: channel.autoRespondKeywords,
+        channelFolder: channel.channelFolder,
+        categoryFolder: channel.categoryFolder,
+        agentContextFolder: agent.agentContextFolder,
       };
       registrations.push({ jid: channel.jid, group });
     }
@@ -159,6 +157,16 @@ export function applyDeclarativeAgentTopology(options: {
     options.filePath,
     options.existingGroups,
   );
+  const configuredJids = new Set(registrations.map((entry) => entry.jid));
+  const staleJids = Object.keys(options.existingGroups).filter(
+    (jid) => !configuredJids.has(jid),
+  );
+  if (registrations.length > 0 && staleJids.length > 0) {
+    logger.warn(
+      { filePath: options.filePath, staleJids },
+      'Existing registered groups are absent from declarative topology',
+    );
+  }
   for (const registration of registrations) {
     options.registerGroup(registration.jid, registration.group);
   }

--- a/src/config.ts
+++ b/src/config.ts
@@ -161,6 +161,10 @@ const configSchema = z
       optionalTrimmedString,
       z.string().optional(),
     ),
+    AGENTS_CONFIG_PATH: z.preprocess(
+      optionalTrimmedString,
+      z.string().default('agents.yaml'),
+    ),
   })
   .passthrough();
 
@@ -343,6 +347,10 @@ export const STORE_DIR = path.resolve(PROJECT_ROOT, 'store');
 export const GROUPS_DIR = path.resolve(PROJECT_ROOT, 'groups');
 export const DATA_DIR = path.resolve(PROJECT_ROOT, 'data');
 export const MAIN_GROUP_FOLDER = 'main';
+export const AGENTS_CONFIG_PATH = path.resolve(
+  PROJECT_ROOT,
+  CONFIG.AGENTS_CONFIG_PATH,
+);
 
 export const LOCAL_RUNTIME = CONFIG.LOCAL_RUNTIME;
 export const STARTUP_CONFIRMATIONS = CONFIG.STARTUP_CONFIRMATIONS;

--- a/src/index.ts
+++ b/src/index.ts
@@ -2,6 +2,7 @@ import { createHash, randomUUID } from 'crypto';
 import { Effect } from 'effect';
 import fs from 'fs';
 import path from 'path';
+import { applyDeclarativeAgentTopology } from './agent-topology.js';
 import { syncAvatars } from './avatar-sync.js';
 import {
   initializeBackends,
@@ -18,6 +19,7 @@ import { SlackChannel } from './channels/slack.js';
 import { TelegramChannel } from './channels/telegram.js';
 import { WhatsAppChannel } from './channels/whatsapp.js';
 import {
+  AGENTS_CONFIG_PATH,
   buildTriggerPattern,
   CHANNEL_ROSTER_CACHE_TTL_MS,
   CHANNEL_ROSTER_ROLE_FILTERS,
@@ -2503,6 +2505,11 @@ async function main(): Promise<void> {
   initDatabase();
   logger.info('Database initialized');
   loadState();
+  applyDeclarativeAgentTopology({
+    filePath: AGENTS_CONFIG_PATH,
+    existingGroups: registeredGroups,
+    registerGroup,
+  });
   sanitizePersistedTelegramAvatarUrls();
 
   const webState: WebStateProvider = {


### PR DESCRIPTION
## Summary

- Add `agents.yaml` topology loading at startup, controlled by `AGENTS_CONFIG_PATH`.
- Validate declarative agent/channel registrations with Zod and upsert them through the existing `registerGroup` path.
- Document the config format and add parser/application tests.

## Tests

- `bun test src/agent-topology.test.ts`
- `bun run typecheck`
- `bun test`

Fixes #57


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added support for declarative agent topology via `agents.yaml` configuration file
  * Added `AGENTS_CONFIG_PATH` environment variable to specify custom topology file location (defaults to `agents.yaml`)

* **Documentation**
  * Added declarative topology documentation to README with sample configuration structure
  * Updated `.env.example` with new configuration settings

* **Tests**
  * Added comprehensive test coverage for agent topology loading and application

<!-- end of auto-generated comment: release notes by coderabbit.ai -->