### PR TITLE
feat(discord): add session command namespace

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,6 +113,11 @@ You can add your own channel- or agent-specific slash flows by creating `discord
 
 Command names must be lowercase Discord slash-command names (`a-z`, `0-9`, `_`, `-`). OmniClaw merges built-ins with runtime command files and syncs them per Discord guild on startup and subscription changes, so restart the bot after editing command files.
 
+Discord session control is exposed through the built-in `/session` namespace:
+`/session new`, `/session resume`, `/session list`, `/session current`,
+`/session end`, and `/session rename`. The legacy `/resume` and `/sessions`
+aliases remain registered for one release and return a deprecation notice.
+
 By default, every built-in and workspace slash flow is enabled for every agent. To specialize an agent, add `discordCommands` to its `agents.yaml` entry. `enabled` is an optional allowlist; `disabled` is applied after the allowlist:
 
 ```yaml

--- a/container/agent-runner/src/index.ts
+++ b/container/agent-runner/src/index.ts
@@ -1228,6 +1228,7 @@ async function runQuery(
       additionalDirectories: extraDirs.length > 0 ? extraDirs : undefined,
       resume: sessionId,
       resumeSessionAt: sessionId ? resumeAt : undefined,
+      forkSession: containerInput.forkSession === true,
       systemPrompt: globalClaudeMd
         ? {
             type: 'preset' as const,

--- a/packages/protocol/src/index.d.ts
+++ b/packages/protocol/src/index.d.ts
@@ -24,6 +24,8 @@ export interface ContainerInput {
   prompt: string;
   sessionId?: string;
   resumeAt?: string;
+  /** When true, resume from sessionId but create a new branched session. */
+  forkSession?: boolean;
   groupFolder: string;
   /** Host-side runtime key for IPC/session isolation (defaults to groupFolder). */
   runtimeFolder?: string;

--- a/packages/protocol/src/index.ts
+++ b/packages/protocol/src/index.ts
@@ -36,6 +36,8 @@ export interface ContainerInput {
   prompt: string;
   sessionId?: string;
   resumeAt?: string;
+  /** When true, resume from sessionId but create a new branched session. */
+  forkSession?: boolean;
   groupFolder: string;
   /** Host-side runtime key for IPC/session isolation (defaults to groupFolder). */
   runtimeFolder?: string;

--- a/src/channels/discord.ts
+++ b/src/channels/discord.ts
@@ -189,6 +189,22 @@ export interface SessionCommandResult {
   message: string;
 }
 
+export type SessionCommandName =
+  | 'new'
+  | 'resume'
+  | 'list'
+  | 'current'
+  | 'end'
+  | 'rename';
+
+export interface SessionCommandOptions {
+  sessionId?: string;
+  name?: string;
+  resumeFrom?: string;
+  limit?: number;
+  deprecatedAlias?: 'resume' | 'sessions';
+}
+
 export interface DiscordChannelOpts {
   botId: string;
   token: string;
@@ -204,10 +220,10 @@ export interface DiscordChannelOpts {
     userName: string,
   ) => void;
   onSessionCommand?: (
-    command: 'resume' | 'sessions',
+    command: SessionCommandName,
     chatJid: string,
     group: RegisteredGroup,
-    sessionId?: string,
+    options?: SessionCommandOptions,
   ) => SessionCommandResult;
 }
 
@@ -1240,7 +1256,7 @@ export class DiscordChannel implements Channel {
       return;
     }
 
-    // Handle system commands (resume, sessions) directly on the host
+    // Handle system commands directly on the host.
     if (SYSTEM_COMMAND_NAMES.has(interaction.commandName)) {
       if (
         !interaction.memberPermissions?.has(PermissionFlagsBits.ManageChannels)
@@ -1257,14 +1273,7 @@ export class DiscordChannel implements Channel {
         });
         return;
       }
-      const sessionId =
-        interaction.options.getString('session_id') ?? undefined;
-      const result = this.opts.onSessionCommand(
-        interaction.commandName as 'resume' | 'sessions',
-        chatJid,
-        group,
-        sessionId,
-      );
+      const result = this.dispatchSessionCommand(interaction, chatJid, group);
       await interaction.editReply({ content: result.message });
       return;
     }
@@ -1362,6 +1371,59 @@ export class DiscordChannel implements Channel {
           'I acknowledged the command, but failed to queue it. Check OmniClaw logs for details.',
         ephemeral: true,
       });
+    }
+  }
+
+  private dispatchSessionCommand(
+    interaction: ChatInputCommandInteraction,
+    chatJid: string,
+    group: RegisteredGroup,
+  ): SessionCommandResult {
+    if (!this.opts.onSessionCommand) {
+      return { message: 'Session commands are not configured.' };
+    }
+
+    if (interaction.commandName === 'resume') {
+      return this.opts.onSessionCommand('resume', chatJid, group, {
+        sessionId: interaction.options.getString('session_id') ?? undefined,
+        deprecatedAlias: 'resume',
+      });
+    }
+
+    if (interaction.commandName === 'sessions') {
+      return this.opts.onSessionCommand('list', chatJid, group, {
+        deprecatedAlias: 'sessions',
+      });
+    }
+
+    const subcommand = interaction.options.getSubcommand(false);
+    switch (subcommand) {
+      case 'new':
+        return this.opts.onSessionCommand('new', chatJid, group, {
+          name: interaction.options.getString('name') ?? undefined,
+          resumeFrom: interaction.options.getString('resume_from') ?? undefined,
+        });
+      case 'resume':
+        return this.opts.onSessionCommand('resume', chatJid, group, {
+          sessionId: interaction.options.getString('session_id') ?? undefined,
+        });
+      case 'list':
+        return this.opts.onSessionCommand('list', chatJid, group, {
+          limit: interaction.options.getInteger('limit') ?? undefined,
+        });
+      case 'current':
+        return this.opts.onSessionCommand('current', chatJid, group);
+      case 'end':
+        return this.opts.onSessionCommand('end', chatJid, group, {
+          sessionId: interaction.options.getString('session_id') ?? undefined,
+        });
+      case 'rename':
+        return this.opts.onSessionCommand('rename', chatJid, group, {
+          sessionId: interaction.options.getString('session_id') ?? undefined,
+          name: interaction.options.getString('name') ?? undefined,
+        });
+      default:
+        return { message: 'Unknown session subcommand.' };
     }
   }
 }

