### PR TITLE
fix: validate Discord embed media URLs

### DIFF
--- a/src/channels/discord.ts
+++ b/src/channels/discord.ts
@@ -1075,7 +1075,9 @@ export class DiscordChannel implements Channel {
             safeName,
             'embed',
           );
-          const bytes = await downloadBinaryAttachment(imageUrl);
+          const bytes = await downloadBinaryAttachment(imageUrl, {
+            validateRemoteUrl: true,
+          });
           fs.writeFileSync(filePath, bytes);
           embedParts.push(formatImageMarker(path.basename(filePath)));
         } catch (err) {

--- a/src/media.test.ts
+++ b/src/media.test.ts
@@ -186,6 +186,38 @@ describe('downloadBinaryAttachment', () => {
     expect(fetchMock).not.toHaveBeenCalled();
   });
 
+  it('does not follow redirects for validated direct-IP URLs', async () => {
+    const fetchMock = mock(
+      (_url: string | URL | Request, init?: RequestInit) => {
+        if (init?.redirect !== 'manual') {
+          return Promise.resolve(
+            new Response(createStream(['redirected-private-bytes'])),
+          );
+        }
+
+        return Promise.resolve(
+          new Response(null, {
+            status: 302,
+            headers: { Location: 'http://127.0.0.1/private.png' },
+          }),
+        );
+      },
+    ) as unknown as typeof globalThis.fetch;
+    globalThis.fetch = fetchMock;
+
+    await expect(
+      downloadBinaryAttachment('http://93.184.216.34/public.png', {
+        validateRemoteUrl: true,
+      }),
+    ).rejects.toThrow('Download failed with status 302');
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    expect(fetchMock).toHaveBeenCalledWith(
+      'http://93.184.216.34/public.png',
+      expect.objectContaining({ redirect: 'manual' }),
+    );
+  });
+
   it('enforces default max bytes (10 MiB)', () => {
     expect(MAX_BINARY_DOWNLOAD_BYTES).toBe(10 * 1024 * 1024);
   });

--- a/src/media.test.ts
+++ b/src/media.test.ts
@@ -141,6 +141,51 @@ describe('downloadBinaryAttachment', () => {
     ).rejects.toThrow('Download failed with status 404');
   });
 
