### PR TITLE
feat(web): roll up structured lane reasons on /system

### DIFF
--- a/src/web/system.test.ts
+++ b/src/web/system.test.ts
@@ -214,6 +214,18 @@ describe('buildHealthData', () => {
     expect(health.queue.processing_groups).toBe(0);
     expect(health.queue.running_tasks).toBe(0);
     expect(health.queue.retrying_groups).toBe(0);
+    expect(health.queue.message_lane_reasons).toEqual({
+      running: 0,
+      'cooling-down': 0,
+      'back-pressure': 0,
+      retrying: 0,
+      'no-work': 0,
+    });
+    expect(health.queue.task_lane_reasons).toEqual({
+      running: 0,
+      'back-pressure': 0,
+      'no-work': 0,
+    });
   });
 
   it('aggregates queue rollup across all tracked groups', () => {
@@ -279,6 +291,140 @@ describe('buildHealthData', () => {
     expect(health.queue.processing_groups).toBe(2); // g1, g3
     expect(health.queue.running_tasks).toBe(1); // only g1 has activeTask
     expect(health.queue.retrying_groups).toBe(2); // g2, g3
+  });
+
+  it('rolls up message and task lane reason codes', () => {
+    const details: GroupQueueDetail[] = [
+      // running message lane + running task lane (active task)
+      {
+        folderKey: 'g1',
+        messageLane: {
+          active: true,
+          idle: false,
+          pendingCount: 0,
+          containerName: 'g1-msg',
+        },
+        taskLane: {
+          active: true,
+          pendingCount: 0,
+          containerName: 'g1-task',
+          activeTask: {
+            taskId: 't1',
+            promptPreview: 'p',
+            startedAt: Date.now(),
+            runningMs: 100,
+          },
+        },
+        retryCount: 0,
+      },
+      // cooling-down message lane (idle:true) + back-pressure task lane
+      {
+        folderKey: 'g2',
+        messageLane: {
+          active: false,
+          idle: true,
+          pendingCount: 0,
+          containerName: 'g2-msg',
+        },
+        taskLane: {
+          active: false,
+          pendingCount: 2,
+          containerName: null,
+          activeTask: null,
+        },
+        retryCount: 0,
+      },
+      // retrying message lane + no-work task lane
+      {
+        folderKey: 'g3',
+        messageLane: {
+          active: false,
+          idle: false,
+          pendingCount: 0,
+          containerName: null,
+        },
+        taskLane: {
+          active: false,
+          pendingCount: 0,
+          containerName: null,
+          activeTask: null,
+        },
+        retryCount: 1,
+      },
+      // back-pressure message lane + no-work task lane
+      {
+        folderKey: 'g4',
+        messageLane: {
+          active: false,
+          idle: false,
+          pendingCount: 5,
+          containerName: null,
+        },
+        taskLane: {
+          active: false,
+          pendingCount: 0,
+          containerName: null,
+          activeTask: null,
+        },
+        retryCount: 0,
+      },
+      // no-work message lane + no-work task lane
+      {
+        folderKey: 'g5',
+        messageLane: {
+          active: false,
+          idle: false,
+          pendingCount: 0,
+          containerName: null,
+        },
+        taskLane: {
+          active: false,
+          pendingCount: 0,
+          containerName: null,
+          activeTask: null,
+        },
+        retryCount: 0,
+      },
+    ];
+    const health = buildHealthData(makeState([makeAgent()], details), 0);
+    expect(health.queue.message_lane_reasons).toEqual({
+      running: 1,
+      'cooling-down': 1,
+      'back-pressure': 1,
+      retrying: 1,
+      'no-work': 1,
+    });
+    expect(health.queue.task_lane_reasons).toEqual({
+      running: 1,
+      'back-pressure': 1,
+      'no-work': 3,
+    });
+  });
+
+  it('honors explicit lane reason fields when provided', () => {
+    const details: GroupQueueDetail[] = [
+      {
+        folderKey: 'g1',
+        messageLane: {
+          active: false,
+          idle: false,
+          pendingCount: 0,
+          containerName: null,
+          reason: 'running',
+        },
+        taskLane: {
+          active: false,
+          pendingCount: 0,
+          containerName: null,
+          activeTask: null,
+          reason: 'back-pressure',
+        },
+        retryCount: 0,
+      },
+    ];
+    const health = buildHealthData(makeState([makeAgent()], details), 0);
+    expect(health.queue.message_lane_reasons.running).toBe(1);
+    expect(health.queue.task_lane_reasons['back-pressure']).toBe(1);
   });
 });
 
