### PR TITLE
feat(web): surface total and max retry counts on /system queue card

### DIFF
--- a/src/web/system.test.ts
+++ b/src/web/system.test.ts
@@ -317,6 +317,8 @@ describe('buildHealthData', () => {
     expect(health.queue.processing_groups).toBe(0);
     expect(health.queue.running_tasks).toBe(0);
     expect(health.queue.retrying_groups).toBe(0);
+    expect(health.queue.total_retries).toBe(0);
+    expect(health.queue.max_retries).toBe(0);
     expect(health.queue.message_lane_reasons).toEqual({
       running: 0,
       'cooling-down': 0,
@@ -394,6 +396,51 @@ describe('buildHealthData', () => {
     expect(health.queue.processing_groups).toBe(2); // g1, g3
     expect(health.queue.running_tasks).toBe(1); // only g1 has activeTask
     expect(health.queue.retrying_groups).toBe(2); // g2, g3
+    expect(health.queue.total_retries).toBe(3); // 0 + 2 + 1
+    expect(health.queue.max_retries).toBe(2); // g2 leads with 2
+  });
+
+  it('rolls up retry intensity independently of retrying group count', () => {
+    // A single stuck group with many retries should inflate total/max
+    // without inflating retrying_groups beyond 1.
+    const details: GroupQueueDetail[] = [
+      {
+        folderKey: 'stuck',
+        messageLane: {
+          active: false,
+          idle: false,
+          pendingCount: 0,
+          containerName: null,
+        },
+        taskLane: {
+          active: false,
+          pendingCount: 0,
+          containerName: null,
+          activeTask: null,
+        },
+        retryCount: 17,
+      },
+      {
+        folderKey: 'healthy',
+        messageLane: {
+          active: false,
+          idle: true,
+          pendingCount: 0,
+          containerName: null,
+        },
+        taskLane: {
+          active: false,
+          pendingCount: 0,
+          containerName: null,
+          activeTask: null,
+        },
+        retryCount: 0,
+      },
+    ];
+    const health = buildHealthData(makeState([makeAgent()], details), 0);
+    expect(health.queue.retrying_groups).toBe(1);
+    expect(health.queue.total_retries).toBe(17);
+    expect(health.queue.max_retries).toBe(17);
   });
 
   it('rolls up message and task lane reason codes', () => {
@@ -619,6 +666,15 @@ describe('renderSystemContent', () => {
     expect(html).toContain('id="sys-queue-pending-messages"');
     expect(html).toContain('id="sys-queue-pending-tasks"');
     expect(html).toContain('id="sys-queue-retrying"');
+    expect(html).toContain('id="sys-queue-total-retries"');
+    expect(html).toContain('id="sys-queue-max-retries"');
+    // single group with retryCount=4 → total=4, max=4
+    expect(html).toContain(
+      '<span class="metric-value" id="sys-queue-total-retries">4</span>',
+    );
+    expect(html).toContain(
+      '<span class="metric-value" id="sys-queue-max-retries">4</span>',
+    );
     // pending message count should appear (7)
     expect(html).toContain(
       '<span class="metric-value" id="sys-queue-pending-messages">7</span>',

--- a/src/web/system.ts
+++ b/src/web/system.ts
@@ -101,8 +101,21 @@ export interface HealthData {
      * tasks without drilling into /ipc.
      */
     longest_running_task_ms: number;
-    /** Sum of consecutive retry counts across all group folders. */
+    /** Number of group folders whose consecutive retry count is greater than zero. */
     retrying_groups: number;
+    /**
+     * Sum of consecutive retry counts across all group folders. A single
+     * group stuck retrying many times will inflate this without changing
+     * `retrying_groups`, so the two together describe both the breadth
+     * and the intensity of retry pressure.
+     */
+    total_retries: number;
+    /**
+     * Highest consecutive retry count observed across all group folders.
+     * Useful for spotting a single stuck group at a glance, since
+     * `retrying_groups` only counts groups but not their individual depth.
+     */
+    max_retries: number;
     /**
      * Count of message lanes by structured reason code. Keys are the same
      * `MessageLaneReason` values exposed on the IPC inspector page.
@@ -187,6 +200,8 @@ export function buildHealthData(
   let runningTasks = 0;
   let longestRunningTaskMs = 0;
   let retryingGroups = 0;
+  let totalRetries = 0;
+  let maxRetries = 0;
   const messageLaneReasons: Record<MessageLaneReason, number> = {
     running: 0,
     'cooling-down': 0,
@@ -210,6 +225,8 @@ export function buildHealthData(
       }
     }
     if (g.retryCount > 0) retryingGroups++;
+    totalRetries += g.retryCount;
+    if (g.retryCount > maxRetries) maxRetries = g.retryCount;
     messageLaneReasons[deriveMessageLaneReasonFromDetail(g)]++;
     taskLaneReasons[deriveTaskLaneReasonFromDetail(g)]++;
   }
@@ -266,6 +283,8 @@ export function buildHealthData(
       running_tasks: runningTasks,
       longest_running_task_ms: longestRunningTaskMs,
       retrying_groups: retryingGroups,
+      total_retries: totalRetries,
+      max_retries: maxRetries,
       message_lane_reasons: messageLaneReasons,
       task_lane_reasons: taskLaneReasons,
     },
@@ -503,6 +522,16 @@ export function renderSystemContent(
           'retrying',
           String(health.queue.retrying_groups),
           'sys-queue-retrying',
+        ) +
+        metricRow(
+          'total retries',
+          String(health.queue.total_retries),
+          'sys-queue-total-retries',
+        ) +
+        metricRow(
+          'max retries',
+          String(health.queue.max_retries),
+          'sys-queue-max-retries',
         ) +
         `<div class="metric-sub">message lane reasons</div>` +
         reasonRollup(


### PR DESCRIPTION
## Summary

Adds two new metric rows to the queue rollup card on `/system` so operators can spot retry pressure at a glance without drilling into `/ipc`:

- *total retries* — sum of consecutive `retryCount` across every tracked group
- *max retries* — highest consecutive `retryCount` on any single group

## Motivation

Part of #644 (operator observability rollup). The queue card already shows `retrying_groups` (breadth — how many groups have retries), but a single stuck group with `retryCount=17` barely moves that number from `1` → still `1`. Total/max retries surface the *intensity* so a stuck-but-singular group is obvious at a glance, and an operator can decide whether to open `/ipc` to investigate further.

This pairs naturally with the existing in-flight observability work:
- #688 (message-lane running age) — _is anything wedged?_
- #691 (last error on /ipc) — _what's the failure?_
- #703 (longest running task age on /system) — _how long has it been?_
- This PR — _how hard is it failing?_

## What changed

- `src/web/system.ts`:
  - `HealthData.queue` gains `total_retries: number` and `max_retries: number`
  - Both computed inside the existing `queueDetails` loop — single pass, no extra iteration
  - Two `metricRow(...)` calls rendered directly under the existing `retrying` row, with stable IDs `sys-queue-total-retries` and `sys-queue-max-retries`
- `src/web/system.test.ts`:
  - Zero-state assertion: empty queue → `total_retries === 0`, `max_retries === 0`
  - Aggregation assertion across 3 groups (`retryCount = 0, 2, 1`) → total `3`, max `2`
  - New focused test: a single `retryCount=17` group → `retrying_groups=1`, `total=17`, `max=17` (proves breadth vs intensity are independent)
  - Rendering assertion: both IDs present in HTML, values appear in `metric-value` spans

## Verification

- `bun test` → 2066 pass / 0 fail
- `bunx tsc --noEmit` → clean
- `bunx prettier --check src/web/system.{ts,test.ts}` → clean

## Backward compatibility

- Additive on `HealthData.queue` — no removals, no renames
- Both fields derived from `g.retryCount` already exposed on `GroupQueueDetail`, so no orchestrator or backend changes
- No SSE payload shape change; `/system` uses full-page SSR swap for live updates

## Related

- #644 — operator observability rollup
- #688, #691, #703 — sibling observability surfaces


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added queue retry metrics to system health monitoring, tracking total and maximum retry counts across all queues to provide better visibility into retry behavior.
  * System dashboard now displays the new queue retry metrics in the health monitoring interface.

* **Tests**
  * Extended test coverage for queue retry metrics and system health data assertions.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/omniaura/omniclaw/pull/707?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->