### PR TITLE
feat: add SDLC Discord driver commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@ bun test
 
 ## Discord Slash Flows
 
-Discord bots can expose slash-command shortcuts that queue a reusable prompt into the current channel's agent. OmniClaw ships with built-ins like `/mergemaster`, `/taskbooker`, and `/scheduler`.
+Discord bots can expose slash-command shortcuts that queue a reusable prompt into the current channel's agent. OmniClaw ships with built-ins for the software development lifecycle: `/product-driver`, `/issue-driver`, `/research-driver`, `/implement-driver`, `/qa-driver`, `/mergemaster`, `/taskbooker`, and `/scheduler`.
 
 You can add your own channel- or agent-specific slash flows by creating `discord-commands.json` in a runtime workspace folder such as `groups/<agent>/` or `groups/<channel-folder>/`:
 
@@ -112,6 +112,25 @@ You can add your own channel- or agent-specific slash flows by creating `discord
 ```
 
 Command names must be lowercase Discord slash-command names (`a-z`, `0-9`, `_`, `-`). OmniClaw merges built-ins with runtime command files and syncs them per Discord guild on startup and subscription changes, so restart the bot after editing command files.
+
+By default, every built-in and workspace slash flow is enabled for every agent. To specialize an agent, add `discordCommands` to its `agents.yaml` entry. `enabled` is an optional allowlist; `disabled` is applied after the allowlist:
+
+```yaml
+agents:
+  product:
+    name: Product Driver
+    discordCommands:
+      enabled:
+        - product-driver
+        - issue-driver
+        - research-driver
+      disabled:
+        - mergemaster
+    channels:
+      - jid: 'dc:123456'
+        trigger: '@Product'
+        discordGuildId: '789'
+```
 
 ## Requirements
 
@@ -151,6 +170,9 @@ agents:
     backend: docker
     agentRuntime: opencode
     description: Infrastructure and OmniClaw development agent
+    discordCommands:
+      disabled:
+        - product-driver
     channels:
       - jid: 'dc:123456'
         trigger: '@OCPeyton'

--- a/src/agent-topology.test.ts
+++ b/src/agent-topology.test.ts
@@ -41,6 +41,12 @@ agents:
     agentRuntime: opencode
     description: Infrastructure agent
     serverFolder: servers/omniaura
+    discordCommands:
+      enabled:
+        - product-driver
+        - issue-driver
+      disabled:
+        - mergemaster
     containerConfig:
       timeout: 300000
       memory: 4096
@@ -72,6 +78,10 @@ agents:
       discordGuildId: '789',
       serverFolder: 'servers/omniaura',
       channelFolder: 'servers/omniaura/omniclaw',
+      discordCommands: {
+        enabled: ['product-driver', 'issue-driver'],
+        disabled: ['mergemaster'],
+      },
       containerConfig: {
         timeout: 300000,
         memory: 4096,
@@ -183,6 +193,23 @@ agents:
 
     expect(() => loadDeclarativeAgentTopology(filePath)).toThrow(
       /Unrecognized key: "chanels"/,
+    );
+  });
+
+  it('rejects invalid Discord command filter names', () => {
+    const filePath = writeTopology(`
+agents:
+  main:
+    discordCommands:
+      disabled:
+        - "Bad Command!"
+    channels:
+      - jid: "dc:123"
+        trigger: "@Omni"
+`);
+
+    expect(() => loadDeclarativeAgentTopology(filePath)).toThrow(
+      /must be a Discord slash command name/,
     );
   });
 

--- a/src/agent-topology.ts
+++ b/src/agent-topology.ts
@@ -11,6 +11,15 @@ const folderSchema = z
 
 const backendSchema = z.enum(['apple-container', 'docker']);
 const agentRuntimeSchema = z.enum(['claude-agent-sdk', 'opencode', 'codex']);
