### PR TITLE
feat(web): surface message lane running age on /ipc

### DIFF
--- a/src/group-queue.test.ts
+++ b/src/group-queue.test.ts
@@ -1207,6 +1207,65 @@ describe('GroupQueue.getDetailedStats message lane run age', () => {
     await Bun.sleep(5);
   });
 
+  it('does not reset startedAt on sendMessage when lane is already running', async () => {
+    const queue = new GroupQueue({
+      dataDir: '/tmp/omniclaw-test-data-msgage-running',
+      maxActiveContainers: 1,
+      maxIdleContainers: 0,
+      maxTaskContainers: 1,
+      fsImpl: fsStub,
+    });
+
+    let resolveRun: (() => void) | null = null;
+    queue.setProcessMessagesFn(
+      () =>
+        new Promise<boolean>((resolve) => {
+          resolveRun = () => resolve(true);
+        }),
+    );
+
+    const backendSend = mock(() => true);
+    queue.enqueueMessageCheck('groupD@g.us');
+    await Bun.sleep(5);
+    queue.registerProcess(
+      'groupD@g.us',
+      { killed: false } as any,
+      'msg-ctr-d',
+      'groupD-folder',
+      {
+        sendMessage: backendSend,
+        closeStdin: mock(),
+        runAgent: mock(async () => ({
+          status: 'success' as const,
+          result: null,
+        })),
+      } as any,
+      'message',
+    );
+
+    // Snapshot the initial run start time while the lane is `running`.
+    const inFlight = queue
+      .getDetailedStats()
+      .find((d) => d.folderKey === 'groupD@g.us');
+    const originalStartedAt = inFlight?.messageLane.startedAt;
+    expect(typeof originalStartedAt).toBe('number');
+
+    // Wait long enough for Date.now() to advance.
+    await Bun.sleep(10);
+
+    // Follow-up sendMessage on an already-running lane must NOT restamp
+    // startedAt — otherwise long-running/stuck runs get underreported on /ipc.
+    const sent = await queue.sendMessage('groupD@g.us', 'follow-up');
+    expect(sent).toBe(true);
+    const afterFollowUp = queue
+      .getDetailedStats()
+      .find((d) => d.folderKey === 'groupD@g.us');
+    expect(afterFollowUp?.messageLane.startedAt).toBe(originalStartedAt);
+
+    resolveRun!();
+    await Bun.sleep(5);
+  });
+
   it('clears startedAt/runningMs after a message run finishes', async () => {
     const queue = new GroupQueue({
       dataDir: '/tmp/omniclaw-test-data-msgage-done',

--- a/src/group-queue.test.ts
+++ b/src/group-queue.test.ts
@@ -1138,6 +1138,75 @@ describe('GroupQueue.getDetailedStats message lane run age', () => {
     expect(after?.messageLane.runningMs).toBeNull();
   });
 
+  it('clears startedAt/runningMs while in cooldown and restamps when sendMessage resumes', async () => {
+    const queue = new GroupQueue({
+      dataDir: '/tmp/omniclaw-test-data-msgage-cooldown',
+      maxActiveContainers: 1,
+      maxIdleContainers: 1,
+      maxTaskContainers: 1,
+      fsImpl: fsStub,
+    });
+
+    let resolveRun: (() => void) | null = null;
+    queue.setProcessMessagesFn(
+      () =>
+        new Promise<boolean>((resolve) => {
+          resolveRun = () => resolve(true);
+        }),
+    );
+
+    const backendSend = mock(() => true);
+    queue.enqueueMessageCheck('groupC@g.us');
+    await Bun.sleep(5);
+    queue.registerProcess(
+      'groupC@g.us',
+      { killed: false } as any,
+      'msg-ctr-c',
+      'groupC-folder',
+      {
+        sendMessage: backendSend,
+        closeStdin: mock(),
+        runAgent: mock(async () => ({
+          status: 'success' as const,
+          result: null,
+        })),
+      } as any,
+      'message',
+    );
+
+    // While running we have an age.
+    const inFlight = queue
+      .getDetailedStats()
+      .find((d) => d.folderKey === 'groupC@g.us');
+    expect(typeof inFlight?.messageLane.startedAt).toBe('number');
+    expect(typeof inFlight?.messageLane.runningMs).toBe('number');
+
+    // Entering cooldown clears the age so /ipc doesn't grow it while idle.
+    queue.notifyIdle('groupC@g.us');
+    const cooling = queue
+      .getDetailedStats()
+      .find((d) => d.folderKey === 'groupC@g.us');
+    expect(cooling?.messageLane.idle).toBe(true);
+    expect(cooling?.messageLane.startedAt).toBeNull();
+    expect(cooling?.messageLane.runningMs).toBeNull();
+
+    // Resuming via sendMessage stamps a fresh start time.
+    const beforeResume = Date.now();
+    const sent = await queue.sendMessage('groupC@g.us', 'wake up');
+    expect(sent).toBe(true);
+    const resumed = queue
+      .getDetailedStats()
+      .find((d) => d.folderKey === 'groupC@g.us');
+    expect(resumed?.messageLane.idle).toBe(false);
+    expect(typeof resumed?.messageLane.startedAt).toBe('number');
+    expect(resumed?.messageLane.startedAt).toBeGreaterThanOrEqual(beforeResume);
+    expect(typeof resumed?.messageLane.runningMs).toBe('number');
+    expect(resumed?.messageLane.runningMs).toBeGreaterThanOrEqual(0);
+
+    resolveRun!();
+    await Bun.sleep(5);
+  });
+
   it('clears startedAt/runningMs after a message run finishes', async () => {
     const queue = new GroupQueue({
       dataDir: '/tmp/omniclaw-test-data-msgage-done',

--- a/src/group-queue.test.ts
+++ b/src/group-queue.test.ts
@@ -1087,3 +1087,76 @@ describe('GroupQueue.getDetailedStats reason codes', () => {
     expect(fresh.getDetailedStats()).toEqual([]);
   });
 });
+
+describe('GroupQueue.getDetailedStats message lane run age', () => {
+  const fsStub = {
+    ...realFs,
+    mkdirSync: mock(),
+    writeFileSync: mock(),
+    renameSync: mock(),
+  };
+
+  it('reports startedAt/runningMs while a message run is in flight', async () => {
+    const queue = new GroupQueue({
+      dataDir: '/tmp/omniclaw-test-data-msgage',
+      maxActiveContainers: 1,
+      maxIdleContainers: 0,
+      maxTaskContainers: 1,
+      fsImpl: fsStub,
+    });
+
+    let resolveRun: (() => void) | null = null;
+    queue.setProcessMessagesFn(
+      () =>
+        new Promise<boolean>((resolve) => {
+          resolveRun = () => resolve(true);
+        }),
+    );
+
+    const before = Date.now();
+    queue.enqueueMessageCheck('groupA@g.us');
+    await Bun.sleep(5);
+
+    const inFlight = queue
+      .getDetailedStats()
+      .find((d) => d.folderKey === 'groupA@g.us');
+    expect(inFlight?.messageLane.active).toBe(true);
+    expect(typeof inFlight?.messageLane.startedAt).toBe('number');
+    expect(inFlight?.messageLane.startedAt).toBeGreaterThanOrEqual(before);
+    expect(typeof inFlight?.messageLane.runningMs).toBe('number');
+    expect(inFlight?.messageLane.runningMs).toBeGreaterThanOrEqual(0);
+
+    resolveRun!();
+    await Bun.sleep(5);
+
+    const after = queue
+      .getDetailedStats()
+      .find((d) => d.folderKey === 'groupA@g.us');
+    // After the run finishes the lane returns to idle and the timer clears.
+    expect(after?.messageLane.active).toBe(false);
+    expect(after?.messageLane.startedAt).toBeNull();
+    expect(after?.messageLane.runningMs).toBeNull();
+  });
+
+  it('clears startedAt/runningMs after a message run finishes', async () => {
+    const queue = new GroupQueue({
+      dataDir: '/tmp/omniclaw-test-data-msgage-done',
+      maxActiveContainers: 1,
+      maxIdleContainers: 0,
+      maxTaskContainers: 1,
+      fsImpl: fsStub,
+    });
+
+    queue.setProcessMessagesFn(async () => true);
+    queue.enqueueMessageCheck('groupB@g.us');
+    await Bun.sleep(20);
+
+    const detail = queue
+      .getDetailedStats()
+      .find((d) => d.folderKey === 'groupB@g.us');
+    // After completion the lane should be idle with timers cleared.
+    expect(detail?.messageLane.active).toBe(false);
+    expect(detail?.messageLane.startedAt).toBeNull();
+    expect(detail?.messageLane.runningMs).toBeNull();
+  });
+});

--- a/src/group-queue.ts
+++ b/src/group-queue.ts
@@ -527,6 +527,9 @@ export class GroupQueue {
     }
 
     this.transitionMessageLaneState(groupJid, 'cooldown');
+    // Clear the run timer when entering cooldown so /ipc doesn't show a
+    // growing "running age" while the lane is actually idle-waiting.
+    state.messageRunStartedAt = null;
 
     // A processing slot just freed up — let waiting messages start.
     this.drainWaitingMessages();
@@ -609,6 +612,9 @@ export class GroupQueue {
     }
     // Container was idle — mark it active again (single-method bookkeeping)
     this.transitionMessageLaneState(chatJid, 'running');
+    // Stamp the start of this resumed run so /ipc reports the age of the
+    // current message run, not the original container-start timer.
+    state.messageRunStartedAt = Date.now();
     const channelJid = toChannelJid(chatJid);
 
     // Use Effect-based queue if available

--- a/src/group-queue.ts
+++ b/src/group-queue.ts
@@ -610,11 +610,15 @@ export class GroupQueue {
     if (state.messageLaneState === 'idle' || !state.messageGroupFolder) {
       return false;
     }
-    // Container was idle — mark it active again (single-method bookkeeping)
-    this.transitionMessageLaneState(chatJid, 'running');
-    // Stamp the start of this resumed run so /ipc reports the age of the
-    // current message run, not the original container-start timer.
-    state.messageRunStartedAt = Date.now();
+    // Container was idle — mark it active again (single-method bookkeeping).
+    // Only restamp the run timer on a real cooldown → running transition;
+    // follow-up sendMessage() calls while already running must NOT reset
+    // messageRunStartedAt, otherwise long-running/stuck runs get underreported
+    // on /ipc every time a new message arrives.
+    const resumed = this.transitionMessageLaneState(chatJid, 'running');
+    if (resumed) {
+      state.messageRunStartedAt = Date.now();
+    }
     const channelJid = toChannelJid(chatJid);
 
     // Use Effect-based queue if available

--- a/src/group-queue.ts
+++ b/src/group-queue.ts
@@ -69,6 +69,18 @@ export interface GroupQueueDetail {
      * {@link deriveMessageLaneReasonFromDetail} when missing.
      */
     reason?: MessageLaneReason;
+    /**
+     * Epoch ms when the current message run started. Null when the lane is
+     * idle (cooldown or no work). Operators use this with {@link runningMs}
+     * to spot stuck or long-running message runs.
+     */
+    startedAt?: number | null;
+    /**
+     * Milliseconds elapsed since the current message run started. Null when
+     * the lane is idle. Derived as `Date.now() - startedAt` in
+     * {@link GroupQueue.getDetailedStats}.
+     */
+    runningMs?: number | null;
   };
   taskLane: {
     active: boolean;
@@ -158,6 +170,8 @@ interface GroupState {
   messageContainerName: string | null;
   messageGroupFolder: string | null;
   messageBackend: AgentBackend | null;
+  /** Epoch ms when the current message run started; null when idle. */
+  messageRunStartedAt: number | null;
   retryCount: number;
 
   // Task lane
@@ -262,6 +276,7 @@ export class GroupQueue {
         messageContainerName: null,
         messageGroupFolder: null,
         messageBackend: null,
+        messageRunStartedAt: null,
         retryCount: 0,
 
         taskActive: false,
@@ -313,6 +328,7 @@ export class GroupQueue {
     }
 
     this.transitionMessageLaneState(groupJid, 'running');
+    state.messageRunStartedAt = Date.now();
     this.dequeuePendingMessage(groupJid);
     this.activeCount++;
     return { started: true, processingCount };
@@ -325,6 +341,7 @@ export class GroupQueue {
     state.messageContainerName = null;
     state.messageGroupFolder = null;
     state.messageBackend = null;
+    state.messageRunStartedAt = null;
     this.activeCount--;
   }
 
@@ -946,6 +963,11 @@ export class GroupQueue {
           pendingCount: state.pendingMessageJids.length,
           containerName: state.messageContainerName,
           reason: messageReason,
+          startedAt: state.messageRunStartedAt,
+          runningMs:
+            state.messageRunStartedAt !== null
+              ? Date.now() - state.messageRunStartedAt
+              : null,
         },
         taskLane: {
           active: state.taskActive,

--- a/src/web/ipc-inspector.test.ts
+++ b/src/web/ipc-inspector.test.ts
@@ -244,6 +244,64 @@ describe('renderIpcInspector', () => {
     expect(html).toContain('&lt;script&gt;');
   });
 
+  it('renders message lane running age when runningMs is provided', () => {
+    const detail: GroupQueueDetail = {
+      folderKey: 'agent-epsilon',
+      messageLane: {
+        active: true,
+        idle: false,
+        pendingCount: 0,
+        containerName: 'ctr-eps-msg',
+        reason: 'running',
+        startedAt: Date.now() - 45000,
+        runningMs: 45000,
+      },
+      taskLane: {
+        active: false,
+        pendingCount: 0,
+        containerName: null,
+        activeTask: null,
+        reason: 'no-work',
+      },
+      retryCount: 0,
+    };
+    const html = renderIpcInspector(
+      makeState({ getQueueDetails: () => [detail] }),
+    );
+    expect(html).toContain('lane-age');
+    // 45000 ms formats as 45.0s
+    expect(html).toContain('45.0s');
+  });
+
+  it('omits message lane age when runningMs is null/undefined', () => {
+    const detail: GroupQueueDetail = {
+      folderKey: 'agent-zeta',
+      messageLane: {
+        active: false,
+        idle: false,
+        pendingCount: 0,
+        containerName: null,
+        reason: 'no-work',
+        startedAt: null,
+        runningMs: null,
+      },
+      taskLane: {
+        active: false,
+        pendingCount: 0,
+        containerName: null,
+        activeTask: null,
+        reason: 'no-work',
+      },
+      retryCount: 0,
+    };
+    const html = renderIpcInspector(
+      makeState({ getQueueDetails: () => [detail] }),
+    );
+    // The CSS rule for .lane-age is bundled in the shell, so only assert that
+    // no element with class="lane-age" is emitted in the rendered markup.
+    expect(html).not.toContain('class="lane-age"');
+  });
+
   it('allowlists lane reason codes before rendering class names', () => {
     const xssDetail: GroupQueueDetail = {
       folderKey: 'agent-xss',

--- a/src/web/ipc-inspector.ts
+++ b/src/web/ipc-inspector.ts
@@ -47,9 +47,14 @@ export function renderIpcInspectorContent(state: WebStateProvider): string {
         deriveTaskLaneReasonFromDetail(g),
         TASK_REASON_CODES,
       );
+      const msgRunningMs = g.messageLane.runningMs;
+      const msgAge =
+        typeof msgRunningMs === 'number' && msgRunningMs >= 0
+          ? `<span class="lane-age" title="running for ${escapeHtml(formatDuration(msgRunningMs))}">${escapeHtml(formatDuration(msgRunningMs))}</span>`
+          : '';
       return `<tr>
         <td class="folder-key">${escapeHtml(g.folderKey)}</td>
-        <td><span class="lane-badge lane-${msgStatus}">${msgStatus}</span>${msgReason}</td>
+        <td><span class="lane-badge lane-${msgStatus}">${msgStatus}</span>${msgReason}${msgAge}</td>
         <td>${g.messageLane.pendingCount}</td>
         <td><span class="lane-badge lane-${taskStatus}">${taskStatus}</span>${taskReason}</td>
         <td>${g.taskLane.pendingCount}</td>

--- a/src/web/shared.ts
+++ b/src/web/shared.ts
@@ -566,6 +566,7 @@ function shellCSS(): string {
     `.folder-key{font-size:11px}`,
     `.task-info{font-size:10px;color:var(--text-dim);max-width:300px;overflow:hidden;text-overflow:ellipsis;white-space:nowrap}`,
     `.retry-count{color:var(--yellow);font-weight:600}`,
+    `.lane-age{display:inline-block;font-size:9px;font-weight:500;padding:1px 5px;margin-left:4px;border-radius:3px;color:var(--text-dim);background:rgba(99,106,126,.08);font-variant-numeric:tabular-nums}`,
     `.event-time{font-size:10px;color:var(--text-dim);white-space:nowrap}`,
     `.event-source{font-size:11px;color:var(--blue)}`,
     `.event-summary{font-size:11px;max-width:500px;overflow:hidden;text-overflow:ellipsis;white-space:nowrap}`,


### PR DESCRIPTION
## Summary

Adds visibility into how long a message lane has been processing on `/ipc`, mirroring the existing task-lane `runningMs` surface.

- `GroupState` now tracks `messageRunStartedAt` (set in `startMessageRun`, cleared in `finishMessageRun`)
- `GroupQueueDetail.messageLane` exposes optional `startedAt` and `runningMs` fields
- IPC inspector renders a `.lane-age` badge next to the message-lane status whenever a run is in flight (e.g. `0.4s`, `2.1m`)
- New CSS class `.lane-age` styled consistently with `.lane-reason` (tabular numerals for monotonic readability)

## Motivation

Part of #644 (operator observability rollup). Acceptance criteria item:

> /ipc shows active runs per lane with current state and age

The task lane already shows `runningMs` via `activeTask.runningMs`. This PR closes the gap for the message lane so operators can spot stuck or long-running message runs at a glance.

## Verification

- `bun test` → 2026 pass / 0 fail (+3 new tests)
- `bunx tsc --noEmit` → clean
- New tests:
  - `GroupQueue.getDetailedStats message lane run age` — verifies `startedAt`/`runningMs` are populated in-flight and cleared on completion
  - `renderIpcInspector` — verifies the `.lane-age` badge is rendered when `runningMs` is provided and omitted when it is null

## Backward compatibility

The new `startedAt` / `runningMs` fields are optional on `GroupQueueDetail.messageLane`, so existing fixtures and external consumers remain valid. Reason-code derivation paths are untouched.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * The IPC inspector now displays message-lane run duration in the group queue view, showing real-time elapsed time for active message processing.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/omniaura/omniclaw/pull/688)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->