### PR TITLE
feat(container): add crawl tool shims

### DIFF
--- a/container/.dockerignore
+++ b/container/.dockerignore
@@ -2,9 +2,11 @@
 !Dockerfile
 !Dockerfile.base
 !agent-browser-wrapper.sh
+!discrawl.sh
 !agent-exec.sh
 !entrypoint.sh
 !exec-shim.sh
+!gitcrawl.sh
 !shared-entrypoint.sh
 !agent-runner/
 !agent-runner/**

--- a/container/Dockerfile.base
+++ b/container/Dockerfile.base
@@ -68,6 +68,17 @@ RUN curl -fsSL https://cli.github.com/packages/githubcli-archive-keyring.gpg \
     && apt-get update && apt-get install -y gh \
     && rm -rf /var/lib/apt/lists/*
 
+# Install local-first crawl tools. gitcrawl also provides the gh shim at
+# /usr/local/bin/gh; unsupported and mutating commands fall back to /usr/bin/gh.
+ARG GITCRAWL_VERSION=v0.2.1
+ARG DISCRAWL_VERSION=v0.6.6
+ENV GITCRAWL_GH_PATH=/usr/bin/gh
+COPY gitcrawl.sh discrawl.sh /tmp/
+RUN chmod +x /tmp/gitcrawl.sh /tmp/discrawl.sh \
+    && GITCRAWL_VERSION="${GITCRAWL_VERSION}" /tmp/gitcrawl.sh \
+    && DISCRAWL_VERSION="${DISCRAWL_VERSION}" /tmp/discrawl.sh \
+    && rm -f /tmp/gitcrawl.sh /tmp/discrawl.sh
+
 # Install Graphite CLI for stacked PRs workflow (pinned to stable version)
 ARG GRAPHITE_VERSION=1.8.5
 RUN npm install -g @withgraphite/graphite-cli@${GRAPHITE_VERSION}

--- a/container/discrawl.sh
+++ b/container/discrawl.sh
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Installs discrawl into the agent image so agents can query or sync local
+# Discord archives from the same tool surface used by the host.
+
+DISCRAWL_VERSION="${DISCRAWL_VERSION:-v0.6.6}"
+INSTALL_DIR="${INSTALL_DIR:-/usr/local/bin}"
+
+tmp_gobin="$(mktemp -d)"
+cleanup() {
+  rm -rf "$tmp_gobin"
+}
+trap cleanup EXIT
+
+GOBIN="$tmp_gobin" go install "github.com/openclaw/discrawl/cmd/discrawl@${DISCRAWL_VERSION}"
+
+install -m 0755 "$tmp_gobin/discrawl" "$INSTALL_DIR/discrawl"
+
+"$INSTALL_DIR/discrawl" --version

--- a/container/gitcrawl.sh
+++ b/container/gitcrawl.sh
@@ -1,0 +1,29 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Installs gitcrawl into the agent image and enables its gh-compatible shim.
+# The real GitHub CLI remains at /usr/bin/gh and is used by gitcrawl for
+# unsupported or mutating commands.
+
+GITCRAWL_VERSION="${GITCRAWL_VERSION:-v0.2.1}"
+INSTALL_DIR="${INSTALL_DIR:-/usr/local/bin}"
+REAL_GH_PATH="${GITCRAWL_GH_PATH:-/usr/bin/gh}"
+
+if [ ! -x "$REAL_GH_PATH" ]; then
+  echo "gitcrawl shim requires real gh at $REAL_GH_PATH" >&2
+  exit 1
+fi
+
+tmp_gobin="$(mktemp -d)"
+cleanup() {
+  rm -rf "$tmp_gobin"
+}
+trap cleanup EXIT
+
+GOBIN="$tmp_gobin" go install "github.com/openclaw/gitcrawl/cmd/gitcrawl@${GITCRAWL_VERSION}"
+
+install -m 0755 "$tmp_gobin/gitcrawl" "$INSTALL_DIR/gitcrawl"
+ln -sf "$INSTALL_DIR/gitcrawl" "$INSTALL_DIR/gitcrawl-gh"
+ln -sf "$INSTALL_DIR/gitcrawl" "$INSTALL_DIR/gh"
+
+"$INSTALL_DIR/gitcrawl" --version

--- a/src/container-tooling.test.ts
+++ b/src/container-tooling.test.ts
@@ -1,0 +1,51 @@
+import { describe, expect, it } from 'bun:test';
+import fs from 'node:fs';
+import path from 'node:path';
+
+const repoRoot = path.resolve(import.meta.dir, '..');
+
+function read(relativePath: string): string {
+  return fs.readFileSync(path.join(repoRoot, relativePath), 'utf-8');
+}
+
+describe('agent container crawl tooling', () => {
+  it('keeps crawl install scripts in the container build context', () => {
+    const dockerignore = read('container/.dockerignore');
+
+    expect(dockerignore).toContain('!gitcrawl.sh');
+    expect(dockerignore).toContain('!discrawl.sh');
+  });
+
+  it('installs pinned gitcrawl and discrawl versions in the base image', () => {
+    const dockerfile = read('container/Dockerfile.base');
+
+    expect(dockerfile).toContain('ARG GITCRAWL_VERSION=v0.2.1');
+    expect(dockerfile).toContain('ARG DISCRAWL_VERSION=v0.6.6');
+    expect(dockerfile).toContain('COPY gitcrawl.sh discrawl.sh /tmp/');
+    expect(dockerfile).toContain('/tmp/gitcrawl.sh');
+    expect(dockerfile).toContain('/tmp/discrawl.sh');
+  });
+
+  it('configures gitcrawl as the gh shim while preserving the real gh fallback', () => {
+    const dockerfile = read('container/Dockerfile.base');
+    const script = read('container/gitcrawl.sh');
+
+    expect(dockerfile).toContain('ENV GITCRAWL_GH_PATH=/usr/bin/gh');
+    expect(script).toContain('github.com/openclaw/gitcrawl/cmd/gitcrawl');
+    expect(script).toContain(
+      'ln -sf "$INSTALL_DIR/gitcrawl" "$INSTALL_DIR/gh"',
+    );
+    expect(script).toContain(
+      'ln -sf "$INSTALL_DIR/gitcrawl" "$INSTALL_DIR/gitcrawl-gh"',
+    );
+  });
+
+  it('installs the discrawl command from the openclaw module', () => {
+    const script = read('container/discrawl.sh');
+
+    expect(script).toContain('github.com/openclaw/discrawl/cmd/discrawl');
+    expect(script).toContain(
+      'install -m 0755 "$tmp_gobin/discrawl" "$INSTALL_DIR/discrawl"',
+    );
+  });
+});


### PR DESCRIPTION
## Summary

- add `container/gitcrawl.sh` and `container/discrawl.sh` install scripts for the agent base image
- install pinned `gitcrawl` and `discrawl` versions during the base image build
- expose gitcrawl's `gh` shim at `/usr/local/bin/gh` while preserving the real GitHub CLI fallback at `/usr/bin/gh`
- add a focused container tooling contract test

## Verification

- `bun test src/container-tooling.test.ts`
- `bun run typecheck`
- `bun run format:check`
- `bash -n container/gitcrawl.sh && bash -n container/discrawl.sh`

## Notes

- This wires the tools into the agent image and `gh` command path. It does not add crawl scheduling policy or Discord/GitHub archive retention configuration; those remain product/runtime decisions.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Integrated gitcrawl and discrawl tools into the container base image with configurable versions and automated installation.
  * Container now includes support for local-first crawl operations.

* **Tests**
  * Added comprehensive validation tests for container tooling assets, including version pinning, script placement, and tool configuration verification.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->