+const discordCommandNameSchema = z
+  .string()
+  .regex(/^[a-z0-9_-]{1,32}$/, 'must be a Discord slash command name');
+const discordCommandsSchema = z
+  .object({
+    enabled: z.array(discordCommandNameSchema).optional(),
+    disabled: z.array(discordCommandNameSchema).optional(),
+  })
+  .strict();
 const additionalMountSchema = z
   .object({
     hostPath: z.string().min(1),
@@ -59,6 +68,7 @@ const agentSchema = z
     containerConfig: containerConfigSchema.optional(),
     serverFolder: z.string().min(1).optional(),
     agentContextFolder: z.string().min(1).optional(),
+    discordCommands: discordCommandsSchema.optional(),
     channels: z.array(channelSchema).min(1),
   })
   .strict();
@@ -140,6 +150,7 @@ export function loadDeclarativeAgentTopology(
         channelFolder: channel.channelFolder,
         categoryFolder: channel.categoryFolder,
         agentContextFolder: agent.agentContextFolder,
+        discordCommands: agent.discordCommands,
       };
       registrations.push({ jid: channel.jid, group });
     }

--- a/src/agent-topology.ts
+++ b/src/agent-topology.ts
@@ -14,7 +14,7 @@ const agentRuntimeSchema = z.enum(['claude-agent-sdk', 'opencode', 'codex']);
 const discordCommandNameSchema = z
   .string()
   .regex(/^[a-z0-9_-]{1,32}$/, 'must be a Discord slash command name');
-const discordCommandsSchema = z
+export const discordCommandsSchema = z
   .object({
     enabled: z.array(discordCommandNameSchema).optional(),
     disabled: z.array(discordCommandNameSchema).optional(),

--- a/src/db.test.ts
+++ b/src/db.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, beforeEach } from 'bun:test';
+import { describe, it, expect, beforeEach, spyOn } from 'bun:test';
 
 import {
   _countGitHubWebhookDeliveriesForTest,
@@ -70,6 +70,30 @@ describe('registered group persistence', () => {
       enabled: ['product-driver', 'issue-driver'],
       disabled: ['mergemaster'],
     });
+  });
+
+  it('ignores malformed persisted Discord command filters', () => {
+    const warnSpy = spyOn(logger, 'warn').mockImplementation(() => {});
+
+    try {
+      setRegisteredGroup('dc:123', {
+        name: 'Product',
+        folder: 'product',
+        trigger: '@Product',
+        added_at: '2026-01-01T00:00:00.000Z',
+        discordCommands: {
+          enabled: 'product-driver',
+        } as unknown as never,
+      });
+
+      expect(getRegisteredGroup('dc:123')?.discordCommands).toBeUndefined();
+      expect(warnSpy).toHaveBeenCalledWith(
+        expect.objectContaining({ jid: 'dc:123' }),
+        'Invalid discord_commands in DB, ignoring',
+      );
+    } finally {
+      warnSpy.mockRestore();
+    }
   });
 });
 

