### PR TITLE
feat(web): roll up per-agent exec status on /system

### DIFF
--- a/src/web/system.test.ts
+++ b/src/web/system.test.ts
@@ -204,6 +204,109 @@ describe('buildHealthData', () => {
     expect(health.agents.total).toBe(0);
     expect(health.agents.by_backend).toEqual({});
     expect(health.agents.by_runtime).toEqual({});
+    expect(health.agents.by_exec_status).toEqual({
+      executing: 0,
+      'running-task': 0,
+      idle: 0,
+      queued: 0,
+      offline: 0,
+      disabled: 0,
+    });
+  });
+
+  it('rolls up agents by derived execution status', () => {
+    const agents = [
+      makeAgent({ id: 'a1', folder: 'g1' }),
+      makeAgent({ id: 'a2', folder: 'g2' }),
+      makeAgent({ id: 'a3', folder: 'g3' }),
+      makeAgent({ id: 'a4', folder: 'g-missing' }),
+      makeAgent({ id: 'a5', folder: 'g5', enabled: false }),
+    ];
+    const details: GroupQueueDetail[] = [
+      // executing: active and not idle
+      {
+        folderKey: 'g1',
+        messageLane: {
+          active: true,
+          idle: false,
+          pendingCount: 0,
+          containerName: 'g1-msg',
+        },
+        taskLane: {
+          active: false,
+          pendingCount: 0,
+          containerName: null,
+          activeTask: null,
+        },
+        retryCount: 0,
+      },
+      // running-task: task lane active
+      {
+        folderKey: 'g2',
+        messageLane: {
+          active: false,
+          idle: true,
+          pendingCount: 0,
+          containerName: 'g2-msg',
+        },
+        taskLane: {
+          active: true,
+          pendingCount: 0,
+          containerName: 'g2-task',
+          activeTask: {
+            taskId: 't',
+            promptPreview: 'p',
+            startedAt: Date.now(),
+            runningMs: 100,
+          },
+        },
+        retryCount: 0,
+      },
+      // idle: container alive but waiting
+      {
+        folderKey: 'g3',
+        messageLane: {
+          active: false,
+          idle: true,
+          pendingCount: 0,
+          containerName: 'g3-msg',
+        },
+        taskLane: {
+          active: false,
+          pendingCount: 0,
+          containerName: null,
+          activeTask: null,
+        },
+        retryCount: 0,
+      },
+      // g5 is in queue details but agent is disabled, so should count disabled
+      {
+        folderKey: 'g5',
+        messageLane: {
+          active: true,
+          idle: false,
+          pendingCount: 0,
+          containerName: 'g5-msg',
+        },
+        taskLane: {
+          active: false,
+          pendingCount: 0,
+          containerName: null,
+          activeTask: null,
+        },
+        retryCount: 0,
+      },
+    ];
+    const health = buildHealthData(makeState(agents, details), 0);
+    expect(health.agents.total).toBe(5);
+    expect(health.agents.by_exec_status).toEqual({
+      executing: 1, // a1
+      'running-task': 1, // a2
+      idle: 1, // a3
+      queued: 0,
+      offline: 1, // a4 (no queue detail)
+      disabled: 1, // a5 (enabled=false beats queue state)
+    });
   });
 
   it('reports zero queue rollup when no groups are tracked', () => {
@@ -564,6 +667,57 @@ describe('renderSystemContent', () => {
     // The g1 task lane has pending=1, active=false -> back-pressure count 1.
     expect(html).toContain(
       '<span class="breakdown-val" id="sys-queue-task-reason-back-pressure">1</span>',
+    );
+  });
+
+  it('renders agent exec-status rollup with stable IDs and exec-* classes', () => {
+    const agents = [
+      makeAgent({ id: 'a1', folder: 'g1' }),
+      makeAgent({ id: 'a2', folder: 'g-missing' }),
+      makeAgent({ id: 'a3', folder: 'g3', enabled: false }),
+    ];
+    const details: GroupQueueDetail[] = [
+      {
+        folderKey: 'g1',
+        messageLane: {
+          active: true,
+          idle: false,
+          pendingCount: 0,
+          containerName: 'g1-msg',
+        },
+        taskLane: {
+          active: false,
+          pendingCount: 0,
+          containerName: null,
+          activeTask: null,
+        },
+        retryCount: 0,
+      },
+    ];
+    const html = renderSystemContent(makeState(agents, details), 0);
+    expect(html).toContain('by state');
+    for (const status of [
+      'executing',
+      'running-task',
+      'idle',
+      'queued',
+      'offline',
+      'disabled',
+    ]) {
+      expect(html).toContain(`id="sys-agents-state-${status}"`);
+      expect(html).toContain(`exec-${status}`);
+    }
+    // a1 (g1) -> executing
+    expect(html).toContain(
+      '<span class="breakdown-val" id="sys-agents-state-executing">1</span>',
+    );
+    // a2 (g-missing) -> offline
+    expect(html).toContain(
+      '<span class="breakdown-val" id="sys-agents-state-offline">1</span>',
+    );
+    // a3 (enabled=false) -> disabled
+    expect(html).toContain(
+      '<span class="breakdown-val" id="sys-agents-state-disabled">1</span>',
     );
   });
 

--- a/src/web/system.ts
+++ b/src/web/system.ts
@@ -8,6 +8,7 @@ import {
   type MessageLaneReason,
   type TaskLaneReason,
 } from '../group-queue.js';
+import { getAgentExecStatus, type AgentExecStatus } from './agents-page.js';
 import { renderShell, escapeHtml } from './shared.js';
 import { allPageScripts } from './page-scripts.js';
 
@@ -23,6 +24,15 @@ const TASK_LANE_REASONS: readonly TaskLaneReason[] = [
   'running',
   'back-pressure',
   'no-work',
+];
+
+const AGENT_EXEC_STATUSES: readonly AgentExecStatus[] = [
+  'executing',
+  'running-task',
+  'idle',
+  'queued',
+  'offline',
+  'disabled',
 ];
 
 export interface HealthData {
@@ -55,6 +65,12 @@ export interface HealthData {
     total: number;
     by_backend: Record<string, number>;
     by_runtime: Record<string, number>;
+    /**
+     * Count of local agents by derived execution status (idle, executing,
+     * running-task, queued, offline, disabled). Mirrors the per-agent badge
+     * shown on the /agents page so /system and /agents agree on the rollup.
+     */
+    by_exec_status: Record<AgentExecStatus, number>;
   };
   containers: {
     active: number;
@@ -132,9 +148,22 @@ export function buildHealthData(
 
   const byBackend: Record<string, number> = {};
   const byRuntime: Record<string, number> = {};
+  const byExecStatus: Record<AgentExecStatus, number> = {
+    executing: 0,
+    'running-task': 0,
+    idle: 0,
+    queued: 0,
+    offline: 0,
+    disabled: 0,
+  };
   for (const agent of agents) {
     byBackend[agent.backend] = (byBackend[agent.backend] || 0) + 1;
     byRuntime[agent.agentRuntime] = (byRuntime[agent.agentRuntime] || 0) + 1;
+    const status: AgentExecStatus =
+      agent.enabled === false
+        ? 'disabled'
+        : getAgentExecStatus(agent.folder, queueDetails);
+    byExecStatus[status]++;
   }
 
   let activeTasks = 0,
@@ -203,6 +232,7 @@ export function buildHealthData(
       total: agents.length,
       by_backend: byBackend,
       by_runtime: byRuntime,
+      by_exec_status: byExecStatus,
     },
     containers: {
       active: Math.max(0, stats.activeContainers - stats.idleContainers),
@@ -280,12 +310,13 @@ function reasonRollup<T extends string>(
   obj: Record<T, number>,
   order: readonly T[],
   idPrefix: string,
+  keyClassPrefix: string = 'reason',
 ): string {
   return order
     .map(
       (reason) =>
         `<div class="breakdown-item">` +
-        `<span class="breakdown-key reason-${reason}">${escapeHtml(reason)}</span>` +
+        `<span class="breakdown-key ${keyClassPrefix}-${reason}">${escapeHtml(reason)}</span>` +
         `<span class="breakdown-val" id="${idPrefix}-${reason}">${obj[reason] ?? 0}</span>` +
         `</div>`,
     )
@@ -389,6 +420,13 @@ export function renderSystemContent(
     metricCard(
       'agents',
       metricRow('total', String(health.agents.total), 'sys-agents-total') +
+        `<div class="metric-sub">by state</div>` +
+        reasonRollup(
+          health.agents.by_exec_status,
+          AGENT_EXEC_STATUSES,
+          'sys-agents-state',
+          'exec',
+        ) +
         `<div class="metric-sub">by backend</div>` +
         breakdownList(health.agents.by_backend) +
         `<div class="metric-sub">by runtime</div>` +


### PR DESCRIPTION
## Summary

Adds a *per-agent execution status rollup* to the `/system` page agents card, closing the per-agent state breakdown acceptance criterion in #644 (operator observability rollup).

Today an operator can see total agent count plus a breakdown by backend and runtime, but no aggregate view of how many agents are actually executing, idle, queued, offline, or disabled. The `/agents` page already surfaces this per-row via `getAgentExecStatus`; this PR rolls that derivation up to `/system` so a single glance shows the fleet state.

## What changed

- `HealthData.agents` gains a new optional rollup field, `by_exec_status: Record<AgentExecStatus, number>` (no breaking changes — existing fields preserved).
- `buildHealthData` derives the status for each local agent via the existing `getAgentExecStatus(folder, queueDetails)` helper, with the same `enabled === false → 'disabled'` override that `/agents` already uses.
- The agents metric card now renders a *by state* breakdown above the existing backend/runtime breakdowns. Rows have stable IDs (`sys-agents-state-{status}`) so live updates can target them, and the key spans use the same `exec-*` CSS classes already styled in `shared.ts`.
- The shared `reasonRollup` helper grew an optional `keyClassPrefix` parameter (default `reason`) so the same renderer powers queue reason rollups (`reason-*`) and agent state rollups (`exec-*`) — no duplicated rendering logic.

## Why this surface (and not a new page)

Per #644's scope, observability work should extend `/ipc` and `/system` rather than add new top-level routes. The agents card on `/system` already groups agent-related metrics, and the new rollup answers the most common at-a-glance question ("how many agents are doing real work right now?") without leaving the existing layout.

## Tests

2 new tests, 0 regressions:

- `buildHealthData → rolls up agents by derived execution status` — exercises executing / running-task / idle / offline / disabled buckets together, including the `enabled=false` override beating an active queue lane.
- `renderSystemContent → renders agent exec-status rollup with stable IDs and exec-* classes` — verifies all six bucket IDs and CSS classes are present and counts are correct for executing/offline/disabled.
- Updated `handles zero agents` to assert all six buckets initialize to 0.

Full suite: `bun test` → *2029 pass / 0 fail*, `bunx tsc --noEmit` → clean.

## Backward compatibility

`by_exec_status` is an additive field on `HealthData.agents`; no existing fixtures or API consumers need to change. `reasonRollup`'s new parameter is optional and defaults to the prior `reason-*` class prefix.

Toward #644.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * The system page now displays a breakdown of agents by execution state (executing, running task, idle, queued, offline, disabled).

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/omniaura/omniclaw/pull/693)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->