### PR TITLE
test: cover task rendering date fallbacks

### DIFF
--- a/src/web/tasks.test.ts
+++ b/src/web/tasks.test.ts
@@ -222,7 +222,11 @@ describe('renderTaskTableRows', () => {
         if (value === 'throw-once') {
           throw new Error('date unavailable');
         }
-        super(value);
+        if (value === undefined) {
+          super();
+        } else {
+          super(value);
+        }
       }
     }
 
@@ -250,7 +254,11 @@ describe('renderTaskTableRows', () => {
         if (value === 'throw-relative') {
           throw new Error('date unavailable');
         }
-        super(value);
+        if (value === undefined) {
+          super();
+        } else {
+          super(value);
+        }
       }
     }
 

--- a/src/web/tasks.test.ts
+++ b/src/web/tasks.test.ts
@@ -180,6 +180,94 @@ describe('renderTaskTableRows', () => {
       globalThis.Date = RealDate;
     }
   });
+
+  it('formats hour-level relative times with deterministic current time', () => {
+    const RealDate = Date;
+    const fixedNow = new RealDate('2026-05-08T12:00:00.000Z');
+
+    class FixedDate extends RealDate {
+      constructor(value?: string | number | Date) {
+        super(value ?? fixedNow.getTime());
+      }
+
+      static now() {
+        return fixedNow.getTime();
+      }
+    }
+
+    globalThis.Date = FixedDate as DateConstructor;
+    try {
+      const html = renderTaskTableRows([
+        makeTask({
+          id: 'task-hour-relative',
+          next_run: '2026-05-08T14:00:00.000Z',
+          last_run: '2026-05-08T09:00:00.000Z',
+          last_result: 'success',
+        }),
+      ]);
+
+      expect(html).toContain('>in 2h</td>');
+      expect(html).toContain('class="td-time run-success"');
+      expect(html).toContain('>3h ago</td>');
+    } finally {
+      globalThis.Date = RealDate;
+    }
+  });
+
+  it('falls back to raw one-shot schedule values when Date construction fails', () => {
+    const RealDate = Date;
+
+    class ThrowingDate extends RealDate {
+      constructor(value?: string | number | Date) {
+        if (value === 'throw-once') {
+          throw new Error('date unavailable');
+        }
+        super(value);
+      }
+    }
+
+    globalThis.Date = ThrowingDate as DateConstructor;
+    try {
+      const html = renderTaskTableRows([
+        makeTask({
+          id: 'task-once-fallback',
+          schedule_type: 'once',
+          schedule_value: 'throw-once',
+        }),
+      ]);
+
+      expect(html).toContain('<span class="sched-label">throw-once</span>');
+    } finally {
+      globalThis.Date = RealDate;
+    }
+  });
+
+  it('falls back to raw run timestamps when Date construction fails', () => {
+    const RealDate = Date;
+
+    class ThrowingDate extends RealDate {
+      constructor(value?: string | number | Date) {
+        if (value === 'throw-relative') {
+          throw new Error('date unavailable');
+        }
+        super(value);
+      }
+    }
+
+    globalThis.Date = ThrowingDate as DateConstructor;
+    try {
+      const html = renderTaskTableRows([
+        makeTask({
+          id: 'task-relative-fallback',
+          next_run: 'throw-relative',
+        }),
+      ]);
+
+      expect(html).toContain('>throw-relative</td>');
+    } finally {
+      globalThis.Date = RealDate;
+    }
+  });
 });
 
 describe('renderTasksContent', () => {


### PR DESCRIPTION
## Summary

- Add deterministic task table rendering tests for hour-level relative timestamps.
- Add Date monkey-patch tests covering one-shot schedule and run timestamp fallback branches.
- Bring `src/web/tasks.ts` to 100% line coverage in the Bun coverage report.

## Test Counts

- Before: `2127 pass`, `0 fail`, `5729 expect() calls`, `104 files`
- After: `2130 pass`, `0 fail`, `5734 expect() calls`, `104 files`

## Verification

- `bun test src/web/tasks.test.ts`
- `bun test`
- `bun test --coverage`

## Coverage Notes

- Covered file: `src/web/tasks.ts`
- Before coverage for `src/web/tasks.ts`: 100% funcs, 94.87% lines; uncovered lines `241-244`, `265-266`, `270-271`
- After coverage for `src/web/tasks.ts`: 100% funcs, 100% lines
- Remaining repo-level gaps are still concentrated in large integration-heavy modules like `src/index.ts`, channel adapters, discovery routes, local backend, and DB edge paths.

Reviewer request: please leave review feedback directly on the GitHub PR, preferably as file/line comments where applicable.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Expanded test coverage for task schedule and time display functionality, including validation of relative time formatting, deterministic behavior, and fallback handling for error conditions.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/omniaura/omniclaw/pull/737?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->