--- a/src/db.test.ts
+++ b/src/db.test.ts
@@ -10,6 +10,7 @@ import {
   getAgentHealth,
   getAllAgentHealth,
   getAllChats,
+  getRegisteredGroup,
   getDeltaCursorFromDb,
   getMessagesSince,
   getNewMessages,
@@ -19,6 +20,7 @@ import {
   setAgent,
   setDeltaCursorInDb,
   setAgentHealth,
+  setRegisteredGroup,
   storeChatMetadata,
   storeMessage,
   updateTask,
@@ -50,6 +52,26 @@ function store(overrides: {
     is_from_me: overrides.is_from_me ?? false,
   });
 }
+
+describe('registered group persistence', () => {
+  it('persists Discord command filters', () => {
+    setRegisteredGroup('dc:123', {
+      name: 'Product',
+      folder: 'product',
+      trigger: '@Product',
+      added_at: '2026-01-01T00:00:00.000Z',
+      discordCommands: {
+        enabled: ['product-driver', 'issue-driver'],
+        disabled: ['mergemaster'],
+      },
+    });
+
+    expect(getRegisteredGroup('dc:123')?.discordCommands).toEqual({
+      enabled: ['product-driver', 'issue-driver'],
+      disabled: ['mergemaster'],
+    });
+  });
+});
 
 // --- storeMessage (NewMessage format) ---
 

--- a/src/db.ts
+++ b/src/db.ts
@@ -39,6 +39,7 @@ interface RegisteredGroupRow {
   description: string | null;
   auto_respond_to_questions: number | null;
   auto_respond_keywords: string | null;
+  discord_commands: string | null;
 }
 
 /** Row type for agents table SELECT * queries */
@@ -148,6 +149,11 @@ function mapRowToRegisteredGroup(
       row.auto_respond_keywords,
       { jid: row.jid },
       'auto_respond_keywords',
+    ),
+    discordCommands: safeJsonParse<RegisteredGroup['discordCommands']>(
+      row.discord_commands,
+      { jid: row.jid },
+      'discord_commands',
     ),
   };
 }
@@ -1236,8 +1242,8 @@ export function getRegisteredGroup(
 /** Insert or replace a registered group entry. */
 export function setRegisteredGroup(jid: string, group: RegisteredGroup): void {
   db.query(
-    `INSERT OR REPLACE INTO registered_groups (jid, name, folder, trigger_pattern, added_at, container_config, requires_trigger, discord_bot_id, discord_guild_id, server_folder, backend, description, auto_respond_to_questions, auto_respond_keywords)
-     VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+    `INSERT OR REPLACE INTO registered_groups (jid, name, folder, trigger_pattern, added_at, container_config, requires_trigger, discord_bot_id, discord_guild_id, server_folder, backend, description, auto_respond_to_questions, auto_respond_keywords, discord_commands)
+     VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
   ).run(
     jid,
     group.name,
@@ -1255,6 +1261,7 @@ export function setRegisteredGroup(jid: string, group: RegisteredGroup): void {
     group.autoRespondKeywords
       ? JSON.stringify(group.autoRespondKeywords)
       : null,
+    group.discordCommands ? JSON.stringify(group.discordCommands) : null,
   );
 }
 

--- a/src/db.ts
+++ b/src/db.ts
@@ -3,6 +3,7 @@ import { randomUUID } from 'crypto';
 import fs from 'fs';
 import path from 'path';
 
+import { discordCommandsSchema } from './agent-topology.js';
 import { DATA_DIR, STORE_DIR } from './config.js';
 import { TrustStore } from './discovery/trust-store.js';
 import { logger } from './logger.js';
@@ -123,6 +124,23 @@ function normalizeAgentRuntime(
   return 'claude-agent-sdk';
 }
 
+function parseDiscordCommands(
+  value: string | null,
+  jid: string,
+): RegisteredGroup['discordCommands'] {
+  const parsed = safeJsonParse<unknown>(value, { jid }, 'discord_commands');
+  if (parsed === undefined) return undefined;
+  const result = discordCommandsSchema.safeParse(parsed);
+  if (!result.success) {
+    logger.warn(
+      { jid, issues: result.error.issues },
+      'Invalid discord_commands in DB, ignoring',
+    );
+    return undefined;
+  }
+  return result.data;
+}
+
 /** Map a database row to a RegisteredGroup object (without jid field) */
 function mapRowToRegisteredGroup(
   row: RegisteredGroupRow,
@@ -150,11 +168,7 @@ function mapRowToRegisteredGroup(
       { jid: row.jid },
       'auto_respond_keywords',
     ),
-    discordCommands: safeJsonParse<RegisteredGroup['discordCommands']>(
-      row.discord_commands,
-      { jid: row.jid },
-      'discord_commands',
-    ),
+    discordCommands: parseDiscordCommands(row.discord_commands, row.jid),
   };
 }
 

--- a/src/discord-command-flows.test.ts
+++ b/src/discord-command-flows.test.ts
@@ -34,7 +34,12 @@ describe('discord command flows', () => {
       (command) => command.name,
     );
 
+    expect(names).toContain('implement-driver');
+    expect(names).toContain('issue-driver');
     expect(names).toContain('mergemaster');
+    expect(names).toContain('product-driver');
+    expect(names).toContain('qa-driver');
+    expect(names).toContain('research-driver');
     expect(names).toContain('taskbooker');
     expect(names).toContain('scheduler');
   });
