### PR TITLE
test: cover media and discovery simulation paths

### DIFF
--- a/src/backends/types.test.ts
+++ b/src/backends/types.test.ts
@@ -7,6 +7,7 @@ import {
   getContainerConfig,
   getServerFolder,
   getBackendType,
+  getAgentRuntime,
   type AgentOrGroup,
 } from './types.js';
 import type { Agent, RegisteredGroup } from '../types.js';
@@ -143,6 +144,26 @@ describe('backends/types.ts', () => {
         'apple-container',
       );
       expect(getBackendType(makeGroup({ backend: 'docker' }))).toBe('docker');
+    });
+  });
+
+  describe('getAgentRuntime', () => {
+    it('returns runtime from an Agent directly', () => {
+      expect(getAgentRuntime(makeAgent({ agentRuntime: 'opencode' }))).toBe(
+        'opencode',
+      );
+    });
+
+    it('returns runtime from a RegisteredGroup', () => {
+      expect(getAgentRuntime(makeGroup({ agentRuntime: 'opencode' }))).toBe(
+        'opencode',
+      );
+    });
+
+    it('defaults RegisteredGroups to the Claude Agent SDK runtime', () => {
+      expect(getAgentRuntime(makeGroup({ agentRuntime: undefined }))).toBe(
+        'claude-agent-sdk',
+      );
     });
   });
 });

--- a/src/media.test.ts
+++ b/src/media.test.ts
@@ -13,6 +13,7 @@ import {
   isTextByExtension,
   readStreamWithByteLimit,
   resolveWorkspaceFolder,
+  storeMediaAttachment,
   IMAGE_EXTENSIONS,
   MAX_BINARY_DOWNLOAD_BYTES,
   MAX_TEXT_DOWNLOAD_BYTES,
@@ -185,6 +186,53 @@ describe('buildSafeMediaPath', () => {
 });
 
 // ---------------------------------------------------------------------------
+// storeMediaAttachment
+// ---------------------------------------------------------------------------
+
+describe('storeMediaAttachment', () => {
+  const testFolder = `__store_media_test_${Date.now()}`;
+
+  afterEach(() => {
+    try {
+      fs.rmSync(path.join(GROUPS_DIR, testFolder), { recursive: true });
+    } catch {
+      // ignore
+    }
+  });
+
+  it('downloads bytes, writes a safe filename, and returns a descriptor', async () => {
+    globalThis.fetch = mock(() =>
+      Promise.resolve(new Response(createStream(['image-bytes']))),
+    ) as unknown as typeof globalThis.fetch;
+
+    const attachment = await storeMediaAttachment({
+      url: 'https://example.test/unsafe.png',
+      group: { folder: testFolder },
+      messageId: 'msg-1',
+      rawFilename: '../unsafe.png',
+      type: 'image',
+      mimeType: 'image/png',
+      filenamePrefix: 'photo',
+      maxBytes: 100,
+    });
+
+    expect(attachment).toEqual({
+      type: 'image',
+      mimeType: 'image/png',
+      localPath: path.join(
+        GROUPS_DIR,
+        testFolder,
+        'media',
+        'msg-1-photo-unsafe.png',
+      ),
+      originalUrl: 'https://example.test/unsafe.png',
+      filename: 'msg-1-photo-unsafe.png',
+    });
+    expect(fs.readFileSync(attachment.localPath, 'utf8')).toBe('image-bytes');
+  });
+});
+
+// ---------------------------------------------------------------------------
 // Marker formatting
 // ---------------------------------------------------------------------------
 
@@ -311,6 +359,10 @@ describe('cleanupExpiredMedia', () => {
   it('does nothing when media dir does not exist', () => {
     // Should not throw
     cleanupExpiredMedia({ folder: 'nonexistent-folder-xyz' });
+  });
+
+  it('swallows non-critical cleanup errors', () => {
+    cleanupExpiredMedia({ folder: '../outside-groups' });
   });
 });
 

--- a/src/simtest/discovery-sim.test.ts
+++ b/src/simtest/discovery-sim.test.ts
@@ -129,4 +129,128 @@ describe('createSimDiscoveryEnvironment', () => {
 
     await reader!.cancel();
   });
+
+  it('supports deterministic runtime toggles in network page state', () => {
+    const env = createSimDiscoveryEnvironment(new FakeState());
+    const runtime = env.context.runtime as unknown as {
+      setEnabled(enabled: boolean): { enabled: boolean; active: boolean };
+      isRemoteAccessAllowed(): boolean;
+    };
+
+    expect(env.getNetworkPageState().runtime.active).toBe(true);
+    expect(runtime.setEnabled(false)).toMatchObject({
+      enabled: false,
+      active: false,
+    });
+    expect(runtime.isRemoteAccessAllowed()).toBe(false);
+    expect(env.getNetworkPageState().runtime.active).toBe(false);
+
+    runtime.setEnabled(true);
+    expect(env.getNetworkPageState().runtime.active).toBe(true);
+  });
+
+  it('simulates pair request approval, rejection, and revocation state', () => {
+    const env = createSimDiscoveryEnvironment(new FakeState());
+    const originalDateNow = Date.now;
+    let now = 1_700_000_000_000;
+    const trustStore = env.context.trustStore as unknown as {
+      createPairRequest: (
+        fromInstanceId: string,
+        fromName: string,
+        fromHost: string,
+        fromPort: number,
+        callbackToken: string,
+      ) => { id: string; status: string; fromInstanceId: string };
+      approvePairRequest: (id: string) => { sharedSecret: string };
+      rejectPairRequest: (id: string) => void;
+      revokePeer: (instanceId: string) => void;
+      resetPeerToDiscovered: (instanceId: string) => void;
+      getPeer: (
+        instanceId: string,
+      ) => { status: string; sharedSecret: string | null } | null;
+      getPendingRequests: () => Array<{ status: string }>;
+    };
+
+    Date.now = () => now++;
+    try {
+      const approved = trustStore.createPairRequest(
+        'peer-new',
+        'New Peer',
+        'new-sim.local',
+        3100,
+        'token-a',
+      );
+      const rejected = trustStore.createPairRequest(
+        'peer-rejected',
+        'Rejected Peer',
+        'reject-sim.local',
+        3101,
+        'token-b',
+      );
+
+      expect(approved).toMatchObject({
+        status: 'pending',
+        fromInstanceId: 'peer-new',
+      });
+      expect(trustStore.getPendingRequests()).toHaveLength(2);
+
+      expect(trustStore.approvePairRequest(approved.id).sharedSecret).toBe(
+        'sim-secret-peer-new',
+      );
+      expect(trustStore.getPeer('peer-new')).toMatchObject({
+        status: 'trusted',
+        sharedSecret: 'sim-secret-peer-new',
+      });
+
+      trustStore.rejectPairRequest(rejected.id);
+      expect(
+        trustStore.getPendingRequests().map((request) => request.status),
+      ).toEqual(['approved', 'rejected']);
+
+      trustStore.revokePeer('peer-new');
+      expect(trustStore.getPeer('peer-new')).toMatchObject({
+        status: 'revoked',
+        sharedSecret: null,
+      });
+
+      trustStore.resetPeerToDiscovered('peer-new');
+      expect(trustStore.getPeer('peer-new')).toMatchObject({
+        status: 'discovered',
+      });
+    } finally {
+      Date.now = originalDateNow;
+    }
+  });
+
+  it('resets simulated peers and rejects mutations for missing peers', () => {
+    const env = createSimDiscoveryEnvironment(new FakeState());
+
+    env.addRemotePeer({
+      instanceId: 'peer-temp',
+      name: 'Temporary Peer',
+      host: 'temp-sim.local',
+      address: '192.168.1.90',
+      channelFolder: 'temp',
+    });
+    env.setPeerOnline('peer-temp', false);
+    expect(env.listRemotePeers()).toHaveLength(2);
+    expect(
+      env.listRemotePeers().find((peer) => peer.instanceId === 'peer-temp'),
+    ).toMatchObject({ online: false });
+
+    env.reset();
+    expect(env.listRemotePeers()).toEqual([
+      expect.objectContaining({ instanceId: 'peer-remote-1', online: true }),
+    ]);
+    expect(() =>
+      env.addRemoteLog('missing-peer', {
+        level: 'info',
+        msg: 'no-op',
+        source: 'missing-peer',
+      }),
+    ).toThrow('Remote peer not found: missing-peer');
+    expect(() => env.setPeerOnline('missing-peer', true)).toThrow(
+      'Remote peer not found: missing-peer',
+    );
+  });
 });


