### PR TITLE
fix: order Discord slash command options

### DIFF
--- a/src/discord-command-flows.test.ts
+++ b/src/discord-command-flows.test.ts
@@ -255,6 +255,51 @@ describe('discord command flows', () => {
     ).toBe(ApplicationCommandOptionType.Integer);
   });
 
+  it('orders required slash options before optional ones', () => {
+    const tempRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'omniclaw-flows-'));
+    const groupsDir = path.join(tempRoot, 'groups');
+
+    try {
+      fs.mkdirSync(path.join(groupsDir, 'test-agent'), { recursive: true });
+      fs.writeFileSync(
+        path.join(groupsDir, 'test-agent', 'discord-commands.json'),
+        JSON.stringify({
+          commands: [
+            {
+              name: 'ordered-test',
+              description: 'Ordering check',
+              prompt: 'Run with {{required_arg}} and {{optional_arg}}',
+              options: [
+                {
+                  name: 'optional_arg',
+                  description: 'Optional first in source',
+                  required: false,
+                },
+                {
+                  name: 'required_arg',
+                  description: 'Required second in source',
+                  required: true,
+                },
+              ],
+            },
+          ],
+        }),
+      );
+
+      const payload = buildDiscordSlashCommandPayloads(
+        [makeGroup()],
+        groupsDir,
+      ).find((command) => command.name === 'ordered-test');
+
+      expect(payload?.options?.map((option) => option.name)).toEqual([
+        'required_arg',
+        'optional_arg',
+      ]);
+    } finally {
+      fs.rmSync(tempRoot, { recursive: true, force: true });
+    }
+  });
+
   it('ignores invalid commands and invalid options from custom files', () => {
     const tempRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'omniclaw-flows-'));
     const groupsDir = path.join(tempRoot, 'groups');

--- a/src/discord-command-flows.ts
+++ b/src/discord-command-flows.ts
@@ -472,7 +472,10 @@ export function buildDiscordSlashCommandPayloads(
     .map((command) => ({
       name: command.name,
       description: command.description,
-      options: command.options?.map((option) => toDiscordOptionData(option)),
+      options: command.options
+        ?.slice()
+        .sort((a, b) => Number(Boolean(b.required)) - Number(Boolean(a.required)))
+        .map((option) => toDiscordOptionData(option)),
     }));
 }
 

--- a/src/discord-command-flows.ts
+++ b/src/discord-command-flows.ts
@@ -474,7 +474,9 @@ export function buildDiscordSlashCommandPayloads(
       description: command.description,
       options: command.options
         ?.slice()
-        .sort((a, b) => Number(Boolean(b.required)) - Number(Boolean(a.required)))
+        .sort(
+          (a, b) => Number(Boolean(b.required)) - Number(Boolean(a.required)),
+        )
         .map((option) => toDiscordOptionData(option)),
     }));
 }


### PR DESCRIPTION
## Summary
- Sort Discord slash command options so required options always come before optional ones in the payload sent to Discord.
- Add a regression test that loads a custom command with mixed required/optional options and asserts the final payload order.

## Verification
- bun test src/discord-command-flows.test.ts
- bun run build
- Live verified on macmini after update: PRIMARY, OCPEYTON, DEX, CODY all synced slash commands successfully.
- Live verified on orangepi5 after update: RIND and ZEST both synced slash commands successfully.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Discord slash commands now display required options before optional ones, improving command clarity.

* **Tests**
  * Added test coverage for slash command option ordering.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->