### PR TITLE
fix(web): reject active remote image content

### DIFF
--- a/src/web/image-cache.test.ts
+++ b/src/web/image-cache.test.ts
@@ -1,4 +1,4 @@
-import { randomUUID } from 'crypto';
+import { createHash, randomUUID } from 'crypto';
 import fs from 'fs';
 import http from 'node:http';
 import path from 'path';
@@ -56,6 +56,105 @@ describe('serveCachedRemoteImage', () => {
             throw new Error('should not fetch blocked url');
           }) as RemoteImageFetch,
         },
+      );
+
+      expect(response).toBeNull();
+    } finally {
+      clearTestImageCache(testImageCacheDir);
+    }
+  });
+
+  it('rejects active content types from upstream responses', async () => {
+    const testImageCacheDir = path.join(
+      DATA_DIR,
+      'image-cache-image-cache-test',
+      randomUUID(),
+    );
+
+    clearTestImageCache(testImageCacheDir);
+
+    try {
+      const response = await serveCachedRemoteImage(
+        'active-content-key',
+        async () => 'https://93.184.216.34/avatar.html',
+        {
+          cacheDir: testImageCacheDir,
+          fetchImpl: (async () =>
+            new Response('<script>alert(1)</script>', {
+              status: 200,
+              headers: { 'content-type': 'text/html; charset=utf-8' },
+            })) as RemoteImageFetch,
+        },
+      );
+
+      expect(response).toBeNull();
+      expect(fs.readdirSync(testImageCacheDir)).toEqual([]);
+    } finally {
+      clearTestImageCache(testImageCacheDir);
+    }
+  });
+
+  it('rejects svg images because they can contain active script content', async () => {
+    const testImageCacheDir = path.join(
+      DATA_DIR,
+      'image-cache-image-cache-test',
+      randomUUID(),
+    );
+
+    clearTestImageCache(testImageCacheDir);
+
+    try {
+      const response = await serveCachedRemoteImage(
+        'svg-content-key',
+        async () => 'https://93.184.216.34/avatar.svg',
+        {
+          cacheDir: testImageCacheDir,
+          fetchImpl: (async () =>
+            new Response('<svg><script>alert(1)</script></svg>', {
+              status: 200,
+              headers: { 'content-type': 'image/svg+xml' },
+            })) as RemoteImageFetch,
+        },
+      );
+
+      expect(response).toBeNull();
+      expect(fs.readdirSync(testImageCacheDir)).toEqual([]);
+    } finally {
+      clearTestImageCache(testImageCacheDir);
+    }
+  });
+
+  it('does not replay cached entries with unsafe content types', async () => {
+    const testImageCacheDir = path.join(
+      DATA_DIR,
+      'image-cache-image-cache-test',
+      randomUUID(),
+    );
+
+    clearTestImageCache(testImageCacheDir);
+
+    try {
+      const cacheHash = createHash('sha256')
+        .update('unsafe-cache-key')
+        .digest('hex');
+
+      fs.mkdirSync(testImageCacheDir, { recursive: true });
+      fs.writeFileSync(
+        path.join(testImageCacheDir, `${cacheHash}.bin`),
+        '<script>alert(1)</script>',
+      );
+      fs.writeFileSync(
+        path.join(testImageCacheDir, `${cacheHash}.json`),
+        JSON.stringify({
+          contentType: 'text/html',
+          fetchedAt: Date.now(),
+        }),
+      );
+
+      const response = await serveCachedRemoteImage(
+        'unsafe-cache-key',
+        async () => null,
+        { cacheDir: testImageCacheDir },
       );
 
       expect(response).toBeNull();

--- a/src/web/image-cache.ts
+++ b/src/web/image-cache.ts
@@ -13,6 +13,16 @@ const IMAGE_CACHE_DIR = path.join(DATA_DIR, 'image-cache');
 const ONE_DAY_MS = 24 * 60 * 60 * 1000;
 const BROWSER_CACHE_CONTROL = 'private, max-age=86400';
 const REMOTE_IMAGE_FETCH_TIMEOUT_MS = 10_000;
+const ALLOWED_REMOTE_IMAGE_CONTENT_TYPES = new Set([
+  'image/avif',
+  'image/bmp',
+  'image/gif',
+  'image/jpeg',
+  'image/png',
+  'image/webp',
+  'image/x-icon',
+  'image/vnd.microsoft.icon',
+]);
 
 /** Default maximum bytes to buffer from a remote image fetch (5 MiB). */
 const DEFAULT_MAX_IMAGE_BYTES = 5 * 1024 * 1024;
@@ -222,6 +232,17 @@ function readMeta(metaPath: string): CacheMetadata | null {
   }
 }
 
+function normalizeAllowedImageContentType(
+  contentType: string | null,
+): string | null {
+  if (!contentType) return null;
+  const mimeType = contentType.split(';', 1)[0]?.trim().toLowerCase();
+  if (!mimeType || !ALLOWED_REMOTE_IMAGE_CONTENT_TYPES.has(mimeType)) {
+    return null;
+  }
+  return mimeType;
+}
+
 function buildCachedResponse(dataPath: string, contentType: string): Response {
   // Read eagerly so the response body remains valid even if later test cleanup
   // removes the cache directory before the body stream is consumed.
@@ -229,6 +250,7 @@ function buildCachedResponse(dataPath: string, contentType: string): Response {
     headers: {
       'Content-Type': contentType,
       'Cache-Control': BROWSER_CACHE_CONTROL,
+      'X-Content-Type-Options': 'nosniff',
     },
   });
 }
@@ -401,7 +423,17 @@ export async function serveCachedRemoteImage(
     fs.existsSync(dataPath) &&
     Date.now() - meta.fetchedAt < ONE_DAY_MS
   ) {
-    return buildCachedResponse(dataPath, meta.contentType);
+    const cachedContentType = normalizeAllowedImageContentType(
+      meta.contentType,
+    );
+    if (cachedContentType) {
+      return buildCachedResponse(dataPath, cachedContentType);
+    }
+
+    logger.warn(
+      { cacheKey, contentType: meta.contentType },
+      'Ignoring cached remote image with unsafe content type',
+    );
   }
 
   const url = await resolveUrl();
@@ -458,8 +490,20 @@ export async function serveCachedRemoteImage(
       return null;
     }
 
-    const contentType =
-      upstream.headers.get('content-type') || 'application/octet-stream';
+    const contentType = normalizeAllowedImageContentType(
+      upstream.headers.get('content-type'),
+    );
+    if (!contentType) {
+      logger.warn(
+        {
+          cacheKey,
+          imageUrl: describeImageUrl(url),
+          contentType: upstream.headers.get('content-type') || '',
+        },
+        'Rejected remote image with unsafe content type',
+      );
+      return null;
+    }
 
     if (!upstream.body) {
       logger.warn(


### PR DESCRIPTION
## Summary

- Closes #674 by rejecting remote avatar/icon responses unless the upstream `Content-Type` is a known raster image type.
- Adds `X-Content-Type-Options: nosniff` to cached image responses and refuses to replay cached entries with unsafe MIME metadata.
- Adds regression tests for HTML payloads, SVG script payloads, and unsafe cached metadata.

## Verification

- `bun test src/web/image-cache.test.ts src/web/routes.test.ts`
- `bun run typecheck`