@@ -118,6 +123,41 @@ describe('discord command flows', () => {
 
       expect(triage?.description).toBe('Channel-level triage');
       expect(triage?.prompt).toBe('Channel triage {{goal}}');
+    } finally {
+      fs.rmSync(tempRoot, { recursive: true, force: true });
+    }
+  });
+
+  it('filters built-in and custom commands by agent command config', () => {
+    const tempRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'omniclaw-flows-'));
+    const groupsDir = path.join(tempRoot, 'groups');
+
+    try {
+      fs.mkdirSync(path.join(groupsDir, 'test-agent'), { recursive: true });
+      fs.writeFileSync(
+        path.join(groupsDir, 'test-agent', 'discord-commands.json'),
+        JSON.stringify({
+          commands: [
+            {
+              name: 'custom-spike',
+              description: 'Run a custom spike',
+              prompt: 'Spike {{goal}}',
+            },
+          ],
+        }),
+      );
+
+      const names = getDiscordFlowDefinitionsForGroup(
+        makeGroup({
+          discordCommands: {
+            enabled: ['product-driver', 'issue-driver', 'custom-spike'],
+            disabled: ['issue-driver'],
+          },
+        }),
+        groupsDir,
+      ).map((command) => command.name);
+
+      expect(names).toEqual(['custom-spike', 'product-driver']);
     } finally {
       fs.rmSync(tempRoot, { recursive: true, force: true });
     }

--- a/src/discord-command-flows.test.ts
+++ b/src/discord-command-flows.test.ts
@@ -163,6 +163,52 @@ describe('discord command flows', () => {
     }
   });
 
+  it('treats an empty enabled list as deny-all', () => {
+    const names = getDiscordFlowDefinitionsForGroup(
+      makeGroup({
+        discordCommands: { enabled: [] },
+      }),
+    ).map((command) => command.name);
+
+    expect(names).toEqual([]);
+  });
+
+  it('does not let custom command files override system commands', () => {
+    const tempRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'omniclaw-flows-'));
+    const groupsDir = path.join(tempRoot, 'groups');
+    const warnSpy = spyOn(logger, 'warn').mockImplementation(() => {});
+
+    try {
+      fs.mkdirSync(path.join(groupsDir, 'test-agent'), { recursive: true });
+      fs.writeFileSync(
+        path.join(groupsDir, 'test-agent', 'discord-commands.json'),
+        JSON.stringify({
+          commands: [
+            {
+              name: 'resume',
+              description: 'Malicious resume override',
+              prompt: 'This should never replace the host system command.',
+            },
+          ],
+        }),
+      );
+
+      const resume = getDiscordFlowDefinitionsForGroup(
+        makeGroup(),
+        groupsDir,
+      ).find((command) => command.name === 'resume');
+
+      expect(resume?.system).toBe(true);
+      expect(resume?.prompt).toBe('');
+      expect(warnSpy).toHaveBeenCalledWith(
+        expect.objectContaining({ command: 'resume' }),
+        'Ignoring custom Discord command that conflicts with a system command',
+      );
+    } finally {
+      fs.rmSync(tempRoot, { recursive: true, force: true });
+    }
+  });
+
   it('ignores custom commands with oversized prompts', () => {
     const tempRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'omniclaw-flows-'));
     const groupsDir = path.join(tempRoot, 'groups');

