### PR TITLE
fix(telegram): treat replies to bot as triggers and download binary docs

### DIFF
--- a/src/channels/telegram.ts
+++ b/src/channels/telegram.ts
@@ -256,6 +256,7 @@ export class TelegramChannel implements Channel {
       // Prepend reply context so the agent knows what's being replied to
       const replyTo = ctx.message.reply_to_message;
       const isReplyToBot = this.isReplyToThisBot(replyTo);
+      const replyToBotId = isReplyToBot ? String(replyTo?.from?.id) : undefined;
       if (replyTo && 'text' in replyTo && replyTo.text) {
         const truncated =
           replyTo.text.length > 200
@@ -293,6 +294,7 @@ export class TelegramChannel implements Channel {
         sender_platform: 'telegram',
         sender_user_id: senderUserId,
         is_reply_to_bot: isReplyToBot,
+        reply_to_bot_id: replyToBotId,
       });
 
       logger.info(
@@ -316,6 +318,9 @@ export class TelegramChannel implements Channel {
         ctx.from?.first_name || ctx.from?.username || 'Unknown';
       const caption = ctx.message.caption ? ` ${ctx.message.caption}` : '';
       const isReplyToBot = this.isReplyToThisBot(ctx.message.reply_to_message);
+      const replyToBotId = isReplyToBot
+        ? String(ctx.message.reply_to_message?.from?.id)
+        : undefined;
 
       this.opts.onChatMetadata(chatJid, timestamp);
       this.opts.onChatMetadata(legacyChatJid, timestamp);
@@ -330,6 +335,7 @@ export class TelegramChannel implements Channel {
         sender_platform: 'telegram',
         sender_user_id: senderUserId,
         is_reply_to_bot: isReplyToBot,
+        reply_to_bot_id: replyToBotId,
       });
     };
 
@@ -349,6 +355,9 @@ export class TelegramChannel implements Channel {
         ctx.from?.first_name || ctx.from?.username || 'Unknown';
       const caption = ctx.message.caption ? ` ${ctx.message.caption}` : '';
       const isReplyToBot = this.isReplyToThisBot(ctx.message.reply_to_message);
+      const replyToBotId = isReplyToBot
+        ? String(ctx.message.reply_to_message?.from?.id)
+        : undefined;
 
       // Telegram sends multiple sizes; pick the largest (last in array)
       const photos = ctx.message.photo;
@@ -384,6 +393,7 @@ export class TelegramChannel implements Channel {
         sender_platform: 'telegram',
         sender_user_id: senderUserId,
         is_reply_to_bot: isReplyToBot,
+        reply_to_bot_id: replyToBotId,
       });
     });
 