--- a/src/db.test.ts
+++ b/src/db.test.ts
@@ -3,6 +3,7 @@ import { describe, it, expect, beforeEach, spyOn } from 'bun:test';
 import {
   _countGitHubWebhookDeliveriesForTest,
   _initTestDatabase,
+  clearSession,
   cleanupExpiredGitHubWebhookDeliveries,
   createTask,
   deleteTask,
@@ -14,6 +15,8 @@ import {
   getDeltaCursorFromDb,
   getMessagesSince,
   getNewMessages,
+  getSession,
+  getSessionMetadata,
   getTaskById,
   loadAllDeltaCursors,
   recordGitHubWebhookDelivery,
@@ -21,6 +24,9 @@ import {
   setDeltaCursorInDb,
   setAgentHealth,
   setRegisteredGroup,
+  setSession,
+  setSessionName,
+  markSessionEnded,
   storeChatMetadata,
   storeMessage,
   updateTask,
@@ -94,6 +100,26 @@ describe('registered group persistence', () => {
     } finally {
       warnSpy.mockRestore();
     }
+  });
+});
+
+describe('session persistence', () => {
+  it('clears active sessions and stores session metadata', () => {
+    setSession('runtime-a', 'session-1');
+    expect(getSession('runtime-a')).toBe('session-1');
+
+    setSessionName('runtime-a', 'session-1', 'Planning thread');
+    expect(getSessionMetadata('runtime-a', 'session-1')?.name).toBe(
+      'Planning thread',
+    );
+
+    markSessionEnded('runtime-a', 'session-1');
+    expect(typeof getSessionMetadata('runtime-a', 'session-1')?.endedAt).toBe(
+      'string',
+    );
+
+    clearSession('runtime-a');
+    expect(getSession('runtime-a')).toBeUndefined();
   });
 });
 

--- a/src/db.ts
+++ b/src/db.ts
@@ -1205,6 +1205,10 @@ export function setSession(groupFolder: string, sessionId: string): void {
   ).run(groupFolder, sessionId);
 }
 
