### PR TITLE
test(backends): cover shared VM manager lifecycle

### DIFF
--- a/src/backends/shared-vm.test.ts
+++ b/src/backends/shared-vm.test.ts
@@ -1,4 +1,12 @@
-import { afterEach, beforeEach, describe, expect, it, mock, spyOn } from 'bun:test';
+import {
+  afterEach,
+  beforeEach,
+  describe,
+  expect,
+  it,
+  mock,
+  spyOn,
+} from 'bun:test';
 import fs from 'fs';
 import os from 'os';
 import path from 'path';

--- a/src/backends/shared-vm.test.ts
+++ b/src/backends/shared-vm.test.ts
@@ -1,4 +1,7 @@
-import { afterEach, describe, expect, it, mock, spyOn } from 'bun:test';
+import { afterEach, beforeEach, describe, expect, it, mock, spyOn } from 'bun:test';
+import fs from 'fs';
+import os from 'os';
+import path from 'path';
 
 import { LOCAL_RUNTIME, SHARED_CLAUDE_VM_MEMORY } from '../config.js';
 import { SharedVmManager } from './shared-vm.js';
@@ -25,8 +28,22 @@ function makeProcess(
 }
 
 describe('SharedVmManager', () => {
+  const originalExtraDir = process.env.OMNICLAW_EXTRA_DIR;
+  let extraDir = '';
+
+  beforeEach(() => {
+    extraDir = fs.mkdtempSync(path.join(os.tmpdir(), 'omniclaw-extra-'));
+    process.env.OMNICLAW_EXTRA_DIR = extraDir;
+  });
+
   afterEach(() => {
     mock.restore();
+    if (originalExtraDir === undefined) {
+      delete process.env.OMNICLAW_EXTRA_DIR;
+    } else {
+      process.env.OMNICLAW_EXTRA_DIR = originalExtraDir;
+    }
+    fs.rmSync(extraDir, { recursive: true, force: true });
   });
 
   it('returns an existing live container without spawning a new one', async () => {

--- a/src/backends/shared-vm.test.ts
+++ b/src/backends/shared-vm.test.ts
@@ -1,0 +1,125 @@
+import { afterEach, describe, expect, it, mock, spyOn } from 'bun:test';
+
+import { LOCAL_RUNTIME, SHARED_CLAUDE_VM_MEMORY } from '../config.js';
+import { SharedVmManager } from './shared-vm.js';
+
+function makeProcess(
+  exitCode: number,
+  stderr = '',
+): ReturnType<typeof Bun.spawn> {
+  return {
+    stderr: new ReadableStream<Uint8Array>({
+      start(controller) {
+        if (stderr) controller.enqueue(new TextEncoder().encode(stderr));
+        controller.close();
+      },
+    }),
+    stdout: new ReadableStream<Uint8Array>({
+      start(controller) {
+        controller.close();
+      },
+    }),
+    exited: Promise.resolve(exitCode),
+    kill: mock(() => {}),
+  } as unknown as ReturnType<typeof Bun.spawn>;
+}
+
+describe('SharedVmManager', () => {
+  afterEach(() => {
+    mock.restore();
+  });
+
+  it('returns an existing live container without spawning a new one', async () => {
+    const manager = new SharedVmManager();
+    (manager as any).containerName = 'omniclaw-shared-claude-existing';
+    (manager as any).isAlive = mock(async () => true);
+    const spawnSpy = spyOn(Bun, 'spawn');
+
+    await expect(manager.ensureRunning()).resolves.toBe(
+      'omniclaw-shared-claude-existing',
+    );
+    expect((manager as any).isAlive).toHaveBeenCalledWith(
+      'omniclaw-shared-claude-existing',
+    );
+    expect(spawnSpy).not.toHaveBeenCalled();
+  });
+
+  it('deduplicates concurrent starts and uses deterministic container args', async () => {
+    const manager = new SharedVmManager();
+    const nowSpy = spyOn(Date, 'now').mockReturnValue(1234567890);
+    const spawnSpy = spyOn(Bun, 'spawn').mockImplementation((() =>
+      makeProcess(0)) as unknown as typeof Bun.spawn);
+
+    try {
+      const [first, second] = await Promise.all([
+        manager.ensureRunning(),
+        manager.ensureRunning(),
+      ]);
+
+      expect(first).toBe('omniclaw-shared-claude-1234567890');
+      expect(second).toBe(first);
+      expect(manager.getName()).toBe(first);
+      expect(spawnSpy).toHaveBeenCalledTimes(1);
+      expect(spawnSpy.mock.calls[0]?.[0]).toEqual(
+        expect.arrayContaining([
+          LOCAL_RUNTIME,
+          'run',
+          '-d',
+          '--memory',
+          SHARED_CLAUDE_VM_MEMORY,
+          '--name',
+          first,
+          '--entrypoint',
+          '/app/shared-entrypoint.sh',
+        ]),
+      );
+    } finally {
+      nowSpy.mockRestore();
+    }
+  });
+
+  it('clears failed startup state so a later ensureRunning can retry', async () => {
+    const manager = new SharedVmManager();
+    const nowSpy = spyOn(Date, 'now').mockReturnValue(222);
+    const spawnSpy = spyOn(Bun, 'spawn')
+      .mockImplementationOnce((() =>
+        makeProcess(
+          2,
+          'container runtime failed',
+        )) as unknown as typeof Bun.spawn)
+      .mockImplementationOnce((() =>
+        makeProcess(0)) as unknown as typeof Bun.spawn);
+
+    try {
+      await expect(manager.ensureRunning()).rejects.toThrow(
+        'container runtime failed',
+      );
+      await expect(manager.ensureRunning()).resolves.toBe(
+        'omniclaw-shared-claude-222',
+      );
+      expect(spawnSpy).toHaveBeenCalledTimes(2);
+      expect(manager.getName()).toBe('omniclaw-shared-claude-222');
+    } finally {
+      nowSpy.mockRestore();
+    }
+  });
+
+  it('stops the current container once and clears its name before awaiting exit', async () => {
+    const manager = new SharedVmManager();
+    (manager as any).containerName = 'omniclaw-shared-claude-stop-me';
+    const spawnSpy = spyOn(Bun, 'spawn').mockImplementation((() => {
+      expect(manager.getName()).toBeNull();
+      return makeProcess(0);
+    }) as unknown as typeof Bun.spawn);
+
+    await expect(manager.stop()).resolves.toBeUndefined();
+    await expect(manager.stop()).resolves.toBeUndefined();
+
+    expect(spawnSpy).toHaveBeenCalledTimes(1);
+    expect(spawnSpy.mock.calls[0]?.[0]).toEqual([
+      LOCAL_RUNTIME,
+      'stop',
+      'omniclaw-shared-claude-stop-me',
+    ]);
+  });
+});

--- a/src/backends/shared-vm.ts
+++ b/src/backends/shared-vm.ts
@@ -19,7 +19,9 @@ import {
 import { logger } from '../logger.js';
 
 const SHARED_VM_PREFIX = 'omniclaw-shared-claude';
-const EXTRA_DIR = process.env.OMNICLAW_EXTRA_DIR || '/workspace/extra';
+function getExtraDir(): string {
+  return process.env.OMNICLAW_EXTRA_DIR || '/workspace/extra';
+}
 
 export class SharedVmManager {
   private containerName: string | null = null;
@@ -102,13 +104,14 @@ export class SharedVmManager {
   private async start(): Promise<string> {
     const name = `${SHARED_VM_PREFIX}-${Date.now()}`;
     const projectRoot = process.cwd();
+    const extraDir = getExtraDir();
 
     // Ensure parent dirs exist
     fs.mkdirSync(GROUPS_DIR, { recursive: true });
     fs.mkdirSync(path.join(DATA_DIR, 'ipc'), { recursive: true });
     fs.mkdirSync(path.join(DATA_DIR, 'sessions'), { recursive: true });
     fs.mkdirSync(path.join(DATA_DIR, 'env'), { recursive: true });
-    fs.mkdirSync(EXTRA_DIR, { recursive: true });
+    fs.mkdirSync(extraDir, { recursive: true });
 
     const args: string[] = [
       'run',
@@ -129,7 +132,7 @@ export class SharedVmManager {
       '-v',
       `${projectRoot}:/workspace/project:ro`,
       '-v',
-      `${EXTRA_DIR}:/workspace/extra:ro`,
+      `${extraDir}:/workspace/extra:ro`,
       // Agent runner source (shared, read-only)
       '--mount',
       `type=bind,source=${path.join(projectRoot, 'container', 'agent-runner', 'src')},target=/app/src,readonly`,


### PR DESCRIPTION
## Summary

- Adds deterministic tests for `SharedVmManager` lifecycle behavior without invoking the real container runtime.
- Covers live-container reuse, concurrent startup deduplication, failed-start retry cleanup, and stop idempotency.

## Test Count

- Baseline clean tracked suite: 996 passing tests across 48 files.
- After this PR: 1000 passing tests across 49 files.

## Verification

- `bun test src/backends/shared-vm.test.ts`
- `bun test $(git ls-files 'src/**/*.test.ts') src/backends/shared-vm.test.ts`
- `bun run typecheck`

## Notes

- `bun test` against the raw worktree is currently polluted by pre-existing untracked test files in `/workspace/group/omniclaw-repo` and reports unrelated failures. The committed/tracked test suite plus this new test file passes cleanly.

## Remaining Coverage Gaps

- Barrel/type-only modules remain without meaningful direct runtime tests: `src/discovery/types.ts`, `src/web/types.ts`.
- Existing untracked local tests in the shared worktree target `src/discovery/index.ts`, `src/simtest/index.ts`, and `src/web/index.ts`; they were intentionally left untouched.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * The extra workspace mount location is now configurable via OMNICLAW_EXTRA_DIR (defaults to /workspace/extra) and is bind-mounted read-only into the shared VM; the mount parent is created at startup.

* **Tests**
  * Added comprehensive tests for shared VM lifecycle: startup/retention when already running, concurrent startup deduplication, startup failure recovery, and shutdown behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->