### PR TITLE
[codex] fix Telegram scoped DM routing

### DIFF
--- a/container/agent-runner/src/ipc-mcp-stdio.ts
+++ b/container/agent-runner/src/ipc-mcp-stdio.ts
@@ -13,6 +13,7 @@ import { CronExpressionParser } from 'cron-parser';
 import {
   buildChannelMaps,
   buildSendMessageChannelDescription,
+  getCurrentChatJid,
   resolveSendMessageTarget,
 } from './send-message-routing.js';
 
@@ -52,6 +53,14 @@ const { channelByJid } = buildChannelMaps(channels);
 
 // For backwards compatibility, chatJid is a getter
 const chatJid = initialChatJid;
+
+function readCurrentChatJid(): string {
+  return getCurrentChatJid({
+    channels,
+    currentChatFile,
+    initialChatJid,
+  });
+}
 
 // User registry for mention formatting (Issue #66)
 interface UserInfo {
@@ -376,7 +385,7 @@ SCHEDULE VALUE FORMAT (all times are LOCAL timezone):
     const targetJid =
       isMain && args.target_group_jid
         ? args.target_group_jid
-        : getCurrentChatJid();
+        : readCurrentChatJid();
 
     const data = {
       type: 'schedule_task',
@@ -891,7 +900,7 @@ if (chatJid.startsWith('dc:') || chatJid.startsWith('tg:')) {
       const requestId = `reaction-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
       writeIpcFile(MESSAGES_DIR, {
         type: 'react_to_message',
-        chatJid: getCurrentChatJid(),
+        chatJid: readCurrentChatJid(),
         messageId: args.message_id,
         emoji: args.emoji,
         remove: args.remove || false,

--- a/src/index.ts
+++ b/src/index.ts
@@ -782,6 +782,26 @@ function getSubscriptionsForChannelInMemory(
   return [];
 }
 
+function buildMessagePollJids(): string[] {
+  const jids = new Set([
+    ...Object.keys(registeredGroups),
+    ...Object.keys(channelSubscriptions),
+  ]);
+
+  // Telegram messages are stored under scoped JIDs (`tg:<botId>:<chatId>`) so
+  // multiple Telegram bots can coexist. Older registrations still use the
+  // legacy `tg:<chatId>` form; include matching scoped chats in the poll set so
+  // those legacy private/group registrations keep receiving messages.
+  for (const chat of getAllChats()) {
+    const legacyJid = toLegacyTelegramJid(chat.jid);
+    if (legacyJid && jids.has(legacyJid)) {
+      jids.add(chat.jid);
+    }
+  }
+
+  return Array.from(jids);
+}
+
 function buildRegisteredGroupFromSubscription(
   channelJid: string,
   sub: ChannelSubscription,
@@ -2550,12 +2570,7 @@ async function startMessageLoop(): Promise<void> {
   while (true) {
     try {
       refreshChannelSubscriptions();
-      const jids = Array.from(
-        new Set([
-          ...Object.keys(registeredGroups),
-          ...Object.keys(channelSubscriptions),
-        ]),
-      );
+      const jids = buildMessagePollJids();
       const { messages, newTimestamp } = getNewMessages(jids, lastTimestamp);
 
       if (messages.length > 0) {


### PR DESCRIPTION
## Summary

- Include scoped Telegram chat JIDs in the message poll set when they correspond to a legacy registered or subscribed Telegram chat.
- Keep older `tg:<chatId>` registrations working after Telegram messages are stored as `tg:<botId>:<chatId>`.

## Root Cause

Telegram DMs were being stored under scoped IDs such as `tg:8401921193:1991174535`, while the `local-peyton` private chat subscription still used the legacy `tg:1991174535` ID. The subscription lookup could fall back from scoped to legacy, but the message loop only polled registered/subscribed JIDs, so scoped DM messages were never selected for processing.

## Impact

Messages sent to the `local_peyton_bot` private Telegram DM now route to `local-peyton` instead of being stored silently.

## Validation

- `bun run build` passed.
- Restarted the local OmniClaw launchd service and confirmed channels reconnected.
- `bun run typecheck` still fails on existing unrelated errors around `cursor-sdk`, task outcome `skipped`, and `ContainerInput` fields.