+export function clearSession(groupFolder: string): void {
+  db.query('DELETE FROM sessions WHERE group_folder = ?').run(groupFolder);
+}
+
 export function getAllSessions(): Record<string, string> {
   const rows = db
     .prepare('SELECT group_folder, session_id FROM sessions')
@@ -1214,6 +1218,108 @@ export function getAllSessions(): Record<string, string> {
     result[row.group_folder] = row.session_id;
   }
   return result;
+}
+
+export interface SessionMetadata {
+  runtimeFolder: string;
+  sessionId: string;
+  name?: string;
+  endedAt?: string;
+  createdAt: string;
+  updatedAt: string;
+}
+
+function mapSessionMetadataRow(row: {
+  runtime_folder: string;
+  session_id: string;
+  name: string | null;
+  ended_at: string | null;
+  created_at: string;
+  updated_at: string;
+}): SessionMetadata {
+  return {
+    runtimeFolder: row.runtime_folder,
+    sessionId: row.session_id,
+    name: row.name || undefined,
+    endedAt: row.ended_at || undefined,
+    createdAt: row.created_at,
+    updatedAt: row.updated_at,
+  };
+}
+
+export function getSessionMetadata(
+  runtimeFolder: string,
+  sessionId: string,
+): SessionMetadata | undefined {
+  const row = db
+    .prepare(
+      `SELECT runtime_folder, session_id, name, ended_at, created_at, updated_at
+       FROM session_metadata
+       WHERE runtime_folder = ? AND session_id = ?`,
+    )
+    .get(runtimeFolder, sessionId) as
+    | {
+        runtime_folder: string;
+        session_id: string;
+        name: string | null;
+        ended_at: string | null;
+        created_at: string;
+        updated_at: string;
+      }
+    | undefined;
+  return row ? mapSessionMetadataRow(row) : undefined;
+}
+
+export function getSessionMetadataForRuntime(
+  runtimeFolder: string,
+): Record<string, SessionMetadata> {
+  const rows = db
+    .prepare(
+      `SELECT runtime_folder, session_id, name, ended_at, created_at, updated_at
+       FROM session_metadata
+       WHERE runtime_folder = ?`,
+    )
+    .all(runtimeFolder) as Array<{
+    runtime_folder: string;
+    session_id: string;
+    name: string | null;
+    ended_at: string | null;
+    created_at: string;
+    updated_at: string;
+  }>;
+  const result: Record<string, SessionMetadata> = {};
+  for (const row of rows) {
+    const metadata = mapSessionMetadataRow(row);
+    result[metadata.sessionId] = metadata;
+  }
+  return result;
+}
+
+export function setSessionName(
+  runtimeFolder: string,
+  sessionId: string,
+  name: string,
+): void {
+  db.query(
+    `INSERT INTO session_metadata
+       (runtime_folder, session_id, name, updated_at)
+     VALUES (?, ?, ?, datetime('now'))
+     ON CONFLICT(runtime_folder, session_id)
+     DO UPDATE SET name = excluded.name, updated_at = datetime('now')`,
+  ).run(runtimeFolder, sessionId, name);
+}
+
+export function markSessionEnded(
+  runtimeFolder: string,
+  sessionId: string,
+): void {
+  db.query(
+    `INSERT INTO session_metadata
+       (runtime_folder, session_id, ended_at, updated_at)
+     VALUES (?, ?, datetime('now'), datetime('now'))
+     ON CONFLICT(runtime_folder, session_id)
+     DO UPDATE SET ended_at = datetime('now'), updated_at = datetime('now')`,
+  ).run(runtimeFolder, sessionId);
 }
 
 /**

--- a/src/discord-command-flows.test.ts
+++ b/src/discord-command-flows.test.ts
@@ -42,6 +42,7 @@ describe('discord command flows', () => {
     expect(names).toContain('research-driver');
     expect(names).toContain('taskbooker');
     expect(names).toContain('scheduler');
+    expect(names).toContain('session');
   });
 
   it('renders flow prompts with provided values and defaults', () => {
@@ -253,6 +254,31 @@ describe('discord command flows', () => {
       mergemaster?.options?.find((option) => option.name === 'duration_minutes')
         ?.type,
     ).toBe(ApplicationCommandOptionType.Integer);
+  });
+
+  it('builds the session command as native Discord subcommands', () => {
+    const payloads = buildDiscordSlashCommandPayloads([makeGroup()]);
+    const session = payloads.find((command) => command.name === 'session');
+
+    expect(session?.options?.map((option) => option.name)).toEqual([
+      'new',
+      'resume',
+      'list',
+      'current',
+      'end',
+      'rename',
+    ]);
+    expect(
+      session?.options?.every(
+        (option) => option.type === ApplicationCommandOptionType.Subcommand,
+      ),
+    ).toBe(true);
+    const rename = session?.options?.find((option) => option.name === 'rename');
+    expect(
+      rename && 'options' in rename
+        ? rename.options?.map((option) => option.name)
+        : [],
+    ).toEqual(['session_id', 'name']);
   });
 
   it('ignores invalid commands and invalid options from custom files', () => {

--- a/src/discord-command-flows.ts
+++ b/src/discord-command-flows.ts
@@ -27,8 +27,15 @@ export interface DiscordFlowDefinition {
   description: string;
   prompt: string;
   options?: DiscordFlowOptionDefinition[];
+  subcommands?: DiscordFlowSubcommandDefinition[];
   /** System commands are handled by the host, not sent to the agent. */
   system?: boolean;
