### PR TITLE
fix(setup): allow codex channel registration

### DIFF
--- a/.agents/skills/setup/guides/advanced-setup.md
+++ b/.agents/skills/setup/guides/advanced-setup.md
@@ -84,7 +84,7 @@ DISCORD_BOT_<BOT_ID>_TOKEN=<token>
 DISCORD_BOT_DEFAULT=<BOT_ID>
 ```
 
-Optionally: `DISCORD_BOT_<BOT_ID>_RUNTIME=opencode`
+Optionally: `DISCORD_BOT_<BOT_ID>_RUNTIME=opencode` or `DISCORD_BOT_<BOT_ID>_RUNTIME=codex`
 
 **Never remove an existing `DISCORD_BOT_TOKEN` unless user explicitly asks.**
 
@@ -99,7 +99,7 @@ JID format: `dc:<channel_id>`. Ask user to right-click the channel → Copy Chan
   --trigger "@<TRIGGER>" \
   --folder "<FOLDER_NAME>" \
   --discord-bot-id "<BOT_ID>" \
-  --agent-runtime "<claude-agent-sdk|opencode>" \
+  --agent-runtime "<claude-agent-sdk|opencode|codex>" \
   --assistant-name "<AssistantName>"
 ```
 

--- a/.agents/skills/setup/guides/agents-and-context.md
+++ b/.agents/skills/setup/guides/agents-and-context.md
@@ -116,12 +116,14 @@ You are **<AgentName>** (@<Trigger>), <role description>.
 `DISCORD_BOT_IDS` in `.env` uses **your own human-readable keys** (e.g. `PRIMARY`, `OCPEYTON`). These are NOT Discord's numeric snowflake IDs.
 
 ```dotenv
-DISCORD_BOT_IDS=PRIMARY,OCPEYTON
+DISCORD_BOT_IDS=PRIMARY,OCPEYTON,CODEX
 DISCORD_BOT_PRIMARY_TOKEN=<token>
 DISCORD_BOT_OCPEYTON_TOKEN=<token>
+DISCORD_BOT_CODEX_TOKEN=<token>
 DISCORD_BOT_DEFAULT=PRIMARY
 # Optional per-bot runtime override:
 DISCORD_BOT_OCPEYTON_RUNTIME=opencode
+DISCORD_BOT_CODEX_RUNTIME=codex
 ```
 
 The `discord_bot_id` column in `channel_subscriptions` must match one of these keys exactly. Mismatch = messages never reach the agent.
@@ -331,7 +333,7 @@ The `registered_groups.folder` column has a UNIQUE constraint, so you **cannot**
      --trigger "@<Trigger>" \
      --folder "<agent-folder>" \
      --discord-bot-id "<NEW_KEY>" \
-     --agent-runtime "claude-agent-sdk"
+     --agent-runtime "claude-agent-sdk|opencode|codex"
    ```
 
    This creates the `agents` row and `channel_subscriptions` row.

--- a/.agents/skills/setup/scripts/06-register-channel.sh
+++ b/.agents/skills/setup/scripts/06-register-channel.sh
@@ -76,7 +76,7 @@ if [ "$HAS_AGENTS_TABLE" = "1" ] && [ "$HAS_ROUTES_TABLE" = "1" ]; then
   [ -z "$BACKEND" ] && BACKEND="apple-container"
 
   case "$AGENT_RUNTIME" in
-    claude-agent-sdk|opencode) ;;
+    claude-agent-sdk|opencode|codex) ;;
     "") AGENT_RUNTIME="claude-agent-sdk" ;;
     *) AGENT_RUNTIME="claude-agent-sdk" ;;
   esac


### PR DESCRIPTION
## Summary

- Allow `06-register-channel.sh` to preserve `--agent-runtime codex` instead of falling back to `claude-agent-sdk`.
- Update setup docs to list `codex` as a supported Discord bot/channel runtime.

## Validation

- `bash -n .agents/skills/setup/scripts/06-register-channel.sh`
- `bun test src/config.test.ts src/db.test.ts`