--- a/src/discord-command-flows.ts
+++ b/src/discord-command-flows.ts
@@ -67,6 +67,130 @@ const BUILTIN_COMMANDS: DiscordFlowDefinition[] = [
     ],
   },
   {
+    name: 'product-driver',
+    description: 'Drive product discovery and issue creation',
+    prompt:
+      'You are product driver for {{repo}} for the next {{duration_minutes}} minutes.\n\nGoal: {{goal}}\n\nYour job is to turn ambiguous product direction into concrete product progress. Start by reading the repo context, open issues, recent PRs, product docs, and relevant user conversations. De-duplicate before filing anything.\n\nExpected output:\n- identify the highest-leverage product gaps or opportunities\n- file clear issues with user problem, scope, acceptance criteria, and test notes when the repo needs tracking issues\n- direct small exploratory PRs only when code discovery is needed to clarify the product path\n- keep implementation delegated or narrowly exploratory; do not drift into broad feature work\n- leave a short queue update naming filed issues, delegated owners, blockers, and next decisions needed',
+    options: [
+      {
+        name: 'repo',
+        description: 'Repository or product area to drive',
+        type: 'string',
+        defaultValue: 'the target repo',
+      },
+      {
+        name: 'goal',
+        description: 'Product outcome or customer problem',
+        type: 'string',
+        defaultValue: 'meaningful product progress',
+      },
+      {
+        name: 'duration_minutes',
+        description: 'How long to stay in product-driver mode',
+        type: 'integer',
+        defaultValue: 60,
+      },
+    ],
+  },
+  {
+    name: 'issue-driver',
+    description: 'Triage, dedupe, and file actionable issues',
+    prompt:
+      'You are issue driver for {{repo}} for the next {{duration_minutes}} minutes.\n\nGoal: {{goal}}\n\nWork the issue queue like a product-minded engineer. Inspect existing issues and recent PRs first, then decide whether to update, close, split, prioritize, or file new issues. Prefer fewer high-quality issues over many vague ones.\n\nIssue quality bar:\n- concrete problem statement and why it matters\n- reproduction or evidence when applicable\n- proposed scope, non-goals, acceptance criteria, and verification plan\n- priority recommendation and dependencies\n- links to relevant files, PRs, conversations, or docs\n\nDo not implement fixes unless explicitly asked. End with a concise issue ledger and recommended next owners.',
+    options: [
+      {
+        name: 'repo',
+        description: 'Repository or project issue queue',
+        type: 'string',
+        defaultValue: 'the target repo',
+      },
+      {
+        name: 'goal',
+        description: 'Triage theme or product area',
+        type: 'string',
+        defaultValue: 'open issue quality and prioritization',
+      },
+      {
+        name: 'duration_minutes',
+        description: 'How long to stay in issue-driver mode',
+        type: 'integer',
+        defaultValue: 45,
+      },
+    ],
+  },
+  {
+    name: 'research-driver',
+    description: 'Run technical/product research and propose paths',
+    prompt:
+      'You are research driver for {{repo}} for the next {{duration_minutes}} minutes.\n\nQuestion or area: {{goal}}\n\nBuild evidence before recommending direction. Read primary sources, current repo code, open issues, and comparable implementations. When web research is needed, prefer official docs, source repos, specs, and recent primary references over summaries.\n\nDeliverables:\n- concise findings with source links or file references\n- option set with tradeoffs, risks, and confidence level\n- recommended next step and smallest validation PR or spike\n- issues to file only when they are actionable and de-duplicated\n\nDo not present speculation as fact; call out unknowns and verification gaps.',
+    options: [
+      {
+        name: 'repo',
+        description: 'Repository or product area to research',
+        type: 'string',
+        defaultValue: 'the target repo',
+      },
+      {
+        name: 'goal',
+        description: 'Research question or decision',
+        type: 'string',
+        required: true,
+      },
+      {
+        name: 'duration_minutes',
+        description: 'Research timebox in minutes',
+        type: 'integer',
+        defaultValue: 45,
+      },
+    ],
+  },
+  {
+    name: 'implement-driver',
+    description: 'Take a scoped issue through a PR-ready patch',
+    prompt:
+      'You are implementation driver for {{repo}}.\n\nTarget: {{goal}}\n\nTake one well-scoped change from intent to PR-ready state. Inspect the existing code and tests first, confirm the smallest coherent implementation path, then write the patch, add or update focused tests, run the relevant validation, and push or open/update the PR if repo policy expects it.\n\nConstraints:\n- keep scope tight and avoid unrelated refactors\n- preserve user or teammate work in the worktree\n- document any product or technical ambiguity instead of guessing silently\n- request review when the PR is ready, with a short verification summary\n\nIf the target is not implementation-ready, file or update an issue with the missing requirements and hand it back to product/issue driver.',
+    options: [
+      {
+        name: 'repo',
+        description: 'Repository to modify',
+        type: 'string',
+        defaultValue: 'the target repo',
+      },
+      {
+        name: 'goal',
+        description: 'Issue, PR, or scoped implementation target',
+        type: 'string',
+        required: true,
+      },
+    ],
+  },
+  {
+    name: 'qa-driver',
+    description: 'Verify behavior, PRs, and release readiness',
+    prompt:
+      'You are QA driver for {{repo}} for the next {{duration_minutes}} minutes.\n\nTarget: {{goal}}\n\nValidate behavior from the user and release perspective. Inspect the diff or feature path, identify risk areas, run the most relevant automated and manual checks available in this environment, and file focused follow-up issues for defects or missing coverage.\n\nQA checklist:\n- confirm expected behavior and edge cases from product context\n- run targeted tests before broad tests when possible\n- reproduce reported bugs with clear steps and evidence\n- verify UI/API behavior where applicable\n- separate blockers from follow-up polish\n\nDo not merge. End with pass/fail status, evidence, blockers, and recommended next action.',
+    options: [
+      {
+        name: 'repo',
+        description: 'Repository, PR, or feature to verify',
+        type: 'string',
+        defaultValue: 'the target repo',
+      },
+      {
+        name: 'goal',
+        description: 'Behavior, issue, or PR to validate',
+        type: 'string',
+        required: true,
+      },
+      {
+        name: 'duration_minutes',
+        description: 'QA timebox in minutes',
+        type: 'integer',
+        defaultValue: 45,
+      },
+    ],
+  },
+  {
     name: 'taskbooker',
     description: 'Have the agent book and delegate a work plan',
     prompt:
@@ -255,6 +379,19 @@ function loadFlowFile(filePath: string): DiscordFlowDefinition[] {
   }
 }
 
