### PR TITLE
test: cover task preprocessor edge cases

### DIFF
--- a/src/task-preprocessor.test.ts
+++ b/src/task-preprocessor.test.ts
@@ -3,7 +3,10 @@ import fs from 'fs';
 import os from 'os';
 import path from 'path';
 
-import { runTaskPreprocessor } from './task-preprocessor.js';
+import {
+  normalizePreprocessScriptPath,
+  runTaskPreprocessor,
+} from './task-preprocessor.js';
 import type { ScheduledTask } from './types.js';
 
 let workflowsDir: string;
@@ -196,6 +199,86 @@ it('supports explicit workflow error actions', () => {
   });
 });
 
+it('defaults to running the original prompt when workflow stdout is empty', () => {
+  fs.writeFileSync(path.join(workflowsDir, 'workflow.ts'), '');
+
+  expect(runTaskPreprocessor(task(), { workflowsDir })).toEqual({
+    action: 'run',
+    prompt: 'sync connector packages',
+  });
+});
+
+it('defaults to running the original prompt when JSON has no action', () => {
+  fs.writeFileSync(
+    path.join(workflowsDir, 'workflow.ts'),
+    'console.log(JSON.stringify({ note: "only metadata" }));',
+  );
+
+  expect(runTaskPreprocessor(task(), { workflowsDir })).toEqual({
+    action: 'run',
+    prompt: 'sync connector packages',
+  });
+});
+
+it('caps replacement prompt length before returning it', () => {
+  fs.writeFileSync(
+    path.join(workflowsDir, 'workflow.ts'),
+    `
+console.log(JSON.stringify({
+  action: "run",
+  prompt: "b".repeat(20)
+}));
+`,
+  );
+
+  expect(
+    runTaskPreprocessor(task(), { workflowsDir, maxPromptFragmentChars: 6 }),
+  ).toEqual({
+    action: 'run',
+    prompt: 'bbbbbb\n\n[preprocessor prompt truncated to 6 characters]',
+  });
+});
+
+it('sanitizes multiline workflow skip reasons', () => {
+  fs.writeFileSync(
+    path.join(workflowsDir, 'workflow.ts'),
+    `
+console.log(JSON.stringify({
+  action: "skip",
+  reason: "\\u001b[31mno changes\\u001b[0m\\n\\n  after scan"
+}));
+`,
+  );
+
+  expect(runTaskPreprocessor(task(), { workflowsDir })).toEqual({
+    action: 'skip',
+    reason: 'no changes after scan',
+  });
+});
+
+it('reports malformed JSON output as a sanitized preprocessor error', () => {
+  fs.writeFileSync(path.join(workflowsDir, 'workflow.ts'), 'console.log("{");');
+
+  const result = runTaskPreprocessor(task(), { workflowsDir });
+
+  expect(result.action).toBe('error');
+  if (result.action !== 'error') throw new Error('expected error result');
+  expect(result.error.length).toBeLessThanOrEqual(512);
+  expect(result.error).toContain('JSON');
+});
+
+it('reports invalid workflow actions as preprocessor errors', () => {
+  fs.writeFileSync(
+    path.join(workflowsDir, 'workflow.ts'),
+    'console.log(JSON.stringify({ action: "pause" }));',
+  );
+
+  expect(runTaskPreprocessor(task(), { workflowsDir })).toEqual({
+    action: 'error',
+    error: 'preprocessor action must be "run", "skip", or "error"',
+  });
+});
+
 it('rejects workflow paths outside the workflows directory', () => {
   const result = runTaskPreprocessor(task({ preprocess_script: '../x.ts' }), {
     workflowsDir,
@@ -206,11 +289,80 @@ it('rejects workflow paths outside the workflows directory', () => {
   expect(result.error).toContain('Path traversal detected');
 });
 
+it('rejects non-string preprocess_script values before spawning', () => {
+  const result = runTaskPreprocessor(
+    task({ preprocess_script: 42 as unknown as string }),
+    { workflowsDir },
+  );
+
+  expect(result).toEqual({
+    action: 'error',
+    error: 'preprocess_script must be a string or null',
+  });
+});
+
+it('rejects empty preprocess_script paths after normalization', () => {
+  const result = runTaskPreprocessor(task({ preprocess_script: '   ' }), {
+    workflowsDir,
+  });
+
+  expect(result).toEqual({
+    action: 'error',
+    error: 'preprocess_script must be a non-empty path',
+  });
+});
+
+it('rejects preprocess_script paths with unsupported extensions', () => {
+  const result = runTaskPreprocessor(
+    task({ preprocess_script: 'workflow.sh' }),
+    {
+      workflowsDir,
+    },
+  );
+
+  expect(result).toEqual({
+    action: 'error',
+    error: 'preprocess_script must point to a JS or TypeScript file',
+  });
+});
+
 it('does nothing when no preprocessor is configured', () => {
   expect(
     runTaskPreprocessor(task({ preprocess_script: null }), { workflowsDir }),
   ).toEqual({
     action: 'run',
     prompt: 'sync connector packages',
+  });
+});
+
+describe('normalizePreprocessScriptPath', () => {
+  it('normalizes missing and blank script paths to null', () => {
+    expect(normalizePreprocessScriptPath(undefined)).toEqual({
+      ok: true,
+      path: null,
+    });
+    expect(normalizePreprocessScriptPath(null)).toEqual({
+      ok: true,
+      path: null,
+    });
+    expect(normalizePreprocessScriptPath('   ')).toEqual({
+      ok: true,
+      path: null,
+    });
+  });
+
+  it('accepts supported JavaScript and TypeScript workflow extensions', () => {
+    for (const scriptPath of [
+      'workflow.ts',
+      'workflow.tsx',
+      'workflow.js',
+      'workflow.mjs',
+      'workflow.cjs',
+    ]) {
+      expect(normalizePreprocessScriptPath(scriptPath)).toEqual({
+        ok: true,
+        path: scriptPath,
+      });
+    }
   });
 });


### PR DESCRIPTION
## Summary

- Adds deterministic task preprocessor tests for default run decisions, prompt replacement capping, malformed JSON, invalid actions, sanitized skip reasons, and script path validation.
- Covers `normalizePreprocessScriptPath` directly for missing, blank, and supported extension inputs.

## Test Count / Coverage

- Before: `2111 pass`, `5629 expect() calls`, coverage `All files 91.20% funcs / 89.99% lines`.
- After: `2122 pass`, `5648 expect() calls`, coverage `All files 91.20% funcs / 90.05% lines`.
- `src/task-preprocessor.ts` line coverage improved from `88.05%` to `94.02%`.

## Verification

- `bun test --coverage`
- `bun test && bun run typecheck`

## Remaining Coverage Gaps

- Large integration-heavy modules remain the main gaps: `src/index.ts`, channel adapters, `src/backends/local-backend.ts`, `src/discovery/routes.ts`, `src/db.ts`, and simtest helpers.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Expanded test coverage for task preprocessing and script validation, including comprehensive edge case handling. New tests verify behavior for empty workflow outputs, missing JSON fields, malformed JSON structures, and invalid file extensions. Added validation tests for script path normalization with support for JavaScript and TypeScript file formats.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/omniaura/omniclaw/pull/714?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->