### PR TITLE
test: cover avatar and image cache edge cases

### DIFF
--- a/src/avatar-sync.test.ts
+++ b/src/avatar-sync.test.ts
@@ -71,6 +71,17 @@ afterEach(() => {
 });
 
 describe('detectDominantPlatform', () => {
+  it('returns the platform with the most matching subscriptions', () => {
+    expect(
+      detectDominantPlatform([
+        { channelJid: 'dc:general' },
+        { channelJid: 'slack:C123' },
+        { channelJid: 'slack:D456' },
+        { channelJid: 'tg:bot-1:-100' },
+      ]),
+    ).toBe('slack');
+  });
+
   it('ignores unknown channel prefixes and returns undefined when none match', () => {
     expect(
       detectDominantPlatform([
@@ -82,6 +93,22 @@ describe('detectDominantPlatform', () => {
 });
 
 describe('buildAvatarCandidates', () => {
+  it('skips subscriptions when no compatible channel can fetch avatars', () => {
+    const candidates = buildAvatarCandidates(
+      [
+        { channelJid: 'dc:123', discordBotId: 'MISSING' },
+        { channelJid: 'tg:bot-1:-100' },
+        { channelJid: 'slack:C123' },
+      ],
+      [
+        { ...makeChannel('discord', 'MISSING'), getAvatarUrl: undefined },
+        makeChannel('telegram', 'other-bot'),
+      ],
+    );
+
+    expect(candidates).toEqual([]);
+  });
+
   it('prefers the matching Discord bot for an agent', () => {
     const candidates = buildAvatarCandidates(
       [
@@ -112,6 +139,38 @@ describe('buildAvatarCandidates', () => {
     expect(candidates[0]?.platform).toBe('telegram');
     expect(candidates[0]?.identity).toBe('bot-1');
     expect(candidates[1]?.platform).toBe('slack');
+  });
+
+  it('uses deterministic platform ranking to break subscription-count ties', () => {
+    const candidates = buildAvatarCandidates(
+      [
+        { channelJid: 'dc:123', discordBotId: 'BOT' },
+        { channelJid: 'slack:C123' },
+        { channelJid: 'tg:bot-1:-100' },
+      ],
+      [
+        makeChannel('discord', 'BOT'),
+        makeChannel('slack'),
+        makeChannel('telegram', 'bot-1'),
+      ],
+    );
+
+    expect(candidates.map((candidate) => candidate.platform)).toEqual([
+      'telegram',
+      'slack',
+      'discord',
+    ]);
+  });
+
+  it('matches legacy Telegram subscriptions to legacy-capable channels', () => {
+    const candidates = buildAvatarCandidates(
+      [{ channelJid: 'tg:-10012345' }],
+      [makeChannel('telegram', 'ignored')],
+    );
+
+    expect(candidates).toHaveLength(1);
+    expect(candidates[0]?.platform).toBe('telegram');
+    expect(candidates[0]?.identity).toBe('legacy');
   });
 });
 

--- a/src/web/image-cache.test.ts
+++ b/src/web/image-cache.test.ts
@@ -37,6 +37,98 @@ describe('describeImageUrl', () => {
 });
 
 describe('serveCachedRemoteImage', () => {
+  it('serves a fresh safe cached image without resolving or fetching', async () => {
+    const testImageCacheDir = path.join(
+      DATA_DIR,
+      'image-cache-image-cache-test',
+      randomUUID(),
+    );
+
+    clearTestImageCache(testImageCacheDir);
+
+    try {
+      const cacheHash = createHash('sha256')
+        .update('fresh-cache-key')
+        .digest('hex');
+
+      fs.mkdirSync(testImageCacheDir, { recursive: true });
+      fs.writeFileSync(
+        path.join(testImageCacheDir, `${cacheHash}.bin`),
+        new Uint8Array([1, 2, 3]),
+      );
+      fs.writeFileSync(
+        path.join(testImageCacheDir, `${cacheHash}.json`),
+        JSON.stringify({
+          contentType: 'image/png; charset=binary',
+          fetchedAt: Date.now(),
+        }),
+      );
+
+      const response = await serveCachedRemoteImage(
+        'fresh-cache-key',
+        async () => {
+          throw new Error('fresh cache entry should not resolve upstream URL');
+        },
+        { cacheDir: testImageCacheDir },
+      );
+
+      expect(response).not.toBeNull();
+      expect(response!.headers.get('content-type')).toBe('image/png');
+      expect(response!.headers.get('x-content-type-options')).toBe('nosniff');
+      expect(await response!.arrayBuffer()).toEqual(
+        new Uint8Array([1, 2, 3]).buffer,
+      );
+    } finally {
+      clearTestImageCache(testImageCacheDir);
+    }
+  });
+
+  it('refreshes stale cached images from upstream', async () => {
+    const testImageCacheDir = path.join(
+      DATA_DIR,
+      'image-cache-image-cache-test',
+      randomUUID(),
+    );
+
+    clearTestImageCache(testImageCacheDir);
+
+    try {
+      const cacheHash = createHash('sha256')
+        .update('stale-cache-key')
+        .digest('hex');
+
+      fs.mkdirSync(testImageCacheDir, { recursive: true });
+      fs.writeFileSync(path.join(testImageCacheDir, `${cacheHash}.bin`), 'old');
+      fs.writeFileSync(
+        path.join(testImageCacheDir, `${cacheHash}.json`),
+        JSON.stringify({
+          contentType: 'image/png',
+          fetchedAt: Date.now() - 2 * 24 * 60 * 60 * 1000,
+        }),
+      );
+
+      const response = await serveCachedRemoteImage(
+        'stale-cache-key',
+        async () => 'https://93.184.216.34/avatar.png',
+        {
+          cacheDir: testImageCacheDir,
+          fetchImpl: (async () =>
+            new Response(new Uint8Array([9, 8, 7]), {
+              headers: { 'content-type': 'image/webp' },
+            })) as RemoteImageFetch,
+        },
+      );
+
+      expect(response).not.toBeNull();
+      expect(response!.headers.get('content-type')).toBe('image/webp');
+      expect(new Uint8Array(await response!.arrayBuffer())).toEqual(
+        new Uint8Array([9, 8, 7]),
+      );
+    } finally {
+      clearTestImageCache(testImageCacheDir);
+    }
+  });
+
   it('rejects loopback image urls before fetching', async () => {
     const testImageCacheDir = path.join(
       DATA_DIR,
@@ -436,6 +528,19 @@ describe('serveCachedRemoteImage byte cap', () => {
 });
 
 describe('validateRemoteImageUrl', () => {
+  it.each([
+    ['http://0.0.0.0/avatar.png', 'private address is not allowed'],
+    ['http://172.16.0.1/avatar.png', 'private address is not allowed'],
+    ['http://100.64.0.1/avatar.png', 'private address is not allowed'],
+    ['http://240.0.0.1/avatar.png', 'private address is not allowed'],
+    ['http://[fc00::1]/avatar.png', 'private address is not allowed'],
+    ['http://[fe80::1]/avatar.png', 'private address is not allowed'],
+    ['http://[ff02::1]/avatar.png', 'private address is not allowed'],
+    ['http://cdn.localhost/avatar.png', 'loopback host is not allowed'],
+  ])('rejects blocked local address %s', async (url, expected) => {
+    await expect(validateRemoteImageUrl(url)).resolves.toBe(expected);
+  });
+
   it('rejects localhost hosts', async () => {
     await expect(
       validateRemoteImageUrl('http://localhost:3000/avatar.png'),


### PR DESCRIPTION
## Summary

- Add deterministic avatar selection tests for dominant platform counting, candidate filtering, tie ranking, and legacy Telegram subscriptions.
- Add remote image cache tests for fresh cache replay, stale cache refresh, and SSRF guard coverage across private IPv4/IPv6/local host ranges.

## Test Count

- Before: `2027 pass, 0 fail, 5426 expect() calls`
- After: `2041 pass, 0 fail, 5447 expect() calls`

## Coverage

- Before: 90.03% line coverage overall
- After: 90.06% line coverage overall
- `src/avatar-sync.ts`: 97.33% -> 100.00% line coverage
- `src/web/image-cache.ts`: 92.89% -> 93.15% line coverage

## Verification

- `bun test src/web/image-cache.test.ts src/avatar-sync.test.ts`
- `bun test`
- `bun test --coverage`

## Remaining Gaps

- Large runtime adapters remain low coverage because they require heavier integration harnesses: `src/channels/discord.ts`, `src/channels/slack.ts`, `src/channels/telegram.ts`, `src/channels/whatsapp.ts`.
- Orchestrator and backend runtime paths remain the biggest uncovered areas: `src/index.ts`, `src/backends/local-backend.ts`, `src/discovery/routes.ts`, and `src/db.ts`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved test coverage for avatar synchronization platform selection logic, including dominant platform detection and legacy channel mapping.
  * Enhanced test coverage for image caching behavior, validating cache freshness and upstream refresh logic.
  * Expanded URL validation test suite to comprehensively cover private address ranges and loopback address blocking.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/omniaura/omniclaw/pull/690)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->