### PR TITLE
setup: move sleep prevention from caffeinate to OS pmset

### DIFF
--- a/.agents/skills/setup/SKILL.md
+++ b/.agents/skills/setup/SKILL.md
@@ -19,6 +19,7 @@ description: Run initial OmniClaw setup. Use when user wants to install dependen
 | add agent to channel, subscribe agent, register agent in chat, new channel for agent                                          | → read [guides/agents-and-context.md](guides/agents-and-context.md) (see "Adding an existing agent to a new channel" or "Adding a new agent to an existing channel") |
 | agent identity, context, workspace mounts, agent-to-agent routing, triggers, wrong identity, sender identity, channel context | → read [guides/agents-and-context.md](guides/agents-and-context.md)                                                                                                  |
 | linger, ssh disconnect, service dies, agents go offline                                                                       | → [Linger fix](#linger-fix) below                                                                                                                                    |
+| mac mini, mac server mode, force-shutdown, pmset, sleep, autorestart, auto-login, mac wakes up                                | → [Mac server-mode fix](#mac-server-mode-fix) below                                                                                                                  |
 | broken, not working, error, troubleshoot                                                                                      | → read [guides/troubleshooting.md](guides/troubleshooting.md)                                                                                                        |
 
 ---
@@ -107,6 +108,28 @@ loginctl show-user $(whoami) | grep Linger
 ```
 
 Without linger, systemd tears down all user services when the last session ends. This is also handled automatically by step 10 (`08-setup-service.sh`) during fresh install.
+
+---
+
+## Mac server-mode fix
+
+**macOS only.** If user reports the Mac (especially a Mac mini) requiring force-shutdowns, going to sleep, or not coming back after a power blip:
+
+```bash
+./.claude/skills/setup/scripts/00-check-mac-server-mode.sh
+```
+
+Parse the status block. If `NEEDS_FIXUP=true`, AskUserQuestion whether to apply the fixup. If yes, tell the user to open a new terminal tab and run:
+
+```bash
+sudo bash .agents/skills/setup/scripts/mac-server-mode.sh
+```
+
+The fixup is sudo-only and interactive (it prompts to enable SSH), so it cannot run from this shell. The script sets `pmset sleep=0`, `autorestart=1`, `tcpkeepalive=1`, `womp=1`, and `disksleep=0`, and prompts the user to enable Remote Login. It does not script auto-login (macOS stores the password obfuscated-not-encrypted) — the user must enable it via System Settings > Users & Groups > Automatic Login.
+
+After the user reports done, re-run `00-check-mac-server-mode.sh` to confirm.
+
+**Note:** sleep prevention lives at the OS layer (`pmset`), not in app code. Earlier versions wrapped the launchd `ProgramArguments` with `caffeinate -dimsu`; that was removed in favor of this OS-level config, which also avoids forcing the display awake on headless servers.
 
 ---
 

--- a/.agents/skills/setup/guides/fresh-install.md
+++ b/.agents/skills/setup/guides/fresh-install.md
@@ -23,6 +23,31 @@ Run `./.claude/skills/setup/scripts/01-check-environment.sh` and parse the statu
 
 Install brew/nvm first if needed. Re-run environment check after to confirm NODE_OK=true.
 
+## 1b. Mac Server-Mode Check (macOS only)
+
+If `PLATFORM=macos` from the previous step, run `./.claude/skills/setup/scripts/00-check-mac-server-mode.sh` and parse the status block.
+
+This check matters most for **Mac mini** deployments (where `IS_MAC_MINI=true`), but applies to any macOS host that needs to stay up 24/7. The Mac needs:
+
+- `SLEEP=0` (system never sleeps)
+- `AUTORESTART=1` (auto-restart after power failure)
+- `SSH_OK=true` (Remote Login enabled, so you can administer the box)
+- `AUTOLOGIN_OK=true` (user auto-logs in after reboot — required for the launchd user agent to start without manual login)
+
+**If `NEEDS_FIXUP=true`:** AskUserQuestion whether to apply the server-mode fixup.
+
+If yes, tell the user to open a new terminal tab and run (the fixup needs `sudo`, which won't work from this shell):
+
+```bash
+sudo bash <FIXUP_SCRIPT>
+```
+
+…where `<FIXUP_SCRIPT>` is the path emitted in the status block (`.agents/skills/setup/scripts/mac-server-mode.sh`). The script is idempotent and prints pmset state before/after, prompts to enable SSH, and tells the user how to enable auto-login (it does not script auto-login because macOS stores the password obfuscated-not-encrypted — leave that step to the user via System Settings > Users & Groups > Automatic Login).
+
+After the user reports back that the script finished, re-run `00-check-mac-server-mode.sh` to confirm `NEEDS_FIXUP=false`. If the user declines, note it and proceed — they can run the fixup later.
+
+**Note:** sleep prevention is intentionally handled at the OS layer (via `pmset`), not by wrapping the launchd command in `caffeinate`. The OS knows how to do this correctly; app-level caffeinate also forced the display awake on headless servers, which was wasteful.
+
 ## 2. Install Dependencies
 
 Run `./.claude/skills/setup/scripts/02-install-deps.sh` and parse the status block.

--- a/.agents/skills/setup/scripts/00-check-mac-server-mode.sh
+++ b/.agents/skills/setup/scripts/00-check-mac-server-mode.sh
@@ -1,0 +1,106 @@
+#!/bin/bash
+set -u
+
+# 00-check-mac-server-mode.sh — Inspect macOS server-readiness settings.
+#
+# On macOS (especially Mac mini deployments), the OS must be configured to
+# stay awake, auto-restart after power failure, allow SSH, and auto-login
+# so that omniclaw can run as a 24/7 headless service.
+#
+# This script reports current state. Fixup is applied by mac-server-mode.sh
+# (which requires sudo and is intentionally not invoked from here).
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_ROOT="$(cd "$SCRIPT_DIR/../../../.." && pwd)"
+LOG_FILE="$PROJECT_ROOT/logs/setup.log"
+
+mkdir -p "$PROJECT_ROOT/logs"
+
+log() { echo "[$(date '+%Y-%m-%d %H:%M:%S')] [check-mac-server-mode] $*" >> "$LOG_FILE"; }
+
+# Detect platform
+case "$(uname -s)" in
+  Darwin*) PLATFORM="macos" ;;
+  *)       PLATFORM="other" ;;
+esac
+
+if [ "$PLATFORM" != "macos" ]; then
+  log "Not macOS, skipping"
+  cat <<EOF
+=== OMNICLAW SETUP: CHECK_MAC_SERVER_MODE ===
+PLATFORM: $PLATFORM
+APPLICABLE: false
+STATUS: skipped
+LOG: logs/setup.log
+=== END ===
+EOF
+  exit 0
+fi
+
+# Detect Mac mini specifically.
+# Older Intel Mac minis report hw.model like "Macmini9,1". Apple Silicon Macs
+# report opaque codes like "Mac16,11" (M4 Pro Mac mini), so fall back to
+# system_profiler for the human-readable model name.
+HW_MODEL="$(sysctl -n hw.model 2>/dev/null || echo unknown)"
+IS_MAC_MINI="false"
+if echo "$HW_MODEL" | grep -qi macmini; then
+  IS_MAC_MINI="true"
+else
+  MODEL_NAME="$(system_profiler SPHardwareDataType 2>/dev/null | awk -F': ' '/Model Name/{print $2; exit}' || true)"
+  if echo "${MODEL_NAME:-}" | grep -qi "Mac mini"; then
+    IS_MAC_MINI="true"
+  fi
+fi
+log "hw.model=$HW_MODEL is_mac_mini=$IS_MAC_MINI"
+
+# pmset sleep — want 0 (never)
+SLEEP_VALUE="$(pmset -g 2>/dev/null | awk '/ sleep /{print $2; exit}' || echo unknown)"
+SLEEP_OK="false"
+if [ "$SLEEP_VALUE" = "0" ]; then SLEEP_OK="true"; fi
+
+# pmset autorestart — want 1 (restart after power failure)
+AUTORESTART_VALUE="$(pmset -g 2>/dev/null | awk '/autorestart/{print $2; exit}' || echo unknown)"
+AUTORESTART_OK="false"
+if [ "$AUTORESTART_VALUE" = "1" ]; then AUTORESTART_OK="true"; fi
+
+# systemsetup -getremotelogin — want On
+# (requires Full Disk Access on newer macOS; tolerate failure gracefully)
+SSH_RAW="$(systemsetup -getremotelogin 2>&1 || true)"
+SSH_OK="false"
+case "$SSH_RAW" in
+  *"Remote Login: On"*) SSH_OK="true" ;;
+esac
+
+# Auto-login — want set (we do not script this; just report)
+AUTOLOGIN_USER="$(defaults read /Library/Preferences/com.apple.loginwindow autoLoginUser 2>/dev/null || true)"
+AUTOLOGIN_OK="false"
+if [ -n "$AUTOLOGIN_USER" ]; then AUTOLOGIN_OK="true"; fi
+
+log "sleep=$SLEEP_VALUE ok=$SLEEP_OK autorestart=$AUTORESTART_VALUE ok=$AUTORESTART_OK ssh_ok=$SSH_OK autologin_ok=$AUTOLOGIN_OK"
+
+# Overall status
+NEEDS_FIXUP="false"
+if [ "$SLEEP_OK" != "true" ] || [ "$AUTORESTART_OK" != "true" ] || [ "$SSH_OK" != "true" ] || [ "$AUTOLOGIN_OK" != "true" ]; then
+  NEEDS_FIXUP="true"
+fi
+
+FIXUP_SCRIPT="$SCRIPT_DIR/mac-server-mode.sh"
+
+cat <<EOF
+=== OMNICLAW SETUP: CHECK_MAC_SERVER_MODE ===
+PLATFORM: $PLATFORM
+HW_MODEL: $HW_MODEL
+IS_MAC_MINI: $IS_MAC_MINI
+SLEEP: $SLEEP_VALUE
+SLEEP_OK: $SLEEP_OK
+AUTORESTART: $AUTORESTART_VALUE
+AUTORESTART_OK: $AUTORESTART_OK
+SSH_OK: $SSH_OK
+AUTOLOGIN_USER: ${AUTOLOGIN_USER:-not_set}
+AUTOLOGIN_OK: $AUTOLOGIN_OK
+NEEDS_FIXUP: $NEEDS_FIXUP
+FIXUP_SCRIPT: $FIXUP_SCRIPT
+STATUS: success
+LOG: logs/setup.log
+=== END ===
+EOF

--- a/.agents/skills/setup/scripts/08-setup-service.sh
+++ b/.agents/skills/setup/scripts/08-setup-service.sh
@@ -105,8 +105,6 @@ case "$PLATFORM" in
     <string>com.omniclaw</string>
     <key>ProgramArguments</key>
     <array>
-        <string>/usr/bin/caffeinate</string>
-        <string>-dimsu</string>
         <string>${NODE_PATH}</string>
         <string>${PROJECT_PATH}/dist/index.js</string>
     </array>

--- a/.agents/skills/setup/scripts/mac-server-mode.sh
+++ b/.agents/skills/setup/scripts/mac-server-mode.sh
@@ -1,0 +1,39 @@
+#!/bin/bash
+# Mac server-mode setup. Run with: sudo bash mac-server-mode.sh
+set -u
+
+if [[ $EUID -ne 0 ]]; then
+  echo "ERROR: run with sudo: sudo bash $0"
+  exit 1
+fi
+
+echo "=== PMSET BEFORE ==="
+pmset -g custom
+echo
+
+echo "=== APPLYING SERVER-MODE SETTINGS ==="
+pmset -a sleep 0           && echo "  sleep       -> 0"
+pmset -a disksleep 0       && echo "  disksleep   -> 0"
+pmset -a autorestart 1     && echo "  autorestart -> 1"
+pmset -a tcpkeepalive 1    && echo "  tcpkeepalive-> 1"
+pmset -a womp 1            && echo "  womp        -> 1"
+systemsetup -setrestartfreeze on 2>&1 | sed 's/^/  /'
+systemsetup -setwaitforstartupafterpowerfailure 0 2>&1 | sed 's/^/  /'
+echo
+
+echo "=== PMSET AFTER ==="
+pmset -g custom
+echo
+
+echo "=== SSH ==="
+systemsetup -getremotelogin
+read -r -p "Enable Remote Login (SSH) now? [y/N] " yn
+[[ "$yn" =~ ^[Yy]$ ]] && systemsetup -setremotelogin on && echo "SSH enabled."
+echo
+
+echo "=== AUTO-LOGIN ==="
+defaults read /Library/Preferences/com.apple.loginwindow autoLoginUser 2>&1 \
+  || echo "  no autoLoginUser set"
+echo "  -> Enable via System Settings > Users & Groups > Automatic Login."
+echo
+echo "DONE."


### PR DESCRIPTION
## Summary

Two related setup changes (Mac server mode):

- **Drop the `caffeinate -dimsu` wrapper** from the launchd plist that `08-setup-service.sh` generates. Sleep prevention belongs in OS config (`pmset`), not in the supervisor command. `-dimsu` also forced the display awake, which is pointless on a headless Mac mini.
- **Add a Mac server-mode step** to the `/setup` skill. New `00-check-mac-server-mode.sh` inspects `pmset sleep`, `autorestart`, Remote Login, and auto-login, and reports current state. If anything is off-spec, the skill asks the user whether to apply a bundled sudo-only fixup script (`mac-server-mode.sh`), which the user runs in a separate terminal tab.

## Why

- The Mac mini was force-shutting itself because the OS was configured with `sleep=1, autorestart=0`. App-level `caffeinate` was treating a symptom; OS-level `pmset` is the right layer.
- Future installs on a Mac mini should be guided through the server-mode fixup as part of `/setup` rather than discovered after the box wedges.

## Implementation notes / judgment calls

- **No `caffeinate` lived in `src/`.** The only reference was in `.agents/skills/setup/scripts/08-setup-service.sh`, which templated the launchd plist's `ProgramArguments` to invoke `/usr/bin/caffeinate -dimsu` ahead of bun. Removed those two `<string>` entries; no other code paths, imports, or tests reference it.
- **The standalone `launchd/com.omniclaw.plist` template** (checked in, separate from the generator) never had a caffeinate wrapper, so no change needed there.
- **Setup skill structure.** The skill at `.agents/skills/setup/` already has a `scripts/` convention (`01-check-environment.sh`, `02-install-deps.sh`, …) with structured `=== OMNICLAW SETUP: … ===` status blocks. I followed that pattern exactly: new check script numbered `00-` (it runs before the existing environment check semantically, since it's about the host's readiness to be a 24/7 server), emits the same status block format, logs to `logs/setup.log`. The fixup script (`mac-server-mode.sh`) is bundled in the same `scripts/` directory.
- **The Mac mini detection in the task spec (`sysctl -n hw.model | grep -qi macmini`) does not match on Apple Silicon Macs**, which report opaque codes like `Mac16,11` (M4 Pro Mac mini) instead of `Macmini9,1`. I extended detection to fall back to `system_profiler SPHardwareDataType` for the human-readable model name. Verified on the user's `Mac16,11`: `IS_MAC_MINI=true`.
- **Routing.** Added a row to the SKILL.md route table for "mac mini, pmset, autorestart, auto-login" → a new "Mac server-mode fix" section, mirroring the existing "Linger fix" entry for Linux.
- **Wiring into fresh install.** Added a "1b. Mac Server-Mode Check (macOS only)" step in `guides/fresh-install.md`, right after the platform detection step.
- **`sudo` from a non-interactive shell is not viable**, so the skill tells the user to open a new terminal tab and run `sudo bash <script>`. The fixup script itself is the user's verbatim script from the spec.

## Follow-ups (not in this PR)

- `launchd/com.omniclaw.plist` (the standalone template, separate from the generated one) is gitignored-adjacent but checked in. If it's still in use anywhere downstream, it does not include `caffeinate` either — left untouched per the constraint about not modifying service config in this PR.
- Repo has pre-existing typecheck failures on `main` (e.g. `cursor-sdk` runtime not in `AgentRuntime` union, `skipped` not in `TaskOutcomeState`). They are unrelated to this PR; ran `bun run typecheck` before and after my changes and the failure set is identical.

## Test plan

- [ ] On Mac mini M4 Pro: run `./.claude/skills/setup/scripts/00-check-mac-server-mode.sh` — verify `IS_MAC_MINI=true`, status block parses, current `pmset` values are reported.
- [ ] If `NEEDS_FIXUP=true`, run `sudo bash .agents/skills/setup/scripts/mac-server-mode.sh` from a new terminal tab — verify it applies pmset settings idempotently and prompts for SSH.
- [ ] Re-run `00-check-mac-server-mode.sh` and confirm `NEEDS_FIXUP=false` (or only `AUTOLOGIN_OK=false` if the user opted to skip enabling auto-login).
- [ ] Run a fresh `/setup` on a clean macOS host and confirm the generated `~/Library/LaunchAgents/com.omniclaw.plist` no longer references `/usr/bin/caffeinate`, and that the service starts under just `${NODE_PATH} ${PROJECT_PATH}/dist/index.js`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added macOS server configuration detection and optimization tools for systems running 24/7 operations, including power management and remote access settings.

* **Documentation**
  * Updated fresh installation guide with new macOS server configuration verification steps.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/omniaura/omniclaw/pull/747?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->