+  it('rejects validated remote URLs that resolve to private addresses', async () => {
+    const fetchMock = mock(() =>
+      Promise.resolve(new Response(createStream(['should-not-fetch']))),
+    ) as unknown as typeof globalThis.fetch;
+    globalThis.fetch = fetchMock;
+
+    await expect(
+      downloadBinaryAttachment('https://example.test/private.png', {
+        validateRemoteUrl: true,
+        lookupHostAddresses: async () => ['127.0.0.1'],
+      }),
+    ).rejects.toThrow(
+      'Remote attachment URL rejected: resolved private address is not allowed',
+    );
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it('pins DNS when downloading validated hostname URLs', async () => {
+    const fetchMock = mock(() =>
+      Promise.resolve(new Response(createStream(['should-not-fetch']))),
+    ) as unknown as typeof globalThis.fetch;
+    globalThis.fetch = fetchMock;
+    const pinnedFetch = mock(
+      (_url: string, _address: string, _timeoutMs: number) =>
+        Promise.resolve(new Response(createStream(['pinned-bytes']))),
+    );
+
+    const bytes = await downloadBinaryAttachment(
+      'https://cdn.example.test/file.png',
+      {
+        validateRemoteUrl: true,
+        lookupHostAddresses: async () => ['203.0.113.10'],
+        fetchWithPinnedDnsImpl: pinnedFetch,
+      },
+    );
+
+    expect(bytes.toString()).toBe('pinned-bytes');
+    expect(pinnedFetch).toHaveBeenCalledWith(
+      'https://cdn.example.test/file.png',
+      '203.0.113.10',
+      15_000,
+    );
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
   it('enforces default max bytes (10 MiB)', () => {
     expect(MAX_BINARY_DOWNLOAD_BYTES).toBe(10 * 1024 * 1024);
   });

--- a/src/media.ts
+++ b/src/media.ts
@@ -121,9 +121,13 @@ export async function readStreamWithByteLimit(
  */
 export async function fetchWithTimeout(
   url: string,
-  options?: { timeoutMs?: number },
+  options?: {
+    timeoutMs?: number;
+    redirect?: NonNullable<RequestInit['redirect']>;
+  },
 ): Promise<Response> {
   return fetch(url, {
+    redirect: options?.redirect,
     signal: AbortSignal.timeout(
       options?.timeoutMs ?? DEFAULT_DOWNLOAD_TIMEOUT_MS,
     ),
@@ -133,6 +137,7 @@ export async function fetchWithTimeout(
 export interface AttachmentDownloadOptions {
   maxBytes?: number;
   timeoutMs?: number;
+  redirect?: NonNullable<RequestInit['redirect']>;
   /** Validate and DNS-pin untrusted remote URLs before fetching. */
   validateRemoteUrl?: boolean;
   /** Override DNS resolution (primarily for tests). */
@@ -155,7 +160,9 @@ async function fetchAttachment(
   }
 
   const pinnedAddress = validation.resolvedAddresses[0];
-  if (!pinnedAddress) return fetchWithTimeout(url, options);
+  if (!pinnedAddress) {
+    return fetchWithTimeout(url, { ...options, redirect: 'manual' });
+  }
 
   return (options.fetchWithPinnedDnsImpl ?? fetchWithPinnedDns)(
     url,

--- a/src/media.ts
+++ b/src/media.ts
@@ -12,6 +12,11 @@ import { GROUPS_DIR } from './config.js';
 import { logger } from './logger.js';
 import { assertPathWithin } from './path-security.js';
 import type { MediaAttachment, MediaAttachmentType } from './types.js';
+import {
+  fetchWithPinnedDns,
+  resolveAndValidateRemoteImageUrl,
+  type PinnedRemoteImageFetch,
+} from './web/image-cache.js';
 
 // ---------------------------------------------------------------------------
 // Constants
@@ -125,15 +130,49 @@ export async function fetchWithTimeout(
   });
 }
 
+export interface AttachmentDownloadOptions {
+  maxBytes?: number;
+  timeoutMs?: number;
+  /** Validate and DNS-pin untrusted remote URLs before fetching. */
+  validateRemoteUrl?: boolean;
+  /** Override DNS resolution (primarily for tests). */
+  lookupHostAddresses?: (hostname: string) => Promise<string[]>;
+  /** Override pinned DNS fetch (primarily for tests). */
+  fetchWithPinnedDnsImpl?: PinnedRemoteImageFetch;
+}
+
+async function fetchAttachment(
+  url: string,
+  options?: AttachmentDownloadOptions,
+): Promise<Response> {
+  if (!options?.validateRemoteUrl) return fetchWithTimeout(url, options);
+
+  const validation = await resolveAndValidateRemoteImageUrl(url, {
+    lookupHostAddresses: options.lookupHostAddresses,
+  });
+  if (validation.error) {
+    throw new Error(`Remote attachment URL rejected: ${validation.error}`);
+  }
+
+  const pinnedAddress = validation.resolvedAddresses[0];
+  if (!pinnedAddress) return fetchWithTimeout(url, options);
+
+  return (options.fetchWithPinnedDnsImpl ?? fetchWithPinnedDns)(
+    url,
+    pinnedAddress,
+    options.timeoutMs ?? DEFAULT_DOWNLOAD_TIMEOUT_MS,
+  );
+}
+
 /**
  * Download a binary attachment (image, video, audio) and return its bytes.
  * Enforces `maxBytes` (default: 10 MiB).
  */
 export async function downloadBinaryAttachment(
   url: string,
-  options?: { maxBytes?: number; timeoutMs?: number },
+  options?: AttachmentDownloadOptions,
 ): Promise<Buffer> {
-  const response = await fetchWithTimeout(url, options);
+  const response = await fetchAttachment(url, options);
   if (!response.ok) {
     throw new Error(`Download failed with status ${response.status}`);
   }


### PR DESCRIPTION
## Summary

- Add opt-in remote URL validation and DNS pinning to media attachment downloads.
- Use the validated path for Discord embed images before server-side fetches.
- Add regression tests for private-address rejection and pinned DNS fetch behavior.

Fixes #667.

## Security Impact

Discord embed image URLs are user-controlled. This blocks embed image fetches that resolve to loopback, private, link-local, multicast, CGNAT, or other disallowed addresses, and pins the resolved public address for the actual fetch to reduce DNS rebinding risk.

## Tests

- `bun test src/media.test.ts src/channels/discord.test.ts`
- `bun run typecheck`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced security validation for remote image URLs in Discord embeds.
  * Improved binary attachment downloads with stricter validation controls for remote URLs.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/omniaura/omniclaw/pull/731?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->