### PR TITLE
feat: add deterministic scheduled task preprocessors

### DIFF
--- a/container/agent-runner/src/index.ts
+++ b/container/agent-runner/src/index.ts
@@ -1251,6 +1251,9 @@ async function runQuery(
             OMNICLAW_IS_MAIN: containerInput.isMain ? '1' : '0',
             OMNICLAW_IPC_DIR: PATHS.ipc,
             OMNICLAW_CURRENT_CHAT_FILE: CURRENT_CHAT_FILE,
+            ...(containerInput.taskWorkflowsDir
+              ? { OMNICLAW_TASK_WORKFLOWS_DIR: containerInput.taskWorkflowsDir }
+              : {}),
             ...(containerInput.discordGuildId
               ? { OMNICLAW_DISCORD_GUILD_ID: containerInput.discordGuildId }
               : {}),

--- a/container/agent-runner/src/ipc-mcp-stdio.ts
+++ b/container/agent-runner/src/ipc-mcp-stdio.ts
@@ -16,6 +16,9 @@ const MESSAGES_DIR = path.join(IPC_DIR, 'messages');
 const TASKS_DIR = path.join(IPC_DIR, 'tasks');
 const RESPONSES_DIR = path.join(IPC_DIR, 'responses');
 const USER_REGISTRY_PATH = path.join(IPC_DIR, 'user_registry.json');
+const taskWorkflowsDir =
+  process.env.OMNICLAW_TASK_WORKFLOWS_DIR || 'task-workflows';
+const taskWorkflowsPath = `/workspace/group/${taskWorkflowsDir.replace(/^\/+/, '').replace(/\/+$/, '')}/`;
 
 // Context from environment variables (set by the agent runner)
 const initialChatJid = process.env.OMNICLAW_CHAT_JID!;
@@ -288,7 +291,7 @@ MESSAGING BEHAVIOR - The task agent's output is sent to the user or group. It ca
 \u2022 Only send a message when there's something to report (e.g., "notify me if...")
 \u2022 Never send a message (background maintenance tasks)
 
-DETERMINISTIC PREPROCESSING - For recurring maintenance tasks that can be cheaply triaged in code, write a TypeScript workflow file under /workspace/group/task-workflows/ and pass preprocess_script as its relative path. The workflow runs before the agent and can return {"action":"skip","reason":"no diff"} or {"action":"run","promptPrefix":"..."} as JSON on stdout. Use this to avoid spending agent tokens on no-op checks.
+DETERMINISTIC PREPROCESSING - For recurring maintenance tasks that can be cheaply triaged in code, write a TypeScript workflow file under ${taskWorkflowsPath} and pass preprocess_script as its relative path. The script receives JSON on stdin: { task, repoRoot, workflowsDir, now }. It runs with Bun on the host using a minimal env, so it should not rely on API tokens. Write one JSON result as the last stdout line or prefixed with OMNICLAW_TASK_PREPROCESSOR_RESULT=: {"action":"skip","reason":"no diff"}, {"action":"run","promptPrefix":"..."}, or {"action":"error","message":"..."}. Use this to avoid spending agent tokens on no-op checks.
 
 IMPORTANT: When MODIFYING an existing task, use update_task — it edits the task in place while preserving its ID and run history. Only use cancel_task to destructively delete a task the user no longer wants. Unlike pausing, the task cannot be restored on deletion.
 
@@ -306,7 +309,7 @@ SCHEDULE VALUE FORMAT (all times are LOCAL timezone):
       .string()
       .optional()
       .describe(
-        'Optional relative path under /workspace/group/task-workflows/ to a JS/TS workflow that runs before the agent and returns JSON to skip or augment the prompt.',
+        `Optional relative path under ${taskWorkflowsPath} to a JS/TS workflow that runs before the agent and returns JSON to skip or augment the prompt.`,
       ),
     schedule_type: z
       .enum(['cron', 'interval', 'once'])
@@ -510,7 +513,7 @@ Examples:
       .nullable()
       .optional()
       .describe(
-        'Set or clear the relative /workspace/group/task-workflows/ script that runs before the agent. Pass null to clear it.',
+        `Set or clear the relative ${taskWorkflowsPath} script that runs before the agent. Pass null to clear it.`,
       ),
     schedule_type: z.enum(['cron', 'interval', 'once']).optional(),
     schedule_value: z

--- a/container/agent-runner/src/ipc-mcp-stdio.ts
+++ b/container/agent-runner/src/ipc-mcp-stdio.ts
@@ -288,6 +288,8 @@ MESSAGING BEHAVIOR - The task agent's output is sent to the user or group. It ca
 \u2022 Only send a message when there's something to report (e.g., "notify me if...")
 \u2022 Never send a message (background maintenance tasks)
 
+DETERMINISTIC PREPROCESSING - For recurring maintenance tasks that can be cheaply triaged in code, write a TypeScript workflow file under /workspace/group/task-workflows/ and pass preprocess_script as its relative path. The workflow runs before the agent and can return {"action":"skip","reason":"no diff"} or {"action":"run","promptPrefix":"..."} as JSON on stdout. Use this to avoid spending agent tokens on no-op checks.
+
 IMPORTANT: When MODIFYING an existing task, use update_task — it edits the task in place while preserving its ID and run history. Only use cancel_task to destructively delete a task the user no longer wants. Unlike pausing, the task cannot be restored on deletion.
 
 SCHEDULE VALUE FORMAT (all times are LOCAL timezone):
@@ -299,6 +301,12 @@ SCHEDULE VALUE FORMAT (all times are LOCAL timezone):
       .string()
       .describe(
         'What the agent should do when the task runs. For isolated mode, include all necessary context here.',
+      ),
+    preprocess_script: z
+      .string()
+      .optional()
+      .describe(
+        'Optional relative path under /workspace/group/task-workflows/ to a JS/TS workflow that runs before the agent and returns JSON to skip or augment the prompt.',
       ),
     schedule_type: z
       .enum(['cron', 'interval', 'once'])
@@ -390,6 +398,7 @@ SCHEDULE VALUE FORMAT (all times are LOCAL timezone):
     const data = {
       type: 'schedule_task',
       prompt: args.prompt,
+      preprocess_script: args.preprocess_script,
       schedule_type: args.schedule_type,
       schedule_value: args.schedule_value,
       context_mode: args.context_mode || 'group',
@@ -443,6 +452,7 @@ server.tool(
             id: string;
             groupFolder?: string;
             prompt: string;
+            preprocess_script?: string | null;
             schedule_type: string;
             schedule_value: string;
             status: string;
@@ -453,7 +463,10 @@ server.tool(
               owner === groupFolder ? `${owner} (yours)` : owner;
             const promptPreview =
               t.prompt.length > 50 ? `${t.prompt.slice(0, 50)}...` : t.prompt;
-            return `- [${t.id}] (owner: ${ownerLabel}) ${promptPreview} (${t.schedule_type}: ${t.schedule_value}) - ${t.status}, next: ${t.next_run || 'N/A'}`;
+            const preprocessor = t.preprocess_script
+              ? `, preprocess: ${t.preprocess_script}`
+              : '';
+            return `- [${t.id}] (owner: ${ownerLabel}) ${promptPreview} (${t.schedule_type}: ${t.schedule_value}${preprocessor}) - ${t.status}, next: ${t.next_run || 'N/A'}`;
           },
         )
         .join('\n');
@@ -485,12 +498,20 @@ server.tool(
 
 Examples:
 - update_task({ task_id: "...", prompt: "new instructions" })
+- update_task({ task_id: "...", preprocess_script: "sync-connectors.ts" })
 - update_task({ task_id: "...", schedule_type: "cron", schedule_value: "0 9 * * *" })
 - update_task({ task_id: "...", status: "paused" })
 - update_task({ task_id: "...", status: "active" })`,
   {
     task_id: z.string().describe('ID of the task to update'),
     prompt: z.string().optional().describe('New instructions for the task'),
+    preprocess_script: z
+      .string()
+      .nullable()
+      .optional()
+      .describe(
+        'Set or clear the relative /workspace/group/task-workflows/ script that runs before the agent. Pass null to clear it.',
+      ),
     schedule_type: z.enum(['cron', 'interval', 'once']).optional(),
     schedule_value: z
       .string()
@@ -510,6 +531,7 @@ Examples:
   async (args) => {
     if (
       !args.prompt &&
+      args.preprocess_script === undefined &&
       !args.schedule_type &&
       !args.schedule_value &&
       !args.status &&
@@ -519,7 +541,7 @@ Examples:
         content: [
           {
             type: 'text' as const,
-            text: 'At least one of prompt, schedule_type, schedule_value, or status must be provided.',
+            text: 'At least one of prompt, preprocess_script, schedule_type, schedule_value, status, or context_mode must be provided.',
           },
         ],
         isError: true,
@@ -604,6 +626,7 @@ Examples:
       type: 'edit_task',
       taskId: args.task_id,
       prompt: args.prompt,
+      preprocess_script: args.preprocess_script,
       schedule_type: args.schedule_type,
       schedule_value: args.schedule_value,
       status: args.status,
@@ -617,6 +640,7 @@ Examples:
 
     const changed: string[] = [];
     if (args.prompt) changed.push('prompt');
+    if (args.preprocess_script !== undefined) changed.push('preprocess_script');
     if (args.schedule_type || args.schedule_value) changed.push('schedule');
     if (args.status) changed.push(`status → ${args.status}`);
     if (args.context_mode) changed.push(`context_mode → ${args.context_mode}`);

--- a/container/agent-runner/src/opencode-runtime.ts
+++ b/container/agent-runner/src/opencode-runtime.ts
@@ -675,6 +675,8 @@ export async function runOpenCodeRuntime(
     OMNICLAW_IPC_DIR: ipcInputDir.replace(/\/input-task$|\/input$/, ''),
     OMNICLAW_CURRENT_CHAT_FILE: currentChatFile,
   };
+  if (containerInput.taskWorkflowsDir)
+    mcpEnv.OMNICLAW_TASK_WORKFLOWS_DIR = containerInput.taskWorkflowsDir;
   if (containerInput.discordGuildId)
     mcpEnv.OMNICLAW_DISCORD_GUILD_ID = containerInput.discordGuildId;
   if (containerInput.serverFolder)

--- a/docs/SECURITY.md
+++ b/docs/SECURITY.md
@@ -80,7 +80,26 @@ Messages and task operations are verified against group identity:
 | View all tasks              | ✓          | Own only       |
 | Manage other groups         | ✓          | ✗              |
 
-### 6. Credential Handling
+### 6. Scheduled Task Preprocessors
+
+Scheduled tasks may configure a deterministic JS/TS `preprocess_script` that
+runs on the host before the agent container starts. This is intentionally a
+privileged host-side extension point, so it is constrained separately from
+container execution:
+
+- Workflow paths are relative to the owning group workspace's
+  `task-workflows/` directory by default.
+- Absolute paths and `..` traversal segments are rejected.
+- Only `.ts`, `.tsx`, `.js`, `.mjs`, and `.cjs` workflow files are accepted.
+- The subprocess receives an explicit minimal environment allowlist
+  (`PATH`, temp/home/locale/timezone values, plus OmniClaw task metadata).
+  Host credentials such as `GITHUB_TOKEN`, Anthropic/OpenAI keys, B2 keys, and
+  runtime auth variables are not inherited.
+- Stderr and execution errors are sanitized and truncated before being stored in
+  run logs, handoffs, or web API responses.
+- Timeouts are controlled by `TASK_PREPROCESS_TIMEOUT_MS`.
+
+### 7. Credential Handling
 
 **Mounted Credentials:**
 

--- a/docs/SPEC.md
+++ b/docs/SPEC.md
@@ -610,8 +610,30 @@ When a triggered message arrives, the agent receives all messages since its last
 1. **Agent Context**: Tasks run with their group's working directory and memory
 2. **Full Agent Capabilities**: Scheduled tasks have access to all tools
 3. **Context Modes**: `group` (with conversation history) or `isolated` (fresh session)
-4. **Duplicate Prevention**: Active task tracking prevents concurrent duplicate runs
-5. **Idle Preemption**: Idle containers are preempted when a scheduled task needs to run
+4. **Deterministic Preprocessing**: Optional TypeScript workflows can run before the agent to skip no-op runs or prepend deterministic triage output
+5. **Duplicate Prevention**: Active task tracking prevents concurrent duplicate runs
+6. **Idle Preemption**: Idle containers are preempted when a scheduled task needs to run
+
+### Deterministic Preprocessing
+
+Recurring maintenance tasks can attach a `preprocess_script` pointing to a JS/TS file under the owning group workspace's `task-workflows/` directory. From inside the agent container, that is `/workspace/group/task-workflows/`; on the host, it resolves to `groups/<group_folder>/task-workflows/`. `TASK_WORKFLOWS_DIR` can override the directory name or point at an absolute shared workflow directory. The scheduler executes the workflow with Bun before starting the agent container and passes task metadata as JSON on stdin.
+
+The script must write one JSON object to stdout:
+
+```json
+{ "action": "skip", "reason": "no MCP package diff" }
+```
+
+or:
+
+```json
+{
+  "action": "run",
+  "promptPrefix": "MCP changed in packages/mcp. Sync ditto-cli, ditto-hermes, and ditto-clawhub."
+}
+```
+
+Use this for deterministic triage such as checking `git diff`, package versions, or generated manifests before spending agent tokens. Agents should create the workflow file and then schedule the task with both the script path and the natural-language agent prompt.
 
 ### Schedule Types
 

--- a/docs/SPEC.md
+++ b/docs/SPEC.md
@@ -618,7 +618,30 @@ When a triggered message arrives, the agent receives all messages since its last
 
 Recurring maintenance tasks can attach a `preprocess_script` pointing to a JS/TS file under the owning group workspace's `task-workflows/` directory. From inside the agent container, that is `/workspace/group/task-workflows/`; on the host, it resolves to `groups/<group_folder>/task-workflows/`. `TASK_WORKFLOWS_DIR` can override the directory name or point at an absolute shared workflow directory. The scheduler executes the workflow with Bun before starting the agent container and passes task metadata as JSON on stdin.
 
-The script must write one JSON object to stdout:
+The workflow receives one JSON object on stdin:
+
+```json
+{
+  "task": {
+    "id": "task-abc123",
+    "group_folder": "omniclaw",
+    "chat_jid": "dc:123456789",
+    "prompt": "Sync connector packages when MCP changes.",
+    "schedule_type": "cron",
+    "schedule_value": "0 9 * * *",
+    "context_mode": "isolated",
+    "last_run": "2026-05-16T09:00:00.000Z",
+    "last_result": "Skipped by preprocessor: no MCP package diff",
+    "last_outcome_state": "skipped",
+    "last_outcome_reason": "no MCP package diff"
+  },
+  "repoRoot": "/srv/omniclaw",
+  "workflowsDir": "/srv/omniclaw/groups/omniclaw/task-workflows",
+  "now": "2026-05-17T15:08:04.123Z"
+}
+```
+
+The script should write one JSON object as the last stdout line. For noisy scripts, prefix the result line with `OMNICLAW_TASK_PREPROCESSOR_RESULT=`. Supported actions:
 
 ```json
 { "action": "skip", "reason": "no MCP package diff" }
@@ -632,6 +655,14 @@ or:
   "promptPrefix": "MCP changed in packages/mcp. Sync ditto-cli, ditto-hermes, and ditto-clawhub."
 }
 ```
+
+or:
+
+```json
+{ "action": "error", "message": "Failed to read git diff" }
+```
+
+If the preprocessor script fails, times out, exits non-zero, or emits invalid JSON, the scheduler records the task run as blocked, does not start the agent container, and stores a sanitized/truncated error in task run history.
 
 Use this for deterministic triage such as checking `git diff`, package versions, or generated manifests before spending agent tokens. Agents should create the workflow file and then schedule the task with both the script path and the natural-language agent prompt.
 

--- a/packages/protocol/src/index.d.ts
+++ b/packages/protocol/src/index.d.ts
@@ -62,10 +62,12 @@ export interface ContainerInput {
   githubLinkedContext?: string;
   /** Extra MCP servers to inject into the agent runtime alongside the built-in omniclaw server. */
   mcpServers?: Record<string, Record<string, unknown>>;
+  /** Relative task workflow directory name shown to agents for deterministic scheduled task preprocessors. */
+  taskWorkflowsDir?: string;
 }
 
 /** Explicit agent outcome state for scheduled task runs. */
-export type TaskOutcomeState = 'done' | 'blocked' | 'abandoned';
+export type TaskOutcomeState = 'done' | 'blocked' | 'abandoned' | 'skipped';
 
 /** Signal from the agent indicating how a task run concluded. */
 export interface TaskOutcomeSignal {
@@ -86,7 +88,7 @@ export interface ContainerOutput {
   intermediate?: boolean;
   /** The chat JID this output should be routed to (multi-channel agents). */
   chatJid?: string;
-  /** Explicit agent outcome signal (done/blocked/abandoned). */
+  /** Explicit agent outcome signal (done/blocked/abandoned/skipped). */
   outcome?: TaskOutcomeSignal;
 }
 

--- a/packages/protocol/src/index.ts
+++ b/packages/protocol/src/index.ts
@@ -74,6 +74,8 @@ export interface ContainerInput {
   githubLinkedContext?: string;
   /** Extra MCP servers to inject into the agent runtime alongside the built-in omniclaw server. */
   mcpServers?: Record<string, Record<string, unknown>>;
+  /** Relative task workflow directory name shown to agents for deterministic scheduled task preprocessors. */
+  taskWorkflowsDir?: string;
 }
 
 // ---------------------------------------------------------------------------
@@ -81,7 +83,7 @@ export interface ContainerInput {
 // ---------------------------------------------------------------------------
 
 /** Explicit agent outcome state for scheduled task runs. */
-export type TaskOutcomeState = 'done' | 'blocked' | 'abandoned';
+export type TaskOutcomeState = 'done' | 'blocked' | 'abandoned' | 'skipped';
 
 /** Signal from the agent indicating how a task run concluded. */
 export interface TaskOutcomeSignal {
@@ -106,7 +108,7 @@ export interface ContainerOutput {
   intermediate?: boolean;
   /** The chat JID this output should be routed to (multi-channel agents). */
   chatJid?: string;
-  /** Explicit agent outcome signal (done/blocked/abandoned). */
+  /** Explicit agent outcome signal (done/blocked/abandoned/skipped). */
   outcome?: TaskOutcomeSignal;
 }
 

--- a/src/config.ts
+++ b/src/config.ts
@@ -103,6 +103,10 @@ const configSchema = z
       parseIntegerString,
       z.number().int().positive().default(900000),
     ),
+    TASK_WORKFLOWS_DIR: z.preprocess(
+      optionalTrimmedString,
+      z.string().default('task-workflows'),
+    ),
     CHANNEL_ROSTER_SCOPE: z.preprocess(
       (value) =>
         typeof value === 'string' ? value.trim().toLowerCase() : value,
@@ -377,6 +381,7 @@ export const MOUNT_ALLOWLIST_PATH = path.join(
 export const STORE_DIR = path.resolve(PROJECT_ROOT, 'store');
 export const GROUPS_DIR = path.resolve(PROJECT_ROOT, 'groups');
 export const DATA_DIR = path.resolve(PROJECT_ROOT, 'data');
+export const TASK_WORKFLOWS_DIR = CONFIG.TASK_WORKFLOWS_DIR;
 export const MAIN_GROUP_FOLDER = 'main';
 export const AGENTS_CONFIG_PATH = path.resolve(
   PROJECT_ROOT,

--- a/src/config.ts
+++ b/src/config.ts
@@ -83,6 +83,10 @@ const configSchema = z
       parseIntegerString,
       z.number().int().positive().default(7200000),
     ),
+    TASK_PREPROCESS_TIMEOUT_MS: z.preprocess(
+      parseIntegerString,
+      z.number().int().positive().default(60000),
+    ),
     CONTAINER_MAX_OUTPUT_SIZE: z.preprocess(
       parseIntegerString,
       z.number().int().positive().default(10485760),
@@ -398,6 +402,7 @@ export const SHARED_CLAUDE_VM_MEMORY = CONFIG.SHARED_CLAUDE_VM_MEMORY;
 export const EXEC_CONTAINER_MEMORY =
   CONFIG.EXEC_CONTAINER_MEMORY || CONTAINER_MEMORY;
 export const CONTAINER_TIMEOUT = CONFIG.CONTAINER_TIMEOUT; // 2h default — inactivity timeout for agent output (tool calls, results, text)
+export const TASK_PREPROCESS_TIMEOUT_MS = CONFIG.TASK_PREPROCESS_TIMEOUT_MS; // 60s default — deterministic scheduled task preprocessor timeout
 export const CONTAINER_MAX_OUTPUT_SIZE = CONFIG.CONTAINER_MAX_OUTPUT_SIZE; // 10MB default
 export const IPC_POLL_INTERVAL = 1000;
 export const IDLE_TIMEOUT = CONFIG.IDLE_TIMEOUT; // 2h default — how long to keep container alive after last result

--- a/src/db.migrations.test.ts
+++ b/src/db.migrations.test.ts
@@ -759,6 +759,35 @@ describe('versioned migration framework', () => {
     db.close();
   });
 
+  it('adds preprocess_script to databases already stamped at version 4', () => {
+    const db = new Database(':memory:');
+    runMigrations(
+      db,
+      allMigrations.filter((migration) => migration.version <= 4),
+    );
+    db.exec('ALTER TABLE scheduled_tasks DROP COLUMN preprocess_script');
+    expect(getSchemaVersion(db)).toBe(4);
+
+    const beforeCols = db
+      .query('PRAGMA table_info(scheduled_tasks)')
+      .all() as Array<{
+      name: string;
+    }>;
+    expect(beforeCols.map((c) => c.name)).not.toContain('preprocess_script');
+
+    runMigrations(db, allMigrations);
+
+    const afterCols = db
+      .query('PRAGMA table_info(scheduled_tasks)')
+      .all() as Array<{
+      name: string;
+    }>;
+    expect(getSchemaVersion(db)).toBe(BASELINE_VERSION);
+    expect(afterCols.map((c) => c.name)).toContain('preprocess_script');
+
+    db.close();
+  });
+
   it('is idempotent — running twice is safe', () => {
     const db = new Database(':memory:');
     runMigrations(db, allMigrations);

--- a/src/db.test.ts
+++ b/src/db.test.ts
@@ -667,6 +667,7 @@ describe('task CRUD', () => {
       group_folder: 'main',
       chat_jid: 'group@g.us',
       prompt: 'do something',
+      preprocess_script: 'sync-connectors.ts',
       schedule_type: 'once',
       schedule_value: '2024-06-01T00:00:00.000Z',
       context_mode: 'isolated',
@@ -678,6 +679,7 @@ describe('task CRUD', () => {
     const task = getTaskById('task-1');
     expect(task).toBeDefined();
     expect(task!.prompt).toBe('do something');
+    expect(task!.preprocess_script).toBe('sync-connectors.ts');
     expect(task!.status).toBe('active');
   });
 
@@ -697,6 +699,28 @@ describe('task CRUD', () => {
 
     updateTask('task-2', { status: 'paused' });
     expect(getTaskById('task-2')!.status).toBe('paused');
+  });
+
+  it('updates task preprocessor script', () => {
+    createTask({
+      id: 'task-preprocess',
+      group_folder: 'main',
+      chat_jid: 'group@g.us',
+      prompt: 'test',
+      preprocess_script: 'old.ts',
+      schedule_type: 'once',
+      schedule_value: '2024-06-01T00:00:00.000Z',
+      context_mode: 'isolated',
+      next_run: null,
+      status: 'active',
+      created_at: '2024-01-01T00:00:00.000Z',
+    });
+
+    updateTask('task-preprocess', { preprocess_script: 'new.ts' });
+    expect(getTaskById('task-preprocess')!.preprocess_script).toBe('new.ts');
+
+    updateTask('task-preprocess', { preprocess_script: null });
+    expect(getTaskById('task-preprocess')!.preprocess_script).toBeNull();
   });
 
   it('deletes a task and its run logs', () => {

--- a/src/db.ts
+++ b/src/db.ts
@@ -843,14 +843,15 @@ export function createTask(
 ): void {
   db.query(
     `
-    INSERT INTO scheduled_tasks (id, group_folder, chat_jid, prompt, schedule_type, schedule_value, context_mode, next_run, status, created_at)
-    VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+    INSERT INTO scheduled_tasks (id, group_folder, chat_jid, prompt, preprocess_script, schedule_type, schedule_value, context_mode, next_run, status, created_at)
+    VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
   `,
   ).run(
     task.id,
     task.group_folder,
     task.chat_jid,
     task.prompt,
+    task.preprocess_script ?? null,
     task.schedule_type,
     task.schedule_value,
     task.context_mode || 'isolated',
@@ -885,7 +886,13 @@ export function updateTask(
   updates: Partial<
     Pick<
       ScheduledTask,
-      'prompt' | 'schedule_type' | 'schedule_value' | 'next_run' | 'status'
+      | 'prompt'
+      | 'preprocess_script'
+      | 'schedule_type'
+      | 'schedule_value'
+      | 'next_run'
+      | 'status'
+      | 'context_mode'
     >
   >,
 ): void {
@@ -898,6 +905,10 @@ export function updateTask(
   if (updates.prompt !== undefined) {
     fields.push('prompt = ?');
     values.push(updates.prompt);
+  }
+  if (updates.preprocess_script !== undefined) {
+    fields.push('preprocess_script = ?');
+    values.push(updates.preprocess_script);
   }
   if (updates.schedule_type !== undefined) {
     fields.push('schedule_type = ?');
@@ -914,6 +925,10 @@ export function updateTask(
   if (updates.status !== undefined) {
     fields.push('status = ?');
     values.push(updates.status);
+  }
+  if (updates.context_mode !== undefined) {
+    fields.push('context_mode = ?');
+    values.push(updates.context_mode);
   }
 
   if (fields.length === 0) return;

--- a/src/ipc-processing.test.ts
+++ b/src/ipc-processing.test.ts
@@ -653,6 +653,29 @@ describe('processTaskIpc: task mutation behavior', () => {
     ]);
   });
 
+  it('stores deterministic preprocessor script when scheduling a task', async () => {
+    await processTaskIpc(
+      {
+        type: 'schedule_task',
+        prompt: 'Sync connectors if MCP package changed',
+        preprocess_script: 'sync-connectors-if-mcp-changed.ts',
+        schedule_type: 'interval',
+        schedule_value: '60000',
+        targetJid: 'other@g.us',
+      },
+      'other-group',
+      false,
+      deps,
+    );
+
+    const tasks = getAllTasks();
+    expect(tasks).toHaveLength(1);
+    expect(tasks[0]).toMatchObject({
+      prompt: 'Sync connectors if MCP package changed',
+      preprocess_script: 'sync-connectors-if-mcp-changed.ts',
+    });
+  });
+
   it('blocks a non-main group from scheduling tasks for another group', async () => {
     await processTaskIpc(
       {

--- a/src/ipc-snapshots.test.ts
+++ b/src/ipc-snapshots.test.ts
@@ -72,6 +72,7 @@ describe('ipc-snapshots', () => {
         id: 'task-1',
         groupFolder: 'test-group',
         prompt: 'Do something',
+        preprocess_script: undefined,
         schedule_type: 'interval',
         schedule_value: '60000',
         status: 'active',

--- a/src/ipc-snapshots.ts
+++ b/src/ipc-snapshots.ts
@@ -26,6 +26,7 @@ export function mapTasksForSnapshot(tasks: ScheduledTask[]) {
     id: t.id,
     groupFolder: t.group_folder,
     prompt: t.prompt,
+    preprocess_script: t.preprocess_script,
     schedule_type: t.schedule_type,
     schedule_value: t.schedule_value,
     status: t.status,
@@ -42,6 +43,7 @@ export function writeTasksSnapshot(
     id: string;
     groupFolder: string;
     prompt: string;
+    preprocess_script?: string | null;
     schedule_type: string;
     schedule_value: string;
     status: string;

--- a/src/ipc.ts
+++ b/src/ipc.ts
@@ -34,6 +34,7 @@ import {
   IpcTaskPayload,
   RegisteredGroup,
 } from './types.js';
+import { normalizePreprocessScriptPath } from './task-preprocessor.js';
 import type { IpcEventKind } from './web/ipc-events.js';
 
 export interface IpcDeps {
@@ -679,16 +680,22 @@ export async function processTaskIpc(
           data.context_mode === 'group' || data.context_mode === 'isolated'
             ? data.context_mode
             : 'isolated';
+        const preprocessScript = normalizePreprocessScriptPath(
+          data.preprocess_script,
+        );
+        if (!preprocessScript.ok) {
+          logger.warn(
+            { sourceGroup, targetFolder, error: preprocessScript.error },
+            'Invalid task preprocess_script rejected',
+          );
+          break;
+        }
         createTask({
           id: taskId,
           group_folder: targetFolder,
           chat_jid: targetJid,
           prompt: data.prompt,
-          preprocess_script:
-            typeof data.preprocess_script === 'string' &&
-            data.preprocess_script.trim()
-              ? data.preprocess_script.trim()
-              : null,
+          preprocess_script: preprocessScript.path,
           schedule_type: scheduleType,
           schedule_value: data.schedule_value,
           context_mode: contextMode,
@@ -750,11 +757,21 @@ export async function processTaskIpc(
       > = {};
       if (data.prompt) updates.prompt = data.prompt;
       if (data.preprocess_script !== undefined) {
-        updates.preprocess_script =
-          typeof data.preprocess_script === 'string' &&
-          data.preprocess_script.trim()
-            ? data.preprocess_script.trim()
-            : null;
+        const preprocessScript = normalizePreprocessScriptPath(
+          data.preprocess_script,
+        );
+        if (!preprocessScript.ok) {
+          logger.warn(
+            {
+              taskId: data.taskId,
+              sourceGroup,
+              error: preprocessScript.error,
+            },
+            'Invalid task preprocess_script rejected',
+          );
+          break;
+        }
+        updates.preprocess_script = preprocessScript.path;
       }
       if (data.schedule_type)
         updates.schedule_type = data.schedule_type as

--- a/src/ipc.ts
+++ b/src/ipc.ts
@@ -684,6 +684,11 @@ export async function processTaskIpc(
           group_folder: targetFolder,
           chat_jid: targetJid,
           prompt: data.prompt,
+          preprocess_script:
+            typeof data.preprocess_script === 'string' &&
+            data.preprocess_script.trim()
+              ? data.preprocess_script.trim()
+              : null,
           schedule_type: scheduleType,
           schedule_value: data.schedule_value,
           context_mode: contextMode,
@@ -735,6 +740,7 @@ export async function processTaskIpc(
         Pick<
           typeof task,
           | 'prompt'
+          | 'preprocess_script'
           | 'schedule_type'
           | 'schedule_value'
           | 'next_run'
@@ -743,6 +749,13 @@ export async function processTaskIpc(
         >
       > = {};
       if (data.prompt) updates.prompt = data.prompt;
+      if (data.preprocess_script !== undefined) {
+        updates.preprocess_script =
+          typeof data.preprocess_script === 'string' &&
+          data.preprocess_script.trim()
+            ? data.preprocess_script.trim()
+            : null;
+      }
       if (data.schedule_type)
         updates.schedule_type = data.schedule_type as
           | 'cron'

--- a/src/migrations.ts
+++ b/src/migrations.ts
@@ -208,6 +208,7 @@ const migration1: Migration = {
         group_folder TEXT NOT NULL,
         chat_jid TEXT NOT NULL,
         prompt TEXT NOT NULL,
+        preprocess_script TEXT,
         schedule_type TEXT NOT NULL,
         schedule_value TEXT NOT NULL,
         next_run TEXT,
@@ -408,6 +409,7 @@ const migration1: Migration = {
       'TEXT',
       "'isolated'",
     );
+    addColumnIfNotExists(db, 'scheduled_tasks', 'preprocess_script', 'TEXT');
     addColumnIfNotExists(db, 'scheduled_tasks', 'executing_since', 'TEXT');
     addColumnIfNotExists(db, 'scheduled_tasks', 'last_outcome_state', 'TEXT');
     addColumnIfNotExists(db, 'scheduled_tasks', 'last_outcome_reason', 'TEXT');

--- a/src/migrations.ts
+++ b/src/migrations.ts
@@ -16,7 +16,7 @@ export interface Migration {
  * The version that represents the latest schema. Existing databases that
  * predate the migration framework are advanced through every migration to this.
  */
-export const BASELINE_VERSION = 4;
+export const BASELINE_VERSION = 5;
 
 // ---------------------------------------------------------------------------
 // Schema helpers (available for use in migrations)
@@ -562,6 +562,14 @@ const migration4: Migration = {
   },
 };
 
+const migration5: Migration = {
+  version: 5,
+  description: 'Add deterministic scheduled task preprocessor path',
+  up: (db) => {
+    addColumnIfNotExists(db, 'scheduled_tasks', 'preprocess_script', 'TEXT');
+  },
+};
+
 // ---------------------------------------------------------------------------
 // Migration registry
 // ---------------------------------------------------------------------------
@@ -577,4 +585,5 @@ export const allMigrations: Migration[] = [
   migration2,
   migration3,
   migration4,
+  migration5,
 ];

--- a/src/task-outcome.test.ts
+++ b/src/task-outcome.test.ts
@@ -105,4 +105,16 @@ describe('inferOutcome', () => {
       reason: 'All steps completed',
     });
   });
+
+  it('explicit skipped signal passes through reason', () => {
+    const output: ContainerOutput = {
+      status: 'success',
+      result: 'Skipped by preprocessor: no diff',
+      outcome: { state: 'skipped', reason: 'No relevant diff' },
+    };
+    expect(inferOutcome(output, null, false)).toEqual({
+      state: 'skipped',
+      reason: 'No relevant diff',
+    });
+  });
 });

--- a/src/task-preprocessor.test.ts
+++ b/src/task-preprocessor.test.ts
@@ -68,6 +68,134 @@ it('lets a workflow skip no-op scheduled task runs', () => {
   });
 });
 
+it('parses the last JSON line when workflow stdout has log noise', () => {
+  fs.writeFileSync(
+    path.join(workflowsDir, 'workflow.ts'),
+    `
+console.log("checking git diff...");
+console.log(JSON.stringify({ action: "skip", reason: "no package diff" }));
+`,
+  );
+
+  expect(runTaskPreprocessor(task(), { workflowsDir })).toEqual({
+    action: 'skip',
+    reason: 'no package diff',
+  });
+});
+
+it('parses sentinel-prefixed JSON even when later stdout has log noise', () => {
+  fs.writeFileSync(
+    path.join(workflowsDir, 'workflow.ts'),
+    `
+console.log('OMNICLAW_TASK_PREPROCESSOR_RESULT=' + JSON.stringify({
+  action: "run",
+  prompt: "deterministic prompt"
+}));
+console.log("done");
+`,
+  );
+
+  expect(runTaskPreprocessor(task(), { workflowsDir })).toEqual({
+    action: 'run',
+    prompt: 'deterministic prompt',
+  });
+});
+
+it('does not leak host secrets into workflow environment', () => {
+  const original = process.env.GITHUB_TOKEN;
+  process.env.GITHUB_TOKEN = 'secret-token';
+  fs.writeFileSync(
+    path.join(workflowsDir, 'workflow.ts'),
+    `
+console.log(JSON.stringify({
+  action: "run",
+  promptPrefix: process.env.GITHUB_TOKEN ? "leaked" : "missing"
+}));
+`,
+  );
+
+  try {
+    expect(runTaskPreprocessor(task(), { workflowsDir })).toEqual({
+      action: 'run',
+      prompt: 'missing\n\nsync connector packages',
+    });
+  } finally {
+    if (original === undefined) {
+      delete process.env.GITHUB_TOKEN;
+    } else {
+      process.env.GITHUB_TOKEN = original;
+    }
+  }
+});
+
+it('returns a sanitized error when workflow times out', () => {
+  fs.writeFileSync(
+    path.join(workflowsDir, 'workflow.ts'),
+    'await Bun.sleep(1000);',
+  );
+
+  const result = runTaskPreprocessor(task(), {
+    workflowsDir,
+    timeoutMs: 10,
+  });
+
+  expect(result.action).toBe('error');
+  if (result.action !== 'error') throw new Error('expected error result');
+  expect(result.error).toContain('timed out');
+  expect(result.error.length).toBeLessThanOrEqual(512);
+});
+
+it('returns a sanitized error when workflow output exceeds maxBuffer', () => {
+  fs.writeFileSync(
+    path.join(workflowsDir, 'workflow.ts'),
+    'console.log("x".repeat(1000));',
+  );
+
+  const result = runTaskPreprocessor(task(), {
+    workflowsDir,
+    maxOutputBytes: 16,
+  });
+
+  expect(result.action).toBe('error');
+  if (result.action !== 'error') throw new Error('expected error result');
+  expect(result.error.length).toBeLessThanOrEqual(512);
+});
+
+it('caps promptPrefix length before augmenting the prompt', () => {
+  fs.writeFileSync(
+    path.join(workflowsDir, 'workflow.ts'),
+    `
+console.log(JSON.stringify({
+  action: "run",
+  promptPrefix: "a".repeat(20)
+}));
+`,
+  );
+
+  const result = runTaskPreprocessor(task(), {
+    workflowsDir,
+    maxPromptFragmentChars: 5,
+  });
+
+  expect(result).toEqual({
+    action: 'run',
+    prompt:
+      'aaaaa\n\n[preprocessor promptPrefix truncated to 5 characters]\n\nsync connector packages',
+  });
+});
+
+it('supports explicit workflow error actions', () => {
+  fs.writeFileSync(
+    path.join(workflowsDir, 'workflow.ts'),
+    'console.log(JSON.stringify({ action: "error", message: "git diff failed" }));',
+  );
+
+  expect(runTaskPreprocessor(task(), { workflowsDir })).toEqual({
+    action: 'error',
+    error: 'git diff failed',
+  });
+});
+
 it('rejects workflow paths outside the workflows directory', () => {
   const result = runTaskPreprocessor(task({ preprocess_script: '../x.ts' }), {
     workflowsDir,

--- a/src/task-preprocessor.test.ts
+++ b/src/task-preprocessor.test.ts
@@ -1,0 +1,88 @@
+import { afterEach, beforeEach, describe, expect, it } from 'bun:test';
+import fs from 'fs';
+import os from 'os';
+import path from 'path';
+
+import { runTaskPreprocessor } from './task-preprocessor.js';
+import type { ScheduledTask } from './types.js';
+
+let workflowsDir: string;
+
+beforeEach(() => {
+  workflowsDir = fs.mkdtempSync(path.join(os.tmpdir(), 'omniclaw-pre-'));
+});
+
+afterEach(() => {
+  fs.rmSync(workflowsDir, { recursive: true, force: true });
+});
+
+function task(overrides: Partial<ScheduledTask> = {}): ScheduledTask {
+  return {
+    id: 'task-1',
+    group_folder: 'main',
+    chat_jid: 'main@g.us',
+    prompt: 'sync connector packages',
+    preprocess_script: 'workflow.ts',
+    schedule_type: 'cron',
+    schedule_value: '0 9 * * *',
+    context_mode: 'isolated',
+    next_run: '2026-05-18T09:00:00.000Z',
+    last_run: null,
+    last_result: null,
+    status: 'active',
+    created_at: '2026-05-17T00:00:00.000Z',
+    executing_since: null,
+    ...overrides,
+  };
+}
+
+it('runs a workflow script and prefixes deterministic triage output', () => {
+  fs.writeFileSync(
+    path.join(workflowsDir, 'workflow.ts'),
+    `
+const input = JSON.parse(await Bun.stdin.text());
+console.log(JSON.stringify({
+  action: "run",
+  promptPrefix: "Changed package: " + input.task.id
+}));
+`,
+  );
+
+  const result = runTaskPreprocessor(task(), { workflowsDir });
+
+  expect(result).toEqual({
+    action: 'run',
+    prompt: 'Changed package: task-1\n\nsync connector packages',
+  });
+});
+
+it('lets a workflow skip no-op scheduled task runs', () => {
+  fs.writeFileSync(
+    path.join(workflowsDir, 'workflow.ts'),
+    'console.log(JSON.stringify({ action: "skip", reason: "no MCP diff" }));',
+  );
+
+  expect(runTaskPreprocessor(task(), { workflowsDir })).toEqual({
+    action: 'skip',
+    reason: 'no MCP diff',
+  });
+});
+
+it('rejects workflow paths outside the workflows directory', () => {
+  const result = runTaskPreprocessor(task({ preprocess_script: '../x.ts' }), {
+    workflowsDir,
+  });
+
+  expect(result.action).toBe('error');
+  if (result.action !== 'error') throw new Error('expected error result');
+  expect(result.error).toContain('Path traversal detected');
+});
+
+it('does nothing when no preprocessor is configured', () => {
+  expect(
+    runTaskPreprocessor(task({ preprocess_script: null }), { workflowsDir }),
+  ).toEqual({
+    action: 'run',
+    prompt: 'sync connector packages',
+  });
+});

--- a/src/task-preprocessor.ts
+++ b/src/task-preprocessor.ts
@@ -1,0 +1,186 @@
+import { spawnSync } from 'child_process';
+import path from 'path';
+
+import { GROUPS_DIR, TASK_WORKFLOWS_DIR } from './config.js';
+import { logger } from './logger.js';
+import { assertPathWithin, rejectTraversalSegments } from './path-security.js';
+import type { ScheduledTask } from './types.js';
+
+export type TaskPreprocessDecision =
+  | { action: 'run'; prompt?: string; promptPrefix?: string }
+  | { action: 'skip'; reason?: string };
+
+export type TaskPreprocessResult =
+  | { action: 'run'; prompt: string }
+  | { action: 'skip'; reason: string }
+  | { action: 'error'; error: string };
+
+export interface TaskPreprocessInput {
+  task: Pick<
+    ScheduledTask,
+    | 'id'
+    | 'group_folder'
+    | 'chat_jid'
+    | 'prompt'
+    | 'schedule_type'
+    | 'schedule_value'
+    | 'context_mode'
+    | 'last_run'
+    | 'last_result'
+    | 'last_outcome_state'
+    | 'last_outcome_reason'
+  >;
+  repoRoot: string;
+  workflowsDir: string;
+  now: string;
+}
+
+export interface TaskPreprocessorOptions {
+  workflowsDir?: string;
+  timeoutMs?: number;
+  now?: () => Date;
+}
+
+const DEFAULT_TIMEOUT_MS = 60_000;
+
+function resolveWorkflowPath(scriptPath: string, workflowsDir: string): string {
+  rejectTraversalSegments(scriptPath, 'task preprocess_script');
+  const resolved = path.resolve(workflowsDir, scriptPath);
+  assertPathWithin(resolved, workflowsDir, 'task preprocess_script');
+  if (!/\.(?:ts|tsx|js|mjs|cjs)$/.test(resolved)) {
+    throw new Error('preprocess_script must point to a JS or TypeScript file');
+  }
+  return resolved;
+}
+
+function defaultWorkflowsDir(task: ScheduledTask): string {
+  if (path.isAbsolute(TASK_WORKFLOWS_DIR)) {
+    return TASK_WORKFLOWS_DIR;
+  }
+
+  const groupDir = path.resolve(GROUPS_DIR, task.group_folder);
+  assertPathWithin(groupDir, GROUPS_DIR, 'task workflow group folder');
+  return path.resolve(groupDir, TASK_WORKFLOWS_DIR);
+}
+
+function parseDecision(stdout: string): TaskPreprocessDecision {
+  const trimmed = stdout.trim();
+  if (!trimmed) return { action: 'run' };
+  const parsed = JSON.parse(trimmed) as unknown;
+
+  if (!parsed || typeof parsed !== 'object') {
+    throw new Error('preprocessor output must be a JSON object');
+  }
+
+  const decision = parsed as Record<string, unknown>;
+  if (decision.action === 'skip') {
+    return {
+      action: 'skip',
+      reason:
+        typeof decision.reason === 'string' && decision.reason.trim()
+          ? decision.reason.trim()
+          : undefined,
+    };
+  }
+  if (decision.action === undefined || decision.action === 'run') {
+    return {
+      action: 'run',
+      prompt: typeof decision.prompt === 'string' ? decision.prompt : undefined,
+      promptPrefix:
+        typeof decision.promptPrefix === 'string'
+          ? decision.promptPrefix
+          : undefined,
+    };
+  }
+
+  throw new Error('preprocessor action must be "run" or "skip"');
+}
+
+export function runTaskPreprocessor(
+  task: ScheduledTask,
+  options: TaskPreprocessorOptions = {},
+): TaskPreprocessResult {
+  if (!task.preprocess_script) {
+    return { action: 'run', prompt: task.prompt };
+  }
+
+  const workflowsDir = path.resolve(
+    options.workflowsDir ?? defaultWorkflowsDir(task),
+  );
+  let workflowPath: string;
+  try {
+    workflowPath = resolveWorkflowPath(task.preprocess_script, workflowsDir);
+  } catch (err) {
+    return {
+      action: 'error',
+      error: err instanceof Error ? err.message : String(err),
+    };
+  }
+
+  const input: TaskPreprocessInput = {
+    task: {
+      id: task.id,
+      group_folder: task.group_folder,
+      chat_jid: task.chat_jid,
+      prompt: task.prompt,
+      schedule_type: task.schedule_type,
+      schedule_value: task.schedule_value,
+      context_mode: task.context_mode,
+      last_run: task.last_run,
+      last_result: task.last_result,
+      last_outcome_state: task.last_outcome_state ?? null,
+      last_outcome_reason: task.last_outcome_reason ?? null,
+    },
+    repoRoot: process.cwd(),
+    workflowsDir,
+    now: (options.now ?? (() => new Date()))().toISOString(),
+  };
+
+  const child = spawnSync(process.execPath, ['run', workflowPath], {
+    cwd: process.cwd(),
+    input: JSON.stringify(input),
+    encoding: 'utf8',
+    env: {
+      ...process.env,
+      OMNICLAW_TASK_PREPROCESSOR: '1',
+      OMNICLAW_TASK_ID: task.id,
+    },
+    timeout: options.timeoutMs ?? DEFAULT_TIMEOUT_MS,
+    maxBuffer: 1024 * 1024,
+  });
+
+  if (child.error) {
+    return { action: 'error', error: child.error.message };
+  }
+  if (child.status !== 0) {
+    return {
+      action: 'error',
+      error:
+        child.stderr?.trim() ||
+        `preprocessor exited with status ${child.status ?? 'unknown'}`,
+    };
+  }
+
+  try {
+    const decision = parseDecision(child.stdout ?? '');
+    if (decision.action === 'skip') {
+      return { action: 'skip', reason: decision.reason ?? 'no work' };
+    }
+    const prompt = decision.prompt ?? task.prompt;
+    return {
+      action: 'run',
+      prompt: decision.promptPrefix
+        ? `${decision.promptPrefix.trim()}\n\n${prompt}`
+        : prompt,
+    };
+  } catch (err) {
+    logger.warn(
+      { taskId: task.id, preprocessScript: task.preprocess_script, err },
+      'Invalid task preprocessor output',
+    );
+    return {
+      action: 'error',
+      error: err instanceof Error ? err.message : String(err),
+    };
+  }
+}

--- a/src/task-preprocessor.ts
+++ b/src/task-preprocessor.ts
@@ -1,14 +1,19 @@
 import { spawnSync } from 'child_process';
 import path from 'path';
 
-import { GROUPS_DIR, TASK_WORKFLOWS_DIR } from './config.js';
+import {
+  GROUPS_DIR,
+  TASK_PREPROCESS_TIMEOUT_MS,
+  TASK_WORKFLOWS_DIR,
+} from './config.js';
 import { logger } from './logger.js';
 import { assertPathWithin, rejectTraversalSegments } from './path-security.js';
 import type { ScheduledTask } from './types.js';
 
 export type TaskPreprocessDecision =
   | { action: 'run'; prompt?: string; promptPrefix?: string }
-  | { action: 'skip'; reason?: string };
+  | { action: 'skip'; reason?: string }
+  | { action: 'error'; message?: string };
 
 export type TaskPreprocessResult =
   | { action: 'run'; prompt: string }
@@ -38,18 +43,72 @@ export interface TaskPreprocessInput {
 export interface TaskPreprocessorOptions {
   workflowsDir?: string;
   timeoutMs?: number;
+  maxOutputBytes?: number;
+  maxPromptFragmentChars?: number;
   now?: () => Date;
 }
 
-const DEFAULT_TIMEOUT_MS = 60_000;
+export const TASK_PREPROCESS_RESULT_PREFIX =
+  'OMNICLAW_TASK_PREPROCESSOR_RESULT=';
+
+const DEFAULT_MAX_OUTPUT_BYTES = 1024 * 1024;
+const DEFAULT_MAX_PROMPT_FRAGMENT_CHARS = 8_000;
+const MAX_ERROR_CHARS = 512;
+const ALLOWED_WORKFLOW_EXTENSIONS = new Set([
+  '.ts',
+  '.tsx',
+  '.js',
+  '.mjs',
+  '.cjs',
+]);
+
+export function normalizePreprocessScriptPath(
+  value: unknown,
+): { ok: true; path: string | null } | { ok: false; error: string } {
+  if (value === undefined || value === null) return { ok: true, path: null };
+  if (typeof value !== 'string') {
+    return { ok: false, error: 'preprocess_script must be a string or null' };
+  }
+  const trimmed = value.trim();
+  if (!trimmed) return { ok: true, path: null };
+  try {
+    rejectTraversalSegments(trimmed, 'task preprocess_script');
+  } catch (err) {
+    return {
+      ok: false,
+      error: err instanceof Error ? err.message : String(err),
+    };
+  }
+  if (!ALLOWED_WORKFLOW_EXTENSIONS.has(path.extname(trimmed))) {
+    return {
+      ok: false,
+      error: 'preprocess_script must point to a JS or TypeScript file',
+    };
+  }
+  return { ok: true, path: trimmed };
+}
+
+function sanitizePreprocessorMessage(value: string): string {
+  const stripped = value
+    .replace(/\x1b\[[0-9;?]*[ -/]*[@-~]/g, '')
+    .replace(/[\x00-\x08\x0b\x0c\x0e-\x1f\x7f]/g, '')
+    .replace(/\s+/g, ' ')
+    .trim();
+  return stripped.length > MAX_ERROR_CHARS
+    ? `${stripped.slice(0, MAX_ERROR_CHARS - 1)}…`
+    : stripped;
+}
 
 function resolveWorkflowPath(scriptPath: string, workflowsDir: string): string {
-  rejectTraversalSegments(scriptPath, 'task preprocess_script');
+  const normalized = normalizePreprocessScriptPath(scriptPath);
+  if (!normalized.ok) {
+    throw new Error(normalized.error);
+  }
+  if (!normalized.path) {
+    throw new Error('preprocess_script must be a non-empty path');
+  }
   const resolved = path.resolve(workflowsDir, scriptPath);
   assertPathWithin(resolved, workflowsDir, 'task preprocess_script');
-  if (!/\.(?:ts|tsx|js|mjs|cjs)$/.test(resolved)) {
-    throw new Error('preprocess_script must point to a JS or TypeScript file');
-  }
   return resolved;
 }
 
@@ -64,7 +123,16 @@ function defaultWorkflowsDir(task: ScheduledTask): string {
 }
 
 function parseDecision(stdout: string): TaskPreprocessDecision {
-  const trimmed = stdout.trim();
+  const lines = stdout
+    .split(/\r?\n/)
+    .map((line) => line.trim())
+    .filter(Boolean);
+  const sentinelLine = lines
+    .filter((line) => line.startsWith(TASK_PREPROCESS_RESULT_PREFIX))
+    .at(-1);
+  const trimmed = sentinelLine
+    ? sentinelLine.slice(TASK_PREPROCESS_RESULT_PREFIX.length).trim()
+    : (lines.at(-1) ?? '');
   if (!trimmed) return { action: 'run' };
   const parsed = JSON.parse(trimmed) as unknown;
 
@@ -82,6 +150,15 @@ function parseDecision(stdout: string): TaskPreprocessDecision {
           : undefined,
     };
   }
+  if (decision.action === 'error') {
+    return {
+      action: 'error',
+      message:
+        typeof decision.message === 'string' && decision.message.trim()
+          ? decision.message.trim()
+          : undefined,
+    };
+  }
   if (decision.action === undefined || decision.action === 'run') {
     return {
       action: 'run',
@@ -93,7 +170,34 @@ function parseDecision(stdout: string): TaskPreprocessDecision {
     };
   }
 
-  throw new Error('preprocessor action must be "run" or "skip"');
+  throw new Error('preprocessor action must be "run", "skip", or "error"');
+}
+
+function capPromptFragment(
+  value: string,
+  label: string,
+  maxChars: number,
+): string {
+  if (value.length <= maxChars) return value;
+  return `${value.slice(0, maxChars)}\n\n[${label} truncated to ${maxChars} characters]`;
+}
+
+function buildPreprocessorEnv(): NodeJS.ProcessEnv {
+  const allowedKeys = [
+    'PATH',
+    'HOME',
+    'TMPDIR',
+    'TEMP',
+    'TMP',
+    'TZ',
+    'LANG',
+    'LC_ALL',
+  ];
+  const env: NodeJS.ProcessEnv = {};
+  for (const key of allowedKeys) {
+    if (process.env[key] !== undefined) env[key] = process.env[key];
+  }
+  return env;
 }
 
 export function runTaskPreprocessor(
@@ -136,41 +240,74 @@ export function runTaskPreprocessor(
     now: (options.now ?? (() => new Date()))().toISOString(),
   };
 
-  const child = spawnSync(process.execPath, ['run', workflowPath], {
+  const timeoutMs = options.timeoutMs ?? TASK_PREPROCESS_TIMEOUT_MS;
+  const child = spawnSync('bun', ['run', workflowPath], {
     cwd: process.cwd(),
     input: JSON.stringify(input),
     encoding: 'utf8',
     env: {
-      ...process.env,
+      ...buildPreprocessorEnv(),
       OMNICLAW_TASK_PREPROCESSOR: '1',
       OMNICLAW_TASK_ID: task.id,
     },
-    timeout: options.timeoutMs ?? DEFAULT_TIMEOUT_MS,
-    maxBuffer: 1024 * 1024,
+    timeout: timeoutMs,
+    maxBuffer: options.maxOutputBytes ?? DEFAULT_MAX_OUTPUT_BYTES,
   });
 
   if (child.error) {
-    return { action: 'error', error: child.error.message };
+    const errorWithCode = child.error as Error & { code?: string };
+    return {
+      action: 'error',
+      error: sanitizePreprocessorMessage(
+        errorWithCode.code === 'ETIMEDOUT'
+          ? `preprocessor timed out after ${timeoutMs}ms`
+          : child.error.message,
+      ),
+    };
   }
   if (child.status !== 0) {
     return {
       action: 'error',
-      error:
+      error: sanitizePreprocessorMessage(
         child.stderr?.trim() ||
-        `preprocessor exited with status ${child.status ?? 'unknown'}`,
+          `preprocessor exited with status ${child.status ?? 'unknown'}`,
+      ),
     };
   }
 
   try {
     const decision = parseDecision(child.stdout ?? '');
     if (decision.action === 'skip') {
-      return { action: 'skip', reason: decision.reason ?? 'no work' };
+      return {
+        action: 'skip',
+        reason: sanitizePreprocessorMessage(decision.reason ?? 'no work'),
+      };
     }
-    const prompt = decision.prompt ?? task.prompt;
+    if (decision.action === 'error') {
+      return {
+        action: 'error',
+        error: sanitizePreprocessorMessage(
+          decision.message ?? 'workflow error',
+        ),
+      };
+    }
+    const maxFragmentChars =
+      options.maxPromptFragmentChars ?? DEFAULT_MAX_PROMPT_FRAGMENT_CHARS;
+    const prompt = decision.prompt
+      ? capPromptFragment(
+          decision.prompt,
+          'preprocessor prompt',
+          maxFragmentChars,
+        )
+      : task.prompt;
     return {
       action: 'run',
       prompt: decision.promptPrefix
-        ? `${decision.promptPrefix.trim()}\n\n${prompt}`
+        ? `${capPromptFragment(
+            decision.promptPrefix.trim(),
+            'preprocessor promptPrefix',
+            maxFragmentChars,
+          )}\n\n${prompt}`
         : prompt,
     };
   } catch (err) {
@@ -180,7 +317,9 @@ export function runTaskPreprocessor(
     );
     return {
       action: 'error',
-      error: err instanceof Error ? err.message : String(err),
+      error: sanitizePreprocessorMessage(
+        err instanceof Error ? err.message : String(err),
+      ),
     };
   }
 }

--- a/src/task-scheduler-loop.harness.ts
+++ b/src/task-scheduler-loop.harness.ts
@@ -156,6 +156,10 @@ describe('startSchedulerLoop harness', () => {
         appendTaskRunPhaseEvent: appendTaskRunPhaseEventMock,
         updateTaskAfterRun: updateTaskAfterRunMock,
         writeScheduledRunHandoff: writeScheduledRunHandoffMock,
+        runTaskPreprocessor: (task: ScheduledTask) => ({
+          action: 'run',
+          prompt: task.prompt,
+        }),
         logger: loggerMock,
       };
 

--- a/src/task-scheduler-runner.test.ts
+++ b/src/task-scheduler-runner.test.ts
@@ -134,6 +134,10 @@ describe('startSchedulerLoop task execution', () => {
         appendTaskRunPhaseEvent: mock(() => {}),
         updateTaskAfterRun: mock(() => {}),
         writeScheduledRunHandoff: mock(() => 'handoff.json'),
+        runTaskPreprocessor: (task: ScheduledTask) => ({
+          action: 'run',
+          prompt: task.prompt,
+        }),
         logger: loggerMock,
       } as any);
 
@@ -273,6 +277,10 @@ describe('startSchedulerLoop task execution', () => {
         appendTaskRunPhaseEvent: appendTaskRunPhaseEventMock,
         updateTaskAfterRun: updateTaskAfterRunMock,
         writeScheduledRunHandoff: writeScheduledRunHandoffMock,
+        runTaskPreprocessor: (task: ScheduledTask) => ({
+          action: 'run',
+          prompt: task.prompt,
+        }),
         logger: loggerMock,
       } as any);
 
@@ -305,6 +313,215 @@ describe('startSchedulerLoop task execution', () => {
       expect(notifyIdleMock).not.toHaveBeenCalled();
       expect(closeStdinMock).not.toHaveBeenCalled();
       expect(timeoutCalls).toEqual([60000]);
+    } finally {
+      (globalThis as { setTimeout: typeof setTimeout }).setTimeout =
+        originalSetTimeout;
+    }
+  });
+
+  it('skips agent dispatch when a deterministic preprocessor returns skip', async () => {
+    const task: ScheduledTask = {
+      id: 'task-skip',
+      group_folder: 'main',
+      chat_jid: 'main@g.us',
+      prompt: 'sync connectors',
+      preprocess_script: 'sync-connectors-if-mcp-changed.ts',
+      schedule_type: 'interval',
+      schedule_value: '300000',
+      context_mode: 'isolated',
+      next_run: '2026-01-01T00:00:00.000Z',
+      last_run: null,
+      last_result: null,
+      status: 'active',
+      created_at: '2026-01-01T00:00:00.000Z',
+      executing_since: null,
+    };
+    const resolveBackendMock = mock(() => ({ runAgent: mock(() => {}) }));
+    const logTaskRunMock = mock(() => {});
+    const updateTaskAfterRunMock = mock(() => {});
+    const clearTaskExecutingMock = mock(() => {});
+    const enqueuedRuns: Array<Promise<void>> = [];
+    const originalSetTimeout = globalThis.setTimeout;
+
+    (globalThis as { setTimeout: typeof setTimeout }).setTimeout = ((
+      _fn: Parameters<typeof setTimeout>[0],
+    ) => ({ id: 'poll' })) as unknown as typeof setTimeout;
+
+    try {
+      const deps: SchedulerDependencies = {
+        registeredGroups: () => ({}),
+        getGroupForTask: () => ({
+          name: 'Main',
+          folder: 'main',
+          trigger: '@Bot',
+          added_at: '2026-01-01T00:00:00.000Z',
+        }),
+        getSessions: () => ({}),
+        resumePositionStore: {
+          get: () => undefined,
+          set: () => {},
+          getAll: () => ({}),
+          clear: () => {},
+        },
+        queue: {
+          enqueueTask: (
+            _jid: string,
+            _taskId: string,
+            run: () => Promise<void>,
+          ) => {
+            enqueuedRuns.push(run());
+          },
+          notifyIdle: mock(() => {}),
+          closeStdin: mock(() => {}),
+        } as unknown as SchedulerDependencies['queue'],
+        onProcess: mock(() => {}),
+        sendMessage: mock(async () => undefined),
+        findChannel: () => undefined,
+      };
+
+      startSchedulerLoop(deps, {
+        calculateNextRun: mock(() => '2026-01-01T00:05:00.000Z'),
+        resolveBackend: resolveBackendMock,
+        writeTasksSnapshot: mock(() => {}),
+        advanceTaskNextRun: mock(() => {}),
+        markTaskExecuting: mock(() => {}),
+        clearTaskExecuting: clearTaskExecutingMock,
+        getStaleExecutingTasks: mock(() => []),
+        getOrphanedOnceTasks: mock(() => []),
+        hasSuccessfulRun: mock(() => false),
+        getAllTasks: mock(() => [task]),
+        getDueTasks: mock(() => [task]),
+        getTaskById: mock((taskId: string) =>
+          taskId === task.id ? task : null,
+        ),
+        logTaskRun: logTaskRunMock,
+        appendTaskRunPhaseEvent: mock(() => {}),
+        updateTaskAfterRun: updateTaskAfterRunMock,
+        writeScheduledRunHandoff: mock(() => 'handoff.json'),
+        runTaskPreprocessor: mock(() => ({
+          action: 'skip',
+          reason: 'no MCP diff',
+        })),
+        logger: createLoggerMock(),
+      } as any);
+
+      await Promise.all(enqueuedRuns);
+
+      expect(resolveBackendMock).not.toHaveBeenCalled();
+      expect(logTaskRunMock).toHaveBeenCalledWith(
+        expect.objectContaining({
+          task_id: 'task-skip',
+          status: 'success',
+          result: 'Skipped by preprocessor: no MCP diff',
+          error: null,
+        }),
+      );
+      expect(updateTaskAfterRunMock).toHaveBeenCalledWith(
+        'task-skip',
+        '2026-01-01T00:05:00.000Z',
+        'Skipped by preprocessor: no MCP diff',
+        { state: 'done', reason: 'no MCP diff' },
+      );
+      expect(clearTaskExecutingMock).toHaveBeenCalledWith('task-skip');
+    } finally {
+      (globalThis as { setTimeout: typeof setTimeout }).setTimeout =
+        originalSetTimeout;
+    }
+  });
+
+  it('passes a preprocessed prompt to agent dispatch', async () => {
+    const task: ScheduledTask = {
+      id: 'task-preprocessed',
+      group_folder: 'main',
+      chat_jid: 'main@g.us',
+      prompt: 'sync connectors',
+      preprocess_script: 'sync.ts',
+      schedule_type: 'once',
+      schedule_value: '2026-01-01T00:00:00.000Z',
+      context_mode: 'isolated',
+      next_run: '2026-01-01T00:00:00.000Z',
+      last_run: null,
+      last_result: null,
+      status: 'active',
+      created_at: '2026-01-01T00:00:00.000Z',
+      executing_since: null,
+    };
+    let backendPrompt: string | undefined;
+    const enqueuedRuns: Array<Promise<void>> = [];
+    const originalSetTimeout = globalThis.setTimeout;
+
+    (globalThis as { setTimeout: typeof setTimeout }).setTimeout = ((
+      _fn: Parameters<typeof setTimeout>[0],
+    ) => ({ id: 'poll' })) as unknown as typeof setTimeout;
+
+    try {
+      const deps: SchedulerDependencies = {
+        registeredGroups: () => ({}),
+        getGroupForTask: () => ({
+          name: 'Main',
+          folder: 'main',
+          trigger: '@Bot',
+          added_at: '2026-01-01T00:00:00.000Z',
+        }),
+        getSessions: () => ({}),
+        resumePositionStore: {
+          get: () => undefined,
+          set: () => {},
+          getAll: () => ({}),
+          clear: () => {},
+        },
+        queue: {
+          enqueueTask: (
+            _jid: string,
+            _taskId: string,
+            run: () => Promise<void>,
+          ) => {
+            enqueuedRuns.push(run());
+          },
+          notifyIdle: mock(() => {}),
+          closeStdin: mock(() => {}),
+        } as unknown as SchedulerDependencies['queue'],
+        onProcess: mock(() => {}),
+        sendMessage: mock(async () => undefined),
+        findChannel: () => undefined,
+      };
+
+      startSchedulerLoop(deps, {
+        calculateNextRun: mock(() => null),
+        resolveBackend: mock(() => ({
+          runAgent: async (_group: unknown, input: Record<string, unknown>) => {
+            backendPrompt = input.prompt as string;
+            return { status: 'success', result: 'done' } as ContainerOutput;
+          },
+        })),
+        writeTasksSnapshot: mock(() => {}),
+        advanceTaskNextRun: mock(() => {}),
+        markTaskExecuting: mock(() => {}),
+        clearTaskExecuting: mock(() => {}),
+        getStaleExecutingTasks: mock(() => []),
+        getOrphanedOnceTasks: mock(() => []),
+        hasSuccessfulRun: mock(() => false),
+        getAllTasks: mock(() => [task]),
+        getDueTasks: mock(() => [task]),
+        getTaskById: mock((taskId: string) =>
+          taskId === task.id ? task : null,
+        ),
+        logTaskRun: mock(() => {}),
+        appendTaskRunPhaseEvent: mock(() => {}),
+        updateTaskAfterRun: mock(() => {}),
+        writeScheduledRunHandoff: mock(() => 'handoff.json'),
+        runTaskPreprocessor: mock(() => ({
+          action: 'run',
+          prompt: 'Deterministic diff summary\n\nsync connectors',
+        })),
+        logger: createLoggerMock(),
+      } as any);
+
+      await Promise.all(enqueuedRuns);
+
+      expect(backendPrompt).toBe(
+        'Deterministic diff summary\n\nsync connectors',
+      );
     } finally {
       (globalThis as { setTimeout: typeof setTimeout }).setTimeout =
         originalSetTimeout;
@@ -391,6 +608,10 @@ describe('startSchedulerLoop task execution', () => {
         updateTaskAfterRun: mock(() => {}),
         writeScheduledRunHandoff: mock(() => {
           throw new Error('disk full');
+        }),
+        runTaskPreprocessor: (task: ScheduledTask) => ({
+          action: 'run',
+          prompt: task.prompt,
         }),
         logger: loggerMock,
       } as any);

--- a/src/task-scheduler-runner.test.ts
+++ b/src/task-scheduler-runner.test.ts
@@ -420,7 +420,7 @@ describe('startSchedulerLoop task execution', () => {
         'task-skip',
         '2026-01-01T00:05:00.000Z',
         'Skipped by preprocessor: no MCP diff',
-        { state: 'done', reason: 'no MCP diff' },
+        { state: 'skipped', reason: 'no MCP diff' },
       );
       expect(clearTaskExecutingMock).toHaveBeenCalledWith('task-skip');
     } finally {

--- a/src/task-scheduler.test.ts
+++ b/src/task-scheduler.test.ts
@@ -33,7 +33,7 @@ import {
   findMainGroupJid,
   isMainGroup,
 } from './group-helpers.js';
-import type { RegisteredGroup } from './types.js';
+import type { RegisteredGroup, ScheduledTask } from './types.js';
 
 // ============================================================
 // schedule-utils: calculateNextRun & validateSchedule
@@ -1011,6 +1011,10 @@ describe('execution lease tracking', () => {
           appendTaskRunPhaseEvent,
           updateTaskAfterRun,
           writeScheduledRunHandoff: () => '',
+          runTaskPreprocessor: (task: ScheduledTask) => ({
+            action: 'run',
+            prompt: task.prompt,
+          }),
           logger: {
             info: () => {},
             warn: () => {},
@@ -1134,6 +1138,10 @@ describe('recoverStaleTasks', () => {
       appendTaskRunPhaseEvent: () => {},
       updateTaskAfterRun,
       writeScheduledRunHandoff: () => '',
+      runTaskPreprocessor: (task: ScheduledTask) => ({
+        action: 'run',
+        prompt: task.prompt,
+      }),
       logger: {
         info: () => {},
         warn: () => {},
@@ -1200,6 +1208,10 @@ describe('recoverStaleTasks', () => {
       appendTaskRunPhaseEvent: () => {},
       updateTaskAfterRun,
       writeScheduledRunHandoff: () => '',
+      runTaskPreprocessor: (task: ScheduledTask) => ({
+        action: 'run',
+        prompt: task.prompt,
+      }),
       logger: {
         info: () => {},
         warn: () => {},
@@ -1256,6 +1268,10 @@ describe('recoverStaleTasks', () => {
       appendTaskRunPhaseEvent: () => {},
       updateTaskAfterRun,
       writeScheduledRunHandoff: () => '',
+      runTaskPreprocessor: (task: ScheduledTask) => ({
+        action: 'run',
+        prompt: task.prompt,
+      }),
       logger: {
         info: () => {},
         warn: () => {},
@@ -1312,6 +1328,10 @@ describe('recoverStaleTasks', () => {
       appendTaskRunPhaseEvent: () => {},
       updateTaskAfterRun,
       writeScheduledRunHandoff: () => '',
+      runTaskPreprocessor: (task: ScheduledTask) => ({
+        action: 'run',
+        prompt: task.prompt,
+      }),
       logger: {
         info: () => {},
         warn: () => {},
@@ -1366,6 +1386,10 @@ describe('recoverStaleTasks', () => {
       appendTaskRunPhaseEvent: () => {},
       updateTaskAfterRun,
       writeScheduledRunHandoff: () => '',
+      runTaskPreprocessor: (task: ScheduledTask) => ({
+        action: 'run',
+        prompt: task.prompt,
+      }),
       logger: {
         info: () => {},
         warn: () => {},

--- a/src/task-scheduler.ts
+++ b/src/task-scheduler.ts
@@ -6,6 +6,7 @@ import {
   MAIN_GROUP_FOLDER,
   SCHEDULER_POLL_INTERVAL,
   TIMEZONE,
+  TASK_WORKFLOWS_DIR,
 } from './config.js';
 import { calculateNextRun } from './schedule-utils.js';
 import { resolveBackend } from './backends/index.js';
@@ -47,6 +48,7 @@ const VALID_OUTCOME_STATES = new Set<TaskOutcomeState>([
   'done',
   'blocked',
   'abandoned',
+  'skipped',
 ]);
 
 /**
@@ -273,7 +275,7 @@ async function runTask(
         status: 'success',
         result,
         error: null,
-        outcome_state: 'done',
+        outcome_state: 'skipped',
         outcome_reason: preprocessResult.reason,
       });
       const nextRun =
@@ -281,7 +283,7 @@ async function runTask(
           ? null
           : runtime.calculateNextRun(task.schedule_type, task.schedule_value);
       runtime.updateTaskAfterRun(task.id, nextRun, result, {
-        state: 'done',
+        state: 'skipped',
         reason: preprocessResult.reason,
       });
       appendPhaseEvent('run_finalized', 'ok', false);
@@ -296,7 +298,7 @@ async function runTask(
         next_run: nextRun,
         result,
         error: null,
-        outcome_state: 'done',
+        outcome_state: 'skipped',
         outcome_reason: preprocessResult.reason,
       });
       return;
@@ -423,6 +425,7 @@ async function runTask(
           categoryFolder: group.categoryFolder,
           agentContextFolder: group.agentContextFolder,
           mcpServers: group.containerConfig?.mcpServers,
+          taskWorkflowsDir: TASK_WORKFLOWS_DIR,
         },
         (proc, containerName) =>
           deps.onProcess(

--- a/src/task-scheduler.ts
+++ b/src/task-scheduler.ts
@@ -32,6 +32,7 @@ import { GroupQueue } from './group-queue.js';
 import { logger } from './logger.js';
 import { ResumePositionStore } from './resume-position-store.js';
 import { writeScheduledRunHandoff } from './task-handoffs.js';
+import { runTaskPreprocessor } from './task-preprocessor.js';
 import type {
   Channel,
   ContainerProcess,
@@ -88,6 +89,7 @@ interface SchedulerRuntime {
   appendTaskRunPhaseEvent: typeof appendTaskRunPhaseEvent;
   updateTaskAfterRun: typeof updateTaskAfterRun;
   writeScheduledRunHandoff: typeof writeScheduledRunHandoff;
+  runTaskPreprocessor: typeof runTaskPreprocessor;
   logger: typeof logger;
 }
 
@@ -108,6 +110,7 @@ const defaultSchedulerRuntime: SchedulerRuntime = {
   appendTaskRunPhaseEvent,
   updateTaskAfterRun,
   writeScheduledRunHandoff,
+  runTaskPreprocessor,
   logger,
 };
 
@@ -259,12 +262,91 @@ async function runTask(
 
     appendPhaseEvent('group_resolved', 'ok', false);
 
+    const preprocessResult = runtime.runTaskPreprocessor(task);
+    if (preprocessResult.action === 'skip') {
+      const durationMs = Date.now() - startTime;
+      const result = `Skipped by preprocessor: ${preprocessResult.reason}`;
+      runtime.logTaskRun({
+        task_id: task.id,
+        run_at: runAt,
+        duration_ms: durationMs,
+        status: 'success',
+        result,
+        error: null,
+        outcome_state: 'done',
+        outcome_reason: preprocessResult.reason,
+      });
+      const nextRun =
+        task.schedule_type === 'once'
+          ? null
+          : runtime.calculateNextRun(task.schedule_type, task.schedule_value);
+      runtime.updateTaskAfterRun(task.id, nextRun, result, {
+        state: 'done',
+        reason: preprocessResult.reason,
+      });
+      appendPhaseEvent('run_finalized', 'ok', false);
+      tryWriteHandoff({
+        task_id: task.id,
+        chat_jid: task.chat_jid,
+        group_folder: task.group_folder,
+        context_mode: task.context_mode,
+        run_at: runAt,
+        status: 'success',
+        duration_ms: durationMs,
+        next_run: nextRun,
+        result,
+        error: null,
+        outcome_state: 'done',
+        outcome_reason: preprocessResult.reason,
+      });
+      return;
+    }
+
+    if (preprocessResult.action === 'error') {
+      const durationMs = Date.now() - startTime;
+      const error = `Preprocessor failed: ${preprocessResult.error}`;
+      runtime.logTaskRun({
+        task_id: task.id,
+        run_at: runAt,
+        duration_ms: durationMs,
+        status: 'error',
+        result: null,
+        error,
+        outcome_state: 'blocked',
+        outcome_reason: error,
+      });
+      const nextRun =
+        task.schedule_type === 'once'
+          ? null
+          : runtime.calculateNextRun(task.schedule_type, task.schedule_value);
+      runtime.updateTaskAfterRun(task.id, nextRun, error, {
+        state: 'blocked',
+        reason: error,
+      });
+      appendPhaseEvent('run_finalized', 'error', false, error);
+      tryWriteHandoff({
+        task_id: task.id,
+        chat_jid: task.chat_jid,
+        group_folder: task.group_folder,
+        context_mode: task.context_mode,
+        run_at: runAt,
+        status: 'error',
+        duration_ms: durationMs,
+        next_run: nextRun,
+        result: null,
+        error,
+        outcome_state: 'blocked',
+        outcome_reason: error,
+      });
+      return;
+    }
+
     // Set execution lease only after preflight validation succeeds so
     // missing-group failures do not leave the task stuck in a running state.
     runtime.markTaskExecuting(task.id);
     appendPhaseEvent('lease_acquired', 'ok', false);
 
-    const prompt = task.prompt;
+    const prompt = preprocessResult.prompt;
 
     // Update tasks snapshot for container to read (filtered by group)
     const isMain = task.group_folder === MAIN_GROUP_FOLDER;
@@ -276,6 +358,7 @@ async function runTask(
         id: t.id,
         groupFolder: t.group_folder,
         prompt: t.prompt,
+        preprocess_script: t.preprocess_script,
         schedule_type: t.schedule_type,
         schedule_value: t.schedule_value,
         status: t.status,

--- a/src/types.ts
+++ b/src/types.ts
@@ -181,6 +181,12 @@ export interface ScheduledTask {
   group_folder: string;
   chat_jid: string;
   prompt: string;
+  /**
+   * Optional TypeScript workflow path, relative to TASK_WORKFLOWS_DIR, that runs
+   * before the agent prompt. The workflow can skip a no-op task or modify the
+   * prompt with deterministic triage output.
+   */
+  preprocess_script?: string | null;
   schedule_type: 'cron' | 'interval' | 'once';
   schedule_value: string;
   context_mode: 'group' | 'isolated';
@@ -497,6 +503,7 @@ export interface IpcTaskPayload {
   taskId?: string;
   requestId?: string;
   prompt?: string;
+  preprocess_script?: string | null;
   schedule_type?: string;
   schedule_value?: string;
   context_mode?: string;

--- a/src/web/page-scripts.ts
+++ b/src/web/page-scripts.ts
@@ -1181,7 +1181,7 @@ function openRunHistory(taskId){
       if(detail.length>80)detail=detail.slice(0,77)+"\\u2026";
       var outcomeHtml="";
       if(r.outcome_state){
-        var oClr=r.outcome_state==="done"?"var(--green)":r.outcome_state==="blocked"?"var(--yellow)":"var(--red)";
+        var oClr=r.outcome_state==="done"?"var(--green)":r.outcome_state==="skipped"?"var(--text-dim)":r.outcome_state==="blocked"?"var(--yellow)":"var(--red)";
         outcomeHtml='<span style="background:color-mix(in srgb,'+oClr+' 20%,transparent);color:'+oClr+';padding:1px 6px;border-radius:3px;font-size:10px">'+window.__esc(r.outcome_state)+'</span>';
       }
       html+='<tr style="cursor:pointer" data-run-idx="'+idx+'" data-run-at="'+window.__esc(r.run_at)+'" data-task-id="'+window.__esc(taskId)+'">';

--- a/src/web/routes.test.ts
+++ b/src/web/routes.test.ts
@@ -514,6 +514,28 @@ describe('web routes unit tests', () => {
     expect(body.context_mode).toBe('isolated');
   });
 
+  it('rejects invalid preprocess_script extensions on task creation', async () => {
+    const res = await handle(
+      new Request('http://localhost/api/tasks', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          group_folder: 'agent-one',
+          chat_jid: 'dc:123',
+          prompt: 'Bad preprocessor',
+          preprocess_script: 'workflow.txt',
+          schedule_type: 'interval',
+          schedule_value: '60000',
+        }),
+      }),
+      makeState(),
+    );
+
+    expect(res.status).toBe(400);
+    const body = (await jsonBody(res)) as { error: string };
+    expect(body.error).toContain('JS or TypeScript file');
+  });
+
   it('keeps once tasks next_run unchanged when resumed', async () => {
     let calculateCalls = 0;
     const state = makeState({

--- a/src/web/routes.ts
+++ b/src/web/routes.ts
@@ -40,6 +40,7 @@ import {
 } from './agents-page.js';
 import { sanitizeTelegramAvatarUrl } from '../telegram-avatar.js';
 import { readJsonBody, RequestBodyTooLargeError } from '../request-body.js';
+import { normalizePreprocessScriptPath } from '../task-preprocessor.js';
 
 /** Optional discovery context — set by the orchestrator when discovery is enabled. */
 let discoveryContext: DiscoveryRouteContext | null = null;
@@ -530,6 +531,12 @@ async function handleCreateTask(
   }
 
   const taskId = `task-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
+  const preprocessScript = normalizePreprocessScriptPath(
+    body.preprocess_script,
+  );
+  if (!preprocessScript.ok) {
+    return json({ error: preprocessScript.error }, 400);
+  }
   const task: Omit<
     ScheduledTask,
     | 'last_run'
@@ -542,11 +549,7 @@ async function handleCreateTask(
     group_folder: group_folder as string,
     chat_jid: chat_jid as string,
     prompt: prompt as string,
-    preprocess_script:
-      typeof body.preprocess_script === 'string' &&
-      body.preprocess_script.trim()
-        ? body.preprocess_script.trim()
-        : null,
+    preprocess_script: preprocessScript.path,
     schedule_type: schedule_type as 'cron' | 'interval' | 'once',
     schedule_value: schedule_value as string,
     context_mode: validContextMode,
@@ -610,20 +613,13 @@ async function handleUpdateTask(
     updates.prompt = body.prompt;
   }
   if (body.preprocess_script !== undefined) {
-    if (body.preprocess_script !== null) {
-      if (
-        typeof body.preprocess_script !== 'string' ||
-        body.preprocess_script.trim().length === 0
-      ) {
-        return json(
-          { error: '"preprocess_script" must be a non-empty string or null' },
-          400,
-        );
-      }
-      updates.preprocess_script = body.preprocess_script.trim();
-    } else {
-      updates.preprocess_script = null;
+    const preprocessScript = normalizePreprocessScriptPath(
+      body.preprocess_script,
+    );
+    if (!preprocessScript.ok) {
+      return json({ error: preprocessScript.error }, 400);
     }
+    updates.preprocess_script = preprocessScript.path;
   }
   if (body.schedule_type !== undefined) {
     if (!['cron', 'interval', 'once'].includes(body.schedule_type as string)) {

--- a/src/web/routes.ts
+++ b/src/web/routes.ts
@@ -542,6 +542,11 @@ async function handleCreateTask(
     group_folder: group_folder as string,
     chat_jid: chat_jid as string,
     prompt: prompt as string,
+    preprocess_script:
+      typeof body.preprocess_script === 'string' &&
+      body.preprocess_script.trim()
+        ? body.preprocess_script.trim()
+        : null,
     schedule_type: schedule_type as 'cron' | 'interval' | 'once',
     schedule_value: schedule_value as string,
     context_mode: validContextMode,
@@ -588,7 +593,13 @@ async function handleUpdateTask(
   const updates: Partial<
     Pick<
       ScheduledTask,
-      'prompt' | 'schedule_type' | 'schedule_value' | 'next_run' | 'status'
+      | 'prompt'
+      | 'preprocess_script'
+      | 'schedule_type'
+      | 'schedule_value'
+      | 'next_run'
+      | 'status'
+      | 'context_mode'
     >
   > = {};
 
@@ -597,6 +608,22 @@ async function handleUpdateTask(
       return json({ error: '"prompt" must be a non-empty string' }, 400);
     }
     updates.prompt = body.prompt;
+  }
+  if (body.preprocess_script !== undefined) {
+    if (body.preprocess_script !== null) {
+      if (
+        typeof body.preprocess_script !== 'string' ||
+        body.preprocess_script.trim().length === 0
+      ) {
+        return json(
+          { error: '"preprocess_script" must be a non-empty string or null' },
+          400,
+        );
+      }
+      updates.preprocess_script = body.preprocess_script.trim();
+    } else {
+      updates.preprocess_script = null;
+    }
   }
   if (body.schedule_type !== undefined) {
     if (!['cron', 'interval', 'once'].includes(body.schedule_type as string)) {

--- a/src/web/types.ts
+++ b/src/web/types.ts
@@ -69,7 +69,13 @@ export interface WebStateProvider {
     updates: Partial<
       Pick<
         ScheduledTask,
-        'prompt' | 'schedule_type' | 'schedule_value' | 'next_run' | 'status'
+        | 'prompt'
+        | 'preprocess_script'
+        | 'schedule_type'
+        | 'schedule_value'
+        | 'next_run'
+        | 'status'
+        | 'context_mode'
       >
     >,
   ): void;


### PR DESCRIPTION
## Summary

Adds deterministic preprocessing for scheduled tasks so recurring workflows can do cheap TypeScript triage before spending agent tokens.

- adds optional `preprocess_script` on scheduled tasks, persisted in SQLite and exposed through IPC, MCP `schedule_task` / `update_task`, snapshots, and the web API
- runs JS/TS preprocessors before agent dispatch; scripts live under the owning group workspace at `/workspace/group/task-workflows/` from the agent's perspective
- supports preprocessor decisions to skip no-op runs or augment/replace the prompt before agent launch
- records skipped preprocessor runs as successful task runs and records preprocessor failures as blocked task runs without starting the agent container
- documents the workflow contract in `docs/SPEC.md`

## Workflow contract

The scheduler sends JSON on stdin with task metadata, repo root, workflows dir, and current timestamp. The workflow writes one JSON object to stdout:

```json
{ "action": "skip", "reason": "no MCP diff" }
```

or:

```json
{ "action": "run", "promptPrefix": "MCP changed; sync connector packages." }
```

## Verification

- `bun test` — 2073 pass / 0 fail
- `bunx tsc --noEmit` — pass
- `bunx prettier --check .` — pass
- `bun test src/task-preprocessor.test.ts src/db.test.ts src/ipc-processing.test.ts src/task-scheduler-runner.test.ts src/web/routes.test.ts` — 169 pass / 0 fail


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Tasks can now include an optional preprocessing workflow that executes before the agent starts, enabling duplicate detection and prompt modification through deterministic triage.
  * Added `TASK_WORKFLOWS_DIR` configuration option to specify the directory containing preprocessing workflow scripts.

* **Documentation**
  * Updated task scheduling documentation to describe the preprocessing workflow behavior.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/omniaura/omniclaw/pull/709?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->