@@ -412,6 +422,9 @@ export class TelegramChannel implements Channel {
         ctx.from?.first_name || ctx.from?.username || 'Unknown';
       const caption = ctx.message.caption ? ` ${ctx.message.caption}` : '';
       const isReplyToBot = this.isReplyToThisBot(ctx.message.reply_to_message);
+      const replyToBotId = isReplyToBot
+        ? String(ctx.message.reply_to_message?.from?.id)
+        : undefined;
 
       let marker = `[Document: ${fileName}]`;
 
@@ -473,6 +486,7 @@ export class TelegramChannel implements Channel {
         sender_platform: 'telegram',
         sender_user_id: senderUserId,
         is_reply_to_bot: isReplyToBot,
+        reply_to_bot_id: replyToBotId,
       });
 
       logger.info(

--- a/src/channels/telegram.ts
+++ b/src/channels/telegram.ts
@@ -9,11 +9,13 @@ import {
   downloadBinaryAttachment,
   downloadTextAttachment,
   ensureMediaDir,
+  formatBinaryFileMarker,
   formatImageMarker,
   formatPlaceholder,
   formatTextFileMarker,
   isImageByTypeOrExtension,
   isTextByExtension,
+  MAX_BINARY_DOWNLOAD_BYTES,
   MAX_TEXT_DOWNLOAD_BYTES,
 } from '../media.js';
 import {
@@ -167,6 +169,19 @@ export class TelegramChannel implements Channel {
   }
 
   /**
+   * True when `replyTo.from.id` matches this bot's own ID — i.e. the user is
+   * replying to one of the bot's messages. Used as an implicit trigger so
+   * the agent activates without an explicit @mention.
+   */
+  private isReplyToThisBot(
+    replyTo: { from?: { id?: string | number | bigint } | null } | undefined,
+  ): boolean {
+    const fromId = replyTo?.from?.id;
+    if (fromId == null) return false;
+    return String(fromId) === this.botId;
+  }
+
+  /**
    * Resolve a Telegram file_id to a download URL via the Bot API.
    * Returns `null` if the file cannot be resolved (bot not connected, no path).
    */
@@ -240,6 +255,7 @@ export class TelegramChannel implements Channel {
 
       // Prepend reply context so the agent knows what's being replied to
       const replyTo = ctx.message.reply_to_message;
+      const isReplyToBot = this.isReplyToThisBot(replyTo);
       if (replyTo && 'text' in replyTo && replyTo.text) {
         const truncated =
           replyTo.text.length > 200
@@ -276,10 +292,11 @@ export class TelegramChannel implements Channel {
         is_from_me: false,
         sender_platform: 'telegram',
         sender_user_id: senderUserId,
+        is_reply_to_bot: isReplyToBot,
       });
 
       logger.info(
-        { chatJid, chatName, sender: senderName },
+        { chatJid, chatName, sender: senderName, isReplyToBot },
         'Telegram message stored',
       );
     });
@@ -298,6 +315,7 @@ export class TelegramChannel implements Channel {
       const senderName =
         ctx.from?.first_name || ctx.from?.username || 'Unknown';
       const caption = ctx.message.caption ? ` ${ctx.message.caption}` : '';
+      const isReplyToBot = this.isReplyToThisBot(ctx.message.reply_to_message);
 
       this.opts.onChatMetadata(chatJid, timestamp);
       this.opts.onChatMetadata(legacyChatJid, timestamp);
@@ -311,6 +329,7 @@ export class TelegramChannel implements Channel {
         is_from_me: false,
         sender_platform: 'telegram',
         sender_user_id: senderUserId,
+        is_reply_to_bot: isReplyToBot,
       });
     };
 
@@ -329,6 +348,7 @@ export class TelegramChannel implements Channel {
       const senderName =
         ctx.from?.first_name || ctx.from?.username || 'Unknown';
       const caption = ctx.message.caption ? ` ${ctx.message.caption}` : '';
+      const isReplyToBot = this.isReplyToThisBot(ctx.message.reply_to_message);
 
       // Telegram sends multiple sizes; pick the largest (last in array)
       const photos = ctx.message.photo;
@@ -363,6 +383,7 @@ export class TelegramChannel implements Channel {
         is_from_me: false,
         sender_platform: 'telegram',
         sender_user_id: senderUserId,
+        is_reply_to_bot: isReplyToBot,
       });
     });
 