@@ -373,6 +519,51 @@ describe('renderSystemContent', () => {
     // pending message count should appear (7)
     expect(html).toContain(
       '<span class="metric-value" id="sys-queue-pending-messages">7</span>',
+    );
+  });
+
+  it('renders message and task lane reason rollups with stable IDs', () => {
+    const details: GroupQueueDetail[] = [
+      {
+        folderKey: 'g1',
+        messageLane: {
+          active: true,
+          idle: false,
+          pendingCount: 2,
+          containerName: 'g1-msg',
+        },
+        taskLane: {
+          active: false,
+          pendingCount: 1,
+          containerName: null,
+          activeTask: null,
+        },
+        retryCount: 0,
+      },
+    ];
+    const html = renderSystemContent(makeState([makeAgent()], details), 0);
+    expect(html).toContain('message lane reasons');
+    expect(html).toContain('task lane reasons');
+    // Each message lane reason must have a stable ID, even when count is zero.
+    for (const reason of [
+      'running',
+      'cooling-down',
+      'back-pressure',
+      'retrying',
+      'no-work',
+    ]) {
+      expect(html).toContain(`id="sys-queue-msg-reason-${reason}"`);
+    }
+    for (const reason of ['running', 'back-pressure', 'no-work']) {
+      expect(html).toContain(`id="sys-queue-task-reason-${reason}"`);
+    }
+    // The single g1 message lane is running -> count 1.
+    expect(html).toContain(
+      '<span class="breakdown-val" id="sys-queue-msg-reason-running">1</span>',
+    );
+    // The g1 task lane has pending=1, active=false -> back-pressure count 1.
+    expect(html).toContain(
+      '<span class="breakdown-val" id="sys-queue-task-reason-back-pressure">1</span>',
     );
   });
 

--- a/src/web/system.ts
+++ b/src/web/system.ts
@@ -2,8 +2,28 @@ import fs from 'fs';
 import os from 'os';
 
 import type { WebStateProvider } from './types.js';
+import {
+  deriveMessageLaneReasonFromDetail,
+  deriveTaskLaneReasonFromDetail,
+  type MessageLaneReason,
+  type TaskLaneReason,
+} from '../group-queue.js';
 import { renderShell, escapeHtml } from './shared.js';
 import { allPageScripts } from './page-scripts.js';