+function isCommandEnabledForGroup(
+  command: DiscordFlowDefinition,
+  group: RegisteredGroup,
+): boolean {
+  const config = group.discordCommands;
+  if (!config) return true;
+
+  const enabled = new Set(config.enabled || []);
+  const disabled = new Set(config.disabled || []);
+  if (enabled.size > 0 && !enabled.has(command.name)) return false;
+  return !disabled.has(command.name);
+}
+
 function getGroupCommandPaths(
   group: RegisteredGroup,
   groupsDir = GROUPS_DIR,
@@ -292,7 +429,9 @@ export function getDiscordFlowDefinitionsForGroup(
     }
   }
 
-  return [...commands.values()].sort((a, b) => a.name.localeCompare(b.name));
+  return [...commands.values()]
+    .filter((command) => isCommandEnabledForGroup(command, group))
+    .sort((a, b) => a.name.localeCompare(b.name));
 }
 
 export function buildDiscordSlashCommandPayloads(

--- a/src/discord-command-flows.ts
+++ b/src/discord-command-flows.ts
@@ -263,6 +263,12 @@ const BUILTIN_COMMANDS: DiscordFlowDefinition[] = [
   },
 ];
 
+const BUILTIN_SYSTEM_COMMAND_NAMES = new Set(
+  BUILTIN_COMMANDS.filter((command) => command.system).map(
+    (command) => command.name,
+  ),
+);
+
 function normalizeOptionType(value: unknown): DiscordFlowOptionType {
   return value === 'integer' || value === 'boolean' ? value : 'string';
 }
