### PR TITLE
feat: add factory workflow handoff store

### DIFF
--- a/docs/factory-workflow-handoffs.md
+++ b/docs/factory-workflow-handoffs.md
@@ -1,0 +1,107 @@
+# Factory Workflow Handoffs
+
+This document defines the first durable handoff contract for the SDLC driver
+commands (`/product-driver`, `/issue-driver`, `/research-driver`,
+`/implement-driver`, and `/qa-driver`). The goal is to make driver outputs
+retrievable by later drivers without relying on chat scrollback.
+
+## Workflow Model
+
+A workflow represents one bounded unit of software-factory work, usually a
+single GitHub issue in one repository.
+
+Recommended workflow id:
+
+```text
+<owner>/<repo>#<issue-or-pr-number>
+```
+
+If there is no issue or PR yet, use a synthetic id that includes the repository,
+driver, and start timestamp:
+
+```text
+<owner>/<repo>:<driver>:<YYYYMMDD-HHMMSS>
+```
+
+## Phases
+
+Phases are intentionally small and monotonic:
+
+```text
+discovery -> spec -> impl -> review -> qa -> done
+```
+
+Same-phase updates are allowed. Backward transitions are rejected so downstream
+drivers can derive the current phase from the latest handoff record.
+
+## Handoff Record
+
+Records are stored in SQLite in `factory_handoff_records`. Human-readable
+markdown can be exported later, but SQLite is the source of truth for restart
+survival and queryability.
+
+Required fields:
+
+```json
+{
+  "id": "handoff-uuid",
+  "workflowId": "omniaura/omniclaw#643",
+  "repo": "omniaura/omniclaw",
+  "phase": "spec",
+  "ownerAgentId": "ocpeyton",
+  "driver": "product-driver",
+  "intent": "Define durable factory handoffs",
+  "summary": "The next driver should implement persistence before UI.",
+  "body": "Markdown handoff body for downstream driver context.",
+  "decisions": ["Use SQLite for records and claims"],
+  "artifacts": [
+    {
+      "type": "issue",
+      "label": "#643",
+      "url": "https://github.com/omniaura/omniclaw/issues/643"
+    }
+  ],
+  "blockers": ["Lease primitive still pending"],
+  "createdAt": "2026-05-04T00:00:00.000Z"
+}
+```
+
+Optional fields:
+
+```json
+{
+  "sourceIssue": "643",
+  "sourcePr": "645",
+  "nextDriver": "implement-driver",
+  "nextScope": "schema/module spike",
+  "metadata": { "priority": "P2" }
+}
+```
+
+## Active Claims
+
+Active ownership is stored in `factory_workflow_claims` and keyed by
+`workflow_id`. A claim records:
+
+- `repo`
+- `owner_agent_id`
+- `owner_run_id`
+- `phase`
+- `claimed_at`
+- `heartbeat_at`
+- `expires_at`
+
+Before acquiring a claim, expired rows are deleted. If an unexpired claim exists,
+the acquire call returns the conflicting claim instead of overwriting it. This
+gives slash commands a deterministic duplicate-owner warning path.
+
+## Retrieval
+
+The first integration points should retrieve records by:
+
+- workflow id, for explicit handoff continuation
+- repository plus GitHub issue id, for issue-scoped driver invocations
+- latest record for a workflow, to derive current phase and next driver
+
+Missing or malformed records must not fail slash command startup. Drivers should
+log the problem and proceed with empty handoff context.

--- a/src/db.ts
+++ b/src/db.ts
@@ -6,6 +6,7 @@ import path from 'path';
 import { discordCommandsSchema } from './agent-topology.js';
 import { DATA_DIR, STORE_DIR } from './config.js';
 import { TrustStore } from './discovery/trust-store.js';
