### PR TITLE
feat(web): add queue rollup tile to /system

### DIFF
--- a/src/web/system.test.ts
+++ b/src/web/system.test.ts
@@ -5,6 +5,7 @@ import { buildHealthData, renderSystemContent } from './system.js';
 import type { HealthData } from './system.js';
 import type { WebStateProvider } from './types.js';
 import type { Agent } from '../types.js';
+import type { GroupQueueDetail } from '../group-queue.js';
 
 function makeAgent(overrides: Partial<Agent> = {}): Agent {
   return {
@@ -19,7 +20,10 @@ function makeAgent(overrides: Partial<Agent> = {}): Agent {
   };
 }
 
-function makeState(agents: Agent[] = [makeAgent()]): WebStateProvider {
+function makeState(
+  agents: Agent[] = [makeAgent()],
+  queueDetails: GroupQueueDetail[] = [],
+): WebStateProvider {
   const agentMap: Record<string, Agent> = {};
   for (const a of agents) agentMap[a.id] = a;
   return {
@@ -81,7 +85,7 @@ function makeState(agents: Agent[] = [makeAgent()]): WebStateProvider {
       maxActive: 8,
       maxIdle: 4,
     }),
-    getQueueDetails: () => [],
+    getQueueDetails: () => queueDetails,
     getIpcEvents: () => [],
     getTaskRunLogs: () => [],
     getTaskRunPhaseEvents: () => [],
@@ -200,6 +204,81 @@ describe('buildHealthData', () => {
     expect(health.agents.by_backend).toEqual({});
     expect(health.agents.by_runtime).toEqual({});
   });
+
+  it('reports zero queue rollup when no groups are tracked', () => {
+    const health = buildHealthData(makeState(), 0);
+    expect(health.queue.groups).toBe(0);
+    expect(health.queue.pending_messages).toBe(0);
+    expect(health.queue.pending_tasks).toBe(0);
+    expect(health.queue.processing_groups).toBe(0);
+    expect(health.queue.running_tasks).toBe(0);
+    expect(health.queue.retrying_groups).toBe(0);
+  });
+
+  it('aggregates queue rollup across all tracked groups', () => {
+    const details: GroupQueueDetail[] = [
+      {
+        folderKey: 'g1',
+        messageLane: {
+          active: true,
+          idle: false,
+          pendingCount: 3,
+          containerName: 'g1-msg',
+        },
+        taskLane: {
+          active: true,
+          pendingCount: 2,
+          containerName: 'g1-task',
+          activeTask: {
+            taskId: 't-running',
+            promptPreview: 'do work',
+            startedAt: Date.now() - 5_000,
+            runningMs: 5_000,
+          },
+        },
+        retryCount: 0,
+      },
+      {
+        folderKey: 'g2',
+        messageLane: {
+          active: false,
+          idle: true,
+          pendingCount: 1,
+          containerName: null,
+        },
+        taskLane: {
+          active: false,
+          pendingCount: 4,
+          containerName: null,
+          activeTask: null,
+        },
+        retryCount: 2,
+      },
+      {
+        folderKey: 'g3',
+        messageLane: {
+          active: true,
+          idle: false,
+          pendingCount: 0,
+          containerName: 'g3-msg',
+        },
+        taskLane: {
+          active: false,
+          pendingCount: 0,
+          containerName: null,
+          activeTask: null,
+        },
+        retryCount: 1,
+      },
+    ];
+    const health = buildHealthData(makeState([makeAgent()], details), 0);
+    expect(health.queue.groups).toBe(3);
+    expect(health.queue.pending_messages).toBe(4); // 3 + 1 + 0
+    expect(health.queue.pending_tasks).toBe(6); // 2 + 4 + 0
+    expect(health.queue.processing_groups).toBe(2); // g1, g3
+    expect(health.queue.running_tasks).toBe(1); // only g1 has activeTask
+    expect(health.queue.retrying_groups).toBe(2); // g2, g3
+  });
 });
 
 describe('GET /api/health route', () => {
@@ -256,6 +335,44 @@ describe('renderSystemContent', () => {
     expect(html).toContain('containers');
     expect(html).toContain('agents');
     expect(html).toContain('tasks');
+    expect(html).toContain('queue');
+  });
+
+  it('renders queue rollup with stable IDs', () => {
+    const details: GroupQueueDetail[] = [
+      {
+        folderKey: 'g1',
+        messageLane: {
+          active: true,
+          idle: false,
+          pendingCount: 7,
+          containerName: 'g1-msg',
+        },
+        taskLane: {
+          active: true,
+          pendingCount: 3,
+          containerName: 'g1-task',
+          activeTask: {
+            taskId: 't1',
+            promptPreview: 'preview',
+            startedAt: Date.now(),
+            runningMs: 100,
+          },
+        },
+        retryCount: 4,
+      },
+    ];
+    const html = renderSystemContent(makeState([makeAgent()], details), 0);
+    expect(html).toContain('id="sys-queue-groups"');
+    expect(html).toContain('id="sys-queue-processing"');
+    expect(html).toContain('id="sys-queue-running-tasks"');
+    expect(html).toContain('id="sys-queue-pending-messages"');
+    expect(html).toContain('id="sys-queue-pending-tasks"');
+    expect(html).toContain('id="sys-queue-retrying"');
+    // pending message count should appear (7)
+    expect(html).toContain(
+      '<span class="metric-value" id="sys-queue-pending-messages">7</span>',
+    );
   });
 
   it('renders breakdown lists for agent backends', () => {

--- a/src/web/system.ts
+++ b/src/web/system.ts
@@ -48,6 +48,20 @@ export interface HealthData {
     completed: number;
     total: number;
   };
+  queue: {
+    /** Number of group folders currently tracked by the orchestrator. */
+    groups: number;
+    /** Total messages waiting across all message lanes. */
+    pending_messages: number;
+    /** Total scheduled tasks waiting across all task lanes. */
+    pending_tasks: number;
+    /** Number of groups whose message lane is actively processing. */
+    processing_groups: number;
+    /** Number of groups whose task lane has a task running. */
+    running_tasks: number;
+    /** Sum of consecutive retry counts across all group folders. */
+    retrying_groups: number;
+  };
   sse_clients: number;
   started_at: string;
 }
@@ -77,6 +91,7 @@ export function buildHealthData(
   const agents = Object.values(state.getAgents());
   const tasks = state.getTasks();
   const stats = state.getQueueStats();
+  const queueDetails = state.getQueueDetails();
   const mem = process.memoryUsage();
   const load = os.loadavg();
   const cpuCount = os.cpus().length;
@@ -99,6 +114,19 @@ export function buildHealthData(
     if (t.status === 'active') activeTasks++;
     else if (t.status === 'paused') pausedTasks++;
     else if (t.status === 'completed') completedTasks++;
+  }
+
+  let pendingMessages = 0;
+  let pendingTasks = 0;
+  let processingGroups = 0;
+  let runningTasks = 0;
+  let retryingGroups = 0;
+  for (const g of queueDetails) {
+    pendingMessages += g.messageLane.pendingCount;
+    pendingTasks += g.taskLane.pendingCount;
+    if (g.messageLane.active) processingGroups++;
+    if (g.taskLane.activeTask) runningTasks++;
+    if (g.retryCount > 0) retryingGroups++;
   }
 
   return {
@@ -143,6 +171,14 @@ export function buildHealthData(
       paused: pausedTasks,
       completed: completedTasks,
       total: tasks.length,
+    },
+    queue: {
+      groups: queueDetails.length,
+      pending_messages: pendingMessages,
+      pending_tasks: pendingTasks,
+      processing_groups: processingGroups,
+      running_tasks: runningTasks,
+      retrying_groups: retryingGroups,
     },
     sse_clients: sseClientCount,
     started_at: startedAt,
@@ -307,6 +343,36 @@ export function renderSystemContent(
           'sys-tasks-completed',
         ) +
         metricRow('total', String(health.tasks.total), 'sys-tasks-total'),
+    ) +
+    // Queue rollup (per-group lane aggregates from /ipc, summarized here)
+    metricCard(
+      'queue',
+      metricRow('groups', String(health.queue.groups), 'sys-queue-groups') +
+        metricRow(
+          'processing',
+          String(health.queue.processing_groups),
+          'sys-queue-processing',
+        ) +
+        metricRow(
+          'running tasks',
+          String(health.queue.running_tasks),
+          'sys-queue-running-tasks',
+        ) +
+        metricRow(
+          'pending msgs',
+          String(health.queue.pending_messages),
+          'sys-queue-pending-messages',
+        ) +
+        metricRow(
+          'pending tasks',
+          String(health.queue.pending_tasks),
+          'sys-queue-pending-tasks',
+        ) +
+        metricRow(
+          'retrying',
+          String(health.queue.retrying_groups),
+          'sys-queue-retrying',
+        ),
     ) +
     `</div>` +
     `</div>`


### PR DESCRIPTION
## Summary

Adds a *queue* rollup tile to `/system` that aggregates per-group lane
state across all tracked folders. Same data the `/ipc` inspector already
walks per-row, but rolled up so an operator can see queue pressure at a
glance from the system health page without flipping tabs.

Refs #644 (operator observability rollup — extend `/system` and `/ipc`
with consolidated diagnostics, no new top-level routes).

## What's new

A new `queue` block on the `/api/health` payload + a matching tile on
`/system`:

| field | meaning |
|---|---|
| `groups` | number of folder groups currently tracked |
| `pending_messages` | total messages waiting across all message lanes |
| `pending_tasks` | total scheduled tasks waiting across all task lanes |
| `processing_groups` | groups whose message lane is actively running |
| `running_tasks` | groups whose task lane has an in-flight task |
| `retrying_groups` | groups with a non-zero consecutive retry count |

The rendered tile uses stable `sys-queue-*` IDs so future live SSE
updates can patch values in place without re-rendering the card.

## Why these fields

Issue #644 calls out that operators currently have to cross-reference
multiple pages to answer "is the system busy, blocked, or idle?" These
six numbers cover the cheapest version of that question:

- **Pending counts** — back-pressure visibility
- **Processing / running** — in-flight visibility
- **Retrying** — early signal of trouble before it becomes "offline"

This stays inside the existing `WebStateProvider.getQueueDetails()`
contract — no new APIs, no new routes, no schema changes.

## Tests

- 3 new tests in `src/web/system.test.ts`:
  - empty queue rollup
  - multi-group aggregation (3 groups, mixed states)
  - stable IDs + value rendering on the tile
- All `src/web/` tests: 551 pass
- Full suite: 1946 pass, 0 fail
- `bunx tsc --noEmit`: clean

## Test plan

- [x] `bun test src/web/system.test.ts` (21 pass)
- [x] `bun test src/web/` (551 pass)
- [x] `bun test` (1946 pass)
- [x] `bunx tsc --noEmit` (exit 0)
- [ ] Manual: visit `/system` with active groups and verify the queue
      tile reflects `/ipc` inspector totals


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added queue health monitoring with rollup metrics including pending messages and tasks, processing activity, and retry tracking.
  * New queue section now displays in the system dashboard showing group counts, message/task status, and processing details.

* **Tests**
  * Extended test coverage for queue metrics and health data assertions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->