### PR TITLE
feat: stream agent activity into editable status message

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,5 @@
+# Changelog
+
+## Unreleased
+
+- Changed Discord intermediate agent activity streaming to be on by default for channels that support message edits. Operators who prefer the previous behavior can set `containerConfig.streamIntermediates: false` on the group or agent.

--- a/container/agent-runner/src/__tests__/codex-runtime.test.ts
+++ b/container/agent-runner/src/__tests__/codex-runtime.test.ts
@@ -231,6 +231,16 @@ describe('renderCodexActivity', () => {
     );
   });
 
+  it('redacts secrets from command output before streaming activity', () => {
+    expect(
+      renderCodexActivity({
+        type: 'command_execution',
+        command: 'printenv GITHUB_TOKEN',
+        stdout: 'GITHUB_TOKEN=ghp_1234567890abcdefghijklmnopqrstuv',
+      }),
+    ).toContain('GITHUB_TOKEN=[GITHUB_TOKEN_REDACTED]');
+  });
+
   it('formats file items without treating them as final assistant text', () => {
     expect(
       renderCodexActivity({

--- a/container/agent-runner/src/__tests__/codex-runtime.test.ts
+++ b/container/agent-runner/src/__tests__/codex-runtime.test.ts
@@ -9,6 +9,7 @@ import {
   extractAssistantTextFromItem,
   extractTextFromCodexContent,
   isRecoverableThreadResumeError,
+  renderCodexActivity,
 } from '../codex-runtime.js';
 
 const ORIGINAL_ENV = { ...process.env };
@@ -44,6 +45,7 @@ describe('buildCodexEnv', () => {
 
   it('preserves github auth for Codex shell commands', () => {
     process.env.GITHUB_TOKEN = 'gh-token';
+    delete process.env.GH_TOKEN;
 
     const env = buildCodexEnv({} as any);
 
@@ -211,6 +213,38 @@ describe('extractAssistantTextFromItem', () => {
       extractAssistantTextFromItem({
         type: 'command_execution',
         text: 'ls -la',
+      }),
+    ).toBeNull();
+  });
+});
+
+describe('renderCodexActivity', () => {
+  it('formats command execution items for live status updates', () => {
+    expect(
+      renderCodexActivity({
+        type: 'command_execution',
+        command: "rg 'EXEC_BROKER' src/",
+        stdout: 'src/index.ts:123:EXEC_BROKER',
+      }),
+    ).toBe(
+      "▸ Command execution: rg 'EXEC_BROKER' src/\n```\nsrc/index.ts:123:EXEC_BROKER\n```",
+    );
+  });
+
+  it('formats file items without treating them as final assistant text', () => {
+    expect(
+      renderCodexActivity({
+        type: 'file_read',
+        path: 'src/backends/local-backend.ts',
+      }),
+    ).toBe('▸ File read: src/backends/local-backend.ts');
+  });
+
+  it('ignores assistant items so final text is not duplicated as activity', () => {
+    expect(
+      renderCodexActivity({
+        type: 'assistant_message',
+        text: 'final answer',
       }),
     ).toBeNull();
   });

--- a/container/agent-runner/src/activity-format.ts
+++ b/container/agent-runner/src/activity-format.ts
@@ -1,0 +1,19 @@
+export const TOOL_OUTPUT_SNIPPET_CHARS = 600;
+
+const BEARER_TOKEN_RE = /Bearer\s+[A-Za-z0-9_\-.]{20,}/gi;
+const API_KEY_RE = /\b(?:sk|key|api)[_-][A-Za-z0-9_\-]{16,}/gi;
+const GITHUB_TOKEN_RE = /\bgh[pousr]_[A-Za-z0-9_]{20,}\b/g;
+const HEX_TOKEN_RE = /\b[a-f0-9]{32,}\b/gi;
+const JWT_RE = /eyJ[A-Za-z0-9_\-]+\.eyJ[A-Za-z0-9_\-]+\.[A-Za-z0-9_\-]+/g;
+const JSON_SECRET_VALUE_RE =
+  /("(?:password|secret|token|api[_-]?key)"\s*:\s*)"[^"]+"/gi;
+
+export function redactActivityOutput(text: string): string {
+  return text
+    .replace(BEARER_TOKEN_RE, 'Bearer [REDACTED]')
+    .replace(GITHUB_TOKEN_RE, '[GITHUB_TOKEN_REDACTED]')
+    .replace(API_KEY_RE, '[API_KEY_REDACTED]')
+    .replace(HEX_TOKEN_RE, '[HEX_TOKEN_REDACTED]')
+    .replace(JWT_RE, '[JWT_REDACTED]')
+    .replace(JSON_SECRET_VALUE_RE, '$1"[REDACTED]"');
+}

--- a/container/agent-runner/src/codex-runtime.ts
+++ b/container/agent-runner/src/codex-runtime.ts
@@ -144,6 +144,20 @@ function readString(value: unknown, key: string): string | undefined {
   return typeof candidate === 'string' ? candidate : undefined;
 }
 
+function truncate(value: string, maxLength: number): string {
+  return value.length > maxLength ? `${value.slice(0, maxLength)}...` : value;
+}
+
+function stringifyCompact(value: unknown, maxLength = 160): string | undefined {
+  if (typeof value === 'string') return truncate(value, maxLength);
+  if (value == null) return undefined;
+  try {
+    return truncate(JSON.stringify(value), maxLength);
+  } catch {
+    return truncate(String(value), maxLength);
+  }
+}
+
 function readBoolean(value: unknown, key: string): boolean | undefined {
   const record = asObject(value);
   if (!record) return undefined;
@@ -239,6 +253,46 @@ export function extractAssistantTextFromItem(item: unknown): string | null {
   return extractTextFromCodexContent(record.content);
 }
 
+export function renderCodexActivity(item: unknown): string | null {
+  const record = asObject(item);
+  if (!record) return null;
+  if (extractAssistantTextFromItem(record)) return null;
+
+  const type = (readString(record, 'type') || 'item').toLowerCase();
+  const command =
+    readString(record, 'command') ??
+    readString(readObject(record, 'command'), 'command') ??
+    readString(readObject(record, 'input'), 'command');
+  const pathValue =
+    readString(record, 'path') ??
+    readString(record, 'filePath') ??
+    readString(record, 'file_path') ??
+    readString(readObject(record, 'input'), 'path') ??
+    readString(readObject(record, 'input'), 'filePath') ??
+    readString(readObject(record, 'input'), 'file_path');
+  const name = readString(record, 'name') ?? readString(record, 'toolName');
+  const output =
+    readString(record, 'output') ??
+    readString(record, 'stdout') ??
+    readString(record, 'stderr') ??
+    extractTextFromCodexContent(record.content);
+
+  let label = name || type.replace(/[_-]+/g, ' ');
+  let summary = command || pathValue;
+  if (!summary) {
+    const input = record.input ?? record.params ?? record.arguments;
+    summary = stringifyCompact(input);
+  }
+  if (!summary && !output) return null;
+
+  label = label.charAt(0).toUpperCase() + label.slice(1);
+  const lines = [`▸ ${label}${summary ? `: ${truncate(summary, 180)}` : ''}`];
+  if (output?.trim()) {
+    lines.push('```', truncate(output.trim(), 600), '```');
+  }
+  return lines.join('\n');
+}
+
 function upsertTurnItem(
   turnState: TurnState,
   itemId: string,
@@ -299,6 +353,16 @@ function handleServerRequest(
     request.method === 'execCommandApproval'
   ) {
     log(`Auto-declining unsupported approval request: ${request.method}`);
+    const activity = renderCodexActivity(request.params);
+    if (activity) {
+      writeOutput({
+        status: 'success',
+        result: activity,
+        newSessionId: session.threadId,
+        intermediate: true,
+        ...(currentChatJid ? { chatJid: currentChatJid } : {}),
+      });
+    }
     writeJsonRpcMessage(session, {
       id: request.id,
       result: {
@@ -372,16 +436,25 @@ function handleNotification(
   }
 
   if (notification.method === 'item/completed') {
+    const item = readObject(notification.params, 'item');
     if (session.turnState && route.itemId) {
-      const text = extractAssistantTextFromItem(
-        readObject(notification.params, 'item'),
-      );
+      const text = extractAssistantTextFromItem(item);
       if (text) {
         const existing = session.turnState.textByItem.get(route.itemId) || '';
         if (!existing.trim()) {
           upsertTurnItem(session.turnState, route.itemId, text, false);
         }
       }
+    }
+    const activity = renderCodexActivity(item);
+    if (activity) {
+      writeOutput({
+        status: 'success',
+        result: activity,
+        newSessionId: session.threadId,
+        intermediate: true,
+        ...(currentChatJid ? { chatJid: currentChatJid } : {}),
+      });
     }
     return;
   }

--- a/container/agent-runner/src/codex-runtime.ts
+++ b/container/agent-runner/src/codex-runtime.ts
@@ -27,6 +27,10 @@ import type {
   IpcDrainResult,
   IpcMessage,
 } from '@omniclaw/protocol';
+import {
+  redactActivityOutput,
+  TOOL_OUTPUT_SNIPPET_CHARS,
+} from './activity-format.js';
 
 interface JsonRpcRequest {
   id: string | number;
@@ -288,7 +292,11 @@ export function renderCodexActivity(item: unknown): string | null {
   label = label.charAt(0).toUpperCase() + label.slice(1);
   const lines = [`▸ ${label}${summary ? `: ${truncate(summary, 180)}` : ''}`];
   if (output?.trim()) {
-    lines.push('```', truncate(output.trim(), 600), '```');
+    lines.push(
+      '```',
+      truncate(redactActivityOutput(output.trim()), TOOL_OUTPUT_SNIPPET_CHARS),
+      '```',
+    );
   }
   return lines.join('\n');
 }
@@ -353,7 +361,10 @@ function handleServerRequest(
     request.method === 'execCommandApproval'
   ) {
     log(`Auto-declining unsupported approval request: ${request.method}`);
-    const activity = renderCodexActivity(request.params);
+    const activity = renderCodexActivity({
+      ...asObject(request.params),
+      type: `${request.method} declined`,
+    });
     if (activity) {
       writeOutput({
         status: 'success',

--- a/container/agent-runner/src/opencode-runtime.ts
+++ b/container/agent-runner/src/opencode-runtime.ts
@@ -453,11 +453,27 @@ async function runOpenCodePrompt(
           const output =
             p.state.status === 'completed' ? p.state.output.slice(0, 200) : '';
           if (output) {
-            log(`[tool] ${toolName}(${input}) → ${output}`);
+            const text = `▸ ${toolName}: ${input}\n\`\`\`\n${output}\n\`\`\``;
+            log(`[tool] ${toolName}(${input}) -> ${output}`);
+            writeOutput({
+              status: 'success',
+              result: text,
+              newSessionId: sessionId,
+              intermediate: true,
+              ...(currentChatJid ? { chatJid: currentChatJid } : {}),
+            });
             loggedToolIds.add(id);
             loggedPartCount++;
           } else if (!loggedToolIds.has(`pending:${id}`)) {
+            const text = `▸ ${toolName}: ${input}`;
             log(`[tool] ${toolName}(${input}) ...`);
+            writeOutput({
+              status: 'success',
+              result: text,
+              newSessionId: sessionId,
+              intermediate: true,
+              ...(currentChatJid ? { chatJid: currentChatJid } : {}),
+            });
             loggedToolIds.add(`pending:${id}`);
             loggedPartCount++;
           }

--- a/container/agent-runner/src/opencode-runtime.ts
+++ b/container/agent-runner/src/opencode-runtime.ts
@@ -26,6 +26,10 @@ import type {
   IpcDrainResult,
   IpcMessage,
 } from '@omniclaw/protocol';
+import {
+  redactActivityOutput,
+  TOOL_OUTPUT_SNIPPET_CHARS,
+} from './activity-format.js';
 
 // ---------------------------------------------------------------------------
 // Constants
@@ -451,7 +455,12 @@ async function runOpenCodePrompt(
           const input =
             stateInput != null ? JSON.stringify(stateInput).slice(0, 120) : '';
           const output =
-            p.state.status === 'completed' ? p.state.output.slice(0, 200) : '';
+            p.state.status === 'completed'
+              ? redactActivityOutput(p.state.output).slice(
+                  0,
+                  TOOL_OUTPUT_SNIPPET_CHARS,
+                )
+              : '';
           if (output) {
             const text = `▸ ${toolName}: ${input}\n\`\`\`\n${output}\n\`\`\``;
             log(`[tool] ${toolName}(${input}) -> ${output}`);

--- a/docs/SPEC.md
+++ b/docs/SPEC.md
@@ -368,8 +368,13 @@ containerConfig: {
   ],
   timeout: 600000,
   memory: 4096,  // MB
+  // Channels that implement editMessage stream live agent activity into one
+  // edited status message by default. Set false to keep only final replies.
+  streamIntermediates: false,
 }
 ```
+
+`streamIntermediates` defaults to enabled when the channel adapter supports `editMessage`; currently Discord implements editable messages. Adapters without edit support fall back to final replies only.
 
 ---
 
@@ -394,6 +399,7 @@ interface Channel {
   setTyping?(jid: string, isTyping: boolean): Promise<void>;
   createThread?(jid: string, messageId: string, name: string): Promise<any>;
   sendToThread?(thread: any, text: string): Promise<void>;
+  editMessage?(jid: string, messageId: string, text: string): Promise<void>;
   addReaction?(jid: string, messageId: string, emoji: string): Promise<void>;
   removeReaction?(jid: string, messageId: string, emoji: string): Promise<void>;
   prefixAssistantName?: boolean;
@@ -402,12 +408,12 @@ interface Channel {
 
 ### Supported Channels
 
-| Channel  | Library     | JID Format                                       | Features                                            |
-| -------- | ----------- | ------------------------------------------------ | --------------------------------------------------- |
-| WhatsApp | baileys     | `123@s.whatsapp.net`, `123@g.us`                 | Messages, reactions, typing, groups                 |
-| Discord  | discord.js  | `dc:channel_id`                                  | Messages, reactions, typing, threads, guild context |
-| Telegram | grammy      | `tg:bot_id:chat_id` (legacy `tg:chat_id` compat) | Messages, reactions, typing, groups, DMs            |
-| Slack    | @slack/bolt | `slack:channel_id`                               | Messages, typing, Socket Mode, threads              |
+| Channel  | Library     | JID Format                                       | Features                                                   |
+| -------- | ----------- | ------------------------------------------------ | ---------------------------------------------------------- |
+| WhatsApp | baileys     | `123@s.whatsapp.net`, `123@g.us`                 | Messages, reactions, typing, groups                        |
+| Discord  | discord.js  | `dc:channel_id`                                  | Messages, edits, reactions, typing, threads, guild context |
+| Telegram | grammy      | `tg:bot_id:chat_id` (legacy `tg:chat_id` compat) | Messages, reactions, typing, groups, DMs                   |
+| Slack    | @slack/bolt | `slack:channel_id`                               | Messages, typing, Socket Mode, threads                     |
 
 ### Trigger Behavior
 

--- a/pr-body.md
+++ b/pr-body.md
@@ -1,10 +1,19 @@
 ## Summary
-- expose immutable sender metadata more explicitly in agent prompts by adding `sender_key`, `sender_label`, and `participant_keys` alongside the existing attributes
-- add sender identity observability for participant roster inflation and display-name changes on a stable sender key
-- refresh the sender identity audit doc so it matches the current formatter and logging behavior
 
-## Testing
-- `bun test src/formatting.test.ts src/db.test.ts`
-- `bun run typecheck`
+- Make editable intermediate status messages default-on for channels with `editMessage`, while preserving `containerConfig.streamIntermediates: false` as an opt-out.
+- Keep a bounded live activity buffer for intermediate output and replace that same message with the final reply when the turn completes.
+- Forward Codex and OpenCode tool activity as intermediate output, including compact command/file summaries and capped stdout snippets.
+- Coalesce status edits to avoid channel edit-rate-limit storms, guard first-message creation races, preserve full long final replies via send fallback, and redact streamed tool output.
 
-Refs #204.
+## Operator Note
+
+This changes Discord behavior by default: groups/agents on channels with editable messages now show one live status message during the turn. Set `containerConfig.streamIntermediates: false` to keep the old final-only behavior.
+
+Closes #711.
+
+## Verification
+
+- `bun test ./src/index.test.ts ./container/agent-runner/src/__tests__/codex-runtime.test.ts`
+- `bunx tsc --noEmit`
+- `bun test`
+- `bunx prettier --check .`

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -6,6 +6,7 @@ import {
   storeChatMetadata,
 } from './db.js';
 import {
+  _createIntermediateStatusStreamer,
   _getSlashCommandGroupsFromSubscriptions,
   _getEnabledStartupConfirmationTargets,
   _isAgentEnabled,
@@ -15,6 +16,7 @@ import {
   _setAgents,
   _setChannelSubscriptions,
   _setRegisteredGroups,
+  _truncateIntermediateStatusBuffer,
   getAvailableGroups,
 } from './index.js';
 import type {
@@ -71,6 +73,138 @@ const makeMessage = (overrides: Partial<NewMessage> = {}): NewMessage => ({
   sender_platform: 'telegram',
   sender_user_id: '42',
   ...overrides,
+});
+
+function tick(ms = 5): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+describe('intermediate status streaming', () => {
+  it('creates a status message for the first intermediate and edits it for subsequent updates', async () => {
+    const sends: Array<{ jid: string; text: string }> = [];
+    const edits: Array<{ jid: string; id: string; text: string }> = [];
+    const streamer = _createIntermediateStatusStreamer({
+      channel: {
+        sendMessage: async (jid, text) => {
+          sends.push({ jid, text });
+          return 'status-1';
+        },
+        editMessage: async (jid, id, text) => {
+          edits.push({ jid, id, text });
+        },
+      },
+      chatJid: 'dc:chan',
+      editDebounceMs: 1,
+    });
+
+    await streamer.append('first');
+    await streamer.append('second');
+    await tick();
+
+    expect(sends).toEqual([{ jid: 'dc:chan', text: 'first' }]);
+    expect(edits.at(-1)).toEqual({
+      jid: 'dc:chan',
+      id: 'status-1',
+      text: 'first\nsecond',
+    });
+  });
+
+  it('coalesces concurrent first intermediates into one status message', async () => {
+    let resolveSend: (value: string) => void = () => undefined;
+    const sends: string[] = [];
+    const edits: string[] = [];
+    const streamer = _createIntermediateStatusStreamer({
+      channel: {
+        sendMessage: async (_jid, text) => {
+          sends.push(text);
+          return new Promise<string>((resolve) => {
+            resolveSend = resolve;
+          });
+        },
+        editMessage: async (_jid, _id, text) => {
+          edits.push(text);
+        },
+      },
+      chatJid: 'dc:chan',
+      editDebounceMs: 1,
+    });
+
+    const first = streamer.append('first');
+    const second = streamer.append('second');
+    resolveSend('status-1');
+    await Promise.all([first, second]);
+    await tick();
+
+    expect(sends).toEqual(['first']);
+    expect(edits.at(-1)).toBe('first\nsecond');
+  });
+
+  it('edits the final reply into the status message', async () => {
+    const edits: string[] = [];
+    const streamer = _createIntermediateStatusStreamer({
+      channel: {
+        sendMessage: async () => 'status-1',
+        editMessage: async (_jid, _id, text) => {
+          edits.push(text);
+        },
+      },
+      chatJid: 'dc:chan',
+      editDebounceMs: 1,
+    });
+
+    await streamer.append('working');
+    const edited = await streamer.editFinal('final answer');
+
+    expect(edited).toBe(true);
+    expect(edits.at(-1)).toBe('final answer');
+  });
+
+  it('returns false when final edit fails so callers can fall back to sendMessage', async () => {
+    const streamer = _createIntermediateStatusStreamer({
+      channel: {
+        sendMessage: async () => 'status-1',
+        editMessage: async () => {
+          throw new Error('rate limited');
+        },
+      },
+      chatJid: 'dc:chan',
+      editDebounceMs: 1,
+    });
+
+    await streamer.append('working');
+
+    expect(await streamer.editFinal('final answer')).toBe(false);
+  });
+
+  it('does not silently truncate final replies over the edit limit', async () => {
+    const edits: string[] = [];
+    const streamer = _createIntermediateStatusStreamer({
+      channel: {
+        sendMessage: async () => 'status-1',
+        editMessage: async (_jid, _id, text) => {
+          edits.push(text);
+        },
+      },
+      chatJid: 'dc:chan',
+      editDebounceMs: 1,
+    });
+
+    await streamer.append('working');
+    const edited = await streamer.editFinal('x'.repeat(2001));
+
+    expect(edited).toBe(false);
+    expect(edits.at(-1)).toBe('Final response follows below.');
+  });
+
+  it('truncates live buffers on line boundaries and strips broken fences', () => {
+    const text = ['before', '```', 'secret output', '```', 'after'].join('\n');
+
+    const truncated = _truncateIntermediateStatusBuffer(text, 22);
+
+    expect(truncated).not.toContain('```');
+    expect(truncated.startsWith('...')).toBe(true);
+    expect(truncated.length).toBeLessThanOrEqual(22);
+  });
 });
 
 describe('getAvailableGroups', () => {

--- a/src/index.ts
+++ b/src/index.ts
@@ -256,6 +256,147 @@ const MAX_CHANNEL_AGENT_FANOUT = parseInt(
   10,
 );
 const DISPATCH_KEY_SEP = '::agent::';
+const INTERMEDIATE_BUFFER_LIMIT = 1_800;
+const INTERMEDIATE_EDIT_DEBOUNCE_MS = 750;
+
+type IntermediateStatusChannel = Pick<Channel, 'sendMessage' | 'editMessage'>;
+
+export function _truncateIntermediateStatusBuffer(
+  text: string,
+  limit = INTERMEDIATE_BUFFER_LIMIT,
+): string {
+  if (text.length <= limit) return text;
+
+  const lines = text.split('\n');
+  const kept: string[] = [];
+  let length = 0;
+  for (let i = lines.length - 1; i >= 0; i--) {
+    const line = lines[i] ?? '';
+    const nextLength = length + line.length + (kept.length > 0 ? 1 : 0);
+    if (nextLength > limit - 4) break;
+    kept.unshift(line);
+    length = nextLength;
+  }
+
+  const truncated = ['...', ...kept].join('\n').trimStart();
+  // Once truncation occurs, strip fences from the live buffer so Discord does
+  // not render the rest of the status as a broken code block.
+  return truncated.replace(/```/g, '').slice(-limit);
+}
+
+export function _createIntermediateStatusStreamer(opts: {
+  channel: IntermediateStatusChannel | null;
+  chatJid: string;
+  bufferLimit?: number;
+  editDebounceMs?: number;
+  onDebug?: (err: unknown, message: string) => void;
+}) {
+  const channel = opts.channel;
+  const bufferLimit = opts.bufferLimit ?? INTERMEDIATE_BUFFER_LIMIT;
+  const editDebounceMs = opts.editDebounceMs ?? INTERMEDIATE_EDIT_DEBOUNCE_MS;
+  const onDebug = opts.onDebug ?? (() => undefined);
+  let messageId: string | null = null;
+  let creationPromise: Promise<string | null> | null = null;
+  let buffer = '';
+  let editTimer: ReturnType<typeof setTimeout> | null = null;
+  let editInFlight: Promise<void> | null = null;
+
+  const flushEdit = async (): Promise<void> => {
+    if (!channel?.editMessage || !messageId) return;
+    try {
+      await channel.editMessage(opts.chatJid, messageId, buffer.slice(0, 2000));
+    } catch (err) {
+      onDebug(err, 'Intermediate status edit failed');
+    }
+  };
+
+  const scheduleEdit = (): void => {
+    if (!channel?.editMessage || !messageId) return;
+    if (editTimer) return;
+    editTimer = setTimeout(() => {
+      editTimer = null;
+      editInFlight = flushEdit();
+    }, editDebounceMs);
+  };
+
+  const ensureMessage = async (): Promise<string | null> => {
+    if (!channel) return null;
+    if (messageId) return messageId;
+    if (!creationPromise) {
+      const initialBuffer = buffer;
+      creationPromise = channel
+        .sendMessage(opts.chatJid, initialBuffer.slice(0, 2000))
+        .then((id) => {
+          messageId = typeof id === 'string' ? id : null;
+          if (messageId && buffer !== initialBuffer) scheduleEdit();
+          return messageId;
+        })
+        .catch((err) => {
+          onDebug(err, 'Intermediate status creation failed');
+          return null;
+        });
+    }
+    return creationPromise;
+  };
+
+  return {
+    get messageId(): string | null {
+      return messageId;
+    },
+    get buffer(): string {
+      return buffer;
+    },
+    async append(text: string): Promise<void> {
+      if (!channel) return;
+      const clean = text.replace(/<internal>[\s\S]*?<\/internal>/g, '').trim();
+      if (!clean) return;
+      buffer = _truncateIntermediateStatusBuffer(
+        `${buffer}${buffer ? '\n' : ''}${clean}`,
+        bufferLimit,
+      );
+      const hadMessage = Boolean(messageId);
+      const id = await ensureMessage();
+      if (id && hadMessage) scheduleEdit();
+    },
+    async editFinal(text: string): Promise<boolean> {
+      if (!channel?.editMessage) return false;
+      if (editTimer) {
+        clearTimeout(editTimer);
+        editTimer = null;
+      }
+      await editInFlight;
+      const id = await ensureMessage();
+      if (!id) return false;
+      if (text.length > 2000) {
+        try {
+          await channel.editMessage(
+            opts.chatJid,
+            id,
+            'Final response follows below.',
+          );
+        } catch (err) {
+          onDebug(err, 'Final status-note edit failed');
+        }
+        return false;
+      }
+      try {
+        await channel.editMessage(opts.chatJid, id, text);
+        return true;
+      } catch (err) {
+        onDebug(err, 'Final intermediate edit failed');
+        return false;
+      }
+    },
+    reset(): void {
+      if (editTimer) clearTimeout(editTimer);
+      editTimer = null;
+      editInFlight = null;
+      creationPromise = null;
+      messageId = null;
+      buffer = '';
+    },
+  };
+}
 
 interface ChannelRosterMemberView {
   userId: string;
@@ -1492,38 +1633,15 @@ async function processGroupMessages(dispatchJid: string): Promise<boolean> {
   let outputSentToUser = false;
   // Edited-message streaming: a single status message that gets updated with
   // intermediate tool calls/logs, then replaced by the final reply.
-  let intermediateMessageId: string | null = null;
-  let intermediateBuffer = '';
   const intermediateChannel =
     group.containerConfig?.streamIntermediates !== false && channel?.editMessage
       ? channel
       : null;
-  const appendIntermediateText = async (text: string): Promise<void> => {
-    if (!intermediateChannel) return;
-    const clean = text.replace(/<internal>[\s\S]*?<\/internal>/g, '').trim();
-    if (!clean) return;
-    intermediateBuffer = `${intermediateBuffer}${intermediateBuffer ? '\n' : ''}${clean}`;
-    if (intermediateBuffer.length > 1800) {
-      intermediateBuffer = intermediateBuffer.slice(-1800).trimStart();
-    }
-    try {
-      if (!intermediateMessageId) {
-        const id = await intermediateChannel.sendMessage(
-          chatJid,
-          intermediateBuffer.slice(0, 2000),
-        );
-        if (id && typeof id === 'string') intermediateMessageId = id;
-      } else {
-        await intermediateChannel.editMessage!(
-          chatJid,
-          intermediateMessageId,
-          intermediateBuffer.slice(0, 2000),
-        );
-      }
-    } catch (err) {
-      log.debug({ err }, 'Intermediate streaming failed (non-fatal)');
-    }
-  };
+  const intermediateStatus = _createIntermediateStatusStreamer({
+    channel: intermediateChannel,
+    chatJid,
+    onDebug: (err, message) => log.debug({ err }, message),
+  });
 
   // Patterns that indicate system/auth errors — never send these to channels
   // Adopted from [Upstream PR #298] - Prevents infinite loops from auth failures
@@ -1592,7 +1710,7 @@ async function processGroupMessages(dispatchJid: string): Promise<boolean> {
                 typeof result.result === 'string'
                   ? result.result
                   : JSON.stringify(result.result);
-              await appendIntermediateText(raw);
+              await intermediateStatus.append(raw);
             }
             return;
           }
@@ -1641,22 +1759,14 @@ async function processGroupMessages(dispatchJid: string): Promise<boolean> {
                   const replyId =
                     targetJid === chatJid ? replyAnchorMessageId : null;
                   if (
-                    intermediateMessageId &&
+                    intermediateStatus.messageId &&
                     targetJid === chatJid &&
                     targetChannel === intermediateChannel &&
                     targetChannel.editMessage
                   ) {
-                    try {
-                      await targetChannel.editMessage(
-                        targetJid,
-                        intermediateMessageId,
-                        formatted.slice(0, 2000),
-                      );
-                    } catch (err) {
-                      log.debug(
-                        { err },
-                        'Final intermediate edit failed, falling back to send',
-                      );
+                    const edited =
+                      await intermediateStatus.editFinal(formatted);
+                    if (!edited) {
                       await targetChannel.sendMessage(
                         targetJid,
                         formatted,
@@ -1682,8 +1792,7 @@ async function processGroupMessages(dispatchJid: string): Promise<boolean> {
               }
             }
             // Reset intermediate message so the next user message gets a fresh status message
-            intermediateMessageId = null;
-            intermediateBuffer = '';
+            intermediateStatus.reset();
             // Only reset idle timer on actual results, not session-update markers (result: null)
             resetIdleTimer();
           }

--- a/src/index.ts
+++ b/src/index.ts
@@ -1490,13 +1490,40 @@ async function processGroupMessages(dispatchJid: string): Promise<boolean> {
 
   let hadError = false;
   let outputSentToUser = false;
-  // Edited-message streaming: a single message that gets updated with intermediate tool calls
+  // Edited-message streaming: a single status message that gets updated with
+  // intermediate tool calls/logs, then replaced by the final reply.
   let intermediateMessageId: string | null = null;
+  let intermediateBuffer = '';
   const intermediateChannel =
-    group.containerConfig?.streamIntermediates && channel?.editMessage
+    group.containerConfig?.streamIntermediates !== false && channel?.editMessage
       ? channel
       : null;
-  const streamIntermediates = !!intermediateChannel;
+  const appendIntermediateText = async (text: string): Promise<void> => {
+    if (!intermediateChannel) return;
+    const clean = text.replace(/<internal>[\s\S]*?<\/internal>/g, '').trim();
+    if (!clean) return;
+    intermediateBuffer = `${intermediateBuffer}${intermediateBuffer ? '\n' : ''}${clean}`;
+    if (intermediateBuffer.length > 1800) {
+      intermediateBuffer = intermediateBuffer.slice(-1800).trimStart();
+    }
+    try {
+      if (!intermediateMessageId) {
+        const id = await intermediateChannel.sendMessage(
+          chatJid,
+          intermediateBuffer.slice(0, 2000),
+        );
+        if (id && typeof id === 'string') intermediateMessageId = id;
+      } else {
+        await intermediateChannel.editMessage!(
+          chatJid,
+          intermediateMessageId,
+          intermediateBuffer.slice(0, 2000),
+        );
+      }
+    } catch (err) {
+      log.debug({ err }, 'Intermediate streaming failed (non-fatal)');
+    }
+  };
 
   // Patterns that indicate system/auth errors — never send these to channels
   // Adopted from [Upstream PR #298] - Prevents infinite loops from auth failures
@@ -1560,34 +1587,12 @@ async function processGroupMessages(dispatchJid: string): Promise<boolean> {
         // Adopted from [Upstream PR #243] - Critical stability fix
         try {
           if (result.intermediate) {
-            if (intermediateChannel && result.result) {
+            if (result.result) {
               const raw =
                 typeof result.result === 'string'
                   ? result.result
                   : JSON.stringify(result.result);
-              const text = raw
-                .replace(/<internal>[\s\S]*?<\/internal>/g, '')
-                .trim();
-              if (!text) return;
-              try {
-                if (!intermediateMessageId) {
-                  // First intermediate: send a new standalone message
-                  const id = await intermediateChannel.sendMessage(
-                    chatJid,
-                    text.slice(0, 2000),
-                  );
-                  if (id && typeof id === 'string') intermediateMessageId = id;
-                } else {
-                  // Subsequent intermediates: edit that same status message
-                  await intermediateChannel.editMessage!(
-                    chatJid,
-                    intermediateMessageId,
-                    text.slice(0, 2000),
-                  );
-                }
-              } catch (err) {
-                log.debug({ err }, 'Intermediate streaming failed (non-fatal)');
-              }
+              await appendIntermediateText(raw);
             }
             return;
           }
@@ -1635,11 +1640,36 @@ async function processGroupMessages(dispatchJid: string): Promise<boolean> {
                   // Don't use triggeringMessageId for cross-channel responses — it belongs to the original chat
                   const replyId =
                     targetJid === chatJid ? replyAnchorMessageId : null;
-                  await targetChannel.sendMessage(
-                    targetJid,
-                    formatted,
-                    replyId || undefined,
-                  );
+                  if (
+                    intermediateMessageId &&
+                    targetJid === chatJid &&
+                    targetChannel === intermediateChannel &&
+                    targetChannel.editMessage
+                  ) {
+                    try {
+                      await targetChannel.editMessage(
+                        targetJid,
+                        intermediateMessageId,
+                        formatted.slice(0, 2000),
+                      );
+                    } catch (err) {
+                      log.debug(
+                        { err },
+                        'Final intermediate edit failed, falling back to send',
+                      );
+                      await targetChannel.sendMessage(
+                        targetJid,
+                        formatted,
+                        replyId || undefined,
+                      );
+                    }
+                  } else {
+                    await targetChannel.sendMessage(
+                      targetJid,
+                      formatted,
+                      replyId || undefined,
+                    );
+                  }
                   if (replyAnchorMessageId) replyAnchorMessageId = null;
                   outputSentToUser = true;
                   // Stop typing refresh — prevents the 8s interval from
@@ -1653,6 +1683,7 @@ async function processGroupMessages(dispatchJid: string): Promise<boolean> {
             }
             // Reset intermediate message so the next user message gets a fresh status message
             intermediateMessageId = null;
+            intermediateBuffer = '';
             // Only reset idle timer on actual results, not session-update markers (result: null)
             resetIdleTimer();
           }


### PR DESCRIPTION
## Summary

- Make editable intermediate status messages default-on for channels with `editMessage`, while preserving `containerConfig.streamIntermediates: false` as an opt-out.
- Keep a bounded live activity buffer for intermediate output and replace that same message with the final reply when the turn completes.
- Forward Codex and OpenCode tool activity as intermediate output, including compact command/file summaries and capped stdout snippets.
- Coalesce status edits to avoid channel edit-rate-limit storms, guard first-message creation races, preserve full long final replies via send fallback, and redact streamed tool output.

## Operator Note

This changes Discord behavior by default: groups/agents on channels with editable messages now show one live status message during the turn. Set `containerConfig.streamIntermediates: false` to keep the old final-only behavior.

Closes #711.

## Verification

- `bun test ./src/index.test.ts ./container/agent-runner/src/__tests__/codex-runtime.test.ts`
- `bunx tsc --noEmit`
- `bun test`
- `bunx prettier --check .`
