### PR TITLE
feat(web): surface longest running task age on /system

### DIFF
--- a/src/web/system.test.ts
+++ b/src/web/system.test.ts
@@ -623,6 +623,91 @@ describe('renderSystemContent', () => {
     expect(html).toContain(
       '<span class="metric-value" id="sys-queue-pending-messages">7</span>',
     );
+    // longest running task duration row is present
+    expect(html).toContain('id="sys-queue-longest-running"');
+  });
+
+  it('surfaces the longest running task age across all task lanes', () => {
+    const details: GroupQueueDetail[] = [
+      {
+        folderKey: 'g1',
+        messageLane: {
+          active: false,
+          idle: true,
+          pendingCount: 0,
+          containerName: null,
+        },
+        taskLane: {
+          active: true,
+          pendingCount: 0,
+          containerName: 'g1-task',
+          activeTask: {
+            taskId: 't-short',
+            promptPreview: 'p',
+            startedAt: Date.now(),
+            runningMs: 500,
+          },
+        },
+        retryCount: 0,
+      },
+      {
+        folderKey: 'g2',
+        messageLane: {
+          active: false,
+          idle: true,
+          pendingCount: 0,
+          containerName: null,
+        },
+        taskLane: {
+          active: true,
+          pendingCount: 0,
+          containerName: 'g2-task',
+          activeTask: {
+            taskId: 't-long',
+            promptPreview: 'p',
+            startedAt: Date.now(),
+            runningMs: 125_000,
+          },
+        },
+        retryCount: 0,
+      },
+    ];
+    const health = buildHealthData(makeState([makeAgent()], details), 0);
+    expect(health.queue.longest_running_task_ms).toBe(125_000);
+    const html = renderSystemContent(makeState([makeAgent()], details), 0);
+    // 125000ms => 2.1m via the IPC inspector's formatter
+    expect(html).toContain(
+      '<span class="metric-value" id="sys-queue-longest-running">2.1m</span>',
+    );
+  });
+
+  it('renders an em-dash for longest running when no tasks are running', () => {
+    const details: GroupQueueDetail[] = [
+      {
+        folderKey: 'g1',
+        messageLane: {
+          active: false,
+          idle: true,
+          pendingCount: 0,
+          containerName: null,
+        },
+        taskLane: {
+          active: false,
+          pendingCount: 0,
+          containerName: null,
+          activeTask: null,
+        },
+        retryCount: 0,
+      },
+    ];
+    const health = buildHealthData(makeState([makeAgent()], details), 0);
+    expect(health.queue.running_tasks).toBe(0);
+    expect(health.queue.longest_running_task_ms).toBe(0);
+    const html = renderSystemContent(makeState([makeAgent()], details), 0);
+    // em-dash placeholder when no task is running
+    expect(html).toContain(
+      '<span class="metric-value" id="sys-queue-longest-running">\u2014</span>',
+    );
   });
 
   it('renders message and task lane reason rollups with stable IDs', () => {

--- a/src/web/system.ts
+++ b/src/web/system.ts
@@ -95,6 +95,12 @@ export interface HealthData {
     processing_groups: number;
     /** Number of groups whose task lane has a task running. */
     running_tasks: number;
+    /**
+     * Longest currently-running task age in milliseconds across all task lanes.
+     * Zero when no task is running. Useful for spotting stuck or long-running
+     * tasks without drilling into /ipc.
+     */
+    longest_running_task_ms: number;
     /** Sum of consecutive retry counts across all group folders. */
     retrying_groups: number;
     /**
@@ -179,6 +185,7 @@ export function buildHealthData(
   let pendingTasks = 0;
   let processingGroups = 0;
   let runningTasks = 0;
+  let longestRunningTaskMs = 0;
   let retryingGroups = 0;
   const messageLaneReasons: Record<MessageLaneReason, number> = {
     running: 0,
@@ -196,7 +203,12 @@ export function buildHealthData(
     pendingMessages += g.messageLane.pendingCount;
     pendingTasks += g.taskLane.pendingCount;
     if (g.messageLane.active) processingGroups++;
-    if (g.taskLane.activeTask) runningTasks++;
+    if (g.taskLane.activeTask) {
+      runningTasks++;
+      if (g.taskLane.activeTask.runningMs > longestRunningTaskMs) {
+        longestRunningTaskMs = g.taskLane.activeTask.runningMs;
+      }
+    }
     if (g.retryCount > 0) retryingGroups++;
     messageLaneReasons[deriveMessageLaneReasonFromDetail(g)]++;
     taskLaneReasons[deriveTaskLaneReasonFromDetail(g)]++;
@@ -252,6 +264,7 @@ export function buildHealthData(
       pending_tasks: pendingTasks,
       processing_groups: processingGroups,
       running_tasks: runningTasks,
+      longest_running_task_ms: longestRunningTaskMs,
       retrying_groups: retryingGroups,
       message_lane_reasons: messageLaneReasons,
       task_lane_reasons: taskLaneReasons,
@@ -259,6 +272,17 @@ export function buildHealthData(
     sse_clients: sseClientCount,
     started_at: startedAt,
   };
+}
+
+/**
+ * Format a millisecond duration for human-friendly display in operator surfaces.
+ * Mirrors the helper used by the IPC inspector so the unit progression matches:
+ * `<1s` → ms, `<1m` → seconds (one decimal), otherwise minutes (one decimal).
+ */
+function formatDuration(ms: number): string {
+  if (ms < 1000) return `${ms}ms`;
+  if (ms < 60000) return `${(ms / 1000).toFixed(1)}s`;
+  return `${(ms / 60000).toFixed(1)}m`;
 }
 
 function formatUptime(seconds: number): string {
@@ -457,6 +481,13 @@ export function renderSystemContent(
           'running tasks',
           String(health.queue.running_tasks),
           'sys-queue-running-tasks',
+        ) +
+        metricRow(
+          'longest running',
+          health.queue.running_tasks > 0
+            ? formatDuration(health.queue.longest_running_task_ms)
+            : '\u2014',
+          'sys-queue-longest-running',
         ) +
         metricRow(
           'pending msgs',


### PR DESCRIPTION
## Summary

Adds a *longest running task age* metric to the queue card on `/system`, helping operators spot stuck or long-running tasks from the system health page without drilling into `/ipc`.

- `HealthData.queue` gets a new `longest_running_task_ms: number` field, computed as the max of `taskLane.activeTask.runningMs` across all group folders (0 when no task is running).
- The queue card on `/system` renders a new `longest running` metric row directly under `running tasks`, formatted with the same unit progression as the IPC inspector (`<1s` → ms, `<1m` → seconds, otherwise minutes).
- When no task is running, the row shows an em-dash placeholder rather than `0ms` to match other empty-state surfaces.

## Motivation

Part of #644 (operator observability rollup). The `/system` page already rolls up per-group queue state — pending counts, lane reason codes, retry counts — but currently surfaces no signal for *how long* the longest-running task has been executing. Operators have to open `/ipc` to see runtime durations, then cross-reference the group list.

This adds a single rolled-up duration so a glance at `/system` is enough to tell whether the running tasks are healthy or one is stuck.

## What changed

- `src/web/system.ts`:
  - Add `longest_running_task_ms` to the `HealthData.queue` TypeScript type
  - Track it in the existing `queueDetails` loop (single pass, no extra iteration)
  - Render it in the queue card with a stable `sys-queue-longest-running` ID
  - Add a local `formatDuration(ms)` helper mirroring the IPC inspector's progression
- `src/web/system.test.ts`:
  - Assert the new ID is present in the queue rollup
  - Verify a 125s active task is rendered as `2.1m`
  - Verify the em-dash placeholder when no tasks are running

## Verification

- `bun test` → 2067 pass / 0 fail (+3 new tests)
- `bunx tsc --noEmit` → clean

## Backward compatibility

- The new field is additive on `HealthData.queue` and is computed from data already available on `GroupQueueDetail.taskLane.activeTask.runningMs`, so no orchestrator or backend changes are required.
- No SSE payload shape change: the existing `/system` SSR view is the only consumer; live updates rely on full-page swap, not field-level diffing, so existing live consumers stay valid.

## Related

- #644 — operator observability rollup
- #505 — Web UI Phase 3 (extends an already-shipped surface)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * System page queue metrics card now includes a longest-running task duration metric, displayed in human-readable format with automatic unit selection (milliseconds for short durations, seconds with one decimal place, or minutes with one decimal place for longer tasks).
  * When no tasks are currently running, an em-dash is displayed instead of a duration value to indicate the queue is idle.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/omniaura/omniclaw/pull/703?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->