### PR TITLE
fix(web): escape dashboard topology JSON

### DIFF
--- a/src/web/dashboard.test.ts
+++ b/src/web/dashboard.test.ts
@@ -222,6 +222,42 @@ describe('renderDashboardContent', () => {
     );
   });
 
+  it('escapes topology JSON so script tag sentinels cannot break out', () => {
+    const payload = '</script><script>alert("xss")</script>&\u2028\u2029';
+    const html = renderDashboardContent(
+      makeState({
+        agents: [
+          makeAgent({
+            id: 'local-agent',
+            name: payload,
+            serverFolder: payload,
+          }),
+        ],
+        subscriptions: {
+          'dc:123': [makeSubscription({ channelFolder: payload })],
+        },
+        chats: [
+          {
+            jid: 'dc:123',
+            name: payload,
+            last_message_time: '2026-03-01T00:00:00.000Z',
+          },
+        ],
+      }),
+    );
+
+    expect(html).not.toContain('</script><script>');
+    expect(html).not.toContain('<script>alert("xss")</script>');
+    expect(html).toContain('\\u003c/script\\u003e');
+
+    const topoData = extractTopoData(html);
+    expect(topoData[0]?.name).toBe(payload);
+    expect(topoData[0]?.server).toBe(payload);
+    expect(
+      (topoData[0]?.channels as Array<Record<string, unknown>>)[0]?.name,
+    ).toBe(payload);
+  });
+
   it('only offers local agents in the task modal and escapes labels safely', () => {
     const html = renderDashboardContent(
       makeState({

--- a/src/web/dashboard.ts
+++ b/src/web/dashboard.ts
@@ -1,7 +1,7 @@
 import { createHash } from 'crypto';
 
 import type { WebStateProvider } from './types.js';
-import { renderShell, escapeHtml } from './shared.js';
+import { renderShell, escapeHtml, escapeJsonForHtml } from './shared.js';
 import { allPageScripts } from './page-scripts.js';
 import { buildAgentChannelData } from './agent-channels.js';
 import type { RemotePeerAgents } from '../discovery/types.js';
@@ -26,30 +26,32 @@ export function renderDashboardContent(
   const activeTasks = tasks.filter((t) => t.status === 'active').length;
 
   // Serialize agent topology data for canvas renderer
-  const topoData = JSON.stringify(
-    agentData.map((a) => ({
-      id: a.id,
-      name: a.name,
-      backend: a.backend,
-      runtime: a.agentRuntime,
-      isAdmin: a.isAdmin,
-      remoteInstanceId: a.remoteInstanceId || null,
-      remoteInstanceName: a.remoteInstanceName || null,
-      server: a.serverFolder || null,
-      serverIconUrl: a.serverIconUrl || null,
-      avatarUrl: a.avatarUrl
-        ? a.remoteInstanceId
-          ? `/api/discovery/peers/${encodeURIComponent(a.remoteInstanceId)}/agents/${encodeURIComponent(a.id.split(':').slice(1).join(':'))}/avatar/image?rev=${imageRev(a.avatarUrl)}`
-          : `/api/agents/${encodeURIComponent(a.id)}/avatar/image?rev=${imageRev(a.avatarUrl)}`
-        : null,
-      channels: a.channels.map((ch) => ({
-        jid: ch.jid,
-        name: ch.displayName,
-        category: ch.categoryFolder || null,
-        channelFolder: ch.channelFolder || null,
-        iconUrl: ch.iconUrl || null,
+  const topoData = escapeJsonForHtml(
+    JSON.stringify(
+      agentData.map((a) => ({
+        id: a.id,
+        name: a.name,
+        backend: a.backend,
+        runtime: a.agentRuntime,
+        isAdmin: a.isAdmin,
+        remoteInstanceId: a.remoteInstanceId || null,
+        remoteInstanceName: a.remoteInstanceName || null,
+        server: a.serverFolder || null,
+        serverIconUrl: a.serverIconUrl || null,
+        avatarUrl: a.avatarUrl
+          ? a.remoteInstanceId
+            ? `/api/discovery/peers/${encodeURIComponent(a.remoteInstanceId)}/agents/${encodeURIComponent(a.id.split(':').slice(1).join(':'))}/avatar/image?rev=${imageRev(a.avatarUrl)}`
+            : `/api/agents/${encodeURIComponent(a.id)}/avatar/image?rev=${imageRev(a.avatarUrl)}`
+          : null,
+        channels: a.channels.map((ch) => ({
+          jid: ch.jid,
+          name: ch.displayName,
+          category: ch.categoryFolder || null,
+          channelFolder: ch.channelFolder || null,
+          iconUrl: ch.iconUrl || null,
+        })),
       })),
-    })),
+    ),
   );
 
   const localAgentData = agentData.filter((a) => !a.remoteInstanceId);

--- a/src/web/shared.ts
+++ b/src/web/shared.ts
@@ -26,6 +26,15 @@ export function escapeHtml(str: string): string {
     .replace(/"/g, '&quot;');
 }
 
+export function escapeJsonForHtml(json: string): string {
+  return json
+    .replace(/&/g, '\\u0026')
+    .replace(/</g, '\\u003c')
+    .replace(/>/g, '\\u003e')
+    .replace(/\u2028/g, '\\u2028')
+    .replace(/\u2029/g, '\\u2029');
+}
+
 /** Render just the nav link elements (used for SSE patching of active state). */
 export function renderNavLinks(activePath: string): string {
   return NAV_ITEMS.map(


### PR DESCRIPTION
## Summary

- Fixes #656 by escaping dashboard topology JSON before embedding it in an inert `<script type="application/json">` block.
- Adds regression coverage for `</script><script>...` payloads in agent/server/channel topology metadata.

## Security Impact

Prevents attacker-controlled topology metadata from closing the JSON script tag and executing JavaScript in the authenticated dashboard origin.

## Tests

- `bun test src/web/dashboard.test.ts src/web/shared.test.ts`
- `bun run typecheck`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved security handling of topology data in the dashboard to prevent potential injection vulnerabilities.
  * Added safeguards to properly escape special characters in all topology fields, including remote instance names, server information, and user avatar data, ensuring safe display across the dashboard.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->