### PR TITLE
feat: add Discord session command group

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,6 +113,17 @@ You can add your own channel- or agent-specific slash flows by creating `discord
 
 Command names must be lowercase Discord slash-command names (`a-z`, `0-9`, `_`, `-`). OmniClaw merges built-ins with runtime command files and syncs them per Discord guild on startup and subscription changes, so restart the bot after editing command files.
 
+Session control is exposed as one Discord-native command group:
+
+- `/session new [name] [resume_from]` starts a fresh session for the next message, optionally forking from an existing session.
+- `/session resume [session_id]` switches this channel to a previous session. Omitting `session_id` lists recent sessions.
+- `/session list [limit]` lists recent sessions for the channel.
+- `/session current` shows the active session.
+- `/session end [session_id]` ends the active session, or verifies a specified active session before ending it.
+- `/session rename <session_id> <name>` stores a friendly name shown in session lists.
+
+The legacy `/resume` and `/sessions` aliases remain registered for one release and reply with a deprecation notice that points users to `/session resume` and `/session list`.
+
 By default, every built-in and workspace slash flow is enabled for every agent. To specialize an agent, add `discordCommands` to its `agents.yaml` entry. `enabled` is an optional allowlist; `disabled` is applied after the allowlist:
 
 ```yaml

--- a/README.md
+++ b/README.md
@@ -117,9 +117,9 @@ Session control is exposed as one Discord-native command group:
 
 - `/session new [name] [resume_from]` starts a fresh session for the next message, optionally forking from an existing session.
 - `/session resume [session_id]` switches this channel to a previous session. Omitting `session_id` lists recent sessions.
-- `/session list [limit]` lists recent sessions for the channel.
+- `/session list [limit]` lists recent sessions for the channel (default 10, max 25).
 - `/session current` shows the active session.
-- `/session end [session_id]` ends the active session, or verifies a specified active session before ending it.
+- `/session end [session_id]` ends the active session, optionally verifying the active session ID before ending it.
 - `/session rename <session_id> <name>` stores a friendly name shown in session lists.
 
 The legacy `/resume` and `/sessions` aliases remain registered for one release and reply with a deprecation notice that points users to `/session resume` and `/session list`.