+import { FactoryWorkflowStore } from './factory-workflows.js';
 import { logger } from './logger.js';
 import { allMigrations, runMigrations } from './migrations.js';
 import {
@@ -290,6 +291,10 @@ function applyDiscordRequiresTriggerFix(database: Database): void {
 
 export function createTrustStore(): TrustStore {
   return new TrustStore(db);
+}
+
+export function createFactoryWorkflowStore(): FactoryWorkflowStore {
+  return new FactoryWorkflowStore(db);
 }
 
 export function getOrCreateDiscoveryInstanceId(): string {

--- a/src/factory-workflows.test.ts
+++ b/src/factory-workflows.test.ts
@@ -151,6 +151,33 @@ describe('FactoryWorkflowStore claims', () => {
     db.close();
   });
 
+  it('does not let stale owners refresh expired claims', () => {
+    const { db, store } = makeStore();
+    store.acquireClaim({
+      workflowId: 'workflow-1',
+      repo: 'omniaura/omniclaw',
+      ownerAgentId: 'ocpeyton',
+      ownerRunId: 'run-1',
+      phase: 'impl',
+      ttlMs: 1_000,
+      now: new Date('2026-05-04T00:00:00.000Z'),
+    });
+
+    const refreshed = store.refreshClaim(
+      'workflow-1',
+      'run-1',
+      60_000,
+      new Date('2026-05-04T00:00:02.000Z'),
+    );
+
+    expect(refreshed).toBeUndefined();
+    expect(store.getClaim('workflow-1')?.expiresAt).toBe(
+      '2026-05-04T00:00:01.000Z',
+    );
+
+    db.close();
+  });
+
   it('persists records and claims across database reopen', () => {
     const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'omniclaw-factory-'));
     tempDirs.push(dir);

--- a/src/factory-workflows.test.ts
+++ b/src/factory-workflows.test.ts
@@ -1,0 +1,197 @@
+import { afterEach, describe, expect, it } from 'bun:test';
+import { Database } from 'bun:sqlite';
+import fs from 'fs';
+import os from 'os';
+import path from 'path';
+
+import { createSchema } from './db.js';
+import {
+  FactoryWorkflowStore,
+  validateFactoryPhaseTransition,
+} from './factory-workflows.js';
+
+const tempDirs: string[] = [];
+
+afterEach(() => {
+  for (const dir of tempDirs.splice(0)) fs.rmSync(dir, { recursive: true });
+});
+
+function makeStore(): { db: Database; store: FactoryWorkflowStore } {
+  const db = new Database(':memory:');
+  createSchema(db);
+  return { db, store: new FactoryWorkflowStore(db) };
+}
+
+describe('FactoryWorkflowStore handoffs', () => {
+  it('round-trips a handoff record with structured fields', () => {
+    const { db, store } = makeStore();
+
+    const created = store.createHandoff({
+      id: 'handoff-1',
+      workflowId: 'omniaura/omniclaw#643',
+      repo: 'omniaura/omniclaw',
+      sourceIssue: '643',
+      phase: 'spec',
+      ownerAgentId: 'ocpeyton',
+      driver: 'product-driver',
+      intent: 'Define durable factory handoffs',
+      summary: 'Need durable records before UI work.',
+      body: 'The next driver should implement persistence first.',
+      decisions: ['Use SQLite for records and claims'],
+      artifacts: [{ type: 'issue', label: '#643', url: 'https://example/643' }],
+      blockers: ['Lease primitive still pending'],
+      nextDriver: 'implement-driver',
+      nextScope: 'schema/module spike',
+      metadata: { priority: 'P2' },
+      createdAt: '2026-05-04T00:00:00.000Z',
+    });
+
+    expect(created.id).toBe('handoff-1');
+    expect(store.getHandoff('handoff-1')).toEqual(created);
+    expect(store.findLatestHandoffByIssue('omniaura/omniclaw', '643')).toEqual(
+      created,
+    );
+
+    db.close();
+  });
+
+  it('rejects backward phase transitions for a workflow', () => {
+    const { db, store } = makeStore();
+    store.createHandoff({
+      workflowId: 'workflow-1',
+      repo: 'omniaura/omniclaw',
+      phase: 'qa',
+      ownerAgentId: 'qa-agent',
+      driver: 'qa-driver',
+      intent: 'Verify PR',
+      summary: 'QA started',
+      body: 'Run targeted checks.',
+      createdAt: '2026-05-04T01:00:00.000Z',
+    });
+
+    expect(() =>
+      store.createHandoff({
+        workflowId: 'workflow-1',
+        repo: 'omniaura/omniclaw',
+        phase: 'impl',
+        ownerAgentId: 'impl-agent',
+        driver: 'implement-driver',
+        intent: 'Implement PR',
+        summary: 'Implementation should not reopen after QA',
+        body: 'This should be rejected.',
+        createdAt: '2026-05-04T02:00:00.000Z',
+      }),
+    ).toThrow('Factory workflow cannot move backward: qa -> impl');
+
+    db.close();
+  });
+
+  it('allows same-phase and forward transitions', () => {
+    expect(() => validateFactoryPhaseTransition('impl', 'impl')).not.toThrow();
+    expect(() => validateFactoryPhaseTransition('impl', 'qa')).not.toThrow();
+    expect(() => validateFactoryPhaseTransition('qa', 'review')).toThrow();
+  });
+});
+
+describe('FactoryWorkflowStore claims', () => {
+  it('detects duplicate active workflow owners', () => {
+    const { db, store } = makeStore();
+    const first = store.acquireClaim({
+      workflowId: 'workflow-1',
+      repo: 'omniaura/omniclaw',
+      ownerAgentId: 'ocpeyton',
+      ownerRunId: 'run-1',
+      phase: 'impl',
+      ttlMs: 60_000,
+      now: new Date('2026-05-04T00:00:00.000Z'),
+    });
+    expect(first.acquired).toBe(true);
+
+    const second = store.acquireClaim({
+      workflowId: 'workflow-1',
+      repo: 'omniaura/omniclaw',
+      ownerAgentId: 'cody',
+      ownerRunId: 'run-2',
+      phase: 'impl',
+      ttlMs: 60_000,
+      now: new Date('2026-05-04T00:00:10.000Z'),
+    });
+
+    expect(second.acquired).toBe(false);
+    if (!second.acquired) expect(second.conflict.ownerRunId).toBe('run-1');
+
+    db.close();
+  });
+
+  it('expires stale claims before acquiring a new owner', () => {
+    const { db, store } = makeStore();
+    store.acquireClaim({
+      workflowId: 'workflow-1',
+      repo: 'omniaura/omniclaw',
+      ownerAgentId: 'ocpeyton',
+      ownerRunId: 'run-1',
+      phase: 'impl',
+      ttlMs: 1_000,
+      now: new Date('2026-05-04T00:00:00.000Z'),
+    });
+
+    const result = store.acquireClaim({
+      workflowId: 'workflow-1',
+      repo: 'omniaura/omniclaw',
+      ownerAgentId: 'cody',
+      ownerRunId: 'run-2',
+      phase: 'qa',
+      ttlMs: 60_000,
+      now: new Date('2026-05-04T00:00:02.000Z'),
+    });
+
+    expect(result.acquired).toBe(true);
+    if (result.acquired) expect(result.claim.ownerRunId).toBe('run-2');
+
+    db.close();
+  });
+
+  it('persists records and claims across database reopen', () => {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'omniclaw-factory-'));
+    tempDirs.push(dir);
+    const dbPath = path.join(dir, 'messages.db');
+
+    const db = new Database(dbPath);
+    createSchema(db);
+    const store = new FactoryWorkflowStore(db);
+    store.createHandoff({
+      id: 'handoff-1',
+      workflowId: 'workflow-1',
+      repo: 'omniaura/omniclaw',
+      sourceIssue: '643',
+      phase: 'spec',
+      ownerAgentId: 'ocpeyton',
+      driver: 'product-driver',
+      intent: 'Define workflow',
+      summary: 'Persist handoffs',
+      body: 'Body',
+      createdAt: '2026-05-04T00:00:00.000Z',
+    });
+    store.acquireClaim({
+      workflowId: 'workflow-1',
+      repo: 'omniaura/omniclaw',
+      ownerAgentId: 'ocpeyton',
+      ownerRunId: 'run-1',
+      phase: 'spec',
+      ttlMs: 60_000,
+      now: new Date('2026-05-04T00:00:00.000Z'),
+    });
+    db.close();
+
+    const reopened = new Database(dbPath);
+    createSchema(reopened);
+    const reopenedStore = new FactoryWorkflowStore(reopened);
+
+    expect(reopenedStore.getHandoff('handoff-1')?.workflowId).toBe(
+      'workflow-1',
+    );
+    expect(reopenedStore.getClaim('workflow-1')?.ownerRunId).toBe('run-1');
+
+    reopened.close();
+  });
+});

--- a/src/factory-workflows.test.ts
+++ b/src/factory-workflows.test.ts
@@ -86,6 +86,47 @@ describe('FactoryWorkflowStore handoffs', () => {
     db.close();
   });
 
+  it('uses insertion order to break same-timestamp handoff ties', () => {
+    const { db, store } = makeStore();
+
+    store.createHandoff({
+      id: 'z-handoff',
+      workflowId: 'workflow-1',
+      repo: 'omniaura/omniclaw',
+      sourceIssue: '643',
+      phase: 'spec',
+      ownerAgentId: 'ocpeyton',
+      driver: 'spec-driver',
+      intent: 'First handoff',
+      summary: 'First handoff',
+      body: 'First body',
+      createdAt: '2026-05-04T00:00:00.000Z',
+    });
+    store.createHandoff({
+      id: 'a-handoff',
+      workflowId: 'workflow-1',
+      repo: 'omniaura/omniclaw',
+      sourceIssue: '643',
+      phase: 'impl',
+      ownerAgentId: 'ocpeyton',
+      driver: 'impl-driver',
+      intent: 'Second handoff',
+      summary: 'Second handoff',
+      body: 'Second body',
+      createdAt: '2026-05-04T00:00:00.000Z',
+    });
+
+    expect(store.getLatestHandoff('workflow-1')?.id).toBe('a-handoff');
+    expect(store.findLatestHandoffByIssue('omniaura/omniclaw', '643')?.id).toBe(
+      'a-handoff',
+    );
+    expect(
+      store.listHandoffsForWorkflow('workflow-1').map((row) => row.id),
+    ).toEqual(['z-handoff', 'a-handoff']);
+
+    db.close();
+  });
+
   it('allows same-phase and forward transitions', () => {
     expect(() => validateFactoryPhaseTransition('impl', 'impl')).not.toThrow();
     expect(() => validateFactoryPhaseTransition('impl', 'qa')).not.toThrow();

--- a/src/factory-workflows.ts
+++ b/src/factory-workflows.ts
@@ -1,0 +1,354 @@
+import { Database } from 'bun:sqlite';
+import { randomUUID } from 'crypto';
+
+import type {
+  FactoryHandoffRecord,
+  FactoryWorkflowArtifact,
+  FactoryWorkflowClaim,
+  FactoryWorkflowPhase,
+} from './types.js';
+
+export const FACTORY_WORKFLOW_PHASES: FactoryWorkflowPhase[] = [
+  'discovery',
+  'spec',
+  'impl',
+  'review',
+  'qa',
+  'done',
+];
+
+const PHASE_ORDER = new Map(
+  FACTORY_WORKFLOW_PHASES.map((phase, index) => [phase, index]),
+);
+
+export interface NewFactoryHandoffRecord {
+  id?: string;
+  workflowId: string;
+  repo: string;
+  sourceIssue?: string;
+  sourcePr?: string;
+  phase: FactoryWorkflowPhase;
+  ownerAgentId: string;
+  driver: string;
+  intent: string;
+  summary: string;
+  body: string;
+  decisions?: string[];
+  artifacts?: FactoryWorkflowArtifact[];
+  blockers?: string[];
+  nextDriver?: string;
+  nextScope?: string;
+  metadata?: Record<string, unknown>;
+  createdAt?: string;
+}
+
+export interface AcquireWorkflowClaimInput {
+  workflowId: string;
+  repo: string;
+  ownerAgentId: string;
+  ownerRunId: string;
+  phase: FactoryWorkflowPhase;
+  ttlMs: number;
+  now?: Date;
+}
+
+export type AcquireWorkflowClaimResult =
+  | { acquired: true; claim: FactoryWorkflowClaim }
+  | { acquired: false; conflict: FactoryWorkflowClaim };
+
+interface HandoffRow {
+  id: string;
+  workflow_id: string;
+  repo: string;
+  source_issue: string | null;
+  source_pr: string | null;
+  phase: string;
+  owner_agent_id: string;
+  driver: string;
+  intent: string;
+  summary: string;
+  body: string;
+  decisions_json: string;
+  artifacts_json: string;
+  blockers_json: string;
+  next_driver: string | null;
+  next_scope: string | null;
+  metadata_json: string;
+  created_at: string;
+}
+
+interface ClaimRow {
+  workflow_id: string;
+  repo: string;
+  owner_agent_id: string;
+  owner_run_id: string;
+  phase: string;
+  claimed_at: string;
+  heartbeat_at: string;
+  expires_at: string;
+}
+
+export function isFactoryWorkflowPhase(
+  value: string,
+): value is FactoryWorkflowPhase {
+  return PHASE_ORDER.has(value as FactoryWorkflowPhase);
+}
+
+export function validateFactoryPhaseTransition(
+  from: FactoryWorkflowPhase | null,
+  to: FactoryWorkflowPhase,
+): void {
+  if (!isFactoryWorkflowPhase(to)) {
+    throw new Error(`Invalid factory workflow phase: ${to}`);
+  }
+  if (from === null) return;
+  const fromIndex = PHASE_ORDER.get(from);
+  const toIndex = PHASE_ORDER.get(to);
+  if (fromIndex === undefined || toIndex === undefined) {
+    throw new Error(`Invalid factory workflow transition: ${from} -> ${to}`);
+  }
+  if (toIndex < fromIndex) {
+    throw new Error(`Factory workflow cannot move backward: ${from} -> ${to}`);
+  }
+}
+
+export class FactoryWorkflowStore {
+  constructor(private readonly db: Database) {}
+
+  createHandoff(input: NewFactoryHandoffRecord): FactoryHandoffRecord {
+    const latest = this.getLatestHandoff(input.workflowId);
+    validateFactoryPhaseTransition(latest?.phase ?? null, input.phase);
+
+    const record: FactoryHandoffRecord = {
+      id: input.id ?? randomUUID(),
+      workflowId: input.workflowId,
+      repo: input.repo,
+      sourceIssue: input.sourceIssue,
+      sourcePr: input.sourcePr,
+      phase: input.phase,
+      ownerAgentId: input.ownerAgentId,
+      driver: input.driver,
+      intent: input.intent,
+      summary: input.summary,
+      body: input.body,
+      decisions: input.decisions ?? [],
+      artifacts: input.artifacts ?? [],
+      blockers: input.blockers ?? [],
+      nextDriver: input.nextDriver,
+      nextScope: input.nextScope,
+      metadata: input.metadata ?? {},
+      createdAt: input.createdAt ?? new Date().toISOString(),
+    };
+
+    this.db
+      .prepare(
+        `INSERT INTO factory_handoff_records
+          (id, workflow_id, repo, source_issue, source_pr, phase, owner_agent_id,
+           driver, intent, summary, body, decisions_json, artifacts_json,
+           blockers_json, next_driver, next_scope, metadata_json, created_at)
+         VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+      )
+      .run(
+        record.id,
+        record.workflowId,
+        record.repo,
+        record.sourceIssue ?? null,
+        record.sourcePr ?? null,
+        record.phase,
+        record.ownerAgentId,
+        record.driver,
+        record.intent,
+        record.summary,
+        record.body,
+        JSON.stringify(record.decisions),
+        JSON.stringify(record.artifacts),
+        JSON.stringify(record.blockers),
+        record.nextDriver ?? null,
+        record.nextScope ?? null,
+        JSON.stringify(record.metadata),
+        record.createdAt,
+      );
+
+    return record;
+  }
+
+  getHandoff(id: string): FactoryHandoffRecord | undefined {
+    const row = this.db
+      .prepare('SELECT * FROM factory_handoff_records WHERE id = ?')
+      .get(id) as HandoffRow | undefined;
+    return row ? mapHandoffRow(row) : undefined;
+  }
+
+  getLatestHandoff(workflowId: string): FactoryHandoffRecord | undefined {
+    const row = this.db
+      .prepare(
+        `SELECT * FROM factory_handoff_records
+         WHERE workflow_id = ?
+         ORDER BY created_at DESC, id DESC
+         LIMIT 1`,
+      )
+      .get(workflowId) as HandoffRow | undefined;
+    return row ? mapHandoffRow(row) : undefined;
+  }
+
+  listHandoffsForWorkflow(workflowId: string): FactoryHandoffRecord[] {
+    const rows = this.db
+      .prepare(
+        `SELECT * FROM factory_handoff_records
+         WHERE workflow_id = ?
+         ORDER BY created_at ASC, id ASC`,
+      )
+      .all(workflowId) as HandoffRow[];
+    return rows.map(mapHandoffRow);
+  }
+
+  findLatestHandoffByIssue(
+    repo: string,
+    sourceIssue: string,
+  ): FactoryHandoffRecord | undefined {
+    const row = this.db
+      .prepare(
+        `SELECT * FROM factory_handoff_records
+         WHERE repo = ? AND source_issue = ?
+         ORDER BY created_at DESC, id DESC
+         LIMIT 1`,
+      )
+      .get(repo, sourceIssue) as HandoffRow | undefined;
+    return row ? mapHandoffRow(row) : undefined;
+  }
+
+  acquireClaim(input: AcquireWorkflowClaimInput): AcquireWorkflowClaimResult {
+    if (input.ttlMs <= 0)
+      throw new Error('Workflow claim TTL must be positive');
+    const now = input.now ?? new Date();
+    const nowIso = now.toISOString();
+    const expiresAt = new Date(now.getTime() + input.ttlMs).toISOString();
+
+    this.deleteExpiredClaims(nowIso);
+
+    const existing = this.getClaim(input.workflowId);
+    if (existing) return { acquired: false, conflict: existing };
+
+    const claim: FactoryWorkflowClaim = {
+      workflowId: input.workflowId,
+      repo: input.repo,
+      ownerAgentId: input.ownerAgentId,
+      ownerRunId: input.ownerRunId,
+      phase: input.phase,
+      claimedAt: nowIso,
+      heartbeatAt: nowIso,
+      expiresAt,
+    };
+
+    this.db
+      .prepare(
+        `INSERT INTO factory_workflow_claims
+          (workflow_id, repo, owner_agent_id, owner_run_id, phase,
+           claimed_at, heartbeat_at, expires_at)
+         VALUES (?, ?, ?, ?, ?, ?, ?, ?)`,
+      )
+      .run(
+        claim.workflowId,
+        claim.repo,
+        claim.ownerAgentId,
+        claim.ownerRunId,
+        claim.phase,
+        claim.claimedAt,
+        claim.heartbeatAt,
+        claim.expiresAt,
+      );
+
+    return { acquired: true, claim };
+  }
+
+  refreshClaim(
+    workflowId: string,
+    ownerRunId: string,
+    ttlMs: number,
+    now = new Date(),
+  ): FactoryWorkflowClaim | undefined {
+    if (ttlMs <= 0) throw new Error('Workflow claim TTL must be positive');
+    const nowIso = now.toISOString();
+    const expiresAt = new Date(now.getTime() + ttlMs).toISOString();
+    this.db
+      .prepare(
+        `UPDATE factory_workflow_claims
+         SET heartbeat_at = ?, expires_at = ?
+         WHERE workflow_id = ? AND owner_run_id = ?`,
+      )
+      .run(nowIso, expiresAt, workflowId, ownerRunId);
+    return this.getClaim(workflowId);
+  }
+
+  releaseClaim(workflowId: string, ownerRunId?: string): void {
+    if (ownerRunId) {
+      this.db
+        .prepare(
+          'DELETE FROM factory_workflow_claims WHERE workflow_id = ? AND owner_run_id = ?',
+        )
+        .run(workflowId, ownerRunId);
+      return;
+    }
+    this.db
+      .prepare('DELETE FROM factory_workflow_claims WHERE workflow_id = ?')
+      .run(workflowId);
+  }
+
+  getClaim(workflowId: string): FactoryWorkflowClaim | undefined {
+    const row = this.db
+      .prepare('SELECT * FROM factory_workflow_claims WHERE workflow_id = ?')
+      .get(workflowId) as ClaimRow | undefined;
+    return row ? mapClaimRow(row) : undefined;
+  }
+
+  deleteExpiredClaims(nowIso = new Date().toISOString()): number {
+    const result = this.db
+      .prepare('DELETE FROM factory_workflow_claims WHERE expires_at <= ?')
+      .run(nowIso);
+    return result.changes;
+  }
+}
+
+function mapHandoffRow(row: HandoffRow): FactoryHandoffRecord {
+  return {
+    id: row.id,
+    workflowId: row.workflow_id,
+    repo: row.repo,
+    sourceIssue: row.source_issue ?? undefined,
+    sourcePr: row.source_pr ?? undefined,
+    phase: row.phase as FactoryWorkflowPhase,
+    ownerAgentId: row.owner_agent_id,
+    driver: row.driver,
+    intent: row.intent,
+    summary: row.summary,
+    body: row.body,
+    decisions: parseJson<string[]>(row.decisions_json, []),
+    artifacts: parseJson<FactoryWorkflowArtifact[]>(row.artifacts_json, []),
+    blockers: parseJson<string[]>(row.blockers_json, []),
+    nextDriver: row.next_driver ?? undefined,
+    nextScope: row.next_scope ?? undefined,
+    metadata: parseJson<Record<string, unknown>>(row.metadata_json, {}),
+    createdAt: row.created_at,
+  };
+}
+
+function mapClaimRow(row: ClaimRow): FactoryWorkflowClaim {
+  return {
+    workflowId: row.workflow_id,
+    repo: row.repo,
+    ownerAgentId: row.owner_agent_id,
+    ownerRunId: row.owner_run_id,
+    phase: row.phase as FactoryWorkflowPhase,
+    claimedAt: row.claimed_at,
+    heartbeatAt: row.heartbeat_at,
+    expiresAt: row.expires_at,
+  };
+}
+
+function parseJson<T>(value: string, fallback: T): T {
+  try {
+    return JSON.parse(value) as T;
+  } catch {
+    return fallback;
+  }
+}

--- a/src/factory-workflows.ts
+++ b/src/factory-workflows.ts
@@ -270,13 +270,14 @@ export class FactoryWorkflowStore {
     if (ttlMs <= 0) throw new Error('Workflow claim TTL must be positive');
     const nowIso = now.toISOString();
     const expiresAt = new Date(now.getTime() + ttlMs).toISOString();
-    this.db
+    const result = this.db
       .prepare(
         `UPDATE factory_workflow_claims
          SET heartbeat_at = ?, expires_at = ?
-         WHERE workflow_id = ? AND owner_run_id = ?`,
+         WHERE workflow_id = ? AND owner_run_id = ? AND expires_at > ?`,
       )
-      .run(nowIso, expiresAt, workflowId, ownerRunId);
+      .run(nowIso, expiresAt, workflowId, ownerRunId, nowIso);
+    if (result.changes === 0) return undefined;
     return this.getClaim(workflowId);
   }
 

--- a/src/factory-workflows.ts
+++ b/src/factory-workflows.ts
@@ -184,7 +184,7 @@ export class FactoryWorkflowStore {
       .prepare(
         `SELECT * FROM factory_handoff_records
          WHERE workflow_id = ?
-         ORDER BY created_at DESC, id DESC
+         ORDER BY created_at DESC, rowid DESC
          LIMIT 1`,
       )
       .get(workflowId) as HandoffRow | undefined;
@@ -196,7 +196,7 @@ export class FactoryWorkflowStore {
       .prepare(
         `SELECT * FROM factory_handoff_records
          WHERE workflow_id = ?
-         ORDER BY created_at ASC, id ASC`,
+         ORDER BY created_at ASC, rowid ASC`,
       )
       .all(workflowId) as HandoffRow[];
     return rows.map(mapHandoffRow);
@@ -210,7 +210,7 @@ export class FactoryWorkflowStore {
       .prepare(
         `SELECT * FROM factory_handoff_records
          WHERE repo = ? AND source_issue = ?
-         ORDER BY created_at DESC, id DESC
+         ORDER BY created_at DESC, rowid DESC
          LIMIT 1`,
       )
       .get(repo, sourceIssue) as HandoffRow | undefined;
@@ -224,11 +224,6 @@ export class FactoryWorkflowStore {
     const nowIso = now.toISOString();
     const expiresAt = new Date(now.getTime() + input.ttlMs).toISOString();
 
-    this.deleteExpiredClaims(nowIso);
-
-    const existing = this.getClaim(input.workflowId);
-    if (existing) return { acquired: false, conflict: existing };
-
     const claim: FactoryWorkflowClaim = {
       workflowId: input.workflowId,
       repo: input.repo,
@@ -240,25 +235,41 @@ export class FactoryWorkflowStore {
       expiresAt,
     };
 
-    this.db
-      .prepare(
-        `INSERT INTO factory_workflow_claims
-          (workflow_id, repo, owner_agent_id, owner_run_id, phase,
-           claimed_at, heartbeat_at, expires_at)
-         VALUES (?, ?, ?, ?, ?, ?, ?, ?)`,
-      )
-      .run(
-        claim.workflowId,
-        claim.repo,
-        claim.ownerAgentId,
-        claim.ownerRunId,
-        claim.phase,
-        claim.claimedAt,
-        claim.heartbeatAt,
-        claim.expiresAt,
-      );
+    const transaction = this.db.transaction(() => {
+      this.deleteExpiredClaims(nowIso);
 
-    return { acquired: true, claim };
+      const existing = this.getClaim(input.workflowId);
+      if (existing) return existing;
+
+      this.db
+        .prepare(
+          `INSERT OR IGNORE INTO factory_workflow_claims
+            (workflow_id, repo, owner_agent_id, owner_run_id, phase,
+             claimed_at, heartbeat_at, expires_at)
+           VALUES (?, ?, ?, ?, ?, ?, ?, ?)`,
+        )
+        .run(
+          claim.workflowId,
+          claim.repo,
+          claim.ownerAgentId,
+          claim.ownerRunId,
+          claim.phase,
+          claim.claimedAt,
+          claim.heartbeatAt,
+          claim.expiresAt,
+        );
+
+      return this.getClaim(input.workflowId);
+    });
+
+    const current = transaction() as FactoryWorkflowClaim | undefined;
+    if (current?.ownerRunId === claim.ownerRunId) {
+      return { acquired: true, claim: current };
+    }
+
+    if (current) return { acquired: false, conflict: current };
+
+    throw new Error('Failed to acquire workflow claim');
   }
 
   refreshClaim(

--- a/src/migrations.test.ts
+++ b/src/migrations.test.ts
@@ -154,4 +154,19 @@ describe('migration versioning', () => {
 
     db.close();
   });
+
+  it('creates factory workflow handoff and claim tables', () => {
+    const db = new Database(':memory:');
+
+    runMigrations(db, allMigrations);
+
+    expect(getSchemaVersion(db)).toBe(BASELINE_VERSION);
+    expect(getColumns(db, 'factory_handoff_records')).toContain('workflow_id');
+    expect(getColumns(db, 'factory_handoff_records')).toContain(
+      'artifacts_json',
+    );
+    expect(getColumns(db, 'factory_workflow_claims')).toContain('expires_at');
+
+    db.close();
+  });
 });

--- a/src/migrations.ts
+++ b/src/migrations.ts
@@ -16,7 +16,7 @@ export interface Migration {
  * The version that represents the latest schema. Existing databases that
  * predate the migration framework are advanced through every migration to this.
  */
-export const BASELINE_VERSION = 2;
+export const BASELINE_VERSION = 3;
 
 // ---------------------------------------------------------------------------
 // Schema helpers (available for use in migrations)
@@ -503,6 +503,54 @@ const migration2: Migration = {
   },
 };
 
+const migration3: Migration = {
+  version: 3,
+  description: 'Persist factory workflow handoffs and active claims',
+  up: (db) => {
+    db.exec(`
+      CREATE TABLE IF NOT EXISTS factory_handoff_records (
+        id TEXT PRIMARY KEY,
+        workflow_id TEXT NOT NULL,
+        repo TEXT NOT NULL,
+        source_issue TEXT,
+        source_pr TEXT,
+        phase TEXT NOT NULL,
+        owner_agent_id TEXT NOT NULL,
+        driver TEXT NOT NULL,
+        intent TEXT NOT NULL,
+        summary TEXT NOT NULL,
+        body TEXT NOT NULL,
+        decisions_json TEXT NOT NULL DEFAULT '[]',
+        artifacts_json TEXT NOT NULL DEFAULT '[]',
+        blockers_json TEXT NOT NULL DEFAULT '[]',
+        next_driver TEXT,
+        next_scope TEXT,
+        metadata_json TEXT NOT NULL DEFAULT '{}',
+        created_at TEXT NOT NULL
+      );
+      CREATE INDEX IF NOT EXISTS idx_factory_handoffs_workflow
+        ON factory_handoff_records(workflow_id, created_at DESC);
+      CREATE INDEX IF NOT EXISTS idx_factory_handoffs_repo_issue
+        ON factory_handoff_records(repo, source_issue, created_at DESC);
+
+      CREATE TABLE IF NOT EXISTS factory_workflow_claims (
+        workflow_id TEXT PRIMARY KEY,
+        repo TEXT NOT NULL,
+        owner_agent_id TEXT NOT NULL,
+        owner_run_id TEXT NOT NULL,
+        phase TEXT NOT NULL,
+        claimed_at TEXT NOT NULL,
+        heartbeat_at TEXT NOT NULL,
+        expires_at TEXT NOT NULL
+      );
+      CREATE INDEX IF NOT EXISTS idx_factory_claims_expires_at
+        ON factory_workflow_claims(expires_at);
+      CREATE INDEX IF NOT EXISTS idx_factory_claims_repo
+        ON factory_workflow_claims(repo);
+    `);
+  },
+};
+
 // ---------------------------------------------------------------------------
 // Migration registry
 // ---------------------------------------------------------------------------
@@ -513,4 +561,4 @@ const migration2: Migration = {
  * can use plain `ALTER TABLE` without try/catch — the version tracker
  * guarantees each migration runs exactly once.
  */
-export const allMigrations: Migration[] = [migration1, migration2];
+export const allMigrations: Migration[] = [migration1, migration2, migration3];

--- a/src/types.ts
+++ b/src/types.ts
@@ -212,6 +212,53 @@ export interface TaskRunPhaseEvent {
   error: string | null;
 }
 
+export type FactoryWorkflowPhase =
+  | 'discovery'
+  | 'spec'
+  | 'impl'
+  | 'review'
+  | 'qa'
+  | 'done';
+
+export interface FactoryWorkflowArtifact {
+  type: 'issue' | 'pr' | 'branch' | 'commit' | 'file' | 'url' | 'note';
+  label: string;
+  url?: string;
+  path?: string;
+}
+
+export interface FactoryHandoffRecord {
+  id: string;
+  workflowId: string;
+  repo: string;
+  sourceIssue?: string;
+  sourcePr?: string;
+  phase: FactoryWorkflowPhase;
+  ownerAgentId: string;
+  driver: string;
+  intent: string;
+  summary: string;
+  body: string;
+  decisions: string[];
+  artifacts: FactoryWorkflowArtifact[];
+  blockers: string[];
+  nextDriver?: string;
+  nextScope?: string;
+  metadata: Record<string, unknown>;
+  createdAt: string;
+}
+
+export interface FactoryWorkflowClaim {
+  workflowId: string;
+  repo: string;
+  ownerAgentId: string;
+  ownerRunId: string;
+  phase: FactoryWorkflowPhase;
+  claimedAt: string;
+  heartbeatAt: string;
+  expiresAt: string;
+}
+
 // --- Channel abstraction ---
 
 export interface Channel {


### PR DESCRIPTION
## Summary

- Adds SQLite-backed factory handoff records and active workflow claims for #643.
- Adds a `FactoryWorkflowStore` with monotonic phase validation, issue/workflow retrieval, duplicate-owner detection, TTL expiry, refresh, and release helpers.
- Documents the first durable SDLC driver handoff contract under `docs/`.

## Tests

- `bun test src/factory-workflows.test.ts src/migrations.test.ts`
- `bun run typecheck`
- `bun test`

Closes #643? No. This is the persistence/schema spike; slash command emission/retrieval wiring remains follow-up work.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Persistent factory workflow handoffs with structured state, metadata and artifact storage.
  * Workflow ownership claims with TTL-based expiry and safe acquire/refresh/release semantics.
  * Enforced forward-only workflow phase transitions and retrieval of latest or scoped handoffs.

* **Documentation**
  * Added formal handoff workflow and ownership contract guidance.

* **Tests**
  * Added comprehensive tests covering handoffs, claims, migrations and phase rules.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/omniaura/omniclaw/pull/645)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->