### PR TITLE
fix(security): sanitize markdown output in Web UI conversation viewer (#738)

### DIFF
--- a/src/web/page-scripts.test.ts
+++ b/src/web/page-scripts.test.ts
@@ -130,6 +130,17 @@ describe('conversations page script', () => {
     expect(script).toContain('msg-md');
   });
 
+  it('sanitizes markdown output to block javascript: links and raw HTML', () => {
+    const script = allPageScripts().conversations;
+    // After markdown parsing, the result must pass through the existing
+    // allowlist sanitizer so anchors with javascript: hrefs are stripped.
+    expect(script).toContain(
+      'window.__sanitizeHtml?window.__sanitizeHtml(html):html',
+    );
+    // Pre-markdown escape must still happen to keep raw HTML out of marked.
+    expect(script).toContain('marked.parse(window.__esc(text))');
+  });
+
   it('subscribes to SSE for live message updates', () => {
     const script = allPageScripts().conversations;
     expect(script).toContain('function startLiveSse(){');

--- a/src/web/page-scripts.ts
+++ b/src/web/page-scripts.ts
@@ -1345,10 +1345,12 @@ function conversationsScript(): string {
     '}',
     'loadMarked();',
     '',
-    // Render markdown safely: escape HTML first, then parse markdown
+    // Render markdown safely: escape HTML first, parse markdown,
+    // then sanitize parsed HTML to strip unsafe attributes (e.g. javascript: hrefs)
     'function renderMd(text){',
     '  if(!markedReady)return window.__esc(text);',
-    '  return marked.parse(window.__esc(text));',
+    '  var html=marked.parse(window.__esc(text));',
+    '  return window.__sanitizeHtml?window.__sanitizeHtml(html):html;',
     '}',
     '',
     // Tab switching


### PR DESCRIPTION
## Summary

Fixes #738 — a P1 stored-XSS in the Web UI conversation viewer.

`renderMd()` in `src/web/page-scripts.ts` escaped raw HTML before Markdown parsing but did **not** sanitize the Markdown-generated HTML. A message containing `[click](javascript:alert(document.domain))` could execute script in the authenticated operator session when rendered via `innerHTML`.

## Fix

- `renderMd()` now passes `marked.parse(...)` output through the existing `window.__sanitizeHtml` allowlist sanitizer before returning it.
- `__sanitizeHtml` already routes anchor `href` values through `__sanitizeUrl`, which strips `javascript:` and other unsafe schemes, and forces `rel="noopener noreferrer" target="_blank"`.
- The pre-Markdown `window.__esc(text)` step is preserved so raw HTML in the source text continues to be inert.

This covers all three insertion paths flagged in the issue:
- stored message rendering in `renderMessages()`
- live SSE updates in `appendLiveMessage()`
- search result rendering (same renderer)

## Tests

Added a regression assertion in `src/web/page-scripts.test.ts` that the conversations page script wires `marked.parse(...)` output through `__sanitizeHtml`.

- `bun test` — 2128 pass, 0 fail
- `bun run typecheck` — clean

## Test plan

- [x] Existing 14 page-scripts tests still pass
- [x] New regression test added asserting `__sanitizeHtml` is invoked on Markdown output
- [x] Full suite green (2128 tests)
- [x] `tsc --noEmit` clean
- [ ] Manual: open `/conversations`, render a message containing `[click](javascript:alert(1))`, confirm the rendered anchor has no `href` and clicking does nothing


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced security in markdown rendering by implementing HTML sanitization to prevent raw HTML and JavaScript injection.

* **Tests**
  * Added test coverage to verify markdown content is properly sanitized during rendering.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/omniaura/omniclaw/pull/740?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->