+}
+
+export interface DiscordFlowSubcommandDefinition {
+  name: string;
+  description: string;
+  options?: DiscordFlowOptionDefinition[];
 }
 
 interface DiscordFlowFile {
@@ -239,6 +246,85 @@ const BUILTIN_COMMANDS: DiscordFlowDefinition[] = [
         description: 'Planning timebox in minutes',
         type: 'integer',
         defaultValue: 30,
+      },
+    ],
+  },
+  {
+    name: 'session',
+    description: 'Control agent sessions in this channel',
+    prompt: '',
+    system: true,
+    subcommands: [
+      {
+        name: 'new',
+        description: 'Start a fresh agent session in this channel',
+        options: [
+          {
+            name: 'name',
+            description: 'Optional human-readable session name',
+            type: 'string',
+          },
+          {
+            name: 'resume_from',
+            description: 'Existing session ID to branch from',
+            type: 'string',
+          },
+        ],
+      },
+      {
+        name: 'resume',
+        description: 'Resume a previous session',
+        options: [
+          {
+            name: 'session_id',
+            description: 'Session ID to resume (omit to see recent sessions)',
+            type: 'string',
+          },
+        ],
+      },
+      {
+        name: 'list',
+        description: 'List recent sessions',
+        options: [
+          {
+            name: 'limit',
+            description: 'Maximum number of sessions to show',
+            type: 'integer',
+          },
+        ],
+      },
+      {
+        name: 'current',
+        description: 'Show the active session',
+      },
+      {
+        name: 'end',
+        description: 'End the current or specified session',
+        options: [
+          {
+            name: 'session_id',
+            description: 'Session ID to end (omit for current)',
+            type: 'string',
+          },
+        ],
+      },
+      {
+        name: 'rename',
+        description: 'Rename a session',
+        options: [
+          {
+            name: 'session_id',
+            description: 'Session ID to rename',
+            type: 'string',
+            required: true,
+          },
+          {
+            name: 'name',
+            description: 'New human-readable session name',
+            type: 'string',
+            required: true,
+          },
+        ],
       },
     ],
   },
