### PR TITLE
fix: harden multi-bot startup after shared vm merge

### DIFF
--- a/container/.dockerignore
+++ b/container/.dockerignore
@@ -2,7 +2,9 @@
 !Dockerfile
 !Dockerfile.base
 !agent-browser-wrapper.sh
+!agent-exec.sh
 !entrypoint.sh
 !exec-shim.sh
+!shared-entrypoint.sh
 !agent-runner/
 !agent-runner/**

--- a/docs/SPEC.md
+++ b/docs/SPEC.md
@@ -233,22 +233,23 @@ Configuration constants are in `src/config.ts`. All values can be overridden via
 
 ### Channel Credentials
 
-| Variable                   | Required For | Purpose                                                                      |
-| -------------------------- | ------------ | ---------------------------------------------------------------------------- |
-| `DISCORD_BOT_TOKEN`        | Discord      | Single bot token (backward compatible)                                       |
-| `DISCORD_BOT_IDS`          | Discord      | Ordered bot IDs for prefixed multi-bot config (e.g. `CLAUDE,OPENCODE`)       |
-| `DISCORD_BOT_<ID>_TOKEN`   | Discord      | Token for a specific Discord bot ID                                          |
-| `DISCORD_BOT_<ID>_RUNTIME` | Discord      | Default runtime for that bot ID (`claude-agent-sdk`, `opencode`, or `codex`) |
-| `DISCORD_BOT_DEFAULT`      | Discord      | Default bot ID for unassigned Discord channels                               |
-| `TELEGRAM_BOT_TOKENS`      | Telegram     | Comma/newline-separated bot tokens for multi-bot mode                        |
-| `TELEGRAM_BOT_TOKEN`       | Telegram     | Legacy single bot token (backward compatible)                                |
-| `TELEGRAM_ONLY`            | Telegram     | Run Telegram-only mode (no WhatsApp)                                         |
-| `SLACK_BOT_IDS`            | Slack        | Ordered bot IDs for prefixed multi-bot config (e.g. `OPS,SUPPORT`)           |
-| `SLACK_BOT_<ID>_TOKEN`     | Slack        | Bot token (xoxb-...) for a specific Slack bot ID                             |
-| `SLACK_BOT_<ID>_APP_TOKEN` | Slack        | App token (xapp-...) for a specific Slack bot ID                             |
-| `SLACK_BOT_DEFAULT`        | Slack        | Default Slack bot ID for legacy/unscoped Slack routes in multi-bot mode      |
-| `SLACK_BOT_TOKEN`          | Slack        | Bot token (xoxb-...)                                                         |
-| `SLACK_APP_TOKEN`          | Slack        | Legacy app token for single-bot Socket Mode                                  |
+| Variable                              | Required For | Purpose                                                                      |
+| ------------------------------------- | ------------ | ---------------------------------------------------------------------------- |
+| `DISCORD_BOT_TOKEN`                   | Discord      | Single bot token (backward compatible)                                       |
+| `DISCORD_BOT_IDS`                     | Discord      | Ordered bot IDs for prefixed multi-bot config (e.g. `CLAUDE,OPENCODE`)       |
+| `DISCORD_BOT_<ID>_TOKEN`              | Discord      | Token for a specific Discord bot ID                                          |
+| `DISCORD_BOT_<ID>_RUNTIME`            | Discord      | Default runtime for that bot ID (`claude-agent-sdk`, `opencode`, or `codex`) |
+| `DISCORD_BOT_<ID>_PRIVILEGED_INTENTS` | Discord      | Set to `false` for bot apps without Discord privileged gateway intents       |
+| `DISCORD_BOT_DEFAULT`                 | Discord      | Default bot ID for unassigned Discord channels                               |
+| `TELEGRAM_BOT_TOKENS`                 | Telegram     | Comma/newline-separated bot tokens for multi-bot mode                        |
+| `TELEGRAM_BOT_TOKEN`                  | Telegram     | Legacy single bot token (backward compatible)                                |
+| `TELEGRAM_ONLY`                       | Telegram     | Run Telegram-only mode (no WhatsApp)                                         |
+| `SLACK_BOT_IDS`                       | Slack        | Ordered bot IDs for prefixed multi-bot config (e.g. `OPS,SUPPORT`)           |
+| `SLACK_BOT_<ID>_TOKEN`                | Slack        | Bot token (xoxb-...) for a specific Slack bot ID                             |
+| `SLACK_BOT_<ID>_APP_TOKEN`            | Slack        | App token (xapp-...) for a specific Slack bot ID                             |
+| `SLACK_BOT_DEFAULT`                   | Slack        | Default Slack bot ID for legacy/unscoped Slack routes in multi-bot mode      |
+| `SLACK_BOT_TOKEN`                     | Slack        | Bot token (xoxb-...)                                                         |
+| `SLACK_APP_TOKEN`                     | Slack        | Legacy app token for single-bot Socket Mode                                  |
 
 Discord multi-bot examples:
 

--- a/src/channels/discord.ts
+++ b/src/channels/discord.ts
@@ -192,6 +192,7 @@ export interface SessionCommandResult {
 export interface DiscordChannelOpts {
   botId: string;
   token: string;
+  privilegedIntents?: boolean;
   multiBotMode?: boolean;
   onSyntheticMessage?: (message: NewMessage) => void | Promise<void>;
   registeredGroups?: () => Record<string, RegisteredGroup>;
@@ -222,15 +223,20 @@ export class DiscordChannel implements Channel {
   constructor(opts: DiscordChannelOpts) {
     this.opts = opts;
     this.botId = opts.botId;
-    this.client = new Client({
-      intents: [
-        GatewayIntentBits.Guilds,
-        GatewayIntentBits.GuildMessages,
+    const intents = [
+      GatewayIntentBits.Guilds,
+      GatewayIntentBits.GuildMessages,
+      GatewayIntentBits.DirectMessages,
+      GatewayIntentBits.GuildMessageReactions,
+    ];
+    if (opts.privilegedIntents !== false) {
+      intents.push(
         GatewayIntentBits.MessageContent,
-        GatewayIntentBits.DirectMessages,
-        GatewayIntentBits.GuildMessageReactions,
         GatewayIntentBits.GuildMembers,
-      ],
+      );
+    }
+    this.client = new Client({
+      intents,
       partials: [Partials.Channel, Partials.Message, Partials.Reaction],
     });
   }

--- a/src/config.test.ts
+++ b/src/config.test.ts
@@ -107,8 +107,18 @@ describe('buildDiscordBotConfigFromEnv', () => {
     });
 
     expect(parsed.bots).toEqual([
-      { id: 'CLAUDE', token: 'token-a', runtime: undefined },
-      { id: 'OPENCODE', token: 'token-b', runtime: 'opencode' },
+      {
+        id: 'CLAUDE',
+        token: 'token-a',
+        runtime: undefined,
+        privilegedIntents: true,
+      },
+      {
+        id: 'OPENCODE',
+        token: 'token-b',
+        runtime: 'opencode',
+        privilegedIntents: true,
+      },
     ]);
     expect(parsed.defaultBotId).toBe('OPENCODE');
   });
@@ -131,7 +141,29 @@ describe('buildDiscordBotConfigFromEnv', () => {
     });
 
     expect(parsed.bots).toEqual([
-      { id: 'CODEX', token: 'token-codex', runtime: 'codex' },
+      {
+        id: 'CODEX',
+        token: 'token-codex',
+        runtime: 'codex',
+        privilegedIntents: true,
+      },
+    ]);
+  });
+
+  it('allows a Discord bot to disable privileged intents', () => {
+    const parsed = buildDiscordBotConfigFromEnv({
+      DISCORD_BOT_IDS: 'CODEX',
+      DISCORD_BOT_CODEX_TOKEN: 'token-codex',
+      DISCORD_BOT_CODEX_PRIVILEGED_INTENTS: 'false',
+    });
+
+    expect(parsed.bots).toEqual([
+      {
+        id: 'CODEX',
+        token: 'token-codex',
+        runtime: undefined,
+        privilegedIntents: false,
+      },
     ]);
   });
 
@@ -141,7 +173,12 @@ describe('buildDiscordBotConfigFromEnv', () => {
     });
 
     expect(parsed.bots).toEqual([
-      { id: 'PRIMARY', token: 'legacy-token', runtime: undefined },
+      {
+        id: 'PRIMARY',
+        token: 'legacy-token',
+        runtime: undefined,
+        privilegedIntents: true,
+      },
     ]);
     expect(parsed.defaultBotId).toBe('PRIMARY');
   });

--- a/src/config.ts
+++ b/src/config.ts
@@ -8,6 +8,7 @@ export interface DiscordBotConfig {
   id: string;
   token: string;
   runtime?: AgentRuntime;
+  privilegedIntents: boolean;
 }
 
 export interface SlackBotConfig {
@@ -197,6 +198,16 @@ function parseAgentRuntime(
   return undefined;
 }
 
+function parseOptionalBooleanEnv(
+  value: string | undefined,
+): boolean | undefined {
+  if (value === undefined || value.trim() === '') return undefined;
+  const normalized = value.trim().toLowerCase();
+  if (['1', 'true', 'yes', 'on'].includes(normalized)) return true;
+  if (['0', 'false', 'no', 'off'].includes(normalized)) return false;
+  return undefined;
+}
+
 function sanitizeBotId(raw: string): string {
   return raw
     .trim()
@@ -229,7 +240,20 @@ export function buildDiscordBotConfigFromEnv(env: NodeJS.ProcessEnv): {
           `Invalid OmniClaw configuration:\nDISCORD_BOT_${id}_RUNTIME: expected one of ${AGENT_RUNTIME_VALUES.join(', ')}`,
         );
       }
-      bots.push({ id, token, runtime });
+      const privilegedIntentsValue =
+        env[`DISCORD_BOT_${id}_PRIVILEGED_INTENTS`]?.trim();
+      const privilegedIntents = parseOptionalBooleanEnv(privilegedIntentsValue);
+      if (privilegedIntentsValue && privilegedIntents === undefined) {
+        throw new Error(
+          `Invalid OmniClaw configuration:\nDISCORD_BOT_${id}_PRIVILEGED_INTENTS: expected boolean`,
+        );
+      }
+      bots.push({
+        id,
+        token,
+        runtime,
+        privilegedIntents: privilegedIntents ?? true,
+      });
     }
     const preferredDefault = sanitizeBotId(env.DISCORD_BOT_DEFAULT || '');
     const defaultBotId = bots.some((b) => b.id === preferredDefault)
@@ -240,7 +264,14 @@ export function buildDiscordBotConfigFromEnv(env: NodeJS.ProcessEnv): {
 
   const token = (env.DISCORD_BOT_TOKEN || '').trim();
   const bots = token
-    ? [{ id: 'PRIMARY', token, runtime: undefined as AgentRuntime | undefined }]
+    ? [
+        {
+          id: 'PRIMARY',
+          token,
+          runtime: undefined as AgentRuntime | undefined,
+          privilegedIntents: true,
+        },
+      ]
     : [];
   return {
     bots,

--- a/src/index.ts
+++ b/src/index.ts
@@ -473,6 +473,14 @@ function getDiscordRuntimeDefault(botId?: string): AgentRuntime | undefined {
   return DISCORD_BOTS.find((b) => b.id === botId)?.runtime;
 }
 
+function getErrorCauseMessage(err: unknown): string | undefined {
+  if (!err || typeof err !== 'object' || !('cause' in err)) return undefined;
+  const cause = (err as { cause?: unknown }).cause;
+  if (cause == null) return undefined;
+  if (cause instanceof Error) return cause.message;
+  return String(cause);
+}
+
 function getDiscordBotIdForJid(jid: string): string | undefined {
   if (!jid.startsWith('dc:')) return undefined;
   const primarySub = (channelSubscriptions[jid] || []).find((s) => s.isPrimary);
@@ -2991,6 +2999,7 @@ async function main(): Promise<void> {
                 logger.error(
                   {
                     err,
+                    errCause: getErrorCauseMessage(err),
                     index: idx + 1,
                     total: DISCORD_BOTS.length,
                     botId: bot.id,
@@ -3000,7 +3009,7 @@ async function main(): Promise<void> {
                 return Effect.succeed(null);
               }),
             ),
-          { concurrency: 'unbounded' },
+          { concurrency: 1 },
         ).pipe(
           Effect.map((connected) =>
             connected.filter((ch): ch is DiscordChannel => ch !== null),

--- a/src/index.ts
+++ b/src/index.ts
@@ -2976,6 +2976,7 @@ async function main(): Promise<void> {
               const discord = new DiscordChannel({
                 botId: bot.id,
                 token: bot.token,
+                privilegedIntents: bot.privilegedIntents,
                 multiBotMode: DISCORD_BOTS.length > 1,
                 onSyntheticMessage: (message) => storeAndBroadcast(message),
                 registeredGroups: () => registeredGroups,


### PR DESCRIPTION
## Summary

- include the new shared VM entrypoint scripts in the container build context
- connect Discord bots sequentially instead of unbounded parallel login
- log the underlying Effect `tryPromise` cause for Discord login failures

## Why

After pulling the shared VM merge on the Mac mini, `container/build.sh` failed because `.dockerignore` excluded `agent-exec.sh` and `shared-entrypoint.sh`.

After adding Cody/Dex as separate Discord bot identities, unbounded Discord startup dropped all four bot logins at once. Sequential startup brought PRIMARY, OCPEYTON, and DEX back online. CODY still needs privileged gateway intents enabled in Discord Developer Portal; the improved log now surfaces that as `Used disallowed intents`.

## Validation

- `bun run build`
- `bun test src/config.test.ts src/db.test.ts`
- verified on Mac mini:
  - container image rebuild succeeds
  - Web UI returns `HTTP/1.1 200 OK`
  - launchd service is running
  - PRIMARY, OCPEYTON, and DEX Discord bots connect
