### PR TITLE
feat(web): aggregate pending and retry stat cards on /ipc

### DIFF
--- a/src/web/ipc-inspector.test.ts
+++ b/src/web/ipc-inspector.test.ts
@@ -131,6 +131,29 @@ describe('renderIpcInspector', () => {
     expect(html).toContain('>2<');
   });
 
+  it('shows aggregate pending messages stat card', () => {
+    // alpha has 2 pending msgs, beta has 0 → total 2
+    const html = renderIpcInspector(makeState());
+    expect(html).toContain('id="stat-pending-messages">2<');
+  });
+
+  it('shows aggregate pending tasks stat card', () => {
+    // alpha has 1 pending task, beta has 0 → total 1
+    const html = renderIpcInspector(makeState());
+    expect(html).toContain('id="stat-pending-tasks">1<');
+  });
+
+  it('shows aggregate retrying stat card with retry depth', () => {
+    // beta has retryCount=2 → 1 retrying group, 2 total retries
+    const html = renderIpcInspector(makeState());
+    expect(html).toContain('id="stat-retrying">1 (2)<');
+  });
+
+  it('shows zero retrying when no groups are retrying', () => {
+    const html = renderIpcInspector(makeState({ getQueueDetails: () => [] }));
+    expect(html).toContain('id="stat-retrying">0<');
+  });
+
   it('shows empty state when no groups', () => {
     const html = renderIpcInspector(makeState({ getQueueDetails: () => [] }));
     expect(html).toContain('No groups currently tracked');

--- a/src/web/ipc-inspector.ts
+++ b/src/web/ipc-inspector.ts
@@ -28,6 +28,17 @@ export function renderIpcInspectorContent(state: WebStateProvider): string {
   const queueDetails = state.getQueueDetails();
   const events = state.getIpcEvents(50);
 
+  let pendingMessages = 0;
+  let pendingTasks = 0;
+  let retryingGroups = 0;
+  let totalRetries = 0;
+  for (const g of queueDetails) {
+    pendingMessages += g.messageLane.pendingCount;
+    pendingTasks += g.taskLane.pendingCount;
+    if (g.retryCount > 0) retryingGroups++;
+    totalRetries += g.retryCount;
+  }
+
   const groupRows = queueDetails
     .map((g) => {
       const msgStatus = g.messageLane.idle
@@ -100,6 +111,9 @@ export function renderIpcInspectorContent(state: WebStateProvider): string {
     `<div class="stat-card"><div class="label">processing</div><div class="value" id="stat-processing">${Math.max(0, stats.activeContainers - stats.idleContainers)}/${stats.maxActive}</div></div>` +
     `<div class="stat-card"><div class="label">idle</div><div class="value" id="stat-ipc-idle">${stats.idleContainers}/${stats.maxIdle}</div></div>` +
     `<div class="stat-card"><div class="label">groups tracked</div><div class="value" id="stat-groups">${queueDetails.length}</div></div>` +
+    `<div class="stat-card"><div class="label">pending msgs</div><div class="value" id="stat-pending-messages">${pendingMessages}</div></div>` +
+    `<div class="stat-card"><div class="label">pending tasks</div><div class="value" id="stat-pending-tasks">${pendingTasks}</div></div>` +
+    `<div class="stat-card"><div class="label">retrying</div><div class="value" id="stat-retrying">${retryingGroups > 0 ? `${retryingGroups} (${totalRetries})` : '0'}</div></div>` +
     `<div class="stat-card"><div class="label">recent events</div><div class="value" id="stat-events">${events.length}</div></div>` +
     `</div>` +
     `<section><h2>group queue state</h2>` +


### PR DESCRIPTION
## Summary

Adds three at-a-glance aggregate cards to the `/ipc` stats grid:

- *pending msgs* — total messages waiting across all message lanes
- *pending tasks* — total scheduled tasks waiting across all task lanes
- *retrying* — count of groups with `retryCount > 0`, with total retry depth in parentheses (e.g. `1 (2)`) so a single stuck group is visible without scanning the queue table

Previously the IPC inspector stats grid only surfaced container counts and group/event tallies. To see queue pressure or detect retry storms, an operator had to scan the per-group table row by row. These rollups make the same numbers visible at a glance.

The retry card encodes both breadth (group count) and intensity (total retries) in one cell — matching the convention already established on `/system` (#707).

## Notes

- Hooks into existing `getQueueDetails()` data; no new API surface, no new SSE event shape, no schema change
- Pure additive change to `renderIpcInspectorContent` — same shell, same scripts
- Part of the operator observability rollup tracked in #644

## Test plan

- [x] `bun test src/web/ipc-inspector.test.ts` — 27 pass (4 new tests for the cards)
- [x] `bun test` full suite — 2115 pass, 0 fail
- [x] `bun run typecheck` — clean
- [ ] Manual visual check of `/ipc` in dev

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

**New Features**
- IPC inspector now includes aggregate statistics cards displaying total pending messages, pending tasks, number of retrying queue groups, and cumulative retry count. These new metrics provide comprehensive visibility into queue operations and health status across all monitored groups alongside existing performance data.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/omniaura/omniclaw/pull/719?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->