@@ -388,7 +394,7 @@ function isCommandEnabledForGroup(
 
   const enabled = new Set(config.enabled || []);
   const disabled = new Set(config.disabled || []);
-  if (enabled.size > 0 && !enabled.has(command.name)) return false;
+  if (config.enabled !== undefined && !enabled.has(command.name)) return false;
   return !disabled.has(command.name);
 }
 
@@ -425,6 +431,13 @@ export function getDiscordFlowDefinitionsForGroup(
   for (const filePath of getGroupCommandPaths(group, groupsDir)) {
     if (!fs.existsSync(filePath)) continue;
     for (const command of loadFlowFile(filePath)) {
+      if (BUILTIN_SYSTEM_COMMAND_NAMES.has(command.name)) {
+        logger.warn(
+          { command: command.name, filePath },
+          'Ignoring custom Discord command that conflicts with a system command',
+        );
+        continue;
+      }
       commands.set(command.name, command);
     }
   }
@@ -500,9 +513,7 @@ function stringifyOptionValue(value: string | number | boolean): string {
 }
 
 /** Names of built-in system commands (handled by host, not agent). */
-export const SYSTEM_COMMAND_NAMES = new Set(
-  BUILTIN_COMMANDS.filter((c) => c.system).map((c) => c.name),
-);
+export const SYSTEM_COMMAND_NAMES = new Set(BUILTIN_SYSTEM_COMMAND_NAMES);
 
 export function renderDiscordFlowPrompt(
   command: DiscordFlowDefinition,

--- a/src/index.ts
+++ b/src/index.ts
@@ -805,6 +805,7 @@ function refreshRegisteredGroupsFromCanonicalState(): {
       channelFolder: layers.channelFolder,
       categoryFolder: layers.categoryFolder,
       agentContextFolder: agent?.agentContextFolder,
+      discordCommands: legacy?.discordCommands,
     };
     synthesized++;
   }

--- a/src/index.ts
+++ b/src/index.ts
@@ -467,6 +467,7 @@ function buildRegisteredGroupFromSubscription(
     channelFolder: layers.channelFolder,
     categoryFolder: layers.categoryFolder,
     agentContextFolder: agent?.agentContextFolder || undefined,
+    discordCommands: fallback?.discordCommands,
   };
 }
 

--- a/src/migrations.ts
+++ b/src/migrations.ts
@@ -13,11 +13,10 @@ export interface Migration {
 }
 
 /**
- * The version that represents the full current schema. Existing databases that
- * predate the migration framework are stamped here (they already have
- * everything via the old addColumnIfNotExists pattern).
+ * The version that represents the latest schema. Existing databases that
+ * predate the migration framework are advanced through every migration to this.
  */
-export const BASELINE_VERSION = 1;
+export const BASELINE_VERSION = 2;
 
 // ---------------------------------------------------------------------------
 // Schema helpers (available for use in migrations)
@@ -288,7 +287,8 @@ const migration1: Migration = {
         backend TEXT,
         description TEXT,
         auto_respond_to_questions INTEGER DEFAULT 0,
-        auto_respond_keywords TEXT
+        auto_respond_keywords TEXT,
+        discord_commands TEXT
       );
 
       CREATE TABLE IF NOT EXISTS agents (
@@ -437,6 +437,7 @@ const migration1: Migration = {
       'auto_respond_keywords',
       'TEXT',
     );
+    addColumnIfNotExists(db, 'registered_groups', 'discord_commands', 'TEXT');
     dropColumnIfExists(db, 'registered_groups', 'stream_intermediates');
 
     // agents
@@ -496,6 +497,14 @@ const migration1: Migration = {
   },
 };
 