### PR DESCRIPTION
## Summary

- Add deterministic simulation coverage for discovery runtime toggles, pair request transitions, peer reset, and missing-peer mutation errors.
- Cover media attachment storage descriptor/path behavior and non-critical cleanup error swallowing.
- Cover backend runtime extraction/default behavior for agents and registered groups.

## Verification

- `bun test` before: 1958 pass, 0 fail across 101 files
- `bun test` after: 1966 pass, 0 fail across 101 files
- `bun test --coverage`: 1966 pass, 0 fail; 90.40% funcs / 88.69% lines

## Coverage Notes

- Improved `src/backends/types.ts` from 85.71% funcs / 88.24% lines to 100% / 100%.
- Improved `src/media.ts` from 94.44% funcs / 84.54% lines to 100% / 99.46%.
- Improved `src/simtest/discovery-sim.ts` from 64.52% funcs / 69.38% lines to 75.00% / 81.86%.

Remaining larger gaps are mostly integration-heavy modules: `src/index.ts`, channel adapters, discovery routes, local backend process/container paths, and DB branches.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added comprehensive test coverage for runtime environment management and configuration handling
  * Expanded media attachment and cleanup operation testing for enhanced reliability
  * Enhanced network peer discovery and pairing simulation tests to validate state transitions and behavior

<!-- end of auto-generated comment: release notes by coderabbit.ai -->