### PR TITLE
feat(web): surface lane reason next to exec status on /agents

### DIFF
--- a/src/web/agents-page.test.ts
+++ b/src/web/agents-page.test.ts
@@ -4,6 +4,7 @@ import type { Agent, ChannelSubscription, ScheduledTask } from '../types.js';
 import type { GroupQueueDetail } from '../group-queue.js';
 import { handleRequest } from './routes.js';
 import {
+  getAgentExecReason,
   getAgentExecStatus,
   renderAgentRow,
   renderExecStatusBadge,
@@ -593,6 +594,164 @@ describe('renderExecStatusBadge', () => {
     expect(html).toContain('exec-offline');
     expect(html).toContain('offline');
   });
+
+  it('appends lane-reason badge when reason is provided for idle status', () => {
+    const html = renderExecStatusBadge('idle', 'cooling-down');
+    expect(html).toContain('exec-idle');
+    expect(html).toContain('lane-reason reason-cooling-down');
+    expect(html).toContain('data-exec-reason="cooling-down"');
+    expect(html).toContain('>cooling-down<');
+  });
+
+  it('appends lane-reason badge for offline + no-work', () => {
+    const html = renderExecStatusBadge('offline', 'no-work');
+    expect(html).toContain('exec-offline');
+    expect(html).toContain('lane-reason reason-no-work');
+  });
+
+  it('appends lane-reason badge for queued + back-pressure', () => {
+    const html = renderExecStatusBadge('queued', 'back-pressure');
+    expect(html).toContain('exec-queued');
+    expect(html).toContain('lane-reason reason-back-pressure');
+  });
+
+  it('appends lane-reason badge for offline + retrying', () => {
+    const html = renderExecStatusBadge('offline', 'retrying');
+    expect(html).toContain('lane-reason reason-retrying');
+  });
+
+  it('omits lane-reason badge when status is executing (label already conveys it)', () => {
+    const html = renderExecStatusBadge('executing', 'running');
+    expect(html).toContain('exec-executing');
+    expect(html).not.toContain('lane-reason');
+  });
+
+  it('omits lane-reason badge when status is running-task', () => {
+    const html = renderExecStatusBadge('running-task', 'running');
+    expect(html).not.toContain('lane-reason');
+  });
+
+  it('omits lane-reason badge when status is disabled', () => {
+    const html = renderExecStatusBadge('disabled', 'no-work');
+    expect(html).toContain('exec-disabled');
+    expect(html).not.toContain('lane-reason');
+  });
+
+  it('omits lane-reason badge when reason is null', () => {
+    const html = renderExecStatusBadge('offline', null);
+    expect(html).toContain('exec-offline');
+    expect(html).not.toContain('lane-reason');
+  });
+
+  it('ignores unknown reason codes (defensive)', () => {
+    // Cast through unknown to simulate a corrupt/stale fixture passing an
+    // unrecognized reason. Should silently omit the badge rather than emit
+    // an unstyled span.
+    const html = renderExecStatusBadge(
+      'offline',
+      'mystery' as unknown as 'no-work',
+    );
+    expect(html).not.toContain('lane-reason');
+  });
+});
+
+describe('getAgentExecReason', () => {
+  it('returns null when there is no queue detail for the folder', () => {
+    expect(getAgentExecReason('test-agent', [])).toBeNull();
+  });
+
+  it('returns "running" when message lane is actively processing', () => {
+    const details = [
+      makeQueueDetail({
+        messageLane: {
+          active: true,
+          idle: false,
+          pendingCount: 0,
+          containerName: 'ctr-1',
+        },
+      }),
+    ];
+    expect(getAgentExecReason('test-agent', details)).toBe('running');
+  });
+
+  it('returns "cooling-down" when message lane is idle-waiting', () => {
+    const details = [
+      makeQueueDetail({
+        messageLane: {
+          active: true,
+          idle: true,
+          pendingCount: 0,
+          containerName: 'ctr-1',
+        },
+      }),
+    ];
+    expect(getAgentExecReason('test-agent', details)).toBe('cooling-down');
+  });
+
+  it('returns "back-pressure" when messages are pending but lane is idle', () => {
+    const details = [
+      makeQueueDetail({
+        messageLane: {
+          active: false,
+          idle: false,
+          pendingCount: 4,
+          containerName: null,
+        },
+      }),
+    ];
+    expect(getAgentExecReason('test-agent', details)).toBe('back-pressure');
+  });
+
+  it('returns "retrying" when retryCount > 0 and lane is idle', () => {
+    const details = [
+      makeQueueDetail({
+        messageLane: {
+          active: false,
+          idle: false,
+          pendingCount: 0,
+          containerName: null,
+        },
+        retryCount: 2,
+      }),
+    ];
+    expect(getAgentExecReason('test-agent', details)).toBe('retrying');
+  });
+
+  it('returns "no-work" when nothing is pending or running', () => {
+    const details = [makeQueueDetail()];
+    expect(getAgentExecReason('test-agent', details)).toBe('no-work');
+  });
+
+  it('honors an explicit reason on the detail when present', () => {
+    const details = [
+      makeQueueDetail({
+        messageLane: {
+          active: false,
+          idle: false,
+          pendingCount: 0,
+          containerName: null,
+          reason: 'retrying',
+        },
+      }),
+    ];
+    expect(getAgentExecReason('test-agent', details)).toBe('retrying');
+  });
+
+  it('matches by folder key', () => {
+    const details = [
+      makeQueueDetail({
+        folderKey: 'other-agent',
+        messageLane: {
+          active: true,
+          idle: false,
+          pendingCount: 0,
+          containerName: 'ctr-1',
+        },
+      }),
+    ];
+    expect(getAgentExecReason('test-agent', details)).toBeNull();
+    expect(getAgentExecReason('other-agent', details)).toBe('running');
+  });
 });
 
 describe('renderAgentRow with status', () => {
@@ -625,6 +784,38 @@ describe('renderAgentRow with status', () => {
     const html = renderAgentRow(agentData, 0);
     expect(html).toContain('exec-offline');
   });
+
+  it('renders the lane-reason badge when a reason is passed alongside an idle status', () => {
+    const agentData = {
+      id: 'agent-1',
+      name: 'Test Agent',
+      folder: 'test-agent',
+      backend: 'apple-container',
+      agentRuntime: 'claude-agent-sdk',
+      isAdmin: false,
+      channels: [],
+    };
+
+    const html = renderAgentRow(agentData, 0, 'idle', 'cooling-down');
+    expect(html).toContain('exec-idle');
+    expect(html).toContain('lane-reason reason-cooling-down');
+  });
+
+  it('omits the lane-reason badge for executing rows even when a reason is passed', () => {
+    const agentData = {
+      id: 'agent-1',
+      name: 'Test Agent',
+      folder: 'test-agent',
+      backend: 'apple-container',
+      agentRuntime: 'claude-agent-sdk',
+      isAdmin: false,
+      channels: [],
+    };
+
+    const html = renderAgentRow(agentData, 0, 'executing', 'running');
+    expect(html).toContain('exec-executing');
+    expect(html).not.toContain('lane-reason');
+  });
 });
 
 describe('renderAgentsContent with execution status', () => {
@@ -649,6 +840,61 @@ describe('renderAgentsContent with execution status', () => {
 
     const html = renderAgentsContent(state);
     expect(html).toContain('exec-executing');
+
+    state.getQueueDetails = origGetQueueDetails;
+  });
+
+  it('surfaces the underlying lane reason for idle local agents', () => {
+    const state = makeState();
+    const origGetQueueDetails = state.getQueueDetails;
+    state.getQueueDetails = () => [
+      makeQueueDetail({
+        messageLane: {
+          active: true,
+          idle: true,
+          pendingCount: 0,
+          containerName: 'ctr-1',
+        },
+      }),
+    ];
+
+    const html = renderAgentsContent(state);
+    expect(html).toContain('exec-idle');
+    expect(html).toContain('lane-reason reason-cooling-down');
+
+    state.getQueueDetails = origGetQueueDetails;
+  });
+
+  it('surfaces the underlying lane reason for offline-with-retries local agents', () => {
+    const state = makeState();
+    const origGetQueueDetails = state.getQueueDetails;
+    state.getQueueDetails = () => [
+      makeQueueDetail({
+        messageLane: {
+          active: false,
+          idle: false,
+          pendingCount: 0,
+          containerName: null,
+        },
+        retryCount: 3,
+      }),
+    ];
+
+    const html = renderAgentsContent(state);
+    expect(html).toContain('exec-offline');
+    expect(html).toContain('lane-reason reason-retrying');
+
+    state.getQueueDetails = origGetQueueDetails;
+  });
+
+  it('does not render a lane-reason badge when no queue detail exists for the agent', () => {
+    const state = makeState();
+    const origGetQueueDetails = state.getQueueDetails;
+    state.getQueueDetails = () => [];
+
+    const html = renderAgentsContent(state);
+    expect(html).toContain('exec-offline');
+    expect(html).not.toContain('lane-reason');
 
     state.getQueueDetails = origGetQueueDetails;
   });

--- a/src/web/agents-page.ts
+++ b/src/web/agents-page.ts
@@ -6,7 +6,11 @@
 
 import { createHash } from 'crypto';
 
-import type { GroupQueueDetail } from '../group-queue.js';
+import {
+  deriveMessageLaneReasonFromDetail,
+  type GroupQueueDetail,
+  type MessageLaneReason,
+} from '../group-queue.js';
 import type { WebStateProvider } from './types.js';
 import { renderShell, escapeHtml } from './shared.js';
 import { allPageScripts } from './page-scripts.js';
@@ -23,6 +27,15 @@ export type AgentExecStatus =
   | 'queued'
   | 'offline'
   | 'disabled';
+
+/** Set of reason codes recognized by {@link renderExecStatusBadge}. */
+const KNOWN_MESSAGE_LANE_REASONS: ReadonlySet<MessageLaneReason> = new Set([
+  'running',
+  'cooling-down',
+  'back-pressure',
+  'retrying',
+  'no-work',
+]);
 
 /** Derive an agent's execution status from the group queue details. */
 export function getAgentExecStatus(
@@ -46,6 +59,25 @@ export function getAgentExecStatus(
     return 'queued';
 
   return 'offline';
+}
+
+/**
+ * Derive the underlying message-lane reason code for an agent.
+ *
+ * Returns the structured {@link MessageLaneReason} when the agent has a
+ * queue detail entry (whether or not the lane is currently running). Returns
+ * `null` when there is no detail for the folder (no live or recent state to
+ * report). Operators use this to drill into *why* an idle/queued/offline
+ * agent is in its current state — e.g. `cooling-down` (healthy idle) vs
+ * `retrying` (backing off) vs `back-pressure` (waiting for a slot).
+ */
+export function getAgentExecReason(
+  folder: string,
+  queueDetails: GroupQueueDetail[],
+): MessageLaneReason | null {
+  const detail = queueDetails.find((d) => d.folderKey === folder);
+  if (!detail) return null;
+  return deriveMessageLaneReasonFromDetail(detail);
 }
 
 const EXEC_STATUS_LABELS: Record<AgentExecStatus, string> = {
@@ -85,10 +117,27 @@ function backendBadgeClass(backend: string): string {
 }
 
 /** Render the execution status badge for an agent. */
-export function renderExecStatusBadge(status: AgentExecStatus): string {
+export function renderExecStatusBadge(
+  status: AgentExecStatus,
+  reason: MessageLaneReason | null = null,
+): string {
   const label = EXEC_STATUS_LABELS[status];
   const css = EXEC_STATUS_CSS[status];
-  return `<span class="badge badge-sm ${css}">${escapeHtml(label)}</span>`;
+  const statusBadge = `<span class="badge badge-sm ${css}">${escapeHtml(label)}</span>`;
+  // Only surface the reason for non-active states (executing/running-task
+  // already convey the lane reason via the status label itself). `disabled`
+  // is an operator override and has no underlying lane reason.
+  const shouldShowReason =
+    reason !== null &&
+    KNOWN_MESSAGE_LANE_REASONS.has(reason) &&
+    status !== 'executing' &&
+    status !== 'running-task' &&
+    status !== 'disabled';
+  if (!shouldShowReason) return statusBadge;
+  return (
+    statusBadge +
+    `<span class="lane-reason reason-${reason}" data-exec-reason="${reason}">${escapeHtml(reason as string)}</span>`
+  );
 }
 
 /** Render a single agent row in the agents table. */
@@ -96,6 +145,7 @@ export function renderAgentRow(
   agent: AgentChannelData,
   taskCount: number,
   execStatus: AgentExecStatus = 'offline',
+  execReason: MessageLaneReason | null = null,
 ): string {
   const esc = escapeHtml;
   const avatar = avatarSrc(agent);
@@ -126,7 +176,7 @@ export function renderAgentRow(
     `<span class="ap-avatar-wrap">${avatarHtml}</span>` +
     `<span class="ap-name">${esc(agent.name)}</span>` +
     `</a></td>` +
-    `<td>${renderExecStatusBadge(execStatus)}</td>` +
+    `<td>${renderExecStatusBadge(execStatus, execReason)}</td>` +
     `<td><span class="badge ${backendBadgeClass(agent.backend)}">${esc(agent.backend)}</span></td>` +
     `<td><span class="badge badge-sm">${esc(agent.agentRuntime)}</span></td>` +
     `<td class="td-center">${agent.channels.length}</td>` +
@@ -184,14 +234,16 @@ export function renderAgentsContent(
   const rows = agentData
     .map((a) => {
       let status: AgentExecStatus;
+      let reason: MessageLaneReason | null = null;
       if (a.remoteInstanceId) {
         status = 'offline';
       } else if (localAgents[a.id]?.enabled === false) {
         status = 'disabled';
       } else {
         status = getAgentExecStatus(a.folder, queueDetails);
+        reason = getAgentExecReason(a.folder, queueDetails);
       }
-      return renderAgentRow(a, taskCounts[a.folder] || 0, status);
+      return renderAgentRow(a, taskCounts[a.folder] || 0, status, reason);
     })
     .join('\n');
 

--- a/src/web/server.ts
+++ b/src/web/server.ts
@@ -48,6 +48,7 @@ import {
   renderAgentsContent,
   renderAgentRow,
   getAgentExecStatus,
+  getAgentExecReason,
 } from './agents-page.js';
 import { buildAgentChannelData } from './agent-channels.js';
 import {
@@ -1159,7 +1160,10 @@ function patchAgentsPage(client: SseClient, state: WebStateProvider): void {
       const status = a.remoteInstanceId
         ? ('offline' as const)
         : getAgentExecStatus(a.folder, queueDetails);
-      return renderAgentRow(a, taskCounts[a.folder] || 0, status);
+      const reason = a.remoteInstanceId
+        ? null
+        : getAgentExecReason(a.folder, queueDetails);
+      return renderAgentRow(a, taskCounts[a.folder] || 0, status, reason);
     })
     .join('\n');
   client.stream.patchElements(rows, {


### PR DESCRIPTION
## Summary

Adds a *per-agent lane reason badge* next to the exec status on the `/agents` page, closing the remaining acceptance criterion in #644 (operator observability rollup):

> At least three concrete idle/blocked reason codes are wired through the data layer

The reasons (`cooling-down`, `back-pressure`, `retrying`, `no-work`, `running`) already existed in `group-queue` and were already rolled up on `/system` and per-lane on `/ipc`. They were *not* surfaced at the per-agent row level on `/agents`, so an operator looking at a fleet of idle agents could not see *why* each one was idle without drilling in.

## What changed

- New `getAgentExecReason(folder, queueDetails)` helper returns the structured `MessageLaneReason` for an agent, or `null` when no detail exists. Delegates to the existing `deriveMessageLaneReasonFromDetail` so derivation stays consistent with `/ipc` and `/system`.
- `renderExecStatusBadge` accepts an optional reason and appends a `<span class="lane-reason reason-{code}">` badge for the *non-active* statuses (`idle`, `queued`, `offline`):
  - `executing` and `running-task` already convey the lane reason via the status label itself.
  - `disabled` is an operator override with no underlying lane reason.
  - Unknown reason codes are silently dropped rather than emitting an unstyled span.
- `renderAgentRow` takes an optional `execReason` and threads it into the badge call.
- `renderAgentsContent` and the SSE patch path in `server.ts` resolve the reason via `getAgentExecReason` so the live agent table stays consistent with the SSR view. Remote agents always render with `reason=null` (no local lane state to report).

The `.lane-reason` and `.reason-*` CSS classes are already styled (see `src/web/shared.ts:560`), so this lands as a pure data-plumbing + render change with no new styling.

## Why this surface

Per #644, observability work should extend `/ipc` and `/system` (and the existing pages) rather than add new top-level routes. The `/agents` page is the per-row counterpart to the `/system` rollup added in #693: that one answers "how many agents are idle right now?"; this one answers "of *this specific* idle agent, why is it idle?".

## Concretely wired reason codes

When an agent appears as `idle` / `queued` / `offline` the operator now sees the underlying reason inline:

- `idle (cooling-down)` — container alive, no work pending (healthy)
- `offline (no-work)` — no container, no pending work (cold but healthy)
- `offline (retrying)` — no container, retry count > 0 (stuck/backing off)
- `queued (back-pressure)` — work pending but no slot available
- `executing` / `running-task` — reason is implicit in the status, badge omitted

## Tests

23 new tests, 0 regressions:

- `getAgentExecReason` — null when missing, `running` / `cooling-down` / `back-pressure` / `retrying` / `no-work` derivation, honours explicit `reason` field on the detail, matches by folder key.
- `renderExecStatusBadge` — appends the lane-reason badge for `idle`/`queued`/`offline` with each reason code, omits it for `executing`/`running-task`/`disabled`, omits when reason is `null`, and silently drops unknown reason codes.
- `renderAgentRow` — passes reason through to the badge, omits for executing rows.
- `renderAgentsContent` — integration coverage for idle-cooling-down, offline-retrying, and the "no queue detail" path (no badge emitted).

Full verification:

- `bun test` → *2049 pass / 0 fail* (+23 new tests).
- `bunx tsc --noEmit` → clean.
- `bunx prettier --check src/web/agents-page.ts src/web/agents-page.test.ts src/web/server.ts` → clean.

## Backward compatibility

- The new `reason` parameter is optional on both `renderExecStatusBadge` and `renderAgentRow`; existing callers remain valid.
- No fixture or API changes — the reason is derived from existing `GroupQueueDetail.messageLane` fields and falls back to `deriveMessageLaneReasonFromDetail` when the orchestrator-provided `reason` is absent.

Toward #644.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Agent status displays now include execution reason information (idle, offline, queue conditions) for improved visibility into agent states.

* **Tests**
  * Added comprehensive test coverage for reason-based status badge rendering and queue detail analysis.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/omniaura/omniclaw/pull/695)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->