### PR TITLE
fix: sync Discord slash commands for every bot

### DIFF
--- a/src/channels/discord.ts
+++ b/src/channels/discord.ts
@@ -194,6 +194,7 @@ export interface DiscordChannelOpts {
   token: string;
   privilegedIntents?: boolean;
   multiBotMode?: boolean;
+  slashCommandGroups?: () => RegisteredGroup[];
   onSyntheticMessage?: (message: NewMessage) => void | Promise<void>;
   registeredGroups?: () => Record<string, RegisteredGroup>;
   onReaction?: (
@@ -443,12 +444,15 @@ export class DiscordChannel implements Channel {
 
   async refreshSlashCommands(): Promise<void> {
     if (!this.connected) return;
-    const groups = this.opts.registeredGroups
-      ? Object.values(this.opts.registeredGroups()).filter(
-          (group) =>
-            group.discordBotId === this.botId && !!group.discordGuildId,
-        )
-      : [];
+    const groups = (
+      this.opts.slashCommandGroups
+        ? this.opts.slashCommandGroups()
+        : this.opts.registeredGroups
+          ? Object.values(this.opts.registeredGroups())
+          : []
+    ).filter(
+      (group) => group.discordBotId === this.botId && !!group.discordGuildId,
+    );
 
     const guildGroups = new Map<string, RegisteredGroup[]>();
     for (const group of groups) {

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -1,7 +1,13 @@
 import { beforeEach, describe, expect, it } from 'bun:test';
 
-import { _initTestDatabase, storeChatMetadata } from './db.js';
 import {
+  _initTestDatabase,
+  setChannelSubscription,
+  storeChatMetadata,
+} from './db.js';
+import {
+  _getSlashCommandGroupsFromSubscriptions,
+  _markChannelSubscriptionsDirty,
   _setChannelSubscriptions,
   _setRegisteredGroups,
   getAvailableGroups,
@@ -137,5 +143,43 @@ describe('getAvailableGroups', () => {
     );
 
     expect(getAvailableGroups()).toEqual([]);
+  });
+});
+
+describe('slash command subscription groups', () => {
+  beforeEach(() => {
+    _initTestDatabase();
+    _setRegisteredGroups({});
+    _setChannelSubscriptions({});
+  });
+
+  it('refreshes dirty channel subscriptions before building slash command groups', () => {
+    _setRegisteredGroups({
+      'dc:guild-1:channel-1': {
+        ...BASE_GROUP,
+        name: 'Discord Fallback',
+        folder: 'agent-one',
+        discordBotId: 'bot-a',
+        discordGuildId: 'guild-1',
+      },
+    });
+    setChannelSubscription({
+      ...BASE_SUBSCRIPTION,
+      channelJid: 'dc:guild-1:channel-1',
+      agentId: 'agent-one',
+      trigger: '@Cody',
+      discordBotId: 'bot-a',
+      discordGuildId: 'guild-1',
+    });
+    _markChannelSubscriptionsDirty();
+
+    expect(_getSlashCommandGroupsFromSubscriptions()).toEqual([
+      expect.objectContaining({
+        folder: 'agent-one',
+        trigger: '@Cody',
+        discordBotId: 'bot-a',
+        discordGuildId: 'guild-1',
+      }),
+    ]);
   });
 });

--- a/src/index.ts
+++ b/src/index.ts
@@ -2987,6 +2987,17 @@ async function main(): Promise<void> {
                 multiBotMode: DISCORD_BOTS.length > 1,
                 onSyntheticMessage: (message) => storeAndBroadcast(message),
                 registeredGroups: () => registeredGroups,
+                slashCommandGroups: () =>
+                  Object.entries(channelSubscriptions).flatMap(
+                    ([channelJid, subs]) =>
+                      subs.flatMap((sub) => {
+                        const group = buildRegisteredGroupFromSubscription(
+                          channelJid,
+                          sub,
+                        );
+                        return group ? [group] : [];
+                      }),
+                  ),
                 onSessionCommand: (command, chatJid, group, sessionId) =>
                   handleSessionCommand(command, chatJid, group, sessionId),
                 onReaction: async (chatJid, messageId, emoji, userName) => {

--- a/src/index.ts
+++ b/src/index.ts
@@ -717,6 +717,16 @@ function refreshChannelSubscriptions(): void {
   channelSubscriptionsDirty = false;
 }
 
+function buildSlashCommandGroupsFromSubscriptions(): RegisteredGroup[] {
+  refreshChannelSubscriptions();
+  return Object.entries(channelSubscriptions).flatMap(([channelJid, subs]) =>
+    subs.flatMap((sub) => {
+      const group = buildRegisteredGroupFromSubscription(channelJid, sub);
+      return group ? [group] : [];
+    }),
+  );
+}
+
 /** Mark channel subscriptions as stale so the next loop tick re-reads from DB. */
 function invalidateChannelSubscriptions(): void {
   channelSubscriptionsDirty = true;
@@ -1267,6 +1277,17 @@ export function _setChannelSubscriptions(
   subscriptions: Record<string, ChannelSubscription[]>,
 ): void {
   channelSubscriptions = subscriptions;
+  channelSubscriptionsDirty = false;
+}
+
+/** @internal - exported for testing */
+export function _markChannelSubscriptionsDirty(): void {
+  channelSubscriptionsDirty = true;
+}
+
+/** @internal - exported for testing */
+export function _getSlashCommandGroupsFromSubscriptions(): RegisteredGroup[] {
+  return buildSlashCommandGroupsFromSubscriptions();
 }
 
 /**
@@ -2987,17 +3008,7 @@ async function main(): Promise<void> {
                 multiBotMode: DISCORD_BOTS.length > 1,
                 onSyntheticMessage: (message) => storeAndBroadcast(message),
                 registeredGroups: () => registeredGroups,
-                slashCommandGroups: () =>
-                  Object.entries(channelSubscriptions).flatMap(
-                    ([channelJid, subs]) =>
-                      subs.flatMap((sub) => {
-                        const group = buildRegisteredGroupFromSubscription(
-                          channelJid,
-                          sub,
-                        );
-                        return group ? [group] : [];
-                      }),
-                  ),
+                slashCommandGroups: buildSlashCommandGroupsFromSubscriptions,
                 onSessionCommand: (command, chatJid, group, sessionId) =>
                   handleSessionCommand(command, chatJid, group, sessionId),
                 onReaction: async (chatJid, messageId, emoji, userName) => {


### PR DESCRIPTION
## Summary
- Sync Discord slash commands from canonical channel subscriptions instead of the legacy one-group-per-channel map.
- Keeps existing registeredGroups fallback for older callers.

## Verification
- bun test src/channels/discord.test.ts src/discord-command-flows.test.ts
- bun run build
- Live verified on macmini: PRIMARY, OCPEYTON, DEX, CODY each synced slash commands.
- Live verified on orangepi5: RIND and ZEST each synced slash commands.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Discord slash commands are now dynamically generated from your active channel subscriptions, automatically updating to reflect configuration changes without manual intervention.

* **Improvements**
  * Enhanced Discord command configuration system with flexible, dynamic command group generation based on current subscriptions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->