+
+const MESSAGE_LANE_REASONS: readonly MessageLaneReason[] = [
+  'running',
+  'cooling-down',
+  'back-pressure',
+  'retrying',
+  'no-work',
+];
+
+const TASK_LANE_REASONS: readonly TaskLaneReason[] = [
+  'running',
+  'back-pressure',
+  'no-work',
+];
 
 export interface HealthData {
   status: 'healthy';
@@ -61,6 +81,16 @@ export interface HealthData {
     running_tasks: number;
     /** Sum of consecutive retry counts across all group folders. */
     retrying_groups: number;
+    /**
+     * Count of message lanes by structured reason code. Keys are the same
+     * `MessageLaneReason` values exposed on the IPC inspector page.
+     */
+    message_lane_reasons: Record<MessageLaneReason, number>;
+    /**
+     * Count of task lanes by structured reason code. Keys are the same
+     * `TaskLaneReason` values exposed on the IPC inspector page.
+     */
+    task_lane_reasons: Record<TaskLaneReason, number>;
   };
   sse_clients: number;
   started_at: string;
@@ -121,12 +151,26 @@ export function buildHealthData(
   let processingGroups = 0;
   let runningTasks = 0;
   let retryingGroups = 0;
+  const messageLaneReasons: Record<MessageLaneReason, number> = {
+    running: 0,
+    'cooling-down': 0,
+    'back-pressure': 0,
+    retrying: 0,
+    'no-work': 0,
+  };
+  const taskLaneReasons: Record<TaskLaneReason, number> = {
+    running: 0,
+    'back-pressure': 0,
+    'no-work': 0,
+  };
   for (const g of queueDetails) {
     pendingMessages += g.messageLane.pendingCount;
     pendingTasks += g.taskLane.pendingCount;
     if (g.messageLane.active) processingGroups++;
     if (g.taskLane.activeTask) runningTasks++;
     if (g.retryCount > 0) retryingGroups++;
+    messageLaneReasons[deriveMessageLaneReasonFromDetail(g)]++;
+    taskLaneReasons[deriveTaskLaneReasonFromDetail(g)]++;
   }
 
   return {
@@ -179,6 +223,8 @@ export function buildHealthData(
       processing_groups: processingGroups,
       running_tasks: runningTasks,
       retrying_groups: retryingGroups,
+      message_lane_reasons: messageLaneReasons,
+      task_lane_reasons: taskLaneReasons,
     },
     sse_clients: sseClientCount,
     started_at: startedAt,
@@ -225,6 +271,22 @@ function breakdownList(obj: Record<string, number>): string {
         `<div class="breakdown-item">` +
         `<span class="breakdown-key">${escapeHtml(key)}</span>` +
         `<span class="breakdown-val">${count}</span>` +
+        `</div>`,
+    )
+    .join('');
+}
+
+function reasonRollup<T extends string>(
+  obj: Record<T, number>,
+  order: readonly T[],
+  idPrefix: string,
+): string {
+  return order
+    .map(
+      (reason) =>
+        `<div class="breakdown-item">` +
+        `<span class="breakdown-key reason-${reason}">${escapeHtml(reason)}</span>` +
+        `<span class="breakdown-val" id="${idPrefix}-${reason}">${obj[reason] ?? 0}</span>` +
         `</div>`,
     )
     .join('');
@@ -372,6 +434,18 @@ export function renderSystemContent(
           'retrying',
           String(health.queue.retrying_groups),
           'sys-queue-retrying',
+        ) +
+        `<div class="metric-sub">message lane reasons</div>` +
+        reasonRollup(
+          health.queue.message_lane_reasons,
+          MESSAGE_LANE_REASONS,
+          'sys-queue-msg-reason',
+        ) +
+        `<div class="metric-sub">task lane reasons</div>` +
+        reasonRollup(
+          health.queue.task_lane_reasons,
+          TASK_LANE_REASONS,
+          'sys-queue-task-reason',
         ),
     ) +
     `</div>` +


### PR DESCRIPTION
## Summary

Surfaces per-reason lane rollups on `/system` so operators can see at a glance how many groups are `running`, `cooling-down`, `back-pressure`, `retrying`, or `no-work` without having to scan the full IPC inspector table. Pairs the same reason codes used by `/ipc` with the system page, so the two views agree.

This is a small, focused increment toward issue #644 (operator observability rollup), specifically the acceptance criterion:

> `/system` shows per-agent state breakdown with structured reason codes
> At least three concrete idle/blocked reason codes are wired through the data layer

## Changes

- `src/web/system.ts`
  - Extend `HealthData.queue` with `message_lane_reasons` and `task_lane_reasons` records
  - Aggregate reasons in `buildHealthData` via the existing `deriveMessageLaneReasonFromDetail` / `deriveTaskLaneReasonFromDetail` helpers (honors explicit `messageLane.reason` / `taskLane.reason` when set, falls back to derivation)
  - Render the rollups inside the existing queue metric card with stable IDs (`sys-queue-msg-reason-*`, `sys-queue-task-reason-*`) so the SPA can patch them live without DOM churn
- `src/web/system.test.ts`
  - Zero-state assertion
  - Mixed-reason aggregation across 5 representative groups
  - Explicit-reason-field path coverage

No new endpoints. No new top-level pages. No breaking API changes.

## Test plan

- [x] `bun test` — 2019 pass / 0 fail
- [x] `bunx tsc --noEmit` — clean
- [x] `bunx prettier --check` on touched files — clean

## Notes

- Reason ordering in the rendered list follows the same canonical order used in `src/web/ipc-inspector.ts`, so /system and /ipc remain visually aligned.
- The rollup is computed in the same loop that already aggregates queue stats, so this adds O(groups) work on health snapshot — no measurable overhead.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added detailed queue health metrics displaying message and task lane breakdowns by reason code (running, cooling-down, back-pressure, retrying, no-work)

* **Tests**
  * Expanded test coverage with comprehensive assertions for reason-code aggregations and rendered metric output

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/omniaura/omniclaw/pull/683)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->