--- a/container/agent-runner/src/index.ts
+++ b/container/agent-runner/src/index.ts
@@ -1228,6 +1228,7 @@ async function runQuery(
       additionalDirectories: extraDirs.length > 0 ? extraDirs : undefined,
       resume: sessionId,
       resumeSessionAt: sessionId ? resumeAt : undefined,
+      forkSession: containerInput.forkSession === true,
       systemPrompt: globalClaudeMd
         ? {
             type: 'preset' as const,

--- a/packages/protocol/src/index.d.ts
+++ b/packages/protocol/src/index.d.ts
@@ -24,6 +24,8 @@ export interface ContainerInput {
   prompt: string;
   sessionId?: string;
   resumeAt?: string;
+  /** When true, resume from sessionId but create a new branched session. */
+  forkSession?: boolean;
   groupFolder: string;
   /** Host-side runtime key for IPC/session isolation (defaults to groupFolder). */
   runtimeFolder?: string;

--- a/packages/protocol/src/index.ts
+++ b/packages/protocol/src/index.ts
@@ -36,6 +36,8 @@ export interface ContainerInput {
   prompt: string;
   sessionId?: string;
   resumeAt?: string;
+  /** When true, resume from sessionId but create a new branched session. */
+  forkSession?: boolean;
   groupFolder: string;
   /** Host-side runtime key for IPC/session isolation (defaults to groupFolder). */
   runtimeFolder?: string;

--- a/src/channels/discord.test.ts
+++ b/src/channels/discord.test.ts
@@ -312,6 +312,87 @@ describe('Discord slash flows', () => {
     expect(interaction.followUp).not.toHaveBeenCalled();
   });
 
+  it('forwards /session new resume_from to the host session handler', async () => {
+    let received:
+      | {
+          command: string;
+          resumeFrom?: string;
+          name?: string;
+        }
+      | undefined;
+    const channel = new DiscordChannel({
+      token: 'test-token-not-used',
+      botId: 'PRIMARY',
+      onSessionCommand: (command, _chatJid, _group, options) => {
+        received = {
+          command,
+          resumeFrom: options?.resumeFrom,
+          name: options?.name,
+        };
+        return { message: 'queued' };
+      },
+    });
+
+    setAgent({
+      id: 'clayton-discord',
+      name: 'Clayton',
+      folder: 'clayton-discord',
+      backend: 'apple-container',
+      agentRuntime: 'claude-agent-sdk',
+      isAdmin: false,
+      createdAt: '2026-05-01T00:00:00.000Z',
+    });
+    setChannelSubscription({
+      channelJid: 'dc:1474995286903361772',
+      agentId: 'clayton-discord',
+      trigger: '@Clayton',
+      requiresTrigger: true,
+      priority: 0,
+      isPrimary: true,
+      discordBotId: 'PRIMARY',
+      discordGuildId: '753336633083953213',
+      createdAt: '2026-05-01T00:00:00.000Z',
+    });
+
+    const interaction = {
+      id: '1499999999999999999',
+      commandName: 'session',
+      channelId: '1474995286903361772',
+      guildId: '753336633083953213',
+      inGuild: () => true,
+      memberPermissions: { has: () => true },
+      options: {
+        getSubcommand: () => 'new',
+        getString: (name: string) =>
+          name === 'resume_from'
+            ? '123e4567-e89b-12d3-a456-426614174000'
+            : name === 'name'
+              ? 'launch triage'
+              : null,
+        getInteger: () => null,
+        getBoolean: () => null,
+      },
+      deferReply: mock(async () => {}),
+      editReply: mock(async () => {}),
+      followUp: mock(async () => {}),
+    };
+
+    await (
+      channel as unknown as {
+        handleSlashCommand: (input: typeof interaction) => Promise<void>;
+      }
+    ).handleSlashCommand(interaction);
+
+    expect(received).toEqual({
+      command: 'new',
+      resumeFrom: '123e4567-e89b-12d3-a456-426614174000',
+      name: 'launch triage',
+    });
+    expect(interaction.editReply).toHaveBeenCalledWith({
+      content: 'queued',
+    });
+  });
+
   it('routes legacy /sessions to /session list with deprecation metadata', async () => {
     let received:
       | {

--- a/src/channels/discord.test.ts
+++ b/src/channels/discord.test.ts
@@ -230,6 +230,161 @@ describe('Discord download guards', () => {
 });
 
 describe('Discord slash flows', () => {
+  it('routes /session subcommands to the host session handler', async () => {
+    let received:
+      | {
+          command: string;
+          sessionId?: string;
+          name?: string;
+        }
+      | undefined;
+    const channel = new DiscordChannel({
+      token: 'test-token-not-used',
+      botId: 'PRIMARY',
+      onSessionCommand: (command, _chatJid, _group, options) => {
+        received = {
+          command,
+          sessionId: options?.sessionId,
+          name: options?.name,
+        };
+        return { message: 'renamed' };
+      },
+    });
+
+    setAgent({
+      id: 'clayton-discord',
+      name: 'Clayton',
+      folder: 'clayton-discord',
+      backend: 'apple-container',
+      agentRuntime: 'claude-agent-sdk',
+      isAdmin: false,
+      createdAt: '2026-05-01T00:00:00.000Z',
+    });
+    setChannelSubscription({
+      channelJid: 'dc:1474995286903361772',
+      agentId: 'clayton-discord',
+      trigger: '@Clayton',
+      requiresTrigger: true,
+      priority: 0,
+      isPrimary: true,
+      discordBotId: 'PRIMARY',
+      discordGuildId: '753336633083953213',
+      createdAt: '2026-05-01T00:00:00.000Z',
+    });
+
+    const interaction = {
+      id: '1499999999999999999',
+      commandName: 'session',
+      channelId: '1474995286903361772',
+      guildId: '753336633083953213',
+      inGuild: () => true,
+      memberPermissions: { has: () => true },
+      options: {
+        getSubcommand: () => 'rename',
+        getString: (name: string) =>
+          name === 'session_id'
+            ? '123e4567-e89b-12d3-a456-426614174000'
+            : name === 'name'
+              ? 'launch triage'
+              : null,
+        getInteger: () => null,
+        getBoolean: () => null,
+      },
+      deferReply: mock(async () => {}),
+      editReply: mock(async () => {}),
+      followUp: mock(async () => {}),
+    };
+
+    await (
+      channel as unknown as {
+        handleSlashCommand: (input: typeof interaction) => Promise<void>;
+      }
+    ).handleSlashCommand(interaction);
+
+    expect(received).toEqual({
+      command: 'rename',
+      sessionId: '123e4567-e89b-12d3-a456-426614174000',
+      name: 'launch triage',
+    });
+    expect(interaction.editReply).toHaveBeenCalledWith({
+      content: 'renamed',
+    });
+    expect(interaction.followUp).not.toHaveBeenCalled();
+  });
+
+  it('routes legacy /sessions to /session list with deprecation metadata', async () => {
+    let received:
+      | {
+          command: string;
+          deprecatedAlias?: string;
+        }
+      | undefined;
+    const channel = new DiscordChannel({
+      token: 'test-token-not-used',
+      botId: 'PRIMARY',
+      onSessionCommand: (command, _chatJid, _group, options) => {
+        received = {
+          command,
+          deprecatedAlias: options?.deprecatedAlias,
+        };
+        return { message: 'listed' };
+      },
+    });
+
+    setAgent({
+      id: 'clayton-discord',
+      name: 'Clayton',
+      folder: 'clayton-discord',
+      backend: 'apple-container',
+      agentRuntime: 'claude-agent-sdk',
+      isAdmin: false,
+      createdAt: '2026-05-01T00:00:00.000Z',
+    });
+    setChannelSubscription({
+      channelJid: 'dc:1474995286903361772',
+      agentId: 'clayton-discord',
+      trigger: '@Clayton',
+      requiresTrigger: true,
+      priority: 0,
+      isPrimary: true,
+      discordBotId: 'PRIMARY',
+      discordGuildId: '753336633083953213',
+      createdAt: '2026-05-01T00:00:00.000Z',
+    });
+
+    const interaction = {
+      id: '1499999999999999999',
+      commandName: 'sessions',
+      channelId: '1474995286903361772',
+      guildId: '753336633083953213',
+      inGuild: () => true,
+      memberPermissions: { has: () => true },
+      options: {
+        getSubcommand: () => null,
+        getString: () => null,
+        getInteger: () => null,
+        getBoolean: () => null,
+      },
+      deferReply: mock(async () => {}),
+      editReply: mock(async () => {}),
+      followUp: mock(async () => {}),
+    };
+
+    await (
+      channel as unknown as {
+        handleSlashCommand: (input: typeof interaction) => Promise<void>;
+      }
+    ).handleSlashCommand(interaction);
+
+    expect(received).toEqual({
+      command: 'list',
+      deprecatedAlias: 'sessions',
+    });
+    expect(interaction.editReply).toHaveBeenCalledWith({
+      content: 'listed',
+    });
+  });
+
   it('acknowledges the interaction before queueing the synthetic message', async () => {
     let deferred = false;
     let queued = false;

--- a/src/channels/discord.ts
+++ b/src/channels/discord.ts
@@ -30,8 +30,10 @@ import {
 } from '../db.js';
 import {
   buildDiscordSlashCommandPayloads,
+  type DiscordSessionCommand,
   getDiscordFlowDefinitionsForGroup,
   renderDiscordFlowPrompt,
+  SESSION_COMMAND_NAMES,
   SYSTEM_COMMAND_NAMES,
 } from '../discord-command-flows.js';
 import { logger } from '../logger.js';
@@ -189,6 +191,14 @@ export interface SessionCommandResult {
   message: string;
 }
 
+export interface SessionCommandOptions {
+  sessionId?: string;
+  name?: string;
+  resumeFrom?: string;
+  limit?: number;
+  deprecatedAlias?: 'resume' | 'sessions';
+}
+
 export interface DiscordChannelOpts {
   botId: string;
   token: string;
@@ -204,10 +214,10 @@ export interface DiscordChannelOpts {
     userName: string,
   ) => void;
   onSessionCommand?: (
-    command: 'resume' | 'sessions',
+    command: DiscordSessionCommand,
     chatJid: string,
     group: RegisteredGroup,
-    sessionId?: string,
+    options?: SessionCommandOptions,
   ) => SessionCommandResult;
 }
 
@@ -1240,7 +1250,7 @@ export class DiscordChannel implements Channel {
       return;
     }
 
-    // Handle system commands (resume, sessions) directly on the host
+    // Handle system commands (/session plus legacy aliases) directly on the host.
     if (SYSTEM_COMMAND_NAMES.has(interaction.commandName)) {
       if (
         !interaction.memberPermissions?.has(PermissionFlagsBits.ManageChannels)
@@ -1257,13 +1267,18 @@ export class DiscordChannel implements Channel {
         });
         return;
       }
-      const sessionId =
-        interaction.options.getString('session_id') ?? undefined;
+      const sessionCommand = this.resolveSessionCommand(interaction);
+      if (!sessionCommand) {
+        await interaction.editReply({
+          content: 'Unknown session command.',
+        });
+        return;
+      }
       const result = this.opts.onSessionCommand(
-        interaction.commandName as 'resume' | 'sessions',
+        sessionCommand.command,
         chatJid,
         group,
-        sessionId,
+        sessionCommand.options,
       );
       await interaction.editReply({ content: result.message });
       return;
@@ -1362,6 +1377,79 @@ export class DiscordChannel implements Channel {
           'I acknowledged the command, but failed to queue it. Check OmniClaw logs for details.',
         ephemeral: true,
       });
+    }
+  }
+
+  private resolveSessionCommand(
+    interaction: ChatInputCommandInteraction,
+  ): { command: DiscordSessionCommand; options: SessionCommandOptions } | null {
+    if (interaction.commandName === 'resume') {
+      return {
+        command: 'resume',
+        options: {
+          sessionId: interaction.options.getString('session_id') ?? undefined,
+          deprecatedAlias: 'resume',
+        },
+      };
+    }
+
+    if (interaction.commandName === 'sessions') {
+      return {
+        command: 'list',
+        options: { deprecatedAlias: 'sessions' },
+      };
+    }
+
+    if (interaction.commandName !== 'session') return null;
+
+    const subcommand = interaction.options.getSubcommand(false);
+    if (!SESSION_COMMAND_NAMES.has(subcommand as DiscordSessionCommand)) {
+      return null;
+    }
+
+    switch (subcommand) {
+      case 'new':
+        return {
+          command: 'new',
+          options: {
+            name: interaction.options.getString('name') ?? undefined,
+            resumeFrom:
+              interaction.options.getString('resume_from') ?? undefined,
+          },
+        };
+      case 'resume':
+        return {
+          command: 'resume',
+          options: {
+            sessionId: interaction.options.getString('session_id') ?? undefined,
+          },
+        };
+      case 'list':
+        return {
+          command: 'list',
+          options: {
+            limit: interaction.options.getInteger('limit') ?? undefined,
+          },
+        };
+      case 'end':
+        return {
+          command: 'end',
+          options: {
+            sessionId: interaction.options.getString('session_id') ?? undefined,
+          },
+        };
+      case 'rename':
+        return {
+          command: 'rename',
+          options: {
+            sessionId: interaction.options.getString('session_id') ?? undefined,
+            name: interaction.options.getString('name') ?? undefined,
+          },
+        };
+      case 'current':
+        return { command: 'current', options: {} };
+      default:
+        return null;
     }
   }
 }

--- a/src/db.migrations.test.ts
+++ b/src/db.migrations.test.ts
@@ -145,6 +145,13 @@ describe('db migrations (bun:sqlite)', () => {
     expect(getTableColumns(db, 'agent_health')).toContain('agent_id');
     expect(getTableColumns(db, 'agent_health')).toContain('is_online');
     expect(getTableColumns(db, 'agent_health')).toContain('capabilities');
+    expect(getTableColumns(db, 'pending_session_intents')).toContain(
+      'group_folder',
+    );
+    expect(getTableColumns(db, 'pending_session_intents')).toContain(
+      'fork_from',
+    );
+    expect(getTableColumns(db, 'pending_session_intents')).toContain('name');
 
     // Verify default values applied to existing rows
     const agents = db
@@ -178,6 +185,13 @@ describe('db migrations (bun:sqlite)', () => {
     expect(getTableColumns(db, 'agent_health')).toContain('agent_id');
     expect(getTableColumns(db, 'agent_health')).toContain('is_online');
     expect(getTableColumns(db, 'agent_health')).toContain('capabilities');
+    expect(getTableColumns(db, 'pending_session_intents')).toContain(
+      'group_folder',
+    );
+    expect(getTableColumns(db, 'pending_session_intents')).toContain(
+      'fork_from',
+    );
+    expect(getTableColumns(db, 'pending_session_intents')).toContain('name');
 
     // Write an agent with opencode runtime
     db.query(

--- a/src/db.ts
+++ b/src/db.ts
@@ -1233,6 +1233,7 @@ export function setSession(groupFolder: string, sessionId: string): void {
 
 export function clearSession(groupFolder: string): void {
   db.query('DELETE FROM sessions WHERE group_folder = ?').run(groupFolder);
+  clearPendingSessionIntent(groupFolder);
 }
 
 export function getAllSessions(): Record<string, string> {
@@ -1246,6 +1247,49 @@ export function getAllSessions(): Record<string, string> {
   return result;
 }
 
+export interface PendingSessionIntent {
+  forkFrom?: string;
+  name?: string;
+}
+
+export function getPendingSessionIntent(
+  groupFolder: string,
+): PendingSessionIntent | undefined {
+  const row = db
+    .prepare(
+      'SELECT fork_from, name FROM pending_session_intents WHERE group_folder = ?',
+    )
+    .get(groupFolder) as
+    | { fork_from: string | null; name: string | null }
+    | undefined;
+  if (!row) return undefined;
+  return {
+    forkFrom: row.fork_from || undefined,
+    name: row.name || undefined,
+  };
+}
+
+export function setPendingSessionIntent(
+  groupFolder: string,
+  intent: PendingSessionIntent,
+): void {
+  if (!intent.forkFrom && !intent.name) {
+    clearPendingSessionIntent(groupFolder);
+    return;
+  }
+  db.query(
+    `INSERT OR REPLACE INTO pending_session_intents
+      (group_folder, fork_from, name, created_at)
+      VALUES (?, ?, ?, datetime('now'))`,
+  ).run(groupFolder, intent.forkFrom ?? null, intent.name ?? null);
+}
+
+export function clearPendingSessionIntent(groupFolder: string): void {
+  db.query('DELETE FROM pending_session_intents WHERE group_folder = ?').run(
+    groupFolder,
+  );
+}
+
 /**
  * Expire sessions older than maxAgeMs. Returns the folders that were expired.
  */
@@ -1256,6 +1300,12 @@ export function expireStaleSessions(maxAgeMs: number): string[] {
     .all(cutoff) as Array<{ group_folder: string }>;
   if (stale.length > 0) {
     db.query('DELETE FROM sessions WHERE created_at < ?').run(cutoff);
+    const deleteIntent = db.query(
+      'DELETE FROM pending_session_intents WHERE group_folder = ?',
+    );
+    for (const row of stale) {
+      deleteIntent.run(row.group_folder);
+    }
   }
   return stale.map((r) => r.group_folder);
 }

--- a/src/db.ts
+++ b/src/db.ts
@@ -1231,6 +1231,10 @@ export function setSession(groupFolder: string, sessionId: string): void {
   ).run(groupFolder, sessionId);
 }
 
+export function clearSession(groupFolder: string): void {
+  db.query('DELETE FROM sessions WHERE group_folder = ?').run(groupFolder);
+}
+
 export function getAllSessions(): Record<string, string> {
   const rows = db
     .prepare('SELECT group_folder, session_id FROM sessions')

--- a/src/discord-command-flows.test.ts
+++ b/src/discord-command-flows.test.ts
@@ -10,6 +10,7 @@ import {
   buildDiscordSlashCommandPayloads,
   getDiscordFlowDefinitionsForGroup,
   renderDiscordFlowPrompt,
+  SYSTEM_COMMAND_NAMES,
 } from './discord-command-flows.js';
 import { logger } from './logger.js';
 import type { RegisteredGroup } from './types.js';
@@ -298,6 +299,50 @@ describe('discord command flows', () => {
     } finally {
       fs.rmSync(tempRoot, { recursive: true, force: true });
     }
+  });
+
+  it('builds /session with native Discord subcommands', () => {
+    const payloads = buildDiscordSlashCommandPayloads([makeGroup()]);
+    const session = payloads.find((command) => command.name === 'session');
+
+    expect(session).toBeDefined();
+    expect(session?.options?.map((option) => option.name)).toEqual([
+      'new',
+      'resume',
+      'list',
+      'current',
+      'end',
+      'rename',
+    ]);
+    expect(session?.options?.[0]?.type).toBe(
+      ApplicationCommandOptionType.Subcommand,
+    );
+
+    const rename = session?.options?.find((option) => option.name === 'rename');
+    expect(rename?.type).toBe(ApplicationCommandOptionType.Subcommand);
+    const renameOptions =
+      'options' in rename!
+        ? (rename.options as unknown as ReadonlyArray<{
+            name: string;
+            required?: boolean;
+          }>)
+        : [];
+    expect(
+      renameOptions.find((option) => option.name === 'session_id')?.required,
+    ).toBe(true);
+  });
+
+  it('keeps legacy session aliases registered as system commands', () => {
+    const names = getDiscordFlowDefinitionsForGroup(makeGroup()).map(
+      (command) => command.name,
+    );
+
+    expect(names).toContain('session');
+    expect(names).toContain('resume');
+    expect(names).toContain('sessions');
+    expect(SYSTEM_COMMAND_NAMES.has('session')).toBe(true);
+    expect(SYSTEM_COMMAND_NAMES.has('resume')).toBe(true);
+    expect(SYSTEM_COMMAND_NAMES.has('sessions')).toBe(true);
   });
 
   it('ignores invalid commands and invalid options from custom files', () => {

--- a/src/discord-command-flows.test.ts
+++ b/src/discord-command-flows.test.ts
@@ -320,6 +320,19 @@ describe('discord command flows', () => {
 
     const rename = session?.options?.find((option) => option.name === 'rename');
     expect(rename?.type).toBe(ApplicationCommandOptionType.Subcommand);
+    const list = session?.options?.find((option) => option.name === 'list');
+    const listOptions =
+      'options' in list!
+        ? (list.options as unknown as ReadonlyArray<{
+            name: string;
+            description: string;
+          }>)
+        : [];
+    expect(
+      listOptions.find((option) => option.name === 'limit')?.description,
+    ).toContain('max 25');
+    const end = session?.options?.find((option) => option.name === 'end');
+    expect(end?.description).toContain('active session');
     const renameOptions =
       'options' in rename!
         ? (rename.options as unknown as ReadonlyArray<{

--- a/src/discord-command-flows.ts
+++ b/src/discord-command-flows.ts
@@ -27,6 +27,7 @@ export interface DiscordFlowDefinition {
   description: string;
   prompt: string;
   options?: DiscordFlowOptionDefinition[];
+  subcommands?: DiscordFlowDefinition[];
   /** System commands are handled by the host, not sent to the agent. */
   system?: boolean;
 }
@@ -239,6 +240,97 @@ const BUILTIN_COMMANDS: DiscordFlowDefinition[] = [
         description: 'Planning timebox in minutes',
         type: 'integer',
         defaultValue: 30,
+      },
+    ],
+  },
+  {
+    name: 'session',
+    description: 'Manage the active agent session for this channel',
+    prompt: '',
+    system: true,
+    subcommands: [
+      {
+        name: 'new',
+        description: 'Start a fresh agent session in this channel',
+        prompt: '',
+        system: true,
+        options: [
+          {
+            name: 'name',
+            description: 'Optional friendly name for the next session',
+            type: 'string',
+          },
+          {
+            name: 'resume_from',
+            description: 'Optional existing session ID to fork from',
+            type: 'string',
+          },
+        ],
+      },
+      {
+        name: 'resume',
+        description: 'Resume a previous session in this channel',
+        prompt: '',
+        system: true,
+        options: [
+          {
+            name: 'session_id',
+            description: 'Session ID to resume (omit to see recent sessions)',
+            type: 'string',
+          },
+        ],
+      },
+      {
+        name: 'list',
+        description: 'List recent sessions for this channel',
+        prompt: '',
+        system: true,
+        options: [
+          {
+            name: 'limit',
+            description: 'Maximum number of sessions to show',
+            type: 'integer',
+          },
+        ],
+      },
+      {
+        name: 'current',
+        description: 'Show the active session for this channel',
+        prompt: '',
+        system: true,
+      },
+      {
+        name: 'end',
+        description: 'End the current or specified session',
+        prompt: '',
+        system: true,
+        options: [
+          {
+            name: 'session_id',
+            description: 'Specific session ID to end',
+            type: 'string',
+          },
+        ],
+      },
+      {
+        name: 'rename',
+        description: 'Give a session a friendly name',
+        prompt: '',
+        system: true,
+        options: [
+          {
+            name: 'session_id',
+            description: 'Session ID to rename',
+            type: 'string',
+            required: true,
+          },
+          {
+            name: 'name',
+            description: 'Friendly session name',
+            type: 'string',
+            required: true,
+          },
+        ],
       },
     ],
   },
@@ -472,13 +564,32 @@ export function buildDiscordSlashCommandPayloads(
     .map((command) => ({
       name: command.name,
       description: command.description,
-      options: command.options
-        ?.slice()
-        .sort(
-          (a, b) => Number(Boolean(b.required)) - Number(Boolean(a.required)),
-        )
-        .map((option) => toDiscordOptionData(option)),
+      options: command.subcommands
+        ? command.subcommands.map((subcommand) =>
+            toDiscordSubcommandData(subcommand),
+          )
+        : toSortedDiscordOptionData(command.options),
     }));
+}
+
+function toDiscordSubcommandData(
+  command: DiscordFlowDefinition,
+): ApplicationCommandOptionData {
+  return {
+    type: ApplicationCommandOptionType.Subcommand,
+    name: command.name,
+    description: command.description,
+    options: toSortedDiscordOptionData(command.options),
+  } as ApplicationCommandOptionData;
+}
+
+function toSortedDiscordOptionData(
+  options: DiscordFlowOptionDefinition[] | undefined,
+): ApplicationCommandOptionData[] | undefined {
+  return options
+    ?.slice()
+    .sort((a, b) => Number(Boolean(b.required)) - Number(Boolean(a.required)))
+    .map((option) => toDiscordOptionData(option));
 }
 
 function toDiscordOptionData(
@@ -519,6 +630,23 @@ function stringifyOptionValue(value: string | number | boolean): string {
 
 /** Names of built-in system commands (handled by host, not agent). */
 export const SYSTEM_COMMAND_NAMES = new Set(BUILTIN_SYSTEM_COMMAND_NAMES);
+
+export type DiscordSessionCommand =
+  | 'new'
+  | 'resume'
+  | 'list'
+  | 'current'
+  | 'end'
+  | 'rename';
+
+export const SESSION_COMMAND_NAMES = new Set<DiscordSessionCommand>([
+  'new',
+  'resume',
+  'list',
+  'current',
+  'end',
+  'rename',
+]);
 
 export function renderDiscordFlowPrompt(
   command: DiscordFlowDefinition,

--- a/src/discord-command-flows.ts
+++ b/src/discord-command-flows.ts
@@ -288,7 +288,8 @@ const BUILTIN_COMMANDS: DiscordFlowDefinition[] = [
         options: [
           {
             name: 'limit',
-            description: 'Maximum number of sessions to show',
+            description:
+              'Maximum number of sessions to show (default 10, max 25)',
             type: 'integer',
           },
         ],
@@ -301,13 +302,13 @@ const BUILTIN_COMMANDS: DiscordFlowDefinition[] = [
       },
       {
         name: 'end',
-        description: 'End the current or specified session',
+        description: 'End the active session, optionally confirming its ID',
         prompt: '',
         system: true,
         options: [
           {
             name: 'session_id',
-            description: 'Specific session ID to end',
+            description: 'Active session ID to confirm before ending',
             type: 'string',
           },
         ],

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -2,11 +2,14 @@ import { beforeEach, describe, expect, it } from 'bun:test';
 
 import {
   _initTestDatabase,
+  getPendingSessionIntent,
   setChannelSubscription,
+  setSession,
   storeChatMetadata,
 } from './db.js';
 import {
   _createIntermediateStatusStreamer,
+  _handleSessionCommandForTest,
   _getSlashCommandGroupsFromSubscriptions,
   _getEnabledStartupConfirmationTargets,
   _isAgentEnabled,
@@ -17,8 +20,12 @@ import {
   _setChannelSubscriptions,
   _setRegisteredGroups,
   _truncateIntermediateStatusBuffer,
+  _setSessions,
   getAvailableGroups,
 } from './index.js';
+import { DATA_DIR } from './config.js';
+import fs from 'fs';
+import path from 'path';
 import type {
   Agent,
   ChannelSubscription,
@@ -320,6 +327,78 @@ describe('getAvailableGroups', () => {
     );
 
     expect(getAvailableGroups()).toEqual([]);
+  });
+});
+
+describe('Discord session command state', () => {
+  const sessionId = '123e4567-e89b-12d3-a456-426614174000';
+  const group: RegisteredGroup = {
+    name: 'Session Agent',
+    folder: 'session-agent',
+    trigger: '@Session',
+    added_at: '2024-01-01T00:00:00.000Z',
+  };
+  const sessionsDir = path.join(
+    DATA_DIR,
+    'sessions',
+    group.folder,
+    '.claude',
+    'projects',
+    '-workspace-group',
+  );
+
+  beforeEach(() => {
+    _initTestDatabase();
+    _setRegisteredGroups({});
+    _setChannelSubscriptions({});
+    _setAgents({});
+    _setSessions({});
+    fs.rmSync(path.join(DATA_DIR, 'sessions', group.folder), {
+      recursive: true,
+      force: true,
+    });
+    fs.mkdirSync(sessionsDir, { recursive: true });
+    fs.writeFileSync(path.join(sessionsDir, `${sessionId}.jsonl`), '{}\n');
+  });
+
+  it('persists pending fork and name intents for /session new resume_from', () => {
+    const result = _handleSessionCommandForTest('new', 'dc:channel-1', group, {
+      resumeFrom: sessionId,
+      name: 'launch **triage** `branch`',
+    });
+
+    expect(result.message).toContain(`forked from \`${sessionId}\``);
+    expect(getPendingSessionIntent(group.folder)).toEqual({
+      forkFrom: sessionId,
+      name: 'launch triage branch',
+    });
+  });
+
+  it('renders sanitized session names in host responses', () => {
+    const result = _handleSessionCommandForTest(
+      'rename',
+      'dc:channel-1',
+      group,
+      {
+        sessionId,
+        name: 'release `_cut_` **now**',
+      },
+    );
+
+    expect(result.message).toBe(
+      `Session \`${sessionId}\` renamed to "release cut now".`,
+    );
+  });
+
+  it('keeps /session end as an active-session confirmation', () => {
+    setSession(group.folder, sessionId);
+    _setSessions({ [group.folder]: sessionId });
+
+    const result = _handleSessionCommandForTest('end', 'dc:channel-1', group, {
+      sessionId: 'abcdefab-cdef-abcd-efab-cdefabcdefab',
+    });
+
+    expect(result.message).toContain('is not the active session');
   });
 });
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -81,6 +81,7 @@ import {
   getMessagesSince,
   getNewMessages,
   getOrCreateDiscoveryInstanceId,
+  getPendingSessionIntent,
   getRouterState,
   getSubscriptionsForAgent,
   getTaskById,
@@ -91,6 +92,7 @@ import {
   setAgentHealth,
   setChannelRoute,
   setChannelSubscription,
+  setPendingSessionIntent,
   setRegisteredGroup,
   setRouterState,
   setSession,
@@ -212,8 +214,6 @@ async function shutdown(): Promise<void> {
 
 let lastTimestamp = '';
 let sessions: Record<string, string> = {};
-const pendingForkSessions = new Set<string>();
-const pendingSessionNames = new Map<string, string>();
 const resumePositionStore = createResumePositionStore({
   persistentTaskState: PERSISTENT_TASK_STATE,
   initialResumePositions: {},
@@ -264,6 +264,8 @@ const MAX_CHANNEL_AGENT_FANOUT = parseInt(
 const DISPATCH_KEY_SEP = '::agent::';
 const INTERMEDIATE_BUFFER_LIMIT = 1_800;
 const INTERMEDIATE_EDIT_DEBOUNCE_MS = 750;
+const DEFAULT_SESSION_LIST_LIMIT = 10;
+const MAX_SESSION_LIST_LIMIT = 25;
 
 type IntermediateStatusChannel = Pick<Channel, 'sendMessage' | 'editMessage'>;
 
@@ -543,11 +545,13 @@ function handleSessionCommand(
 
     const limit =
       typeof options.limit === 'number' && options.limit > 0
-        ? Math.min(options.limit, 25)
-        : 10;
+        ? Math.min(options.limit, MAX_SESSION_LIST_LIMIT)
+        : DEFAULT_SESSION_LIST_LIMIT;
     const lines = sessionInfos.slice(0, limit).map((s) => {
       const current = s.sessionId === currentSessionId ? ' **(active)**' : '';
-      const name = names[s.sessionId] ? ` — ${names[s.sessionId]}` : '';
+      const name = names[s.sessionId]
+        ? ` — ${formatSessionName(names[s.sessionId])}`
+        : '';
       const sizeKb = Math.round(s.sizeBytes / 1024);
       const age = formatAge(s.modifiedAt);
       return `\`${s.sessionId}\`${name} — ${sizeKb}KB, ${age}${current}`;
@@ -569,7 +573,7 @@ function handleSessionCommand(
     const sessionFile = path.join(sessionsDir, `${currentSessionId}.jsonl`);
     const stat = fs.existsSync(sessionFile) ? fs.statSync(sessionFile) : null;
     const name = names[currentSessionId]
-      ? `\nName: ${names[currentSessionId]}`
+      ? `\nName: ${formatSessionName(names[currentSessionId])}`
       : '';
     const activity = stat ? `\nLast activity: ${formatAge(stat.mtime)}` : '';
     return {
@@ -590,16 +594,13 @@ function handleSessionCommand(
       }
       sessions[runtimeFolder] = resumeFrom;
       setSession(runtimeFolder, resumeFrom);
-      pendingForkSessions.add(runtimeFolder);
     } else {
       delete sessions[runtimeFolder];
       clearSession(runtimeFolder);
-      pendingForkSessions.delete(runtimeFolder);
     }
     resumePositionStore.set(runtimeFolder, '');
     const name = normalizeSessionName(options.name);
-    if (name) pendingSessionNames.set(runtimeFolder, name);
-    else pendingSessionNames.delete(runtimeFolder);
+    setPendingSessionIntent(runtimeFolder, { forkFrom: resumeFrom, name });
     return {
       message: resumeFrom
         ? `Next message in this channel will start a fresh session forked from \`${resumeFrom}\`.`
@@ -618,8 +619,6 @@ function handleSessionCommand(
       delete sessions[runtimeFolder];
       clearSession(runtimeFolder);
       resumePositionStore.set(runtimeFolder, '');
-      pendingForkSessions.delete(runtimeFolder);
-      pendingSessionNames.delete(runtimeFolder);
       return {
         message: `Session \`${sessionId}\` ended for this channel. The next message will start fresh.`,
       };
@@ -647,7 +646,9 @@ function handleSessionCommand(
     const names = readSessionNames(sessionsDir);
     names[sessionId] = name;
     writeSessionNames(sessionsDir, names);
-    return { message: `Session \`${sessionId}\` renamed to "${name}".` };
+    return {
+      message: `Session \`${sessionId}\` renamed to ${formatSessionName(name)}.`,
+    };
   }
 
   const sessionId = options.sessionId?.trim();
@@ -674,7 +675,7 @@ function handleSessionCommand(
   sessions[runtimeFolder] = sessionId;
   setSession(runtimeFolder, sessionId);
   resumePositionStore.set(runtimeFolder, '');
-  pendingForkSessions.delete(runtimeFolder);
+  setPendingSessionIntent(runtimeFolder, {});
 
   return {
     message: `${prefix}Session switched to \`${sessionId}\`. The next message in this channel will resume from that session.`,
@@ -687,9 +688,16 @@ function validateSessionId(sessionId: string): string | null {
 }
 
 function normalizeSessionName(name: string | undefined): string | undefined {
-  const normalized = name?.trim().replace(/\s+/g, ' ');
+  const normalized = name
+    ?.replace(/[`*_~]/g, '')
+    .trim()
+    .replace(/\s+/g, ' ');
   if (!normalized) return undefined;
   return normalized.slice(0, 80);
+}
+
+function formatSessionName(name: string): string {
+  return `"${normalizeSessionName(name) || 'unnamed'}"`;
 }
 
 function sessionNamesFilePath(sessionsDir: string): string {
@@ -741,9 +749,9 @@ function applyPendingSessionName(
   runtimeFolder: string,
   sessionId: string,
 ): void {
-  const name = pendingSessionNames.get(runtimeFolder);
+  const intent = getPendingSessionIntent(runtimeFolder);
+  const name = intent?.name;
   if (!name) return;
-  pendingSessionNames.delete(runtimeFolder);
   const sessionsDir = getRuntimeSessionsDir(runtimeFolder);
   const names = readSessionNames(sessionsDir);
   names[sessionId] = name;
@@ -1683,6 +1691,21 @@ export function _getEnabledStartupConfirmationTargets() {
   return getEnabledStartupConfirmationTargets();
 }
 
+/** @internal - exported for testing */
+export function _setSessions(nextSessions: Record<string, string>): void {
+  sessions = nextSessions;
+}
+
+/** @internal - exported for testing */
+export function _handleSessionCommandForTest(
+  command: 'new' | 'resume' | 'list' | 'current' | 'end' | 'rename',
+  chatJid: string,
+  group: RegisteredGroup,
+  options: SessionCommandOptions = {},
+): { message: string } {
+  return handleSessionCommand(command, chatJid, group, options);
+}
+
 /**
  * Process all pending messages for a group.
  * Called by the GroupQueue when it's this group's turn.
@@ -2158,7 +2181,21 @@ async function runAgent(
   }
 
   const sessionId = sessions[runtimeGroupFolder];
-  const shouldForkSession = pendingForkSessions.has(runtimeGroupFolder);
+  const pendingSessionIntent = getPendingSessionIntent(runtimeGroupFolder);
+  const shouldForkSession =
+    pendingSessionIntent?.forkFrom != null &&
+    sessionId === pendingSessionIntent.forkFrom;
+  if (pendingSessionIntent?.forkFrom && !shouldForkSession) {
+    logger.warn(
+      {
+        runtimeGroupFolder,
+        expectedSessionId: pendingSessionIntent.forkFrom,
+        actualSessionId: sessionId,
+      },
+      'Discarding stale pending session fork intent because active session drifted',
+    );
+    setPendingSessionIntent(runtimeGroupFolder, {});
+  }
 
   // Update tasks snapshot for container to read (filtered by group)
   writeTasksSnapshot(
@@ -2214,7 +2251,7 @@ async function runAgent(
           sessions[runtimeGroupFolder] = output.newSessionId;
           setSession(runtimeGroupFolder, output.newSessionId);
           applyPendingSessionName(runtimeGroupFolder, output.newSessionId);
-          pendingForkSessions.delete(runtimeGroupFolder);
+          setPendingSessionIntent(runtimeGroupFolder, {});
         }
         if (output.resumeAt) {
           resumePositionStore.set(runtimeGroupFolder, output.resumeAt);
@@ -2319,7 +2356,7 @@ async function runAgent(
       sessions[runtimeGroupFolder] = output.newSessionId;
       setSession(runtimeGroupFolder, output.newSessionId);
       applyPendingSessionName(runtimeGroupFolder, output.newSessionId);
-      pendingForkSessions.delete(runtimeGroupFolder);
+      setPendingSessionIntent(runtimeGroupFolder, {});
     }
     if (output.resumeAt) {
       resumePositionStore.set(runtimeGroupFolder, output.resumeAt);

--- a/src/index.ts
+++ b/src/index.ts
@@ -14,7 +14,10 @@ import {
   buildAgentToChannelsMapFromSubscriptions,
   buildSendToInstruction,
 } from './channel-routes.js';
-import { DiscordChannel } from './channels/discord.js';
+import {
+  DiscordChannel,
+  type SessionCommandOptions,
+} from './channels/discord.js';
 import { SlackChannel } from './channels/slack.js';
 import { TelegramChannel } from './channels/telegram.js';
 import { WhatsAppChannel } from './channels/whatsapp.js';
@@ -57,6 +60,7 @@ import { resolveContextLayers } from './context-layers.js';
 import {
   createTrustStore,
   createTask as dbCreateTask,
+  clearSession,
   deleteTask as dbDeleteTask,
   searchMessages as dbSearchMessages,
   updateTask as dbUpdateTask,
@@ -208,6 +212,8 @@ async function shutdown(): Promise<void> {
 
 let lastTimestamp = '';
 let sessions: Record<string, string> = {};
+const pendingForkSessions = new Set<string>();
+const pendingSessionNames = new Map<string, string>();
 const resumePositionStore = createResumePositionStore({
   persistentTaskState: PERSISTENT_TASK_STATE,
   initialResumePositions: {},
@@ -469,15 +475,15 @@ function getRuntimeGroupFolder(
 }
 
 /**
- * Handle /resume and /sessions Discord slash commands.
+ * Handle Discord session slash commands.
  * These operate on the host's session store directly rather than sending
  * a prompt to the agent.
  */
 function handleSessionCommand(
-  command: 'resume' | 'sessions',
+  command: 'new' | 'resume' | 'list' | 'current' | 'end' | 'rename',
   chatJid: string,
   group: RegisteredGroup,
-  sessionId?: string,
+  options: SessionCommandOptions = {},
 ): { message: string } {
   // Compute the correct runtime folder, accounting for subscription-based
   // multi-agent channels that use makeDispatchKey for session keying.
@@ -498,19 +504,34 @@ function handleSessionCommand(
     'projects',
     '-workspace-group',
   );
+  const prefix = options.deprecatedAlias
+    ? `Deprecated: use \`/session ${options.deprecatedAlias === 'sessions' ? 'list' : 'resume'}\` instead.\n\n`
+    : '';
+  if (options.deprecatedAlias) {
+    logger.warn(
+      {
+        alias: options.deprecatedAlias,
+        replacement: `/session ${options.deprecatedAlias === 'sessions' ? 'list' : 'resume'}`,
+        chatJid,
+        group: group.folder,
+      },
+      'Deprecated Discord session command alias used',
+    );
+  }
 
-  if (command === 'sessions') {
+  if (command === 'list') {
     if (!fs.existsSync(sessionsDir)) {
-      return { message: 'No sessions found for this channel.' };
+      return { message: `${prefix}No sessions found for this channel.` };
     }
     const files = fs
       .readdirSync(sessionsDir)
       .filter((f) => f.endsWith('.jsonl'));
     if (files.length === 0) {
-      return { message: 'No sessions found for this channel.' };
+      return { message: `${prefix}No sessions found for this channel.` };
     }
 
     const currentSessionId = sessions[runtimeFolder];
+    const names = readSessionNames(sessionsDir);
     const sessionInfos = files
       .map((f) => {
         const filePath = path.join(sessionsDir, f);
@@ -520,36 +541,132 @@ function handleSessionCommand(
       })
       .sort((a, b) => b.modifiedAt.getTime() - a.modifiedAt.getTime());
 
-    const lines = sessionInfos.map((s) => {
+    const limit =
+      typeof options.limit === 'number' && options.limit > 0
+        ? Math.min(options.limit, 25)
+        : 10;
+    const lines = sessionInfos.slice(0, limit).map((s) => {
       const current = s.sessionId === currentSessionId ? ' **(active)**' : '';
+      const name = names[s.sessionId] ? ` — ${names[s.sessionId]}` : '';
       const sizeKb = Math.round(s.sizeBytes / 1024);
       const age = formatAge(s.modifiedAt);
-      return `\`${s.sessionId}\` — ${sizeKb}KB, ${age}${current}`;
+      return `\`${s.sessionId}\`${name} — ${sizeKb}KB, ${age}${current}`;
     });
 
     return {
-      message: `**Sessions for this channel** (${runtimeFolder}):\n${lines.join('\n')}`,
+      message: `${prefix}**Sessions for this channel** (${runtimeFolder}):\n${lines.join('\n')}`,
     };
   }
 
-  // command === 'resume'
+  if (command === 'current') {
+    const currentSessionId = sessions[runtimeFolder];
+    if (!currentSessionId) {
+      return { message: 'No active session for this channel.' };
+    }
+    const names = fs.existsSync(sessionsDir)
+      ? readSessionNames(sessionsDir)
+      : {};
+    const sessionFile = path.join(sessionsDir, `${currentSessionId}.jsonl`);
+    const stat = fs.existsSync(sessionFile) ? fs.statSync(sessionFile) : null;
+    const name = names[currentSessionId]
+      ? `\nName: ${names[currentSessionId]}`
+      : '';
+    const activity = stat ? `\nLast activity: ${formatAge(stat.mtime)}` : '';
+    return {
+      message: `**Current session**\nID: \`${currentSessionId}\`${name}${activity}`,
+    };
+  }
+
+  if (command === 'new') {
+    const resumeFrom = options.resumeFrom?.trim();
+    if (resumeFrom) {
+      const validation = validateSessionId(resumeFrom);
+      if (validation) return { message: validation };
+      const sessionFile = path.join(sessionsDir, `${resumeFrom}.jsonl`);
+      if (!fs.existsSync(sessionFile)) {
+        return {
+          message: `Session \`${resumeFrom}\` not found. Use \`/session list\` to list available sessions.`,
+        };
+      }
+      sessions[runtimeFolder] = resumeFrom;
+      setSession(runtimeFolder, resumeFrom);
+      pendingForkSessions.add(runtimeFolder);
+    } else {
+      delete sessions[runtimeFolder];
+      clearSession(runtimeFolder);
+      pendingForkSessions.delete(runtimeFolder);
+    }
+    resumePositionStore.set(runtimeFolder, '');
+    const name = normalizeSessionName(options.name);
+    if (name) pendingSessionNames.set(runtimeFolder, name);
+    else pendingSessionNames.delete(runtimeFolder);
+    return {
+      message: resumeFrom
+        ? `Next message in this channel will start a fresh session forked from \`${resumeFrom}\`.`
+        : 'Next message in this channel will start a fresh session.',
+    };
+  }
+
+  if (command === 'end') {
+    const sessionId = options.sessionId?.trim() || sessions[runtimeFolder];
+    if (!sessionId) {
+      return { message: 'No active session for this channel.' };
+    }
+    const validation = validateSessionId(sessionId);
+    if (validation) return { message: validation };
+    if (sessions[runtimeFolder] === sessionId) {
+      delete sessions[runtimeFolder];
+      clearSession(runtimeFolder);
+      resumePositionStore.set(runtimeFolder, '');
+      pendingForkSessions.delete(runtimeFolder);
+      pendingSessionNames.delete(runtimeFolder);
+      return {
+        message: `Session \`${sessionId}\` ended for this channel. The next message will start fresh.`,
+      };
+    }
+    return {
+      message: `Session \`${sessionId}\` is not the active session for this channel.`,
+    };
+  }
+
+  if (command === 'rename') {
+    const sessionId = options.sessionId?.trim();
+    if (!sessionId) {
+      return { message: 'Session ID is required.' };
+    }
+    const validation = validateSessionId(sessionId);
+    if (validation) return { message: validation };
+    const sessionFile = path.join(sessionsDir, `${sessionId}.jsonl`);
+    if (!fs.existsSync(sessionFile)) {
+      return {
+        message: `Session \`${sessionId}\` not found. Use \`/session list\` to list available sessions.`,
+      };
+    }
+    const name = normalizeSessionName(options.name);
+    if (!name) return { message: 'Session name is required.' };
+    const names = readSessionNames(sessionsDir);
+    names[sessionId] = name;
+    writeSessionNames(sessionsDir, names);
+    return { message: `Session \`${sessionId}\` renamed to "${name}".` };
+  }
+
+  const sessionId = options.sessionId?.trim();
   if (!sessionId) {
     // No session ID provided — show sessions instead
-    return handleSessionCommand('sessions', chatJid, group);
+    return handleSessionCommand('list', chatJid, group, {
+      deprecatedAlias: options.deprecatedAlias,
+    });
   }
 
   // Guard against path traversal — session IDs are hex UUIDs
-  if (!/^[a-f0-9-]+$/i.test(sessionId)) {
-    return {
-      message: `Invalid session ID \`${sessionId}\`. Use \`/sessions\` to list available sessions.`,
-    };
-  }
+  const validation = validateSessionId(sessionId);
+  if (validation) return { message: validation };
 
   // Validate session file exists
   const sessionFile = path.join(sessionsDir, `${sessionId}.jsonl`);
   if (!fs.existsSync(sessionFile)) {
     return {
-      message: `Session \`${sessionId}\` not found. Use \`/sessions\` to list available sessions.`,
+      message: `Session \`${sessionId}\` not found. Use \`/session list\` to list available sessions.`,
     };
   }
 
@@ -557,10 +674,80 @@ function handleSessionCommand(
   sessions[runtimeFolder] = sessionId;
   setSession(runtimeFolder, sessionId);
   resumePositionStore.set(runtimeFolder, '');
+  pendingForkSessions.delete(runtimeFolder);
 
   return {
-    message: `Session switched to \`${sessionId}\`. The next message in this channel will resume from that session.`,
+    message: `${prefix}Session switched to \`${sessionId}\`. The next message in this channel will resume from that session.`,
   };
+}
+
+function validateSessionId(sessionId: string): string | null {
+  if (/^[a-f0-9-]+$/i.test(sessionId)) return null;
+  return `Invalid session ID \`${sessionId}\`. Use \`/session list\` to list available sessions.`;
+}
+
+function normalizeSessionName(name: string | undefined): string | undefined {
+  const normalized = name?.trim().replace(/\s+/g, ' ');
+  if (!normalized) return undefined;
+  return normalized.slice(0, 80);
+}
+
+function sessionNamesFilePath(sessionsDir: string): string {
+  const filePath = path.join(sessionsDir, '.omniclaw-session-names.json');
+  assertPathWithin(filePath, sessionsDir, 'session names file');
+  return filePath;
+}
+
+function readSessionNames(sessionsDir: string): Record<string, string> {
+  try {
+    const filePath = sessionNamesFilePath(sessionsDir);
+    if (!fs.existsSync(filePath)) return {};
+    const parsed = JSON.parse(fs.readFileSync(filePath, 'utf-8')) as unknown;
+    if (!parsed || typeof parsed !== 'object') return {};
+    const names: Record<string, string> = {};
+    for (const [sessionId, name] of Object.entries(parsed)) {
+      if (/^[a-f0-9-]+$/i.test(sessionId) && typeof name === 'string') {
+        names[sessionId] = normalizeSessionName(name) || '';
+      }
+    }
+    return names;
+  } catch (err) {
+    logger.warn({ err, sessionsDir }, 'Failed to read Discord session names');
+    return {};
+  }
+}
+
+function writeSessionNames(
+  sessionsDir: string,
+  names: Record<string, string>,
+): void {
+  fs.mkdirSync(sessionsDir, { recursive: true });
+  const filePath = sessionNamesFilePath(sessionsDir);
+  fs.writeFileSync(filePath, JSON.stringify(names, null, 2));
+}
+
+function getRuntimeSessionsDir(runtimeFolder: string): string {
+  return path.join(
+    DATA_DIR,
+    'sessions',
+    runtimeFolder,
+    '.claude',
+    'projects',
+    '-workspace-group',
+  );
+}
+
+function applyPendingSessionName(
+  runtimeFolder: string,
+  sessionId: string,
+): void {
+  const name = pendingSessionNames.get(runtimeFolder);
+  if (!name) return;
+  pendingSessionNames.delete(runtimeFolder);
+  const sessionsDir = getRuntimeSessionsDir(runtimeFolder);
+  const names = readSessionNames(sessionsDir);
+  names[sessionId] = name;
+  writeSessionNames(sessionsDir, names);
 }
 
 function formatAge(date: Date): string {
@@ -1971,6 +2158,7 @@ async function runAgent(
   }
 
   const sessionId = sessions[runtimeGroupFolder];
+  const shouldForkSession = pendingForkSessions.has(runtimeGroupFolder);
 
   // Update tasks snapshot for container to read (filtered by group)
   writeTasksSnapshot(
@@ -2025,6 +2213,8 @@ async function runAgent(
         if (output.newSessionId) {
           sessions[runtimeGroupFolder] = output.newSessionId;
           setSession(runtimeGroupFolder, output.newSessionId);
+          applyPendingSessionName(runtimeGroupFolder, output.newSessionId);
+          pendingForkSessions.delete(runtimeGroupFolder);
         }
         if (output.resumeAt) {
           resumePositionStore.set(runtimeGroupFolder, output.resumeAt);
@@ -2089,7 +2279,9 @@ async function runAgent(
       {
         prompt,
         sessionId,
-        resumeAt: resumePositionStore.get(runtimeGroupFolder),
+        resumeAt: shouldForkSession
+          ? undefined
+          : resumePositionStore.get(runtimeGroupFolder),
         groupFolder: group.folder,
         runtimeFolder: runtimeGroupFolder,
         chatJid,
@@ -2109,6 +2301,7 @@ async function runAgent(
         githubActivityDelta,
         githubLinkedContext,
         mcpServers: group.containerConfig?.mcpServers,
+        ...(shouldForkSession ? { forkSession: true } : {}),
       },
       (proc, containerName) =>
         queue.registerProcess(
@@ -2125,6 +2318,8 @@ async function runAgent(
     if (output.newSessionId) {
       sessions[runtimeGroupFolder] = output.newSessionId;
       setSession(runtimeGroupFolder, output.newSessionId);
+      applyPendingSessionName(runtimeGroupFolder, output.newSessionId);
+      pendingForkSessions.delete(runtimeGroupFolder);
     }
     if (output.resumeAt) {
       resumePositionStore.set(runtimeGroupFolder, output.resumeAt);

--- a/src/ipc-processing.test.ts
+++ b/src/ipc-processing.test.ts
@@ -9,7 +9,9 @@ import {
   setRegisteredGroup,
   expireStaleSessions,
   getSession,
+  getPendingSessionIntent,
   setSession,
+  setPendingSessionIntent,
   getAllSessions,
   setAgent,
   getAgent,
@@ -21,6 +23,7 @@ import {
   getChannelRoute,
   getAllChannelRoutes,
   getRoutesForAgent,
+  clearPendingSessionIntent,
 } from './db.js';
 import { processTaskIpc, IpcDeps } from './ipc.js';
 import {
@@ -817,6 +820,33 @@ describe('expireStaleSessions', () => {
     setSession('group-y', 'session-1');
     setSession('group-y', 'session-2');
     expect(getSession('group-y')).toBe('session-2');
+  });
+
+  it('persists and clears pending session intents', () => {
+    setPendingSessionIntent('group-intent', {
+      forkFrom: 'session-source',
+      name: 'launch triage',
+    });
+
+    expect(getPendingSessionIntent('group-intent')).toEqual({
+      forkFrom: 'session-source',
+      name: 'launch triage',
+    });
+
+    clearPendingSessionIntent('group-intent');
+    expect(getPendingSessionIntent('group-intent')).toBeUndefined();
+  });
+
+  it('clears pending session intents with stale sessions', () => {
+    setSession('old-group', 'session-old');
+    setPendingSessionIntent('old-group', {
+      forkFrom: 'session-old',
+      name: 'old fork',
+    });
+    _backdateSessionForTest('old-group', '2000-01-01T00:00:00.000Z');
+
+    expect(expireStaleSessions(60_000)).toEqual(['old-group']);
+    expect(getPendingSessionIntent('old-group')).toBeUndefined();
   });
 });
 

--- a/src/migrations.ts
+++ b/src/migrations.ts
@@ -16,7 +16,7 @@ export interface Migration {
  * The version that represents the latest schema. Existing databases that
  * predate the migration framework are advanced through every migration to this.
  */
-export const BASELINE_VERSION = 5;
+export const BASELINE_VERSION = 6;
 
 // ---------------------------------------------------------------------------
 // Schema helpers (available for use in migrations)
@@ -270,6 +270,13 @@ const migration1: Migration = {
       CREATE TABLE IF NOT EXISTS sessions (
         group_folder TEXT PRIMARY KEY,
         session_id TEXT NOT NULL,
+        created_at TEXT NOT NULL DEFAULT (datetime('now'))
+      );
+
+      CREATE TABLE IF NOT EXISTS pending_session_intents (
+        group_folder TEXT PRIMARY KEY,
+        fork_from TEXT,
+        name TEXT,
         created_at TEXT NOT NULL DEFAULT (datetime('now'))
       );
 
@@ -570,6 +577,21 @@ const migration5: Migration = {
   },
 };
 
+const migration6: Migration = {
+  version: 6,
+  description: 'Persist pending Discord session intents',
+  up: (db) => {
+    db.exec(`
+      CREATE TABLE IF NOT EXISTS pending_session_intents (
+        group_folder TEXT PRIMARY KEY,
+        fork_from TEXT,
+        name TEXT,
+        created_at TEXT NOT NULL DEFAULT (datetime('now'))
+      );
+    `);
+  },
+};
+
 // ---------------------------------------------------------------------------
 // Migration registry
 // ---------------------------------------------------------------------------
@@ -586,4 +608,5 @@ export const allMigrations: Migration[] = [
   migration3,
   migration4,
   migration5,
+  migration6,
 ];


### PR DESCRIPTION
## Summary

- Adds a native `/session` Discord command with `new`, `resume`, `list`, `current`, `end`, and `rename` subcommands.
- Keeps legacy `/resume` and `/sessions` aliases, routing them through the new handler with deprecation notices.
- Adds session clearing, pending friendly names, fork-from staging, and Claude SDK `forkSession` forwarding for `/session new resume_from`.
- Documents the new command surface and adds tests for payload registration plus Discord handler routing.

Closes #646.

## Verification

- `bun test src/discord-command-flows.test.ts src/channels/discord.test.ts`
- `bun run typecheck`
- `git diff --check`
- `bun test`
