### PR TITLE
ci: typecheck agent runner

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,6 +45,14 @@ jobs:
       - run: bun install
       - run: npx tsc --noEmit
 
+  agent-runner-typecheck:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: oven-sh/setup-bun@v2
+      - run: cd container/agent-runner && bun install
+      - run: cd container/agent-runner && bunx tsc --noEmit
+
   test:
     runs-on: ubuntu-latest
     steps:

--- a/container/agent-runner/src/index.ts
+++ b/container/agent-runner/src/index.ts
@@ -22,6 +22,7 @@ import {
   PreCompactHookInput,
   PreToolUseHookInput,
 } from '@anthropic-ai/claude-agent-sdk';
+import type { SDKUserMessage } from '@anthropic-ai/claude-agent-sdk';
 
 // Shared protocol types — import type only (erased at runtime, no module needed in container).
 import type {
@@ -29,6 +30,7 @@ import type {
   ChannelInfo,
   ContainerInput,
   ContainerOutput,
+  IpcDrainResult,
   IpcMessage,
 } from '@omniclaw/protocol';
 
@@ -347,19 +349,11 @@ interface SessionsIndex {
   entries: SessionEntry[];
 }
 
-type ContentBlock =
-  | { type: 'text'; text: string }
-  | {
-      type: 'image';
-      source: { type: 'base64'; media_type: string; data: string };
-    };
-
-interface SDKUserMessage {
-  type: 'user';
-  message: { role: 'user'; content: string | ContentBlock[] };
-  parent_tool_use_id: null;
-  session_id: string;
-}
+type ContentBlock = Exclude<
+  SDKUserMessage['message']['content'],
+  string
+>[number];
+type ImageMediaType = 'image/png' | 'image/jpeg' | 'image/gif' | 'image/webp';
 
 // Defaults to the message lane; reassigned to input-task/ after stdin is parsed
 // when containerInput.isScheduledTask is true.
@@ -467,7 +461,7 @@ function stopHeartbeat(): void {
 
 const IMAGE_MARKER_RE = /\[attachment:image file=([^\]]+)\]/g;
 
-const EXT_TO_MEDIA_TYPE: Record<string, string> = {
+const EXT_TO_MEDIA_TYPE: Record<string, ImageMediaType> = {
   '.png': 'image/png',
   '.jpg': 'image/jpeg',
   '.jpeg': 'image/jpeg',
@@ -1691,9 +1685,15 @@ Please review these changes to understand your new capabilities and fixes.
     prompt = `[SCHEDULED TASK - The following message was sent automatically and is not coming directly from the user or group.]\n\n${prompt}`;
   }
   const pending = drainIpcInput();
-  if (pending.length > 0) {
-    log(`Draining ${pending.length} pending IPC messages into initial prompt`);
-    prompt += '\n' + formatIpcMessages(pending);
+  if (pending.shutdown) {
+    log('Shutdown before initial Claude run');
+    return;
+  }
+  if (pending.messages.length > 0) {
+    log(
+      `Draining ${pending.messages.length} pending IPC messages into initial prompt`,
+    );
+    prompt += '\n' + formatIpcMessages(pending.messages);
   }
 
   // Prepend update notification if present

--- a/container/agent-runner/src/opencode-runtime.ts
+++ b/container/agent-runner/src/opencode-runtime.ts
@@ -780,9 +780,15 @@ export async function runOpenCodeRuntime(
     prompt = `[SCHEDULED TASK - The following message was sent automatically and is not coming directly from the user or group.]\n\n${prompt}`;
   }
   const pending = drainIpcInput();
-  if (pending.length > 0) {
-    log(`Draining ${pending.length} pending IPC messages into initial prompt`);
-    prompt += '\n' + formatIpcMessages(pending);
+  if (pending.shutdown) {
+    log('Shutdown before initial OpenCode run');
+    return;
+  }
+  if (pending.messages.length > 0) {
+    log(
+      `Draining ${pending.messages.length} pending IPC messages into initial prompt`,
+    );
+    prompt += '\n' + formatIpcMessages(pending.messages);
   }
 
   // Default timeout from container config

--- a/container/agent-runner/tsconfig.json
+++ b/container/agent-runner/tsconfig.json
@@ -10,7 +10,7 @@
     "declaration": true,
     "types": ["bun-types"],
     "paths": {
-      "@omniclaw/protocol": ["../../packages/protocol/src/index.ts"]
+      "@omniclaw/protocol": ["../../packages/protocol/src/index.d.ts"]
     }
   },
   "include": ["src/**/*"],


### PR DESCRIPTION
## Summary

- Fixes the direct `container/agent-runner` TypeScript drift that made `bunx tsc --noEmit` fail on main
- Uses the Claude SDK `SDKUserMessage` type for streamed messages and narrows image media types to the SDK-supported literals
- Updates stale `IpcDrainResult` call sites to read `messages` / `shutdown`
- Adds a CI job that runs `bunx tsc --noEmit` inside `container/agent-runner`

## Verification

- `cd container/agent-runner && bunx tsc --noEmit`
- `bunx tsc --noEmit`
- `bunx prettier --check .github/workflows/ci.yml container/agent-runner/src/index.ts container/agent-runner/src/opencode-runtime.ts container/agent-runner/tsconfig.json`
- `cd container/agent-runner && bun test src/__tests__/opencode-runtime.test.ts src/__tests__/codex-runtime.test.ts src/__tests__/ipc-lane.test.ts`

Closes #679


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Expanded TypeScript type-checking coverage in CI pipeline for the agent runner.

* **Bug Fixes**
  * Improved handling of shutdown signals during container runtime initialization to prevent unexpected behavior.

* **Refactor**
  * Enhanced type safety for image content processing and IPC message handling in the container runtime.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/omniaura/omniclaw/pull/723?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->