@@ -472,8 +558,22 @@ export function buildDiscordSlashCommandPayloads(
     .map((command) => ({
       name: command.name,
       description: command.description,
-      options: command.options?.map((option) => toDiscordOptionData(option)),
+      options:
+        command.subcommands?.map((subcommand) =>
+          toDiscordSubcommandData(subcommand),
+        ) ?? command.options?.map((option) => toDiscordOptionData(option)),
     }));
+}
+
+function toDiscordSubcommandData(
+  subcommand: DiscordFlowSubcommandDefinition,
+): ApplicationCommandOptionData {
+  return {
+    name: subcommand.name,
+    description: subcommand.description,
+    type: ApplicationCommandOptionType.Subcommand,
+    options: subcommand.options?.map((option) => toDiscordOptionData(option)),
+  } as ApplicationCommandOptionData;
 }
 
 function toDiscordOptionData(

--- a/src/index.ts
+++ b/src/index.ts
@@ -14,7 +14,11 @@ import {
   buildAgentToChannelsMapFromSubscriptions,
   buildSendToInstruction,
 } from './channel-routes.js';
-import { DiscordChannel } from './channels/discord.js';
+import {
+  DiscordChannel,
+  type SessionCommandName,
+  type SessionCommandOptions,
+} from './channels/discord.js';
 import { SlackChannel } from './channels/slack.js';
 import { TelegramChannel } from './channels/telegram.js';
 import { WhatsAppChannel } from './channels/whatsapp.js';
@@ -55,6 +59,7 @@ import {
 } from './config.js';
 import { resolveContextLayers } from './context-layers.js';
 import {
+  clearSession,
   createTrustStore,
   createTask as dbCreateTask,
   deleteTask as dbDeleteTask,
@@ -78,11 +83,13 @@ import {
   getNewMessages,
   getOrCreateDiscoveryInstanceId,
   getRouterState,
+  getSessionMetadataForRuntime,
   getSubscriptionsForAgent,
   getTaskById,
   getTaskRunLogs,
   getTaskRunPhaseEvents,
   initDatabase,
+  markSessionEnded,
   setAgent,
   setAgentHealth,
   setChannelRoute,
@@ -90,6 +97,7 @@ import {
   setRegisteredGroup,
   setRouterState,
   setSession,
+  setSessionName,
   storeChatMetadata,
   storeGuildRoster,
   storeMessage,
@@ -207,6 +215,8 @@ async function shutdown(): Promise<void> {
 
 let lastTimestamp = '';
 let sessions: Record<string, string> = {};
+const pendingSessionNames = new Map<string, string>();
+const pendingSessionForks = new Map<string, string>();
 const resumePositionStore = createResumePositionStore({
   persistentTaskState: PERSISTENT_TASK_STATE,
   initialResumePositions: {},
@@ -315,19 +325,13 @@ function getRuntimeGroupFolder(
   return runtimeFolder;
 }
 
-/**
- * Handle /resume and /sessions Discord slash commands.
- * These operate on the host's session store directly rather than sending
- * a prompt to the agent.
- */
-function handleSessionCommand(
-  command: 'resume' | 'sessions',
+function resolveSessionRuntime(
   chatJid: string,
   group: RegisteredGroup,
-  sessionId?: string,
-): { message: string } {
-  // Compute the correct runtime folder, accounting for subscription-based
-  // multi-agent channels that use makeDispatchKey for session keying.
+): {
+  runtimeFolder: string;
+  sessionsDir: string;
+} {
   const subs = getSubscriptionsForChannelInMemory(chatJid);
   const matchingSub = subs.find((s) => {
     const agent = agents[s.agentId];
@@ -345,69 +349,174 @@ function handleSessionCommand(
     'projects',
     '-workspace-group',
   );
+  return { runtimeFolder, sessionsDir };
+}
 
-  if (command === 'sessions') {
-    if (!fs.existsSync(sessionsDir)) {
-      return { message: 'No sessions found for this channel.' };
-    }
-    const files = fs
-      .readdirSync(sessionsDir)
-      .filter((f) => f.endsWith('.jsonl'));
-    if (files.length === 0) {
-      return { message: 'No sessions found for this channel.' };
+function isValidSessionId(sessionId: string): boolean {
+  return /^[a-f0-9-]+$/i.test(sessionId);
+}
+
+function listSessionFiles(sessionsDir: string): Array<{
+  sessionId: string;
+  modifiedAt: Date;
+  sizeBytes: number;
+}> {
+  if (!fs.existsSync(sessionsDir)) return [];
+  return fs
+    .readdirSync(sessionsDir)
+    .filter((f) => f.endsWith('.jsonl'))
+    .map((f) => {
+      const filePath = path.join(sessionsDir, f);
+      const stat = fs.statSync(filePath);
+      const sessionId = f.replace('.jsonl', '');
+      return { sessionId, modifiedAt: stat.mtime, sizeBytes: stat.size };
+    })
+    .sort((a, b) => b.modifiedAt.getTime() - a.modifiedAt.getTime());
+}
+
+function validateSessionFile(
+  sessionsDir: string,
+  sessionId: string,
+): string | null {
+  if (!isValidSessionId(sessionId)) {
+    return `Invalid session ID \`${sessionId}\`. Use \`/session list\` to list available sessions.`;
+  }
+  const sessionFile = path.join(sessionsDir, `${sessionId}.jsonl`);
+  if (!fs.existsSync(sessionFile)) {
+    return `Session \`${sessionId}\` not found. Use \`/session list\` to list available sessions.`;
+  }
+  return null;
+}
+
+/**
+ * Handle Discord session slash commands on the host rather than sending a
+ * prompt to the agent.
+ */
+function handleSessionCommand(
+  command: SessionCommandName,
+  chatJid: string,
+  group: RegisteredGroup,
+  options: SessionCommandOptions = {},
+): { message: string } {
+  const { runtimeFolder, sessionsDir } = resolveSessionRuntime(chatJid, group);
+  const aliasNotice = options.deprecatedAlias
+    ? `\`/${options.deprecatedAlias}\` is deprecated; use \`/session ${options.deprecatedAlias === 'sessions' ? 'list' : 'resume'}\` instead.\n\n`
+    : '';
+
+  if (command === 'list') {
+    const sessionInfos = listSessionFiles(sessionsDir);
+    if (sessionInfos.length === 0) {
+      return { message: `${aliasNotice}No sessions found for this channel.` };
     }
 
     const currentSessionId = sessions[runtimeFolder];
-    const sessionInfos = files
-      .map((f) => {
-        const filePath = path.join(sessionsDir, f);
-        const stat = fs.statSync(filePath);
-        const sid = f.replace('.jsonl', '');
-        return { sessionId: sid, modifiedAt: stat.mtime, sizeBytes: stat.size };
-      })
-      .sort((a, b) => b.modifiedAt.getTime() - a.modifiedAt.getTime());
-
-    const lines = sessionInfos.map((s) => {
+    const metadataById = getSessionMetadataForRuntime(runtimeFolder);
+    const limit =
+      options.limit && options.limit > 0
+        ? Math.min(Math.floor(options.limit), 25)
+        : sessionInfos.length;
+    const lines = sessionInfos.slice(0, limit).map((s) => {
+      const metadata = metadataById[s.sessionId];
       const current = s.sessionId === currentSessionId ? ' **(active)**' : '';
+      const ended = metadata?.endedAt ? ' _(ended)_' : '';
+      const name = metadata?.name ? ` — ${metadata.name}` : '';
       const sizeKb = Math.round(s.sizeBytes / 1024);
       const age = formatAge(s.modifiedAt);
-      return `\`${s.sessionId}\` — ${sizeKb}KB, ${age}${current}`;
+      return `\`${s.sessionId}\`${name} — ${sizeKb}KB, ${age}${current}${ended}`;
     });
 
     return {
-      message: `**Sessions for this channel** (${runtimeFolder}):\n${lines.join('\n')}`,
+      message: `${aliasNotice}**Sessions for this channel** (${runtimeFolder}):\n${lines.join('\n')}`,
     };
   }
 
-  // command === 'resume'
-  if (!sessionId) {
-    // No session ID provided — show sessions instead
-    return handleSessionCommand('sessions', chatJid, group);
-  }
-
-  // Guard against path traversal — session IDs are hex UUIDs
-  if (!/^[a-f0-9-]+$/i.test(sessionId)) {
+  if (command === 'current') {
+    const currentSessionId = sessions[runtimeFolder];
+    if (!currentSessionId) {
+      return { message: 'No active session for this channel.' };
+    }
+    const metadata =
+      getSessionMetadataForRuntime(runtimeFolder)[currentSessionId];
+    const name = metadata?.name ? ` (${metadata.name})` : '';
     return {
-      message: `Invalid session ID \`${sessionId}\`. Use \`/sessions\` to list available sessions.`,
+      message: `Active session: \`${currentSessionId}\`${name}.`,
     };
   }
 
-  // Validate session file exists
-  const sessionFile = path.join(sessionsDir, `${sessionId}.jsonl`);
-  if (!fs.existsSync(sessionFile)) {
+  if (command === 'new') {
+    const resumeFrom = options.resumeFrom?.trim();
+    if (resumeFrom) {
+      const validationError = validateSessionFile(sessionsDir, resumeFrom);
+      if (validationError) return { message: validationError };
+      pendingSessionForks.set(runtimeFolder, resumeFrom);
+    } else {
+      pendingSessionForks.delete(runtimeFolder);
+    }
+    const name = options.name?.trim();
+    if (name) pendingSessionNames.set(runtimeFolder, name);
+    else pendingSessionNames.delete(runtimeFolder);
+    delete sessions[runtimeFolder];
+    clearSession(runtimeFolder);
+    resumePositionStore.set(runtimeFolder, '');
     return {
-      message: `Session \`${sessionId}\` not found. Use \`/sessions\` to list available sessions.`,
+      message: resumeFrom
+        ? `Fresh session queued from \`${resumeFrom}\`. The next message in this channel will branch from that session.`
+        : 'Fresh session queued. The next message in this channel will start a new session.',
     };
   }
 
-  // Override the session and clear resumeAt so the SDK resumes at latest
-  sessions[runtimeFolder] = sessionId;
-  setSession(runtimeFolder, sessionId);
-  resumePositionStore.set(runtimeFolder, '');
+  if (command === 'resume') {
+    const sessionId = options.sessionId?.trim();
+    if (!sessionId) {
+      return handleSessionCommand('list', chatJid, group, {
+        deprecatedAlias: options.deprecatedAlias,
+      });
+    }
+    const validationError = validateSessionFile(sessionsDir, sessionId);
+    if (validationError) return { message: `${aliasNotice}${validationError}` };
 
-  return {
-    message: `Session switched to \`${sessionId}\`. The next message in this channel will resume from that session.`,
-  };
+    sessions[runtimeFolder] = sessionId;
+    setSession(runtimeFolder, sessionId);
+    resumePositionStore.set(runtimeFolder, '');
+    pendingSessionForks.delete(runtimeFolder);
+    pendingSessionNames.delete(runtimeFolder);
+
+    return {
+      message: `${aliasNotice}Session switched to \`${sessionId}\`. The next message in this channel will resume from that session.`,
+    };
+  }
+
+  if (command === 'end') {
+    const sessionId = options.sessionId?.trim() || sessions[runtimeFolder];
+    if (!sessionId) return { message: 'No active session to end.' };
+    const validationError = validateSessionFile(sessionsDir, sessionId);
+    if (validationError) return { message: validationError };
+    markSessionEnded(runtimeFolder, sessionId);
+    if (sessions[runtimeFolder] === sessionId) {
+      delete sessions[runtimeFolder];
+      clearSession(runtimeFolder);
+      resumePositionStore.set(runtimeFolder, '');
+      pendingSessionForks.delete(runtimeFolder);
+      pendingSessionNames.delete(runtimeFolder);
+    }
+    return {
+      message: `Session \`${sessionId}\` ended. The next message will start a fresh session if this was active.`,
+    };
+  }
+
+  if (command === 'rename') {
+    const sessionId = options.sessionId?.trim();
+    const name = options.name?.trim();
+    if (!sessionId || !name) {
+      return { message: '`/session rename` requires `session_id` and `name`.' };
+    }
+    const validationError = validateSessionFile(sessionsDir, sessionId);
+    if (validationError) return { message: validationError };
+    setSessionName(runtimeFolder, sessionId, name);
+    return { message: `Session \`${sessionId}\` renamed to "${name}".` };
+  }
+
+  return { message: 'Unknown session command.' };
 }
 
 function formatAge(date: Date): string {
@@ -1767,7 +1876,9 @@ async function runAgent(
     );
   }
 
-  const sessionId = sessions[runtimeGroupFolder];
+  const forkFromSessionId = pendingSessionForks.get(runtimeGroupFolder);
+  const sessionId = forkFromSessionId ?? sessions[runtimeGroupFolder];
+  const forkSession = forkFromSessionId !== undefined;
 
   // Update tasks snapshot for container to read (filtered by group)
   writeTasksSnapshot(
@@ -1822,6 +1933,16 @@ async function runAgent(
         if (output.newSessionId) {
           sessions[runtimeGroupFolder] = output.newSessionId;
           setSession(runtimeGroupFolder, output.newSessionId);
+          const pendingName = pendingSessionNames.get(runtimeGroupFolder);
+          if (pendingName) {
+            setSessionName(
+              runtimeGroupFolder,
+              output.newSessionId,
+              pendingName,
+            );
+            pendingSessionNames.delete(runtimeGroupFolder);
+          }
+          pendingSessionForks.delete(runtimeGroupFolder);
         }
         if (output.resumeAt) {
           resumePositionStore.set(runtimeGroupFolder, output.resumeAt);
@@ -1886,6 +2007,7 @@ async function runAgent(
       {
         prompt,
         sessionId,
+        forkSession,
         resumeAt: resumePositionStore.get(runtimeGroupFolder),
         groupFolder: group.folder,
         runtimeFolder: runtimeGroupFolder,
@@ -1922,6 +2044,12 @@ async function runAgent(
     if (output.newSessionId) {
       sessions[runtimeGroupFolder] = output.newSessionId;
       setSession(runtimeGroupFolder, output.newSessionId);
+      const pendingName = pendingSessionNames.get(runtimeGroupFolder);
+      if (pendingName) {
+        setSessionName(runtimeGroupFolder, output.newSessionId, pendingName);
+        pendingSessionNames.delete(runtimeGroupFolder);
+      }
+      pendingSessionForks.delete(runtimeGroupFolder);
     }
     if (output.resumeAt) {
       resumePositionStore.set(runtimeGroupFolder, output.resumeAt);
@@ -3011,8 +3139,8 @@ async function main(): Promise<void> {
                 onSyntheticMessage: (message) => storeAndBroadcast(message),
                 registeredGroups: () => registeredGroups,
                 slashCommandGroups: buildSlashCommandGroupsFromSubscriptions,
-                onSessionCommand: (command, chatJid, group, sessionId) =>
-                  handleSessionCommand(command, chatJid, group, sessionId),
+                onSessionCommand: (command, chatJid, group, options) =>
+                  handleSessionCommand(command, chatJid, group, options),
                 onReaction: async (chatJid, messageId, emoji, userName) => {
                   await handleReactionNotification(
                     chatJid,

--- a/src/migrations.ts
+++ b/src/migrations.ts
@@ -16,7 +16,7 @@ export interface Migration {
  * The version that represents the latest schema. Existing databases that
  * predate the migration framework are advanced through every migration to this.
  */
-export const BASELINE_VERSION = 2;
+export const BASELINE_VERSION = 3;
 
 // ---------------------------------------------------------------------------
 // Schema helpers (available for use in migrations)
@@ -272,6 +272,16 @@ const migration1: Migration = {
         created_at TEXT NOT NULL DEFAULT (datetime('now'))
       );
 
+      CREATE TABLE IF NOT EXISTS session_metadata (
+        runtime_folder TEXT NOT NULL,
+        session_id TEXT NOT NULL,
+        name TEXT,
+        ended_at TEXT,
+        created_at TEXT NOT NULL DEFAULT (datetime('now')),
+        updated_at TEXT NOT NULL DEFAULT (datetime('now')),
+        PRIMARY KEY (runtime_folder, session_id)
+      );
+
       CREATE TABLE IF NOT EXISTS registered_groups (
         jid TEXT PRIMARY KEY,
         name TEXT NOT NULL,
@@ -503,6 +513,24 @@ const migration2: Migration = {
   },
 };
 
+const migration3: Migration = {
+  version: 3,
+  description: 'Persist Discord session metadata',
+  up: (db) => {
+    db.exec(`
+      CREATE TABLE IF NOT EXISTS session_metadata (
+        runtime_folder TEXT NOT NULL,
+        session_id TEXT NOT NULL,
+        name TEXT,
+        ended_at TEXT,
+        created_at TEXT NOT NULL DEFAULT (datetime('now')),
+        updated_at TEXT NOT NULL DEFAULT (datetime('now')),
+        PRIMARY KEY (runtime_folder, session_id)
+      )
+    `);
+  },
+};
+
 // ---------------------------------------------------------------------------
 // Migration registry
 // ---------------------------------------------------------------------------
@@ -513,4 +541,4 @@ const migration2: Migration = {
  * can use plain `ALTER TABLE` without try/catch — the version tracker
  * guarantees each migration runs exactly once.
  */
-export const allMigrations: Migration[] = [migration1, migration2];
+export const allMigrations: Migration[] = [migration1, migration2, migration3];


### PR DESCRIPTION
## Summary

- add a native `/session` Discord slash command with `new`, `resume`, `list`, `current`, `end`, and `rename` subcommands
- keep `/resume` and `/sessions` as deprecated aliases that delegate to `/session resume` and `/session list`
- persist session display names/end markers and queue names/forks for the next emitted session id
- pass `forkSession` through the host/container protocol so `/session new resume_from:` can branch Claude sessions

Closes #646.

## Verification

- `bun test src/discord-command-flows.test.ts src/db.test.ts`
- `bun test src/db.migrations.test.ts src/migrations.test.ts`
- `bun run typecheck`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `/session` Discord command with subcommands (`new`, `resume`, `list`, `current`, `end`, `rename`)
  * Enabled session naming and session branching capabilities

* **Documentation**
  * Updated documentation for new `/session` command structure
  * Marked `/resume` and `/sessions` commands as deprecated (available for one release with deprecation notice)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->