### PR TITLE
test: cover linked GitHub context fetching

### DIFF
--- a/src/github-linked.test.ts
+++ b/src/github-linked.test.ts
@@ -1,12 +1,93 @@
-import { describe, it, expect } from 'bun:test';
+import { beforeEach, describe, it, expect, mock } from 'bun:test';
+
+const githubFetchMock = mock(async (_path: string) => null as unknown);
+const fetchPrReviewsMock = mock(async () => [] as unknown[]);
+const fetchPrReviewCommentsMock = mock(async () => [] as unknown[]);
+const fetchCombinedStatusMock = mock(async () => null as unknown);
+const formatPrMarkdownMock = mock(
+  (pr: { number: number; title: string }) =>
+    `### PR #${pr.number}: ${pr.title}`,
+);
 
 import {
   extractGitHubLinks,
   fetchGitHubLinkedContext,
+  type GitHubLinkedDeps,
   type ParsedGitHubLink,
 } from './github-linked.js';
 
+function linkedDeps(): GitHubLinkedDeps {
+  return {
+    githubFetch: githubFetchMock as unknown as GitHubLinkedDeps['githubFetch'],
+    fetchPrReviews:
+      fetchPrReviewsMock as unknown as GitHubLinkedDeps['fetchPrReviews'],
+    fetchPrReviewComments:
+      fetchPrReviewCommentsMock as unknown as GitHubLinkedDeps['fetchPrReviewComments'],
+    fetchCombinedStatus:
+      fetchCombinedStatusMock as unknown as GitHubLinkedDeps['fetchCombinedStatus'],
+    formatPrMarkdown:
+      formatPrMarkdownMock as unknown as GitHubLinkedDeps['formatPrMarkdown'],
+  };
+}
+
+function makePr(number: number, title = `Test PR ${number}`) {
+  return {
+    number,
+    title,
+    user: { login: 'alice' },
+    head: { ref: `branch-${number}` },
+    base: { ref: 'main' },
+    state: 'open',
+    draft: false,
+    requested_reviewers: [],
+    html_url: `https://github.com/org/repo/pull/${number}`,
+    body: null,
+    created_at: '2026-01-01T00:00:00Z',
+    updated_at: '2026-01-01T00:00:00Z',
+  };
+}
+
+function makeIssue(number: number, title = `Test issue ${number}`) {
+  return {
+    number,
+    title,
+    user: { login: 'bob' },
+    state: 'open',
+    labels: [{ name: 'bug' }, { name: 'p1' }],
+    assignee: { login: 'carol' },
+    html_url: `https://github.com/org/repo/issues/${number}`,
+    body: 'Issue body with useful detail',
+    created_at: '2026-01-01T00:00:00Z',
+    updated_at: '2026-01-01T00:00:00Z',
+  };
+}
+
+const originalGithubToken = process.env.GITHUB_TOKEN;
+
 describe('github-linked', () => {
+  beforeEach(() => {
+    if (originalGithubToken === undefined) {
+      delete process.env.GITHUB_TOKEN;
+    } else {
+      process.env.GITHUB_TOKEN = originalGithubToken;
+    }
+
+    githubFetchMock.mockReset();
+    fetchPrReviewsMock.mockReset();
+    fetchPrReviewCommentsMock.mockReset();
+    fetchCombinedStatusMock.mockReset();
+    formatPrMarkdownMock.mockReset();
+
+    githubFetchMock.mockImplementation(async () => null);
+    fetchPrReviewsMock.mockImplementation(async () => []);
+    fetchPrReviewCommentsMock.mockImplementation(async () => []);
+    fetchCombinedStatusMock.mockImplementation(async () => null);
+    formatPrMarkdownMock.mockImplementation(
+      (pr: { number: number; title: string }) =>
+        `### PR #${pr.number}: ${pr.title}`,
+    );
+  });
+
   describe('extractGitHubLinks', () => {
     it('returns empty array for empty string', () => {
       expect(extractGitHubLinks('')).toEqual([]);
@@ -154,6 +235,200 @@ describe('github-linked', () => {
       const links = extractGitHubLinks(text);
       // extractGitHubLinks returns all, but fetchGitHubLinkedContext caps at 3
       expect(links).toHaveLength(5);
+    });
+
+    it('returns null without a GitHub token and avoids fetches', async () => {
+      delete process.env.GITHUB_TOKEN;
+
+      const result = await fetchGitHubLinkedContext(
+        [{ content: 'https://github.com/org/repo/pull/901' }],
+        linkedDeps(),
+      );
+
+      expect(result).toBeNull();
+      expect(githubFetchMock).not.toHaveBeenCalled();
+    });
+
+    it('fetches PR details, reviews, review comments, and CI status', async () => {
+      process.env.GITHUB_TOKEN = 'test-token';
+      githubFetchMock.mockImplementation(async (path: string) => {
+        if (path === '/repos/org/repo/pulls/902') return makePr(902, 'Ship it');
+        return null;
+      });
+      fetchPrReviewsMock.mockImplementation(async () => [
+        { state: 'APPROVED' },
+      ]);
+      fetchPrReviewCommentsMock.mockImplementation(async () => [
+        { path: 'src/index.ts', body: 'nit' },
+      ]);
+      fetchCombinedStatusMock.mockImplementation(async () => ({
+        state: 'success',
+      }));
+
+      const result = await fetchGitHubLinkedContext(
+        [{ content: 'Review https://github.com/org/repo/pull/902' }],
+        linkedDeps(),
+      );
+
+      expect(result).toContain('# Linked GitHub Context');
+      expect(result).toContain('### PR #902: Ship it');
+      expect(fetchPrReviewsMock).toHaveBeenCalledWith('org', 'repo', 902);
+      expect(fetchPrReviewCommentsMock).toHaveBeenCalledWith(
+        'org',
+        'repo',
+        902,
+      );
+      expect(fetchCombinedStatusMock).toHaveBeenCalledWith(
+        'org',
+        'repo',
+        'branch-902',
+      );
+      expect(formatPrMarkdownMock).toHaveBeenCalledWith(
+        expect.objectContaining({ number: 902 }),
+        [{ state: 'APPROVED' }],
+        [{ path: 'src/index.ts', body: 'nit' }],
+        { state: 'success' },
+      );
+    });
+
+    it('formats issue details and recent comments', async () => {
+      process.env.GITHUB_TOKEN = 'test-token';
+      githubFetchMock.mockImplementation(async (path: string) => {
+        if (path === '/repos/org/repo/issues/903') {
+          return makeIssue(903, 'Broken widget');
+        }
+        if (
+          path ===
+          '/repos/org/repo/issues/903/comments?per_page=10&sort=created&direction=desc'
+        ) {
+          return [
+            {
+              user: { login: 'dana' },
+              body: 'First comment',
+              created_at: 'now',
+            },
+            { user: null, body: 'Anonymous follow-up', created_at: 'now' },
+          ];
+        }
+        return null;
+      });
+
+      const result = await fetchGitHubLinkedContext(
+        [{ content: 'Triage https://github.com/org/repo/issues/903' }],
+        linkedDeps(),
+      );
+
+      expect(result).toContain('### Issue #903: Broken widget');
+      expect(result).toContain(
+        '- Author: bob | Labels: bug, p1 | Assignee: carol',
+      );
+      expect(result).toContain('- Description: Issue body with useful detail');
+      expect(result).toContain('- dana: First comment');
+      expect(result).toContain('- ?: Anonymous follow-up');
+    });
+
+    it('treats issue URLs that point at PRs as PR context', async () => {
+      process.env.GITHUB_TOKEN = 'test-token';
+      githubFetchMock.mockImplementation(async (path: string) => {
+        if (path === '/repos/org/repo/issues/904') {
+          return { ...makeIssue(904), pull_request: {} };
+        }
+        if (path === '/repos/org/repo/pulls/904') {
+          return makePr(904, 'PR via issue URL');
+        }
+        return null;
+      });
+
+      const result = await fetchGitHubLinkedContext(
+        [{ content: 'https://github.com/org/repo/issues/904' }],
+        linkedDeps(),
+      );
+
+      expect(result).toContain('### PR #904: PR via issue URL');
+      expect(fetchPrReviewsMock).toHaveBeenCalledWith('org', 'repo', 904);
+    });
+
+    it('deduplicates links across messages and reuses cached markdown', async () => {
+      process.env.GITHUB_TOKEN = 'test-token';
+      githubFetchMock.mockImplementation(async (path: string) => {
+        if (path === '/repos/org/repo/pulls/905')
+          return makePr(905, 'Cached PR');
+        return null;
+      });
+
+      const first = await fetchGitHubLinkedContext(
+        [
+          { content: 'https://github.com/org/repo/pull/905' },
+          { content: 'duplicate https://github.com/org/repo/pull/905' },
+        ],
+        linkedDeps(),
+      );
+      const second = await fetchGitHubLinkedContext(
+        [{ content: 'again https://github.com/org/repo/pull/905' }],
+        linkedDeps(),
+      );
+
+      expect(first).toContain('### PR #905: Cached PR');
+      expect(second).toBe(first);
+      expect(githubFetchMock).toHaveBeenCalledTimes(1);
+      expect(formatPrMarkdownMock).toHaveBeenCalledTimes(1);
+    });
+
+    it('caps fetches to the first three unique linked items', async () => {
+      process.env.GITHUB_TOKEN = 'test-token';
+      githubFetchMock.mockImplementation(async (path: string) => {
+        const number = Number(path.match(/\/(\d+)$/)?.[1] ?? 0);
+        return makePr(number, `PR ${number}`);
+      });
+
+      const result = await fetchGitHubLinkedContext(
+        [
+          {
+            content: [
+              'https://github.com/org/repo/pull/906',
+              'https://github.com/org/repo/pull/907',
+              'https://github.com/org/repo/pull/908',
+              'https://github.com/org/repo/pull/909',
+              'https://github.com/org/repo/pull/910',
+            ].join(' '),
+          },
+        ],
+        linkedDeps(),
+      );
+
+      expect(githubFetchMock).toHaveBeenCalledTimes(3);
+      expect(result).toContain('### PR #906: PR 906');
+      expect(result).toContain('### PR #907: PR 907');
+      expect(result).toContain('### PR #908: PR 908');
+      expect(result).not.toContain('### PR #909: PR 909');
+      expect(result).not.toContain('### PR #910: PR 910');
+    });
+
+    it('returns successful sections when another linked fetch rejects', async () => {
+      process.env.GITHUB_TOKEN = 'test-token';
+      githubFetchMock.mockImplementation(async (path: string) => {
+        if (path === '/repos/org/repo/pulls/911') return makePr(911, 'Fails');
+        if (path === '/repos/org/repo/issues/912')
+          return makeIssue(912, 'Works');
+        if (path.includes('/comments?')) return [];
+        return null;
+      });
+      fetchPrReviewsMock.mockImplementation(async () => {
+        throw new Error('GitHub unavailable');
+      });
+
+      const result = await fetchGitHubLinkedContext(
+        [
+          {
+            content:
+              'https://github.com/org/repo/pull/911 https://github.com/org/repo/issues/912',
+          },
+        ],
+        linkedDeps(),
+      );
+
+      expect(result).toContain('### Issue #912: Works');
+      expect(result).not.toContain('### PR #911: Fails');
     });
   });
 });

--- a/src/github-linked.test.ts
+++ b/src/github-linked.test.ts
@@ -261,9 +261,7 @@ describe('github-linked', () => {
       fetchPrReviewCommentsMock.mockImplementation(async () => [
         { path: 'src/index.ts', body: 'nit' },
       ]);
-      fetchCombinedStatusMock.mockImplementation(async () => ({
-        state: 'success',
-      }));
+      fetchCombinedStatusMock.mockImplementation(async () => 'success');
 
       const result = await fetchGitHubLinkedContext(
         [{ content: 'Review https://github.com/org/repo/pull/902' }],
@@ -287,7 +285,7 @@ describe('github-linked', () => {
         expect.objectContaining({ number: 902 }),
         [{ state: 'APPROVED' }],
         [{ path: 'src/index.ts', body: 'nit' }],
-        { state: 'success' },
+        'success',
       );
     });
 

--- a/src/github-linked.ts
+++ b/src/github-linked.ts
@@ -34,6 +34,22 @@ interface GitHubIssueComment {
   created_at: string;
 }
 
+export interface GitHubLinkedDeps {
+  githubFetch: typeof githubFetch;
+  fetchPrReviews: typeof fetchPrReviews;
+  fetchPrReviewComments: typeof fetchPrReviewComments;
+  fetchCombinedStatus: typeof fetchCombinedStatus;
+  formatPrMarkdown: typeof formatPrMarkdown;
+}
+
+const defaultDeps: GitHubLinkedDeps = {
+  githubFetch,
+  fetchPrReviews,
+  fetchPrReviewComments,
+  fetchCombinedStatus,
+  formatPrMarkdown,
+};
+
 // --- URL Parsing ---
 
 const GITHUB_URL_REGEX =
@@ -89,24 +105,29 @@ async function fetchSinglePr(
   owner: string,
   repo: string,
   number: number,
+  deps: GitHubLinkedDeps,
 ): Promise<GitHubPr | null> {
-  return githubFetch<GitHubPr>(`/repos/${owner}/${repo}/pulls/${number}`);
+  return deps.githubFetch<GitHubPr>(`/repos/${owner}/${repo}/pulls/${number}`);
 }
 
 async function fetchSingleIssue(
   owner: string,
   repo: string,
   number: number,
+  deps: GitHubLinkedDeps,
 ): Promise<GitHubIssue | null> {
-  return githubFetch<GitHubIssue>(`/repos/${owner}/${repo}/issues/${number}`);
+  return deps.githubFetch<GitHubIssue>(
+    `/repos/${owner}/${repo}/issues/${number}`,
+  );
 }
 
 async function fetchIssueComments(
   owner: string,
   repo: string,
   issueNumber: number,
+  deps: GitHubLinkedDeps,
 ): Promise<GitHubIssueComment[]> {
-  const comments = await githubFetch<GitHubIssueComment[]>(
+  const comments = await deps.githubFetch<GitHubIssueComment[]>(
     `/repos/${owner}/${repo}/issues/${issueNumber}/comments?per_page=10&sort=created&direction=desc`,
   );
   return comments || [];
@@ -143,41 +164,55 @@ function formatLinkedIssueMarkdown(
 
 // --- Per-link fetchers ---
 
-async function fetchLinkedPr(link: ParsedGitHubLink): Promise<string | null> {
+async function fetchLinkedPr(
+  link: ParsedGitHubLink,
+  deps: GitHubLinkedDeps,
+): Promise<string | null> {
   const cacheKey = linkedCacheKey(link);
   const cached = getCached(cacheKey);
   if (cached) return cached;
 
-  const pr = await fetchSinglePr(link.owner, link.repo, link.number);
+  const pr = await fetchSinglePr(link.owner, link.repo, link.number, deps);
   if (!pr) return null;
 
   const [reviews, comments, ciStatus] = await Promise.all([
-    fetchPrReviews(link.owner, link.repo, link.number),
-    fetchPrReviewComments(link.owner, link.repo, link.number),
-    fetchCombinedStatus(link.owner, link.repo, pr.head.ref),
+    deps.fetchPrReviews(link.owner, link.repo, link.number),
+    deps.fetchPrReviewComments(link.owner, link.repo, link.number),
+    deps.fetchCombinedStatus(link.owner, link.repo, pr.head.ref),
   ]);
 
-  const markdown = formatPrMarkdown(pr, reviews, comments, ciStatus);
+  const markdown = deps.formatPrMarkdown(pr, reviews, comments, ciStatus);
   linkedCache.set(cacheKey, { markdown, fetchedAt: Date.now() });
   return markdown;
 }
 
 async function fetchLinkedIssue(
   link: ParsedGitHubLink,
+  deps: GitHubLinkedDeps,
 ): Promise<string | null> {
   const cacheKey = linkedCacheKey(link);
   const cached = getCached(cacheKey);
   if (cached) return cached;
 
-  const issue = await fetchSingleIssue(link.owner, link.repo, link.number);
+  const issue = await fetchSingleIssue(
+    link.owner,
+    link.repo,
+    link.number,
+    deps,
+  );
   if (!issue) return null;
 
   // If this "issue" is actually a PR, fetch as PR for richer data
   if (issue.pull_request) {
-    return fetchLinkedPr({ ...link, type: 'pull' });
+    return fetchLinkedPr({ ...link, type: 'pull' }, deps);
   }
 
-  const comments = await fetchIssueComments(link.owner, link.repo, link.number);
+  const comments = await fetchIssueComments(
+    link.owner,
+    link.repo,
+    link.number,
+    deps,
+  );
   const markdown = formatLinkedIssueMarkdown(issue, comments);
   linkedCache.set(cacheKey, { markdown, fetchedAt: Date.now() });
   return markdown;
@@ -191,6 +226,7 @@ async function fetchLinkedIssue(
  */
 export async function fetchGitHubLinkedContext(
   messages: Array<{ content: string }>,
+  deps: GitHubLinkedDeps = defaultDeps,
 ): Promise<string | null> {
   if (!process.env.GITHUB_TOKEN) return null;
 
@@ -220,7 +256,9 @@ export async function fetchGitHubLinkedContext(
 
   const results = await Promise.allSettled(
     links.map((link) =>
-      link.type === 'pull' ? fetchLinkedPr(link) : fetchLinkedIssue(link),
+      link.type === 'pull'
+        ? fetchLinkedPr(link, deps)
+        : fetchLinkedIssue(link, deps),
     ),
   );
 


### PR DESCRIPTION
## Summary

- Adds deterministic dependency-injected coverage for linked GitHub context fetching without live GitHub API calls.
- Covers PR orchestration, issue formatting, issue-URL-to-PR delegation, token gating, dedup/cache behavior, fetch capping, and partial failure handling.
- Raises `src/github-linked.ts` coverage from 25.00% funcs / 24.49% lines to 100.00% funcs / 99.41% lines.

## Test Counts

- Before: `bun test` passed 1,946 tests across 100 files with 5,198 assertions.
- After: `bun test` passed 1,953 tests across 100 files with 5,225 assertions.
- Coverage after: all files 90.05% funcs / 88.24% lines.

## Verification

- `bun test src/github-linked.test.ts`
- `bun test`
- `bun test --coverage`
- `bun run typecheck`

## Remaining Coverage Gaps

- Large integration-heavy modules remain low coverage: `src/index.ts`, channel adapters, `src/backends/local-backend.ts`, `src/discovery/routes.ts`, and `src/db.ts`.
- `src/github.ts` still has uncovered live-fetch branches and list formatting paths; this PR focuses only on linked-context fetch orchestration.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Greatly expanded coverage for GitHub-linked behavior: validates missing-token handling, PR/issue details and comments rendering, anonymous user handling, deduplication and caching of links, limiting to the first three unique links, and resilient partial failures so successful sections still appear.

* **Refactor**
  * Introduced dependency-injection for GitHub data operations to improve flexibility and make the feature more testable.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->