### PR TITLE
feat(web): add per-agent off switch

### DIFF
--- a/src/db.test.ts
+++ b/src/db.test.ts
@@ -214,6 +214,38 @@ describe('agent runtime persistence', () => {
   });
 });
 
+describe('setAgent enabled-flag preservation', () => {
+  const baseAgent: Agent = {
+    id: 'switch-agent',
+    name: 'Switch Agent',
+    folder: 'switch-agent',
+    backend: 'apple-container',
+    agentRuntime: 'claude-agent-sdk',
+    isAdmin: false,
+    createdAt: '2026-05-04T00:00:00.000Z',
+  };
+
+  it('defaults to enabled on first insert', () => {
+    setAgent(baseAgent);
+    expect(getAllAgents()['switch-agent']?.enabled).toBe(true);
+  });
+
+  it('preserves a disabled flag across re-registration without explicit enabled', () => {
+    setAgent({ ...baseAgent, enabled: false });
+    expect(getAllAgents()['switch-agent']?.enabled).toBe(false);
+
+    // Simulate registerGroup / topology resync — no enabled field passed.
+    setAgent({ ...baseAgent });
+    expect(getAllAgents()['switch-agent']?.enabled).toBe(false);
+  });
+
+  it('respects an explicit enabled=true to re-enable', () => {
+    setAgent({ ...baseAgent, enabled: false });
+    setAgent({ ...baseAgent, enabled: true });
+    expect(getAllAgents()['switch-agent']?.enabled).toBe(true);
+  });
+});
+
 // --- storeMessage (sender_missing counter) ---
 
 describe('storeMessage sender_missing counter', () => {

--- a/src/db.ts
+++ b/src/db.ts
@@ -1488,6 +1488,21 @@ export function getAllAgents(): Record<string, Agent> {
 
 /** Insert or replace an agent record. */
 export function setAgent(agent: Agent): void {
+  // When the caller didn't specify `enabled`, preserve the existing row's
+  // value so registration paths (registerGroup, applyDeclarativeAgentTopology)
+  // don't silently re-enable an agent the user disabled in the Web UI.
+  let enabledValue: 0 | 1;
+  if (agent.enabled === false) {
+    enabledValue = 0;
+  } else if (agent.enabled === true) {
+    enabledValue = 1;
+  } else {
+    const existing = db
+      .prepare('SELECT enabled FROM agents WHERE id = ?')
+      .get(agent.id) as { enabled: number | null } | undefined;
+    enabledValue = existing && existing.enabled === 0 ? 0 : 1;
+  }
+
   db.query(
     `
     INSERT OR REPLACE INTO agents (id, name, description, folder, backend, agent_runtime, container_config, is_admin, server_folder, created_at, agent_context_folder, roster_role_filters, avatar_url, avatar_source, enabled)
@@ -1510,7 +1525,7 @@ export function setAgent(agent: Agent): void {
       : agent.rosterRoleFilters.join(','),
     agent.avatarUrl || null,
     agent.avatarSource || null,
-    agent.enabled === false ? 0 : 1,
+    enabledValue,
   );
 }
 

--- a/src/db.ts
+++ b/src/db.ts
@@ -60,6 +60,7 @@ interface AgentRow {
   roster_role_filters: string | null;
   avatar_url: string | null;
   avatar_source: string | null;
+  enabled: number | null;
 }
 
 interface AgentHealthRow {
@@ -204,6 +205,11 @@ function mapRowToAgent(row: AgentRow): Agent {
     rosterRoleFilters,
     avatarUrl: row.avatar_url || undefined,
     avatarSource: (row.avatar_source as Agent['avatarSource']) || undefined,
+    // Default to enabled when the column is missing (pre-migration row) or null.
+    enabled:
+      row.enabled === null || row.enabled === undefined
+        ? true
+        : row.enabled === 1,
   };
 }
 
@@ -1484,8 +1490,8 @@ export function getAllAgents(): Record<string, Agent> {
 export function setAgent(agent: Agent): void {
   db.query(
     `
-    INSERT OR REPLACE INTO agents (id, name, description, folder, backend, agent_runtime, container_config, is_admin, server_folder, created_at, agent_context_folder, roster_role_filters, avatar_url, avatar_source)
-    VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+    INSERT OR REPLACE INTO agents (id, name, description, folder, backend, agent_runtime, container_config, is_admin, server_folder, created_at, agent_context_folder, roster_role_filters, avatar_url, avatar_source, enabled)
+    VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
   `,
   ).run(
     agent.id,
@@ -1504,7 +1510,19 @@ export function setAgent(agent: Agent): void {
       : agent.rosterRoleFilters.join(','),
     agent.avatarUrl || null,
     agent.avatarSource || null,
+    agent.enabled === false ? 0 : 1,
   );
+}
+
+/**
+ * Update only the enabled flag for an agent (lightweight, avoids full setAgent).
+ * Returns true on success, false if the agent doesn't exist.
+ */
+export function setAgentEnabled(agentId: string, enabled: boolean): boolean {
+  const result = db
+    .query('UPDATE agents SET enabled = ? WHERE id = ?')
+    .run(enabled ? 1 : 0, agentId);
+  return result.changes > 0;
 }
 
 /** Update only the avatar fields for an agent (lightweight, avoids full setAgent). */

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -7,12 +7,21 @@ import {
 } from './db.js';
 import {
   _getSlashCommandGroupsFromSubscriptions,
+  _getEnabledStartupConfirmationTargets,
+  _isAgentEnabled,
   _markChannelSubscriptionsDirty,
+  _selectEnabledSubscriptionsForMessage,
+  _setAgents,
   _setChannelSubscriptions,
   _setRegisteredGroups,
   getAvailableGroups,
 } from './index.js';
-import type { ChannelSubscription, RegisteredGroup } from './types.js';
+import type {
+  Agent,
+  ChannelSubscription,
+  NewMessage,
+  RegisteredGroup,
+} from './types.js';
 
 const BASE_GROUP: RegisteredGroup = {
   name: 'Test Group',
@@ -31,11 +40,31 @@ const BASE_SUBSCRIPTION: ChannelSubscription = {
   createdAt: '2024-01-01T00:00:00.000Z',
 };
 
+const BASE_AGENT: Agent = {
+  id: 'team-agent',
+  name: 'Team Agent',
+  folder: 'team-folder',
+  backend: 'apple-container',
+  agentRuntime: 'claude-agent-sdk',
+  isAdmin: false,
+  createdAt: '2024-01-01T00:00:00.000Z',
+};
+
+const BASE_MESSAGE: NewMessage = {
+  id: 'msg-1',
+  chat_jid: 'team@g.us',
+  sender: 'user-1',
+  sender_name: 'User One',
+  content: '@Omni hello',
+  timestamp: '2024-01-01T00:01:00.000Z',
+};
+
 describe('getAvailableGroups', () => {
   beforeEach(() => {
     _initTestDatabase();
     _setRegisteredGroups({});
     _setChannelSubscriptions({});
+    _setAgents({});
   });
 
   it('returns supported group chats ordered by most recent activity', () => {
@@ -151,6 +180,7 @@ describe('slash command subscription groups', () => {
     _initTestDatabase();
     _setRegisteredGroups({});
     _setChannelSubscriptions({});
+    _setAgents({});
   });
 
   it('refreshes dirty channel subscriptions before building slash command groups', () => {
@@ -180,6 +210,112 @@ describe('slash command subscription groups', () => {
         discordBotId: 'bot-a',
         discordGuildId: 'guild-1',
       }),
+    ]);
+  });
+});
+
+describe('agent off-switch routing guards', () => {
+  beforeEach(() => {
+    _initTestDatabase();
+    _setRegisteredGroups({});
+    _setChannelSubscriptions({});
+    _setAgents({});
+  });
+
+  it('resolves enabled state by agent id or workspace folder', () => {
+    _setAgents({
+      'agent-id': {
+        ...BASE_AGENT,
+        id: 'agent-id',
+        folder: 'workspace-folder',
+        enabled: false,
+      },
+    });
+
+    expect(_isAgentEnabled('agent-id')).toBe(false);
+    expect(_isAgentEnabled('workspace-folder')).toBe(false);
+    expect(_isAgentEnabled('unknown-legacy-folder')).toBe(true);
+  });
+
+  it('marks trigger-matched disabled subscriptions so legacy fallback stays blocked', () => {
+    _setAgents({
+      'team-agent': {
+        ...BASE_AGENT,
+        id: 'team-agent',
+        enabled: false,
+      },
+    });
+    _setRegisteredGroups({
+      'team@g.us': { ...BASE_GROUP, folder: 'team-folder' },
+    });
+    _setChannelSubscriptions({
+      'team@g.us': [{ ...BASE_SUBSCRIPTION, agentId: 'team-agent' }],
+    });
+
+    const selection = _selectEnabledSubscriptionsForMessage('team@g.us', [
+      BASE_MESSAGE,
+    ]);
+
+    expect(selection.selected).toEqual([]);
+    expect(selection.selectedByTrigger).toBe(true);
+    expect(selection.allTriggerMatchesDisabled).toBe(true);
+  });
+
+  it('filters disabled agents out of startup confirmation targets', () => {
+    _setAgents({
+      'disabled-by-id': {
+        ...BASE_AGENT,
+        id: 'disabled-by-id',
+        folder: 'disabled-sub-folder',
+        enabled: false,
+      },
+      'legacy-id': {
+        ...BASE_AGENT,
+        id: 'legacy-id',
+        folder: 'disabled-legacy-folder',
+        enabled: false,
+      },
+      'enabled-agent': {
+        ...BASE_AGENT,
+        id: 'enabled-agent',
+        folder: 'enabled-folder',
+        enabled: true,
+      },
+    });
+    _setRegisteredGroups({
+      'dc:subscribed': {
+        ...BASE_GROUP,
+        name: 'Subscribed',
+        folder: 'disabled-sub-folder',
+        trigger: '@DisabledSub',
+      },
+      'dc:legacy-disabled': {
+        ...BASE_GROUP,
+        name: 'Legacy Disabled',
+        folder: 'disabled-legacy-folder',
+        trigger: '@LegacyDisabled',
+      },
+      'dc:enabled': {
+        ...BASE_GROUP,
+        name: 'Enabled',
+        folder: 'enabled-folder',
+        trigger: '@Enabled',
+      },
+    });
+    _setChannelSubscriptions({
+      'dc:subscribed': [
+        {
+          ...BASE_SUBSCRIPTION,
+          channelJid: 'dc:subscribed',
+          agentId: 'disabled-by-id',
+          trigger: '@DisabledSub',
+          isPrimary: true,
+        },
+      ],
+    });
+
+    expect(_getEnabledStartupConfirmationTargets()).toEqual([
+      { chatJid: 'dc:enabled', trigger: '@Enabled' },
     ]);
   });
 });

--- a/src/index.ts
+++ b/src/index.ts
@@ -2107,6 +2107,12 @@ async function startMessageLoop(): Promise<void> {
           let selectedSubs = triggerSelected.filter(
             (s) => agents[s.agentId]?.enabled !== false,
           );
+          // Distinguish "no subs matched" from "matched subs were all
+          // disabled". The legacy group fallback below should only run when
+          // truly nothing matched — otherwise a disabled agent's trigger
+          // could still dispatch via the chat-level queue key.
+          const allTriggerMatchesDisabled =
+            triggerSelected.length > 0 && selectedSubs.length === 0;
 
           // Attentive follow-up: if agents were selected by explicit trigger/mention,
           // mark them attentive so the next human message is routed without a trigger.
@@ -2149,8 +2155,26 @@ async function startMessageLoop(): Promise<void> {
 
           // Legacy fallback: one-to-one registered group handling
           if (selectedSubs.length === 0) {
+            // If trigger matched only disabled agents, do not fall through.
+            if (allTriggerMatchesDisabled) {
+              logger.debug(
+                { chatJid },
+                'Trigger matched only disabled agents — dispatch skipped',
+              );
+              continue;
+            }
             const group = getRegisteredGroupForJid(chatJid);
             if (!group) continue;
+
+            // Honor off-switch on the legacy registered-group path too: the
+            // group folder doubles as the agent id when the agent exists.
+            if (agents[group.folder]?.enabled === false) {
+              logger.debug(
+                { chatJid, folder: group.folder },
+                'Legacy fallback skipped — agent is disabled',
+              );
+              continue;
+            }
 
             const isMainGroup = group.folder === MAIN_GROUP_FOLDER;
             const needsTrigger =
@@ -2314,6 +2338,13 @@ function recoverPendingMessages(): void {
 
   for (const [chatJid, group] of Object.entries(registeredGroups)) {
     if ((channelSubscriptions[chatJid] || []).length > 0) continue;
+    if (agents[group.folder]?.enabled === false) {
+      logger.debug(
+        { chatJid, folder: group.folder },
+        'Recovery: legacy group skipped — agent is disabled',
+      );
+      continue;
+    }
     const sinceTimestamp = lastAgentTimestamp[chatJid] || '';
     const pending = getMessagesSince(chatJid, sinceTimestamp);
     if (pending.length > 0) {

--- a/src/index.ts
+++ b/src/index.ts
@@ -228,6 +228,17 @@ let messageLoopRunning = false;
 // Consumed (cleared) when the follow-up message is routed.
 const attentiveAgents: Record<string, Set<string>> = {};
 
+function resolveAgentByIdOrFolder(idOrFolder: string): Agent | undefined {
+  return (
+    agents[idOrFolder] ??
+    Object.values(agents).find((agent) => agent.folder === idOrFolder)
+  );
+}
+
+function isAgentEnabled(idOrFolder: string): boolean {
+  return resolveAgentByIdOrFolder(idOrFolder)?.enabled !== false;
+}
+
 // Track consecutive errors per group to prevent infinite error loops.
 // After MAX_CONSECUTIVE_ERRORS, the cursor advances past the failing batch
 // so the system doesn't re-trigger the same error on every poll.
@@ -1284,6 +1295,11 @@ export function _setChannelSubscriptions(
 }
 
 /** @internal - exported for testing */
+export function _setAgents(nextAgents: Record<string, Agent>): void {
+  agents = nextAgents;
+}
+
+/** @internal - exported for testing */
 export function _markChannelSubscriptionsDirty(): void {
   channelSubscriptionsDirty = true;
 }
@@ -1291,6 +1307,52 @@ export function _markChannelSubscriptionsDirty(): void {
 /** @internal - exported for testing */
 export function _getSlashCommandGroupsFromSubscriptions(): RegisteredGroup[] {
   return buildSlashCommandGroupsFromSubscriptions();
+}
+
+/** @internal - exported for testing */
+export function _isAgentEnabled(idOrFolder: string): boolean {
+  return isAgentEnabled(idOrFolder);
+}
+
+/** @internal - exported for testing */
+export function _selectEnabledSubscriptionsForMessage(
+  chatJid: string,
+  groupMessages: NewMessage[],
+): {
+  selected: ChannelSubscription[];
+  selectedByTrigger: boolean;
+  allTriggerMatchesDisabled: boolean;
+} {
+  const { selected: triggerSelected, selectedByTrigger } =
+    selectSubscriptionsForMessage(chatJid, groupMessages);
+  const selected = triggerSelected.filter((s) => isAgentEnabled(s.agentId));
+  return {
+    selected,
+    selectedByTrigger,
+    allTriggerMatchesDisabled:
+      selectedByTrigger && triggerSelected.length > 0 && selected.length === 0,
+  };
+}
+
+function getEnabledStartupConfirmationTargets() {
+  return buildStartupConfirmationTargets(
+    registeredGroups,
+    channelSubscriptions,
+  ).filter((target) => {
+    const idOrFolder =
+      target.agentId ?? registeredGroups[target.chatJid]?.folder;
+    if (!idOrFolder || isAgentEnabled(idOrFolder)) return true;
+    logger.debug(
+      { chatJid: target.chatJid, idOrFolder },
+      'Startup confirmation skipped — agent is disabled',
+    );
+    return false;
+  });
+}
+
+/** @internal - exported for testing */
+export function _getEnabledStartupConfirmationTargets() {
+  return getEnabledStartupConfirmationTargets();
 }
 
 /**
@@ -2102,17 +2164,16 @@ async function startMessageLoop(): Promise<void> {
         }
 
         for (const [chatJid, groupMessages] of messagesByGroup) {
-          const { selected: triggerSelected, selectedByTrigger } =
-            selectSubscriptionsForMessage(chatJid, groupMessages);
-          let selectedSubs = triggerSelected.filter(
-            (s) => agents[s.agentId]?.enabled !== false,
-          );
+          const {
+            selected: selectedByEnabledState,
+            selectedByTrigger,
+            allTriggerMatchesDisabled,
+          } = _selectEnabledSubscriptionsForMessage(chatJid, groupMessages);
+          let selectedSubs = selectedByEnabledState;
           // Distinguish "no subs matched" from "matched subs were all
           // disabled". The legacy group fallback below should only run when
           // truly nothing matched — otherwise a disabled agent's trigger
           // could still dispatch via the chat-level queue key.
-          const allTriggerMatchesDisabled =
-            triggerSelected.length > 0 && selectedSubs.length === 0;
 
           // Attentive follow-up: if agents were selected by explicit trigger/mention,
           // mark them attentive so the next human message is routed without a trigger.
@@ -2131,9 +2192,7 @@ async function startMessageLoop(): Promise<void> {
             if (attentive && attentive.size > 0) {
               const subs = getSubscriptionsForChannelInMemory(chatJid);
               const attentiveSubs = subs.filter(
-                (s) =>
-                  attentive.has(s.agentId) &&
-                  agents[s.agentId]?.enabled !== false,
+                (s) => attentive.has(s.agentId) && isAgentEnabled(s.agentId),
               );
               if (attentiveSubs.length > 0) {
                 // Replace fallback selection with attentive agents — the user is
@@ -2168,7 +2227,7 @@ async function startMessageLoop(): Promise<void> {
 
             // Honor off-switch on the legacy registered-group path too: the
             // group folder doubles as the agent id when the agent exists.
-            if (agents[group.folder]?.enabled === false) {
+            if (!isAgentEnabled(group.folder)) {
               logger.debug(
                 { chatJid, folder: group.folder },
                 'Legacy fallback skipped — agent is disabled',
@@ -2306,7 +2365,7 @@ async function startMessageLoop(): Promise<void> {
 function recoverPendingMessages(): void {
   for (const [chatJid, subs] of Object.entries(channelSubscriptions)) {
     for (const sub of subs) {
-      if (agents[sub.agentId]?.enabled === false) {
+      if (!isAgentEnabled(sub.agentId)) {
         logger.debug(
           { chatJid, agentId: sub.agentId },
           'Recovery: skipping — agent is disabled',
@@ -2338,7 +2397,7 @@ function recoverPendingMessages(): void {
 
   for (const [chatJid, group] of Object.entries(registeredGroups)) {
     if ((channelSubscriptions[chatJid] || []).length > 0) continue;
-    if (agents[group.folder]?.enabled === false) {
+    if (!isAgentEnabled(group.folder)) {
       logger.debug(
         { chatJid, folder: group.folder },
         'Recovery: legacy group skipped — agent is disabled',
@@ -2373,10 +2432,7 @@ function queueStartupConfirmationMessages(): void {
     return;
   }
 
-  const targets = buildStartupConfirmationTargets(
-    registeredGroups,
-    channelSubscriptions,
-  );
+  const targets = getEnabledStartupConfirmationTargets();
 
   for (const target of targets) {
     const content = target.trigger
@@ -3273,13 +3329,7 @@ async function main(): Promise<void> {
   startSchedulerLoop({
     registeredGroups: () => registeredGroups,
     getGroupForTask,
-    isAgentEnabled: (agentFolder) => {
-      // Agent IDs and group_folder values share the same key. Unknown folders
-      // (legacy registered-group tasks) default to enabled.
-      const agent = agents[agentFolder];
-      if (!agent) return true;
-      return agent.enabled !== false;
-    },
+    isAgentEnabled,
     getSessions: () => sessions,
     resumePositionStore,
     queue,

--- a/src/index.ts
+++ b/src/index.ts
@@ -94,6 +94,7 @@ import {
   storeGuildRoster,
   storeMessage,
   updateAgentAvatar,
+  setAgentEnabled,
 } from './db.js';
 import {
   type DiscoveryHandle,
@@ -2103,7 +2104,9 @@ async function startMessageLoop(): Promise<void> {
         for (const [chatJid, groupMessages] of messagesByGroup) {
           const { selected: triggerSelected, selectedByTrigger } =
             selectSubscriptionsForMessage(chatJid, groupMessages);
-          let selectedSubs = triggerSelected;
+          let selectedSubs = triggerSelected.filter(
+            (s) => agents[s.agentId]?.enabled !== false,
+          );
 
           // Attentive follow-up: if agents were selected by explicit trigger/mention,
           // mark them attentive so the next human message is routed without a trigger.
@@ -2121,8 +2124,10 @@ async function startMessageLoop(): Promise<void> {
             const attentive = attentiveAgents[chatJid];
             if (attentive && attentive.size > 0) {
               const subs = getSubscriptionsForChannelInMemory(chatJid);
-              const attentiveSubs = subs.filter((s) =>
-                attentive.has(s.agentId),
+              const attentiveSubs = subs.filter(
+                (s) =>
+                  attentive.has(s.agentId) &&
+                  agents[s.agentId]?.enabled !== false,
               );
               if (attentiveSubs.length > 0) {
                 // Replace fallback selection with attentive agents — the user is
@@ -2277,6 +2282,13 @@ async function startMessageLoop(): Promise<void> {
 function recoverPendingMessages(): void {
   for (const [chatJid, subs] of Object.entries(channelSubscriptions)) {
     for (const sub of subs) {
+      if (agents[sub.agentId]?.enabled === false) {
+        logger.debug(
+          { chatJid, agentId: sub.agentId },
+          'Recovery: skipping — agent is disabled',
+        );
+        continue;
+      }
       const dispatchJid = makeDispatchKey(chatJid, sub.agentId);
       const sinceTimestamp = lastAgentTimestamp[dispatchJid] || '';
       const pending = getMessagesSince(chatJid, sinceTimestamp);
@@ -2599,6 +2611,17 @@ async function main(): Promise<void> {
         agents[agentId].avatarSource =
           (source as Agent['avatarSource']) || undefined;
       }
+    },
+    setAgentEnabled: (agentId, enabled) => {
+      if (!agents[agentId]) return false;
+      const ok = setAgentEnabled(agentId, enabled);
+      if (!ok) return false;
+      agents[agentId].enabled = enabled;
+      logger.info(
+        { agentId, enabled },
+        'Agent enabled flag updated via Web UI',
+      );
+      return true;
     },
     sendMessage: (agentId, chatJid, content, senderName) => {
       const msgId = `web-${randomUUID()}`;
@@ -3219,6 +3242,13 @@ async function main(): Promise<void> {
   startSchedulerLoop({
     registeredGroups: () => registeredGroups,
     getGroupForTask,
+    isAgentEnabled: (agentFolder) => {
+      // Agent IDs and group_folder values share the same key. Unknown folders
+      // (legacy registered-group tasks) default to enabled.
+      const agent = agents[agentFolder];
+      if (!agent) return true;
+      return agent.enabled !== false;
+    },
     getSessions: () => sessions,
     resumePositionStore,
     queue,

--- a/src/migrations.ts
+++ b/src/migrations.ts
@@ -16,7 +16,7 @@ export interface Migration {
  * The version that represents the latest schema. Existing databases that
  * predate the migration framework are advanced through every migration to this.
  */
-export const BASELINE_VERSION = 3;
+export const BASELINE_VERSION = 4;
 
 // ---------------------------------------------------------------------------
 // Schema helpers (available for use in migrations)
@@ -304,7 +304,8 @@ const migration1: Migration = {
         agent_context_folder TEXT,
         roster_role_filters TEXT,
         avatar_url TEXT,
-        avatar_source TEXT
+        avatar_source TEXT,
+        enabled INTEGER NOT NULL DEFAULT 1
       );
 
       CREATE TABLE IF NOT EXISTS channel_routes (
@@ -551,6 +552,14 @@ const migration3: Migration = {
   },
 };
 
+const migration4: Migration = {
+  version: 4,
+  description: 'Add per-agent enabled flag (off switch)',
+  up: (db) => {
+    addColumnIfNotExists(db, 'agents', 'enabled', 'INTEGER NOT NULL', '1');
+  },
+};
+
 // ---------------------------------------------------------------------------
 // Migration registry
 // ---------------------------------------------------------------------------
@@ -561,4 +570,9 @@ const migration3: Migration = {
  * can use plain `ALTER TABLE` without try/catch — the version tracker
  * guarantees each migration runs exactly once.
  */
-export const allMigrations: Migration[] = [migration1, migration2, migration3];
+export const allMigrations: Migration[] = [
+  migration1,
+  migration2,
+  migration3,
+  migration4,
+];

--- a/src/simtest/fake-state.ts
+++ b/src/simtest/fake-state.ts
@@ -616,6 +616,13 @@ export class FakeState implements WebStateProvider {
     agent.avatarSource = (source as Agent['avatarSource']) ?? undefined;
   }
 
+  setAgentEnabled(agentId: string, enabled: boolean): boolean {
+    const agent = this.agents[agentId];
+    if (!agent) return false;
+    agent.enabled = enabled;
+    return true;
+  }
+
   // ---- Admin mutation methods (called by admin API) ----
 
   addAgent(agent: Partial<Agent> & { id: string }): Agent {

--- a/src/task-scheduler.ts
+++ b/src/task-scheduler.ts
@@ -124,6 +124,13 @@ export interface SchedulerDependencies {
     chatJid: string,
     agentFolder: string,
   ) => RegisteredGroup | undefined;
+  /**
+   * Check whether the agent owning `agentFolder` is enabled. When false the
+   * scheduler skips runs for that agent (web UI off-switch). Returns true for
+   * unknown/legacy folders so non-agent tasks (legacy registered groups) keep
+   * running.
+   */
+  isAgentEnabled?: (agentFolder: string) => boolean;
   getSessions: () => Record<string, string>;
   resumePositionStore: ResumePositionStore;
   queue: GroupQueue;
@@ -175,6 +182,17 @@ async function runTask(
     runtime.logger.info(
       { taskId: task.id, status: freshTask?.status ?? 'deleted' },
       'Task no longer active, skipping',
+    );
+    return;
+  }
+
+  // Skip runs when the owning agent is disabled via the web UI off-switch.
+  // next_run was already advanced before this call, so when the agent is
+  // re-enabled, future ticks pick the task up at its next scheduled time.
+  if (deps.isAgentEnabled && !deps.isAgentEnabled(task.group_folder)) {
+    runtime.logger.info(
+      { taskId: task.id, agentFolder: task.group_folder },
+      'Task skipped — agent is disabled',
     );
     return;
   }

--- a/src/types.ts
+++ b/src/types.ts
@@ -336,6 +336,13 @@ export interface Agent {
   avatarUrl?: string;
   /** Which platform the avatar was sourced from. */
   avatarSource?: 'discord' | 'telegram' | 'slack' | 'custom';
+  /**
+   * Whether this agent is enabled. When false, the orchestrator skips message
+   * dispatch and scheduled task execution for this agent. Inbound messages are
+   * still persisted; toggling back to true resumes processing from the next
+   * message. Defaults to true on existing rows via DB migration.
+   */
+  enabled?: boolean;
 }
 
 /** Volatile, sanitized runtime state for discovery/roster views. */

--- a/src/web/agent-channels.test.ts
+++ b/src/web/agent-channels.test.ts
@@ -65,6 +65,7 @@ function makeState(options?: {
     readContextFile: () => null,
     writeContextFile: () => {},
     updateAgentAvatar: () => {},
+    setAgentEnabled: () => true,
     resolveChatImage: async () => null,
     resolveDiscordGuildImage: async () => null,
   };

--- a/src/web/agent-detail.test.ts
+++ b/src/web/agent-detail.test.ts
@@ -128,6 +128,7 @@ function makeState(
     readContextFile: () => null,
     writeContextFile: () => {},
     updateAgentAvatar: () => {},
+    setAgentEnabled: () => true,
     resolveChatImage: async () => null,
     resolveDiscordGuildImage: async () => null,
     ...overrides,

--- a/src/web/agent-detail.ts
+++ b/src/web/agent-detail.ts
@@ -18,6 +18,8 @@ export interface AgentDetailData {
   backend: string;
   agentRuntime: string;
   isAdmin: boolean;
+  /** Whether the agent is enabled. Undefined for remote agents. */
+  enabled?: boolean;
   description?: string;
   createdAt: string;
   remoteInstanceId?: string;
@@ -134,6 +136,8 @@ export function buildAgentDetailData(
     backend: agent.backend,
     agentRuntime: agent.agentRuntime,
     isAdmin: agent.isAdmin,
+    // Default missing/undefined to true (agent is enabled unless explicitly off).
+    enabled: agent.enabled !== false,
     remoteInstanceId: undefined,
     remoteInstanceName: undefined,
     remoteHost: undefined,
@@ -272,7 +276,7 @@ export function renderAgentDetailContent(
       ? `<img class="ad-avatar" src="${avatarSrc}" alt="${esc(data.name)}" onerror="this.style.display='none'">`
       : `<div class="ad-avatar-placeholder">${esc(data.name.charAt(0).toUpperCase())}</div>`) +
     `<div class="ad-header-info">` +
-    `<h2 class="ad-name">${esc(data.name)} <span id="ad-exec-status" class="badge badge-sm exec-offline">offline</span></h2>` +
+    `<h2 class="ad-name">${esc(data.name)} <span id="ad-exec-status" class="badge badge-sm ${data.enabled === false ? 'exec-disabled' : 'exec-offline'}">${data.enabled === false ? 'disabled' : 'offline'}</span></h2>` +
     `<div class="ad-meta">` +
     `<span class="badge ${backendBadge}">${esc(data.backend)}</span>` +
     `<span class="badge">${esc(data.agentRuntime)}</span>` +
@@ -280,6 +284,9 @@ export function renderAgentDetailContent(
       ? `<span class="badge badge-remote">${esc(data.remoteInstanceName || data.remoteInstanceId)}</span>`
       : '') +
     (data.isAdmin ? `<span class="badge badge-admin">admin</span>` : '') +
+    (!data.remoteInstanceId
+      ? ` <button class="btn btn-sm" data-agent-toggle="${data.enabled === false ? 'true' : 'false'}" data-agent-id="${esc(data.id)}">${data.enabled === false ? 'enable' : 'disable'}</button>`
+      : '') +
     `</div>` +
     (data.description
       ? `<div class="ad-desc">${esc(data.description)}</div>`

--- a/src/web/agents-page.test.ts
+++ b/src/web/agents-page.test.ts
@@ -718,13 +718,14 @@ describe('renderAgentsContent with execution status', () => {
       },
     ];
     const html = renderAgentsContent(makeState({}), remotePeers);
-    // Remote row exists but no toggle
+    // Remote row exists but no toggle (order-agnostic).
     expect(html).toContain('Remote Only');
-    expect(html).not.toContain(
-      'data-agent-toggle="true" data-agent-id="peer-2:remote-only"',
+    expect(html).toContain('data-agent-id="peer-2:remote-only"');
+    expect(html).not.toMatch(
+      /data-agent-id="peer-2:remote-only"[^>]*data-agent-toggle=/,
     );
-    expect(html).not.toContain(
-      'data-agent-toggle="false" data-agent-id="peer-2:remote-only"',
+    expect(html).not.toMatch(
+      /data-agent-toggle=[^>]*data-agent-id="peer-2:remote-only"/,
     );
   });
 });

--- a/src/web/agents-page.test.ts
+++ b/src/web/agents-page.test.ts
@@ -92,6 +92,7 @@ function makeState(
     readContextFile: () => null,
     writeContextFile: () => {},
     updateAgentAvatar: () => {},
+    setAgentEnabled: () => true,
     resolveChatImage: async () => null,
     resolveDiscordGuildImage: async () => null,
   };
@@ -676,5 +677,54 @@ describe('renderAgentsContent with execution status', () => {
     const html = renderAgentsContent(makeState(), remotePeers);
     // Remote agents should show offline, not use queue details
     expect(html).toContain('exec-offline');
+  });
+
+  it('renders the disabled badge and an enable button for disabled local agents', () => {
+    const html = renderAgentsContent(
+      makeState({
+        'agent-1': makeAgent({ enabled: false }),
+      }),
+    );
+    expect(html).toContain('exec-disabled');
+    expect(html).toContain('data-disabled="true"');
+    expect(html).toContain('data-agent-toggle="true"');
+    expect(html).toContain('>enable<');
+  });
+
+  it('renders a disable button for enabled local agents', () => {
+    const html = renderAgentsContent(makeState());
+    expect(html).toContain('data-agent-toggle="false"');
+    expect(html).toContain('>disable<');
+  });
+
+  it('omits the toggle button for remote agents', () => {
+    const remotePeers = [
+      {
+        instanceId: 'peer-2',
+        instanceName: 'orangepi',
+        online: true,
+        host: '10.0.0.20',
+        port: 7777,
+        agents: [
+          {
+            id: 'remote-only',
+            name: 'Remote Only',
+            folder: 'remote-only',
+            backend: 'docker' as const,
+            agentRuntime: 'opencode' as const,
+            channels: [],
+          },
+        ],
+      },
+    ];
+    const html = renderAgentsContent(makeState({}), remotePeers);
+    // Remote row exists but no toggle
+    expect(html).toContain('Remote Only');
+    expect(html).not.toContain(
+      'data-agent-toggle="true" data-agent-id="peer-2:remote-only"',
+    );
+    expect(html).not.toContain(
+      'data-agent-toggle="false" data-agent-id="peer-2:remote-only"',
+    );
   });
 });

--- a/src/web/agents-page.ts
+++ b/src/web/agents-page.ts
@@ -21,7 +21,8 @@ export type AgentExecStatus =
   | 'running-task'
   | 'idle'
   | 'queued'
-  | 'offline';
+  | 'offline'
+  | 'disabled';
 
 /** Derive an agent's execution status from the group queue details. */
 export function getAgentExecStatus(
@@ -53,6 +54,7 @@ const EXEC_STATUS_LABELS: Record<AgentExecStatus, string> = {
   idle: 'idle',
   queued: 'queued',
   offline: 'offline',
+  disabled: 'disabled',
 };
 
 const EXEC_STATUS_CSS: Record<AgentExecStatus, string> = {
@@ -61,6 +63,7 @@ const EXEC_STATUS_CSS: Record<AgentExecStatus, string> = {
   idle: 'exec-idle',
   queued: 'exec-queued',
   offline: 'exec-offline',
+  disabled: 'exec-disabled',
 };
 
 function imageRev(value: string): string {
@@ -103,10 +106,20 @@ export function renderAgentRow(
       `<span class="ap-avatar-ph" style="display:none">${esc(agent.name.charAt(0).toUpperCase())}</span>`
     : `<span class="ap-avatar-ph">${esc(agent.name.charAt(0).toUpperCase())}</span>`;
 
+  // Local agents only — remote agents are toggled on their own host.
+  const isLocal = !agent.remoteInstanceId;
+  const isDisabled = execStatus === 'disabled';
+  const toggleLabel = isDisabled ? 'enable' : 'disable';
+  const toggleTarget = isDisabled ? 'true' : 'false';
+  const toggleBtn = isLocal
+    ? ` <button class="btn btn-sm" data-agent-toggle="${toggleTarget}" data-agent-id="${esc(agent.id)}">${toggleLabel}</button>`
+    : '';
+
   return (
     `<tr class="ap-row" data-agent-id="${esc(agent.id)}" data-backend="${esc(agent.backend)}" data-runtime="${esc(agent.agentRuntime)}"` +
     (agent.remoteInstanceId ? ` data-remote="true"` : ` data-remote="false"`) +
     (agent.isAdmin ? ` data-admin="true"` : '') +
+    (isDisabled ? ` data-disabled="true"` : '') +
     `>` +
     `<td class="td-agent-name">` +
     `<a href="${detailUrl}" data-nav data-page="agent-detail" data-agent-id="${esc(agent.id)}" class="ap-agent-link">` +
@@ -131,6 +144,7 @@ export function renderAgentRow(
     (agent.channels.length > 0
       ? ` <a href="/conversations?chat=${encodeURIComponent(agent.channels[0].jid)}" data-nav data-page="conversations" class="btn btn-sm">messages</a>`
       : '') +
+    toggleBtn +
     `</td>` +
     `</tr>`
   );
@@ -166,11 +180,17 @@ export function renderAgentsContent(
     .map((r) => `<option value="${escapeHtml(r)}">${escapeHtml(r)}</option>`)
     .join('');
 
+  const localAgents = state.getAgents();
   const rows = agentData
     .map((a) => {
-      const status = a.remoteInstanceId
-        ? 'offline'
-        : getAgentExecStatus(a.folder, queueDetails);
+      let status: AgentExecStatus;
+      if (a.remoteInstanceId) {
+        status = 'offline';
+      } else if (localAgents[a.id]?.enabled === false) {
+        status = 'disabled';
+      } else {
+        status = getAgentExecStatus(a.folder, queueDetails);
+      }
       return renderAgentRow(a, taskCounts[a.folder] || 0, status);
     })
     .join('\n');

--- a/src/web/context-viewer.test.ts
+++ b/src/web/context-viewer.test.ts
@@ -70,6 +70,7 @@ function makeState(options?: {
     readContextFile: () => null,
     writeContextFile: () => {},
     updateAgentAvatar: () => {},
+    setAgentEnabled: () => true,
     resolveChatImage: async () => null,
     resolveDiscordGuildImage: async () => null,
   };

--- a/src/web/conversations.test.ts
+++ b/src/web/conversations.test.ts
@@ -142,6 +142,7 @@ function makeState(
     readContextFile: () => null,
     writeContextFile: () => {},
     updateAgentAvatar: () => {},
+    setAgentEnabled: () => true,
     ...overrides,
   };
 }

--- a/src/web/dashboard.test.ts
+++ b/src/web/dashboard.test.ts
@@ -103,6 +103,9 @@ function makeState(options?: {
     updateAgentAvatar: () => {
       throw new Error('Unexpected updateAgentAvatar during render');
     },
+    setAgentEnabled: () => {
+      throw new Error('Unexpected setAgentEnabled during render');
+    },
     resolveChatImage: async () => null,
     resolveDiscordGuildImage: async () => null,
   };

--- a/src/web/ipc-inspector.test.ts
+++ b/src/web/ipc-inspector.test.ts
@@ -104,6 +104,7 @@ function makeState(
     readContextFile: () => null,
     writeContextFile: () => {},
     updateAgentAvatar: () => {},
+    setAgentEnabled: () => true,
     ...overrides,
   };
 }

--- a/src/web/logs.test.ts
+++ b/src/web/logs.test.ts
@@ -59,6 +59,7 @@ function makeState(
     readContextFile: () => null,
     writeContextFile: () => {},
     updateAgentAvatar: () => {},
+    setAgentEnabled: () => true,
     ...overrides,
   };
 }

--- a/src/web/page-scripts.ts
+++ b/src/web/page-scripts.ts
@@ -786,7 +786,7 @@ if(searchInput&&tbody){
 }
 
 // ---- Agent on/off toggle (shared with agent-detail) ----
-document.addEventListener("click",function(e){
+function onAgentToggleClick(e){
   var btn=e.target.closest("[data-agent-toggle]");
   if(!btn)return;
   var agentId=btn.getAttribute("data-agent-id");
@@ -799,7 +799,9 @@ document.addEventListener("click",function(e){
     .then(function(r){if(!r.ok)throw new Error("HTTP "+r.status);return r.json();})
     .then(function(){window.__toast&&window.__toast("Agent "+(enabled?"enabled":"disabled"));location.reload();})
     .catch(function(err){window.__toast&&window.__toast(err.message||"Failed","error");btn.disabled=false;btn.textContent=prevText;});
-});
+}
+document.addEventListener("click",onAgentToggleClick);
+window.__cleanup=function(){document.removeEventListener("click",onAgentToggleClick);};
 `;
 }
 
@@ -2363,7 +2365,24 @@ function agentDetailScript(): string {
     '    .catch(function(err){window.__toast&&window.__toast(err.message||"Failed","error");btn.disabled=false;btn.textContent=ns==="paused"?"pause":"resume";});',
     '});',
     '',
-    'window.__cleanup=function(){clearInterval(pollTimer);};',
+    '// Agent on/off toggle',
+    'function onAgentToggleClick(e){',
+    '  var btn=e.target.closest("[data-agent-toggle]");',
+    '  if(!btn)return;',
+    '  var agentId=btn.getAttribute("data-agent-id");',
+    '  var target=btn.getAttribute("data-agent-toggle");',
+    '  if(!agentId||target===null)return;',
+    '  var enabled=target==="true";',
+    '  var prevText=btn.textContent;',
+    '  btn.disabled=true;btn.textContent="...";',
+    '  fetch("/api/agents/"+encodeURIComponent(agentId)+"/enabled",{method:"POST",headers:{"Content-Type":"application/json"},body:JSON.stringify({enabled:enabled})})',
+    '    .then(function(r){if(!r.ok)throw new Error("HTTP "+r.status);return r.json();})',
+    '    .then(function(){window.__toast&&window.__toast("Agent "+(enabled?"enabled":"disabled"));location.reload();})',
+    '    .catch(function(err){window.__toast&&window.__toast(err.message||"Failed","error");btn.disabled=false;btn.textContent=prevText;});',
+    '}',
+    'document.addEventListener("click",onAgentToggleClick);',
+    '',
+    'window.__cleanup=function(){clearInterval(pollTimer);document.removeEventListener("click",onAgentToggleClick);};',
     '})();',
   ].join('\n');
 }

--- a/src/web/page-scripts.ts
+++ b/src/web/page-scripts.ts
@@ -784,6 +784,22 @@ if(searchInput&&tbody){
   if(backendSelect)backendSelect.addEventListener("change",applyFilters);
   if(runtimeSelect)runtimeSelect.addEventListener("change",applyFilters);
 }
+
+// ---- Agent on/off toggle (shared with agent-detail) ----
+document.addEventListener("click",function(e){
+  var btn=e.target.closest("[data-agent-toggle]");
+  if(!btn)return;
+  var agentId=btn.getAttribute("data-agent-id");
+  var target=btn.getAttribute("data-agent-toggle");
+  if(!agentId||target===null)return;
+  var enabled=target==="true";
+  var prevText=btn.textContent;
+  btn.disabled=true;btn.textContent="...";
+  fetch("/api/agents/"+encodeURIComponent(agentId)+"/enabled",{method:"POST",headers:{"Content-Type":"application/json"},body:JSON.stringify({enabled:enabled})})
+    .then(function(r){if(!r.ok)throw new Error("HTTP "+r.status);return r.json();})
+    .then(function(){window.__toast&&window.__toast("Agent "+(enabled?"enabled":"disabled"));location.reload();})
+    .catch(function(err){window.__toast&&window.__toast(err.message||"Failed","error");btn.disabled=false;btn.textContent=prevText;});
+});
 `;
 }
 

--- a/src/web/rate-limit.test.ts
+++ b/src/web/rate-limit.test.ts
@@ -50,6 +50,7 @@ function makeState(
     readContextFile: () => null,
     writeContextFile: () => {},
     updateAgentAvatar: () => {},
+    setAgentEnabled: () => true,
     ...overrides,
   };
 }

--- a/src/web/routes.test.ts
+++ b/src/web/routes.test.ts
@@ -1423,4 +1423,19 @@ describe('POST /api/agents/{id}/enabled (off-switch)', () => {
     );
     expect(res.status).toBe(400);
   });
+
+  it('returns 400 for malformed agent ID encoding', async () => {
+    const state = makeState();
+    const res = await handle(
+      new Request('http://localhost/api/agents/%E0%A4%A/enabled', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ enabled: true }),
+      }),
+      state,
+    );
+    expect(res.status).toBe(400);
+    const body = (await res.json()) as { error: string };
+    expect(body.error).toContain('encoding');
+  });
 });

--- a/src/web/routes.test.ts
+++ b/src/web/routes.test.ts
@@ -120,6 +120,7 @@ function makeState(
     readContextFile: () => null,
     writeContextFile: () => {},
     updateAgentAvatar: () => {},
+    setAgentEnabled: () => true,
     resolveChatImage: async () => null,
     resolveDiscordGuildImage: async () => null,
     ...overrides,
@@ -1356,5 +1357,70 @@ describe('conversation export', () => {
     const disposition = res.headers.get('content-disposition') || '';
     expect(disposition).toContain('My_Chat___Special_-export.json');
     expect(disposition).not.toContain('/');
+  });
+});
+
+describe('POST /api/agents/{id}/enabled (off-switch)', () => {
+  it('persists the enabled flag and returns the new value', async () => {
+    const calls: Array<{ id: string; enabled: boolean }> = [];
+    const state = makeState({
+      setAgentEnabled: (id, enabled) => {
+        calls.push({ id, enabled });
+        return true;
+      },
+    });
+    const res = await handle(
+      new Request('http://localhost/api/agents/agent-1/enabled', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ enabled: false }),
+      }),
+      state,
+    );
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as Record<string, unknown>;
+    expect(body).toEqual({ ok: true, agentId: 'agent-1', enabled: false });
+    expect(calls).toEqual([{ id: 'agent-1', enabled: false }]);
+  });
+
+  it('rejects non-boolean enabled values', async () => {
+    const state = makeState();
+    const res = await handle(
+      new Request('http://localhost/api/agents/agent-1/enabled', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ enabled: 'yes' }),
+      }),
+      state,
+    );
+    expect(res.status).toBe(400);
+    const body = (await res.json()) as { error: string };
+    expect(body.error).toContain('boolean');
+  });
+
+  it('returns 404 when the agent does not exist', async () => {
+    const state = makeState();
+    const res = await handle(
+      new Request('http://localhost/api/agents/missing/enabled', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ enabled: true }),
+      }),
+      state,
+    );
+    expect(res.status).toBe(404);
+  });
+
+  it('rejects invalid JSON', async () => {
+    const state = makeState();
+    const res = await handle(
+      new Request('http://localhost/api/agents/agent-1/enabled', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: 'not json',
+      }),
+      state,
+    );
+    expect(res.status).toBe(400);
   });
 });

--- a/src/web/routes.ts
+++ b/src/web/routes.ts
@@ -212,6 +212,16 @@ export function handleRequest(
     return json({ error: 'Method not allowed' }, 405);
   }
 
+  // Agent on/off switch
+  if (pathname.startsWith('/api/agents/') && pathname.endsWith('/enabled')) {
+    const agentId = decodeURIComponent(
+      pathname.slice('/api/agents/'.length, -'/enabled'.length),
+    );
+    if (!agentId) return json({ error: 'Missing agent ID' }, 400);
+    if (method === 'POST') return handleSetAgentEnabled(agentId, req, state);
+    return json({ error: 'Method not allowed' }, 405);
+  }
+
   // Agent detail API
   if (pathname.startsWith('/api/agents/') && pathname.endsWith('/detail')) {
     const agentId = decodeURIComponent(
@@ -1187,6 +1197,38 @@ async function handleSendMessage(
   } catch (err: any) {
     return json({ error: `Failed to send message: ${err.message}` }, 500);
   }
+}
+
+async function handleSetAgentEnabled(
+  agentId: string,
+  req: Request,
+  state: WebStateProvider,
+): Promise<Response> {
+  const agents = state.getAgents();
+  const agent = agents[agentId];
+  if (!agent) return json({ error: 'Agent not found' }, 404);
+
+  let body: Record<string, unknown>;
+  try {
+    body = await readJsonBody<Record<string, unknown>>(
+      req,
+      MAX_WEB_JSON_BODY_BYTES,
+    );
+  } catch (err) {
+    if (err instanceof RequestBodyTooLargeError) {
+      return json({ error: 'Request body too large' }, 413);
+    }
+    return json({ error: 'Invalid JSON body' }, 400);
+  }
+
+  if (typeof body.enabled !== 'boolean') {
+    return json({ error: '"enabled" must be a boolean' }, 400);
+  }
+
+  const ok = state.setAgentEnabled(agentId, body.enabled);
+  if (!ok) return json({ error: 'Agent not found' }, 404);
+
+  return json({ ok: true, agentId, enabled: body.enabled });
 }
 
 // ---- Helpers ----

--- a/src/web/routes.ts
+++ b/src/web/routes.ts
@@ -214,9 +214,14 @@ export function handleRequest(
 
   // Agent on/off switch
   if (pathname.startsWith('/api/agents/') && pathname.endsWith('/enabled')) {
-    const agentId = decodeURIComponent(
-      pathname.slice('/api/agents/'.length, -'/enabled'.length),
-    );
+    let agentId: string;
+    try {
+      agentId = decodeURIComponent(
+        pathname.slice('/api/agents/'.length, -'/enabled'.length),
+      );
+    } catch {
+      return json({ error: 'Invalid agent ID encoding' }, 400);
+    }
     if (!agentId) return json({ error: 'Missing agent ID' }, 400);
     if (method === 'POST') return handleSetAgentEnabled(agentId, req, state);
     return json({ error: 'Method not allowed' }, 405);

--- a/src/web/server.test.ts
+++ b/src/web/server.test.ts
@@ -164,6 +164,7 @@ function makeState(
     readContextFile: () => null,
     writeContextFile: () => {},
     updateAgentAvatar: () => {},
+    setAgentEnabled: () => true,
     ...overrides,
   };
 }

--- a/src/web/session-auth.test.ts
+++ b/src/web/session-auth.test.ts
@@ -58,6 +58,7 @@ function makeState(
     readContextFile: () => null,
     writeContextFile: () => {},
     updateAgentAvatar: () => {},
+    setAgentEnabled: () => true,
     ...overrides,
   };
 }

--- a/src/web/settings.test.ts
+++ b/src/web/settings.test.ts
@@ -34,6 +34,7 @@ function makeState(): WebStateProvider {
     readContextFile: () => null,
     writeContextFile: () => {},
     updateAgentAvatar: () => {},
+    setAgentEnabled: () => true,
   };
 }
 

--- a/src/web/shared.ts
+++ b/src/web/shared.ts
@@ -706,6 +706,8 @@ function shellCSS(): string {
     `.exec-idle{background:rgba(251,191,36,.1);color:var(--yellow)}`,
     `.exec-queued{background:rgba(34,211,238,.1);color:var(--cyan)}`,
     `.exec-offline{background:var(--surface-2);color:var(--text-dim)}`,
+    `.exec-disabled{background:rgba(220,38,38,.12);color:var(--red,#ef4444)}`,
+    `tr[data-disabled="true"] .ap-name{opacity:.55}`,
     `@keyframes exec-pulse{0%,100%{opacity:1}50%{opacity:.6}}`,
     `.ap-empty{padding:2rem;text-align:center;color:var(--text-dim);font-size:12px}`,
 

--- a/src/web/solid-handler.test.ts
+++ b/src/web/solid-handler.test.ts
@@ -48,6 +48,7 @@ function makeState(): WebStateProvider {
     readContextFile: () => null,
     writeContextFile: () => {},
     updateAgentAvatar: () => {},
+    setAgentEnabled: () => true,
   };
 }
 

--- a/src/web/spa-navigation.test.ts
+++ b/src/web/spa-navigation.test.ts
@@ -108,6 +108,7 @@ function makeState(
     readContextFile: () => null,
     writeContextFile: () => {},
     updateAgentAvatar: () => {},
+    setAgentEnabled: () => true,
     resolveChatImage: async () => null,
     resolveDiscordGuildImage: async () => null,
     ...overrides,

--- a/src/web/system.test.ts
+++ b/src/web/system.test.ts
@@ -97,6 +97,7 @@ function makeState(
     readContextFile: () => null,
     writeContextFile: () => {},
     updateAgentAvatar: () => {},
+    setAgentEnabled: () => true,
   };
 }
 

--- a/src/web/tasks.test.ts
+++ b/src/web/tasks.test.ts
@@ -85,6 +85,7 @@ function makeState(tasks: ScheduledTask[] = [makeTask()]): WebStateProvider {
     readContextFile: () => null,
     writeContextFile: () => {},
     updateAgentAvatar: () => {},
+    setAgentEnabled: () => true,
     resolveChatImage: async () => null,
     resolveDiscordGuildImage: async () => null,
   };

--- a/src/web/types.ts
+++ b/src/web/types.ts
@@ -105,6 +105,14 @@ export interface WebStateProvider {
     url: string | null,
     source: string | null,
   ): void;
+
+  // ---- Agent on/off switch ----
+  /**
+   * Toggle whether the agent is enabled. When disabled, the orchestrator
+   * skips message dispatch and scheduled task execution for this agent.
+   * Returns true if the agent was found and updated.
+   */
+  setAgentEnabled(agentId: string, enabled: boolean): boolean;
   /** Resolve a platform-backed icon for a specific chat/channel JID. */
   resolveChatImage?(chatJid: string): Promise<string | null>;
   /** Resolve a stored agent avatar reference to a fetchable URL. */


### PR DESCRIPTION
## Summary

Adds a per-agent off switch driven from the Web UI. From either the
Agents list or the Agent detail page you can now disable a specific
agent — the orchestrator stops dispatching new messages to it and the
scheduler stops running its scheduled tasks until you re-enable it.
Inbound messages keep persisting; toggling back resumes from the next
unread message on the next loop tick.

## Behavior

- **Agents page** — local agents now show an `enable` / `disable`
  button next to `detail` / `messages`. Disabled rows render with the
  new `disabled` exec status badge and dim the agent name.
- **Agent detail page** — same toggle is available in the header next
  to the existing badges; the status badge flips to `disabled` while
  off.
- **Off semantics** — message dispatch (both trigger and attentive
  follow-up paths) and recovery skip disabled agents. The task
  scheduler skips runs for disabled agents but `next_run` still
  advances normally so re-enabling resumes the recurring schedule
  cleanly.
- Remote (peer) agents do not show the toggle — they are owned by
  their host instance.

## Schema

- New `migrations.ts` `migration3` adds an `enabled INTEGER NOT NULL`
  column to `agents` defaulting to `1`. `BASELINE_VERSION` bumped to 3.
  Idempotent via `addColumnIfNotExists` and the baseline `CREATE TABLE`
  was updated to match.

## API

- `POST /api/agents/:id/enabled` with `{ "enabled": boolean }`.
  Returns `200 { ok, agentId, enabled }`, `400` for invalid body,
  `404` for unknown agent, `413` for oversized body.

## Tests

- `src/web/routes.test.ts` — POST off-switch route: persistence,
  invalid body type, unknown agent, malformed JSON.
- `src/web/agents-page.test.ts` — disabled badge + enable button,
  disable button on enabled rows, no toggle for remote agents.
- All existing Web UI test mocks updated with a `setAgentEnabled` stub.
- `bun tsc --noEmit` clean. Targeted suites green
  (135/135 across the four affected files).
- Repo-wide `bun test` shows the same pre-existing 268-failure
  baseline as `main` — no regressions from this branch.

## Test plan

- [ ] Bring up the dashboard and disable a local agent from the agents
      list — verify status flips to `disabled` and the row dims.
- [ ] Send a message to a chat where the disabled agent is subscribed
      and confirm it does not receive a dispatch (other agents still
      respond normally).
- [ ] Schedule a one-off task that fires within a minute, then disable
      the owning agent — verify the run is skipped with the
      `Task skipped — agent is disabled` log line.
- [ ] Re-enable the agent and verify both message dispatch and the
      next scheduled run fire normally.
- [ ] Confirm the toggle button is not rendered for remote peer
      agents.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Per-agent enable/disable controls in the UI with badges and toggles; changes show a toast and refresh the view.
  * Disabled agents are visually dimmed and marked "disabled" and are skipped for message dispatch and scheduled tasks.
  * HTTP API to toggle agent enabled state so changes persist immediately.

* **Chores**
  * Database schema and migration updated to store agent enabled state so it persists across sessions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->