### PR TITLE
fix(container): bump discrawl to v0.7.0 to match openclaw module path

### DIFF
--- a/container/Dockerfile.base
+++ b/container/Dockerfile.base
@@ -71,7 +71,7 @@ RUN curl -fsSL https://cli.github.com/packages/githubcli-archive-keyring.gpg \
 # Install local-first crawl tools. gitcrawl also provides the gh shim at
 # /usr/local/bin/gh; unsupported and mutating commands fall back to /usr/bin/gh.
 ARG GITCRAWL_VERSION=v0.2.1
-ARG DISCRAWL_VERSION=v0.6.6
+ARG DISCRAWL_VERSION=v0.7.0
 ENV GITCRAWL_GH_PATH=/usr/bin/gh
 COPY gitcrawl.sh discrawl.sh /tmp/
 RUN chmod +x /tmp/gitcrawl.sh /tmp/discrawl.sh \

--- a/container/discrawl.sh
+++ b/container/discrawl.sh
@@ -4,7 +4,7 @@ set -euo pipefail
 # Installs discrawl into the agent image so agents can query or sync local
 # Discord archives from the same tool surface used by the host.
 
-DISCRAWL_VERSION="${DISCRAWL_VERSION:-v0.6.6}"
+DISCRAWL_VERSION="${DISCRAWL_VERSION:-v0.7.0}"
 INSTALL_DIR="${INSTALL_DIR:-/usr/local/bin}"
 
 tmp_gobin="$(mktemp -d)"

--- a/src/container-tooling.test.ts
+++ b/src/container-tooling.test.ts
@@ -20,7 +20,7 @@ describe('agent container crawl tooling', () => {
     const dockerfile = read('container/Dockerfile.base');
 
     expect(dockerfile).toContain('ARG GITCRAWL_VERSION=v0.2.1');
-    expect(dockerfile).toContain('ARG DISCRAWL_VERSION=v0.6.6');
+    expect(dockerfile).toContain('ARG DISCRAWL_VERSION=v0.7.0');
     expect(dockerfile).toContain('COPY gitcrawl.sh discrawl.sh /tmp/');
     expect(dockerfile).toContain('/tmp/gitcrawl.sh');
     expect(dockerfile).toContain('/tmp/discrawl.sh');


### PR DESCRIPTION
## Summary
- Container build fails on `linux/arm64` (Orange Pi 5) because `go install github.com/openclaw/discrawl/cmd/discrawl@v0.6.6` rejects the module path: v0.6.6's `go.mod` still declares `github.com/steipete/discrawl` (predates the rename).
- Bumps `DISCRAWL_VERSION` from `v0.6.6` → `v0.7.0` in `container/Dockerfile.base`, `container/discrawl.sh`, and the matching pin in `src/container-tooling.test.ts`. v0.7.0 is the first tag whose `go.mod` declares `github.com/openclaw/discrawl`.

## Error before fix
```
go: github.com/openclaw/discrawl/cmd/discrawl@v0.6.6: version constraints conflict:
  github.com/openclaw/discrawl@v0.6.6: parsing go.mod:
  module declares its path as: github.com/steipete/discrawl
          but was required as: github.com/openclaw/discrawl
```

## Test plan
- [x] `bun test src/container-tooling.test.ts` — 4 pass
- [x] `CONTAINER_CMD=docker ./container/build.sh latest` — base + agent images build cleanly on `linux/arm64`
- [x] `docker run --rm --entrypoint discrawl omniclaw-agent:latest --version` → `0.7.0`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated discrawl tool to v0.7.0 in container builds

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/omniaura/omniclaw/pull/678)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->