+const migration2: Migration = {
+  version: 2,
+  description: 'Persist per-agent Discord command filters',
+  up: (db) => {
+    addColumnIfNotExists(db, 'registered_groups', 'discord_commands', 'TEXT');
+  },
+};
+
 // ---------------------------------------------------------------------------
 // Migration registry
 // ---------------------------------------------------------------------------
@@ -506,4 +515,4 @@ const migration1: Migration = {
  * can use plain `ALTER TABLE` without try/catch — the version tracker
  * guarantees each migration runs exactly once.
  */
-export const allMigrations: Migration[] = [migration1];
+export const allMigrations: Migration[] = [migration1, migration2];

--- a/src/migrations.ts
+++ b/src/migrations.ts
@@ -287,8 +287,7 @@ const migration1: Migration = {
         backend TEXT,
         description TEXT,
         auto_respond_to_questions INTEGER DEFAULT 0,
-        auto_respond_keywords TEXT,
-        discord_commands TEXT
+        auto_respond_keywords TEXT
       );
 
       CREATE TABLE IF NOT EXISTS agents (
@@ -437,7 +436,6 @@ const migration1: Migration = {
       'auto_respond_keywords',
       'TEXT',
     );
-    addColumnIfNotExists(db, 'registered_groups', 'discord_commands', 'TEXT');
     dropColumnIfExists(db, 'registered_groups', 'stream_intermediates');
 
     // agents

--- a/src/types.ts
+++ b/src/types.ts
@@ -80,6 +80,15 @@ export interface RegisteredGroup {
   categoryFolder?: string; // e.g., 'servers/omni-aura/ditto-assistant'
   /** Agent identity folder. Mounted read-write at /workspace/agent/. */
   agentContextFolder?: string; // e.g., 'agents/peytonomi'
+  /** Discord slash command availability for this agent/channel registration. */
+  discordCommands?: DiscordCommandConfig;
+}
+
+export interface DiscordCommandConfig {
+  /** Optional allowlist. Omit to enable all built-in and workspace commands. */
+  enabled?: string[];
+  /** Optional denylist applied after enabled. */
+  disabled?: string[];
 }
 
 /**


### PR DESCRIPTION
## Summary

Adds SDLC-oriented Discord slash flows for agent coordination:

- `/product-driver`
- `/issue-driver`
- `/research-driver`
- `/implement-driver`
- `/qa-driver`

Also adds per-agent `agents.yaml` control for Discord command availability:

```yaml
discordCommands:
  enabled:
    - product-driver
    - issue-driver
  disabled:
    - mergemaster
```

Omitted `discordCommands` keeps the current default: all built-in and workspace command-file flows are enabled. `enabled` acts as an allowlist when present, and `disabled` is applied after that.

## Notes

- Prompt shape follows the same lightweight slash-command pattern as the existing flows: explicit role, scoped objective, expected deliverables, and clear constraints.
- I used current Claude slash-command docs and public skill/security writeups as input, but did not vendor or execute third-party skill content. The security angle is intentional: marketplace prompt packs should be treated as untrusted and adapted manually.
- The command filter applies after built-ins and workspace `discord-commands.json` files are loaded, so it works for both built-in and custom flows.
- Adds a schema migration for persisted `registered_groups.discord_commands`.

## Verification

- `bun test src/db.test.ts src/discord-command-flows.test.ts src/agent-topology.test.ts src/migrations.test.ts src/db.migrations.test.ts`
- `bun run typecheck`
- `bun run format:check`
- `bun test`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added five new Discord slash commands: `/product-driver`, `/issue-driver`, `/research-driver`, `/implement-driver`, and `/qa-driver`.
  * Introduced per-agent Discord command filtering, allowing administrators to enable or disable specific commands via configuration.

* **Documentation**
  * Updated README with comprehensive documentation on all available Discord slash commands and configuration instructions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->