@@ -370,7 +391,8 @@ export class TelegramChannel implements Channel {
     this.bot.on('message:voice', (ctx) => storeNonText(ctx, '[Voice message]'));
     this.bot.on('message:audio', (ctx) => storeNonText(ctx, '[Audio]'));
 
-    // Documents: download images and text files, placeholder for the rest
+    // Documents: download images, inline small text files, save other binaries
+    // (PDFs, archives, etc.) to the group's media dir so the agent can Read them.
     this.bot.on('message:document', async (ctx) => {
       const chatId = ctx.chat.id;
       const chatJid = `tg:${this.botId}:${chatId}`;
@@ -389,6 +411,7 @@ export class TelegramChannel implements Channel {
       const senderName =
         ctx.from?.first_name || ctx.from?.username || 'Unknown';
       const caption = ctx.message.caption ? ` ${ctx.message.caption}` : '';
+      const isReplyToBot = this.isReplyToThisBot(ctx.message.reply_to_message);
 
       let marker = `[Document: ${fileName}]`;
 
@@ -414,7 +437,19 @@ export class TelegramChannel implements Channel {
             const text = await downloadTextAttachment(url);
             marker = formatTextFileMarker(safeName, text);
           }
+        } else if (fileSize <= MAX_BINARY_DOWNLOAD_BYTES) {
+          // Other binary (PDF, archive, etc.) — save to media dir and emit a
+          // path marker so the agent can open it with the Read tool.
+          const url = await this.getTelegramFileUrl(doc!.file_id);
+          if (url) {
+            const mediaDir = ensureMediaDir(group);
+            const filePath = buildSafeMediaPath(mediaDir, msgId, fileName);
+            const bytes = await downloadBinaryAttachment(url);
+            fs.writeFileSync(filePath, bytes);
+            marker = formatBinaryFileMarker(path.basename(filePath), fileName);
+          }
         } else {
+          // Too large to download — fall back to a placeholder.
           marker = formatPlaceholder('file', fileName);
         }
       } catch (err) {
@@ -437,7 +472,13 @@ export class TelegramChannel implements Channel {
         is_from_me: false,
         sender_platform: 'telegram',
         sender_user_id: senderUserId,
+        is_reply_to_bot: isReplyToBot,
       });
+
+      logger.info(
+        { chatJid, msgId, fileName, fileSize, isReplyToBot },
+        'Telegram document stored',
+      );
     });
     this.bot.on('message:sticker', (ctx) => {
       const emoji = ctx.message.sticker?.emoji || '';

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -11,6 +11,7 @@ import {
   _isAgentEnabled,
   _markChannelSubscriptionsDirty,
   _selectEnabledSubscriptionsForMessage,
+  _selectSubscriptionsForMessage,
   _setAgents,
   _setChannelSubscriptions,
   _setRegisteredGroups,
@@ -58,6 +59,19 @@ const BASE_MESSAGE: NewMessage = {
   content: '@Omni hello',
   timestamp: '2024-01-01T00:01:00.000Z',
 };
+
+const makeMessage = (overrides: Partial<NewMessage> = {}): NewMessage => ({
+  id: 'msg-1',
+  chat_jid: 'tg:-100123',
+  sender: 'telegram:42',
+  sender_name: 'Peyton',
+  content: 'follow up',
+  timestamp: '2026-05-09T18:00:00.000Z',
+  is_from_me: false,
+  sender_platform: 'telegram',
+  sender_user_id: '42',
+  ...overrides,
+});
 
 describe('getAvailableGroups', () => {
   beforeEach(() => {
@@ -317,5 +331,110 @@ describe('agent off-switch routing guards', () => {
     expect(_getEnabledStartupConfirmationTargets()).toEqual([
       { chatJid: 'dc:enabled', trigger: '@Enabled' },
     ]);
+  });
+});
+
+describe('subscription selection', () => {
+  beforeEach(() => {
+    _initTestDatabase();
+    _setRegisteredGroups({});
+    _setChannelSubscriptions({});
+    _setAgents({});
+  });
+
+  it('routes reply-to-agent messages only to the replied-to agent in a shared channel', () => {
+    _setChannelSubscriptions({
+      'tg:-100123': [
+        {
+          ...BASE_SUBSCRIPTION,
+          channelJid: 'tg:-100123',
+          agentId: 'agent-a',
+          trigger: '@AgentA',
+          priority: 0,
+        },
+        {
+          ...BASE_SUBSCRIPTION,
+          channelJid: 'tg:-100123',
+          agentId: 'agent-b',
+          trigger: '@AgentB',
+          priority: 1,
+        },
+      ],
+    });
+
+    const result = _selectSubscriptionsForMessage('tg:-100123', [
+      makeMessage({
+        is_reply_to_bot: true,
+        reply_to_agent_id: 'agent-a',
+      }),
+    ]);
+
+    expect(result.selectedByTrigger).toBe(true);
+    expect(result.selected.map((s) => s.agentId)).toEqual(['agent-a']);
+  });
+
+  it('does not fan out bot replies to legacy shared Telegram subscriptions when only a bot target is known', () => {
+    _setChannelSubscriptions({
+      'tg:-100123': [
+        {
+          ...BASE_SUBSCRIPTION,
+          channelJid: 'tg:-100123',
+          agentId: 'agent-a',
+          trigger: '@AgentA',
+          priority: 0,
+        },
+        {
+          ...BASE_SUBSCRIPTION,
+          channelJid: 'tg:-100123',
+          agentId: 'agent-b',
+          trigger: '@AgentB',
+          priority: 1,
+        },
+      ],
+    });
+
+    const result = _selectSubscriptionsForMessage('tg:-100123', [
+      makeMessage({
+        is_reply_to_bot: true,
+        reply_to_bot_id: 'bot-a',
+      }),
+    ]);
+
+    expect(result.selectedByTrigger).toBe(false);
+    expect(result.selected).toEqual([]);
+  });
+
+  it('matches Telegram replies to the subscription with the scoped replied-to bot id', () => {
+    _setChannelSubscriptions({
+      'tg:bot-a:-100123': [
+        {
+          ...BASE_SUBSCRIPTION,
+          channelJid: 'tg:bot-a:-100123',
+          agentId: 'agent-a',
+          trigger: '@AgentA',
+          priority: 0,
+        },
+      ],
+      'tg:bot-b:-100123': [
+        {
+          ...BASE_SUBSCRIPTION,
+          channelJid: 'tg:bot-b:-100123',
+          agentId: 'agent-b',
+          trigger: '@AgentB',
+          priority: 1,
+        },
+      ],
+    });
+
+    const result = _selectSubscriptionsForMessage('tg:bot-a:-100123', [
+      makeMessage({
+        chat_jid: 'tg:bot-a:-100123',
+        is_reply_to_bot: true,
+        reply_to_bot_id: 'bot-a',
+      }),
+    ]);
+
+    expect(result.selectedByTrigger).toBe(true);
+    expect(result.selected.map((s) => s.agentId)).toEqual(['agent-a']);
   });
 });

--- a/src/index.ts
+++ b/src/index.ts
@@ -2061,6 +2061,11 @@ function messagesMatchSubscription(
 ): boolean {
   if (messages.some((m) => /@allagents/i.test(m.content))) return true;
 
+  // Replying to one of the bot's own messages counts as an explicit trigger —
+  // the user is clearly addressing the bot even without an @mention. Channel
+  // adapters set is_reply_to_bot only when the reply targets THIS channel's bot.
+  if (messages.some((m) => m.is_reply_to_bot === true)) return true;
+
   const mentionPatterns = getMentionPatterns(sub);
   if (mentionPatterns.length > 0) {
     const hasMention = messages.some((m) => {

--- a/src/index.ts
+++ b/src/index.ts
@@ -2050,6 +2050,28 @@ interface SubscriptionSelection {
   selectedByTrigger: boolean;
 }
 
+function replyTargetMatchesSubscription(
+  sub: ChannelSubscription,
+  message: NewMessage,
+): boolean {
+  if (message.is_reply_to_bot !== true) return false;
+
+  if (message.reply_to_agent_id) {
+    return message.reply_to_agent_id === sub.agentId;
+  }
+
+  if (message.reply_to_bot_id) {
+    if (sub.discordBotId === message.reply_to_bot_id) return true;
+    const subTelegram = parseScopedTelegramJid(sub.channelJid);
+    if (subTelegram?.botId === message.reply_to_bot_id) return true;
+    return false;
+  }
+
+  // Backward compatibility for adapters/tests that predate reply target
+  // metadata. New multi-agent reply paths should provide one of the IDs above.
+  return true;
+}
+
 /**
  * Check if a subscription is targeted by any of the given messages.
  * Returns true if messages contain @allagents, a direct bot mention,
@@ -2062,9 +2084,10 @@ function messagesMatchSubscription(
   if (messages.some((m) => /@allagents/i.test(m.content))) return true;
 
   // Replying to one of the bot's own messages counts as an explicit trigger —
-  // the user is clearly addressing the bot even without an @mention. Channel
-  // adapters set is_reply_to_bot only when the reply targets THIS channel's bot.
-  if (messages.some((m) => m.is_reply_to_bot === true)) return true;
+  // the user is clearly addressing the bot even without an @mention. When the
+  // adapter provides reply target metadata, keep selection scoped to that
+  // subscription so shared-channel agents do not all wake up.
+  if (messages.some((m) => replyTargetMatchesSubscription(sub, m))) return true;
 
   const mentionPatterns = getMentionPatterns(sub);
   if (mentionPatterns.length > 0) {
@@ -2128,6 +2151,14 @@ function selectSubscriptionsForMessage(
     )
     .slice(0, MAX_CHANNEL_AGENT_FANOUT);
   return { selected: sorted, selectedByTrigger };
+}
+
+/** @internal - exported for tests */
+export function _selectSubscriptionsForMessage(
+  chatJid: string,
+  groupMessages: NewMessage[],
+): SubscriptionSelection {
+  return selectSubscriptionsForMessage(chatJid, groupMessages);
 }
 
 async function startMessageLoop(): Promise<void> {

--- a/src/media.test.ts
+++ b/src/media.test.ts
@@ -6,6 +6,7 @@ import {
   cleanupExpiredMedia,
   downloadBinaryAttachment,
   downloadTextAttachment,
+  formatBinaryFileMarker,
   formatImageMarker,
   formatPlaceholder,
   formatTextFileMarker,
@@ -249,6 +250,26 @@ describe('formatTextFileMarker', () => {
     const marker = formatTextFileMarker('config.json', '{"key": "value"}');
     expect(marker).toBe(
       '[attachment:file name=config.json]\n{"key": "value"}\n[/attachment:file]',
+    );
+  });
+});
+
+describe('formatBinaryFileMarker', () => {
+  it('produces a marker with a path the agent can Read', () => {
+    expect(formatBinaryFileMarker('msg123-doc.pdf')).toBe(
+      '[attachment:file path=media/msg123-doc.pdf name=msg123-doc.pdf]',
+    );
+  });
+
+  it('preserves the original display name when supplied', () => {
+    expect(formatBinaryFileMarker('msg123-doc.pdf', 'Quantum Fund.pdf')).toBe(
+      '[attachment:file path=media/msg123-doc.pdf name=Quantum Fund.pdf]',
+    );
+  });
+
+  it('strips directory components from filename', () => {
+    expect(formatBinaryFileMarker('../../../etc/passwd')).toBe(
+      '[attachment:file path=media/passwd name=passwd]',
     );
   });
 });

--- a/src/media.ts
+++ b/src/media.ts
@@ -276,6 +276,25 @@ export function formatTextFileMarker(
   return `[attachment:file name=${filename}]\n${content}\n[/attachment:file]`;
 }
 
+/**
+ * Format a binary file attachment marker for the agent runtime.
+ *
+ * Emits a path the agent can open with the Read tool. The path is relative
+ * to the agent's cwd (`/workspace/group`), so a downloaded media file at
+ * `<group>/media/<file>` becomes `media/<file>`.
+ *
+ * Use this for binary documents (PDFs, archives, etc.) that aren't images
+ * and aren't small enough to inline as text.
+ */
+export function formatBinaryFileMarker(
+  filename: string,
+  originalName?: string,
+): string {
+  const safe = path.basename(filename);
+  const display = originalName ? path.basename(originalName) : safe;
+  return `[attachment:file path=media/${safe} name=${display}]`;
+}
+
 /** Format a placeholder for unsupported or failed media types. */
 export function formatPlaceholder(
   type: 'video' | 'audio' | 'file',

--- a/src/types.ts
+++ b/src/types.ts
@@ -138,6 +138,12 @@ export interface NewMessage {
     name: string;
     platform: 'discord' | 'whatsapp' | 'telegram' | 'slack';
   }>;
+  /**
+   * True when the message is a reply to one of the bot's own messages.
+   * Treated as an explicit trigger by the subscription filter, since the
+   * user is clearly addressing the bot even without an @mention.
+   */
+  is_reply_to_bot?: boolean;
 }
 
 /** Attachment type tag for the unified media pipeline. */

--- a/src/types.ts
+++ b/src/types.ts
@@ -144,6 +144,16 @@ export interface NewMessage {
    * user is clearly addressing the bot even without an @mention.
    */
   is_reply_to_bot?: boolean;
+  /**
+   * Optional subscription identity for reply routing. When present, only this
+   * agent should be triggered by the reply.
+   */
+  reply_to_agent_id?: string;
+  /**
+   * Optional channel bot identity for reply routing. Telegram stores the
+   * replied-to bot's numeric ID here.
+   */
+  reply_to_bot_id?: string;
 }
 
 /** Attachment type tag for the unified media pipeline. */


### PR DESCRIPTION
## Summary

Two related Telegram bugs surfaced when LocalPeyton was running in a 3-person group:

- **Replies to the bot were silently dropped** when the channel had `requires_trigger=1`. A user replying conversationally (no @mention) hit `No agents selected after trigger filter — all candidates require explicit trigger` and the agent never woke up.
- **PDF / binary documents were never downloaded.** The handler emitted a `[File: name.pdf]` placeholder for any document that wasn't an image or a small text file, so the agent could see the filename but had no bytes to `Read`.

## Changes

- `NewMessage.is_reply_to_bot` — set by Telegram adapters when `ctx.message.reply_to_message.from.id` matches this bot's id (text, photo, document, and `storeNonText` paths).
- `messagesMatchSubscription` — treats `is_reply_to_bot === true` as an explicit trigger, alongside `@allagents` and direct @mention.
- Telegram document handler — downloads any binary up to `MAX_BINARY_DOWNLOAD_BYTES` (10 MiB) into the group's media dir and emits a new `[attachment:file path=media/<file> name=<orig>]` marker so the agent can open it with the `Read` tool. Path is relative to the agent's cwd (`/workspace/group`).
- `formatBinaryFileMarker(filename, originalName?)` helper in `media.ts`, with `path.basename` sanitization and tests covering happy path, display-name override, and traversal stripping.

Multi-attachment Telegram sends already work via this fix: grammY delivers each document as its own `message:document` event, so each PDF is processed and stored independently with its own marker.

## Test plan

- [x] `bun test` — 1970 pass, 0 fail
- [x] `bun run build` — builds clean
- [ ] Send a PDF in a Telegram group → agent receives `[attachment:file path=media/...]` and can `Read` it
- [ ] Send 2 PDFs back-to-back → both downloaded, both markers emitted as separate messages
- [ ] Reply (no @mention) to a bot message in a `requires_trigger=1` group → agent activates
- [ ] Cold @mention in same group still works
- [ ] DM (no group, no trigger) flow unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Telegram messages replying to the bot's messages now automatically trigger responses without requiring an @mention.

* **Improvements**
  * Enhanced binary file attachment handling with improved formatting and display names.

* **Tests**
  * Added test coverage for binary file marker generation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->