### PR TITLE
feat(web): surface recent task outcomes rollup on /system

### DIFF
--- a/src/db.migrations.test.ts
+++ b/src/db.migrations.test.ts
@@ -112,6 +112,13 @@ function getTableColumns(db: Database, table: string): string[] {
   return columns.map((c) => c.name);
 }
 
+function getIndexNames(db: Database, table: string): string[] {
+  const indexes = db.query(`PRAGMA index_list(${table})`).all() as Array<{
+    name: string;
+  }>;
+  return indexes.map((index) => index.name);
+}
+
 describe('db migrations (bun:sqlite)', () => {
   it('migrates legacy observed agents schema and keeps rows readable/writable', () => {
     // Use in-memory DB to avoid file system and module caching issues.
@@ -851,6 +858,40 @@ describe('versioned migration framework', () => {
     for (const name of expected) {
       expect(tableNames).toContain(name);
     }
+
+    db.close();
+  });
+
+  it('indexes task run logs by run timestamp on fresh DB', () => {
+    const db = new Database(':memory:');
+    runMigrations(db, allMigrations);
+
+    expect(getIndexNames(db, 'task_run_logs')).toContain(
+      'idx_task_run_logs_run_at',
+    );
+
+    db.close();
+  });
+
+  it('adds task run timestamp index to existing migrated DBs', () => {
+    const db = new Database(':memory:');
+    runMigrations(
+      db,
+      allMigrations.filter((migration) => migration.version <= 6),
+    );
+    db.exec('DROP INDEX IF EXISTS idx_task_run_logs_run_at');
+
+    expect(getSchemaVersion(db)).toBe(6);
+    expect(getIndexNames(db, 'task_run_logs')).not.toContain(
+      'idx_task_run_logs_run_at',
+    );
+
+    runMigrations(db, allMigrations);
+
+    expect(getSchemaVersion(db)).toBe(BASELINE_VERSION);
+    expect(getIndexNames(db, 'task_run_logs')).toContain(
+      'idx_task_run_logs_run_at',
+    );
 
     db.close();
   });

--- a/src/db.test.ts
+++ b/src/db.test.ts
@@ -6,6 +6,8 @@ import {
   cleanupExpiredGitHubWebhookDeliveries,
   createTask,
   deleteTask,
+  getRecentTaskOutcomeStats,
+  logTaskRun,
   getAllAgents,
   getAgentHealth,
   getAllAgentHealth,
@@ -739,6 +741,111 @@ describe('task CRUD', () => {
 
     deleteTask('task-3');
     expect(getTaskById('task-3')).toBeNull();
+  });
+});
+
+describe('getRecentTaskOutcomeStats', () => {
+  function seedTask(id: string): void {
+    createTask({
+      id,
+      group_folder: 'main',
+      chat_jid: 'group@g.us',
+      prompt: 'p',
+      schedule_type: 'once',
+      schedule_value: '2026-01-01T00:00:00.000Z',
+      context_mode: 'isolated',
+      next_run: null,
+      status: 'active',
+      created_at: '2026-01-01T00:00:00.000Z',
+    });
+  }
+
+  it('returns zeroes when there are no task runs', () => {
+    const stats = getRecentTaskOutcomeStats('2026-01-01T00:00:00.000Z');
+    expect(stats.total).toBe(0);
+    expect(stats.success).toBe(0);
+    expect(stats.error).toBe(0);
+    expect(stats.by_outcome_state).toEqual({
+      done: 0,
+      blocked: 0,
+      abandoned: 0,
+      unknown: 0,
+    });
+  });
+
+  it('aggregates success/error split and outcome state buckets within the window', () => {
+    seedTask('t-recent');
+    seedTask('t-other');
+
+    const insideWindow = '2026-05-22T12:00:00.000Z';
+    const olderThanWindow = '2026-05-21T00:00:00.000Z';
+
+    // Inside the window: 2 done success, 1 blocked success, 1 error abandoned,
+    // 1 error with no outcome (unknown).
+    logTaskRun({
+      task_id: 't-recent',
+      run_at: insideWindow,
+      duration_ms: 100,
+      status: 'success',
+      result: 'ok',
+      error: null,
+      outcome_state: 'done',
+    });
+    logTaskRun({
+      task_id: 't-recent',
+      run_at: insideWindow,
+      duration_ms: 100,
+      status: 'success',
+      result: 'ok',
+      error: null,
+      outcome_state: 'done',
+    });
+    logTaskRun({
+      task_id: 't-other',
+      run_at: insideWindow,
+      duration_ms: 100,
+      status: 'success',
+      result: 'ok',
+      error: null,
+      outcome_state: 'blocked',
+    });
+    logTaskRun({
+      task_id: 't-other',
+      run_at: insideWindow,
+      duration_ms: 100,
+      status: 'error',
+      result: null,
+      error: 'boom',
+      outcome_state: 'abandoned',
+    });
+    logTaskRun({
+      task_id: 't-other',
+      run_at: insideWindow,
+      duration_ms: 100,
+      status: 'error',
+      result: null,
+      error: 'no outcome',
+    });
+
+    // Outside the window: should NOT be counted.
+    logTaskRun({
+      task_id: 't-recent',
+      run_at: olderThanWindow,
+      duration_ms: 50,
+      status: 'success',
+      result: 'old',
+      error: null,
+      outcome_state: 'done',
+    });
+
+    const stats = getRecentTaskOutcomeStats('2026-05-22T00:00:00.000Z');
+    expect(stats.total).toBe(5);
+    expect(stats.success).toBe(3);
+    expect(stats.error).toBe(2);
+    expect(stats.by_outcome_state.done).toBe(2);
+    expect(stats.by_outcome_state.blocked).toBe(1);
+    expect(stats.by_outcome_state.abandoned).toBe(1);
+    expect(stats.by_outcome_state.unknown).toBe(1);
   });
 });
 

--- a/src/db.ts
+++ b/src/db.ts
@@ -1145,6 +1145,63 @@ export function hasSuccessfulRun(taskId: string): boolean {
   return row !== undefined && row !== null;
 }
 
+/**
+ * Aggregate task run outcomes since the given ISO timestamp. Returns total
+ * counts plus a status (success/error) split and a by-outcome-state breakdown
+ * (done / blocked / abandoned / unknown). Used by the /system page to surface
+ * "recent task outcomes" without requiring a per-task drill-down.
+ */
+export function getRecentTaskOutcomeStats(sinceIso: string): {
+  total: number;
+  success: number;
+  error: number;
+  by_outcome_state: {
+    done: number;
+    blocked: number;
+    abandoned: number;
+    unknown: number;
+  };
+} {
+  const rows = db
+    .prepare(
+      `SELECT status, outcome_state, COUNT(*) AS count
+       FROM task_run_logs
+       WHERE run_at >= ?
+       GROUP BY status, outcome_state`,
+    )
+    .all(sinceIso) as Array<{
+    status: string;
+    outcome_state: string | null;
+    count: number;
+  }>;
+
+  const result = {
+    total: 0,
+    success: 0,
+    error: 0,
+    by_outcome_state: {
+      done: 0,
+      blocked: 0,
+      abandoned: 0,
+      unknown: 0,
+    },
+  };
+
+  for (const row of rows) {
+    const n = row.count;
+    result.total += n;
+    if (row.status === 'success') result.success += n;
+    else if (row.status === 'error') result.error += n;
+    const state = row.outcome_state;
+    if (state === 'done') result.by_outcome_state.done += n;
+    else if (state === 'blocked') result.by_outcome_state.blocked += n;
+    else if (state === 'abandoned') result.by_outcome_state.abandoned += n;
+    else result.by_outcome_state.unknown += n;
+  }
+
+  return result;
+}
+
 // --- Router state accessors ---
 
 export function getRouterState(key: string): string | undefined {

--- a/src/index.ts
+++ b/src/index.ts
@@ -89,6 +89,7 @@ import {
   getRouterState,
   getSubscriptionsForAgent,
   getTaskById,
+  getRecentTaskOutcomeStats,
   getTaskRunLogs,
   getTaskRunPhaseEvents,
   initDatabase,
@@ -3086,6 +3087,7 @@ async function main(): Promise<void> {
     getTaskRunLogs: (taskId, limit) => getTaskRunLogs(taskId, limit),
     getTaskRunPhaseEvents: (taskId, runAt) =>
       getTaskRunPhaseEvents(taskId, runAt),
+    getRecentTaskOutcomes: (sinceIso) => getRecentTaskOutcomeStats(sinceIso),
     searchMessages: (query, chatJid, limit, filters) =>
       dbSearchMessages({
         query,

--- a/src/migrations.ts
+++ b/src/migrations.ts
@@ -16,7 +16,7 @@ export interface Migration {
  * The version that represents the latest schema. Existing databases that
  * predate the migration framework are advanced through every migration to this.
  */
-export const BASELINE_VERSION = 6;
+export const BASELINE_VERSION = 7;
 
 // ---------------------------------------------------------------------------
 // Schema helpers (available for use in migrations)
@@ -238,6 +238,7 @@ const migration1: Migration = {
         FOREIGN KEY (task_id) REFERENCES scheduled_tasks(id)
       );
       CREATE INDEX IF NOT EXISTS idx_task_run_logs ON task_run_logs(task_id, run_at);
+      CREATE INDEX IF NOT EXISTS idx_task_run_logs_run_at ON task_run_logs(run_at);
 
       CREATE TABLE IF NOT EXISTS task_run_phase_events (
         id INTEGER PRIMARY KEY AUTOINCREMENT,
@@ -592,6 +593,17 @@ const migration6: Migration = {
   },
 };
 
+const migration7: Migration = {
+  version: 7,
+  description: 'Index task run logs by run timestamp',
+  up: (db) => {
+    db.exec(`
+      CREATE INDEX IF NOT EXISTS idx_task_run_logs_run_at
+        ON task_run_logs(run_at);
+    `);
+  },
+};
+
 // ---------------------------------------------------------------------------
 // Migration registry
 // ---------------------------------------------------------------------------
@@ -609,4 +621,5 @@ export const allMigrations: Migration[] = [
   migration4,
   migration5,
   migration6,
+  migration7,
 ];

--- a/src/web/system.test.ts
+++ b/src/web/system.test.ts
@@ -576,6 +576,84 @@ describe('buildHealthData', () => {
     expect(health.queue.message_lane_reasons.running).toBe(1);
     expect(health.queue.task_lane_reasons['back-pressure']).toBe(1);
   });
+
+  it('defaults recent task outcomes to zeroes when provider lacks getRecentTaskOutcomes', () => {
+    const health = buildHealthData(makeState(), 0);
+    expect(health.recent_task_outcomes.total).toBe(0);
+    expect(health.recent_task_outcomes.success).toBe(0);
+    expect(health.recent_task_outcomes.error).toBe(0);
+    expect(health.recent_task_outcomes.by_outcome_state).toEqual({
+      done: 0,
+      blocked: 0,
+      abandoned: 0,
+      unknown: 0,
+    });
+    expect(health.recent_task_outcomes.window_ms).toBeGreaterThan(0);
+  });
+
+  it('surfaces recent task outcomes from the provider', () => {
+    const base = makeState();
+    let calledWithSince: string | null = null;
+    const state: WebStateProvider = {
+      ...base,
+      getRecentTaskOutcomes: (sinceIso) => {
+        calledWithSince = sinceIso;
+        return {
+          total: 5,
+          success: 3,
+          error: 2,
+          by_outcome_state: {
+            done: 2,
+            blocked: 1,
+            abandoned: 1,
+            unknown: 1,
+          },
+        };
+      },
+    };
+    const health = buildHealthData(state, 0);
+    const since = calledWithSince as string | null;
+    expect(since).not.toBeNull();
+    // Provider receives a valid ISO timestamp in the recent past.
+    expect(new Date(since!).toISOString()).toBe(since!);
+    expect(Date.now() - new Date(since!).getTime()).toBeGreaterThan(0);
+    expect(health.recent_task_outcomes.total).toBe(5);
+    expect(health.recent_task_outcomes.success).toBe(3);
+    expect(health.recent_task_outcomes.error).toBe(2);
+    expect(health.recent_task_outcomes.by_outcome_state).toEqual({
+      done: 2,
+      blocked: 1,
+      abandoned: 1,
+      unknown: 1,
+    });
+  });
+
+  it('renders the recent task outcomes tile on /system', () => {
+    const base = makeState();
+    const state: WebStateProvider = {
+      ...base,
+      getRecentTaskOutcomes: () => ({
+        total: 7,
+        success: 4,
+        error: 3,
+        by_outcome_state: {
+          done: 3,
+          blocked: 2,
+          abandoned: 1,
+          unknown: 1,
+        },
+      }),
+    };
+    const html = renderSystemContent(state, 0);
+    expect(html).toContain('recent task outcomes');
+    expect(html).toContain('sys-recent-total');
+    expect(html).toContain('sys-recent-success');
+    expect(html).toContain('sys-recent-error');
+    expect(html).toContain('sys-recent-outcome-done');
+    expect(html).toContain('sys-recent-outcome-blocked');
+    expect(html).toContain('sys-recent-outcome-abandoned');
+    expect(html).toContain('sys-recent-outcome-unknown');
+  });
 });
 
 describe('GET /api/health route', () => {

--- a/src/web/system.ts
+++ b/src/web/system.ts
@@ -1,7 +1,7 @@
 import fs from 'fs';
 import os from 'os';
 
-import type { WebStateProvider } from './types.js';
+import type { RecentTaskOutcomes, WebStateProvider } from './types.js';
 import {
   deriveMessageLaneReasonFromDetail,
   deriveTaskLaneReasonFromDetail,
@@ -34,6 +34,23 @@ const AGENT_EXEC_STATUSES: readonly AgentExecStatus[] = [
   'offline',
   'disabled',
 ];
+
+/**
+ * Window for the "recent task outcomes" rollup on /system. Picked at one hour
+ * so the tile reflects the recent operator-visible past without dragging in
+ * stale data from yesterday's runs.
+ */
+const RECENT_OUTCOMES_WINDOW_MS = 60 * 60 * 1000;
+
+const OUTCOME_STATES: readonly (keyof RecentTaskOutcomes['by_outcome_state'])[] =
+  ['done', 'blocked', 'abandoned', 'unknown'];
+
+const EMPTY_RECENT_OUTCOMES: RecentTaskOutcomes = {
+  total: 0,
+  success: 0,
+  error: 0,
+  by_outcome_state: { done: 0, blocked: 0, abandoned: 0, unknown: 0 },
+};
 
 export interface HealthData {
   status: 'healthy';
@@ -127,6 +144,13 @@ export interface HealthData {
      */
     task_lane_reasons: Record<TaskLaneReason, number>;
   };
+  /**
+   * Aggregate of task run outcomes from the last
+   * {@link RECENT_OUTCOMES_WINDOW_MS} milliseconds. Mirrors the per-task data
+   * already available on /tasks but rolled up across every task so the
+   * operator can spot recent errors or stalls at a glance.
+   */
+  recent_task_outcomes: RecentTaskOutcomes & { window_ms: number };
   sse_clients: number;
   started_at: string;
 }
@@ -231,6 +255,13 @@ export function buildHealthData(
     taskLaneReasons[deriveTaskLaneReasonFromDetail(g)]++;
   }
 
+  const sinceIso = new Date(
+    Date.now() - RECENT_OUTCOMES_WINDOW_MS,
+  ).toISOString();
+  const recentOutcomes: RecentTaskOutcomes = state.getRecentTaskOutcomes
+    ? state.getRecentTaskOutcomes(sinceIso)
+    : EMPTY_RECENT_OUTCOMES;
+
   return {
     status: 'healthy',
     version: APP_VERSION,
@@ -287,6 +318,10 @@ export function buildHealthData(
       max_retries: maxRetries,
       message_lane_reasons: messageLaneReasons,
       task_lane_reasons: taskLaneReasons,
+    },
+    recent_task_outcomes: {
+      ...recentOutcomes,
+      window_ms: RECENT_OUTCOMES_WINDOW_MS,
     },
     sse_clients: sseClientCount,
     started_at: startedAt,
@@ -486,6 +521,37 @@ export function renderSystemContent(
           'sys-tasks-completed',
         ) +
         metricRow('total', String(health.tasks.total), 'sys-tasks-total'),
+    ) +
+    // Recent task outcomes (rolled up across all tasks in the last window)
+    metricCard(
+      'recent task outcomes',
+      metricRow(
+        'window',
+        formatDuration(health.recent_task_outcomes.window_ms),
+        'sys-recent-window',
+      ) +
+        metricRow(
+          'total',
+          String(health.recent_task_outcomes.total),
+          'sys-recent-total',
+        ) +
+        metricRow(
+          'success',
+          String(health.recent_task_outcomes.success),
+          'sys-recent-success',
+        ) +
+        metricRow(
+          'error',
+          String(health.recent_task_outcomes.error),
+          'sys-recent-error',
+        ) +
+        `<div class="metric-sub">by outcome state</div>` +
+        reasonRollup(
+          health.recent_task_outcomes.by_outcome_state,
+          OUTCOME_STATES,
+          'sys-recent-outcome',
+          'outcome',
+        ),
     ) +
     // Queue rollup (per-group lane aggregates from /ipc, summarized here)
     metricCard(

--- a/src/web/types.ts
+++ b/src/web/types.ts
@@ -45,6 +45,14 @@ export interface WebStateProvider {
   getTaskRunLogs(taskId: string, limit?: number): TaskRunLog[];
   /** Phase events for a specific task run (identified by taskId + run_at timestamp). */
   getTaskRunPhaseEvents(taskId: string, runAt: string): TaskRunPhaseEvent[];
+  /**
+   * Aggregate task run outcomes since the given ISO timestamp. Used by the
+   * /system page to roll up recent task outcomes (success/error counts and
+   * outcome-state breakdown) without drilling into individual tasks. Optional
+   * so the existing FakeState and test stubs continue to compile; when absent,
+   * the /system page renders zeroes for the rollup.
+   */
+  getRecentTaskOutcomes?(sinceIso: string): RecentTaskOutcomes;
   /** Search messages by content with optional filters. */
   searchMessages(
     query: string,
@@ -143,6 +151,24 @@ export interface QueueStats {
   idleContainers: number;
   maxActive: number;
   maxIdle: number;
+}
+
+/**
+ * Aggregate of recent task run outcomes. Buckets cover the success/error split
+ * from `task_run_logs.status` and the agent-reported outcome state
+ * (done/blocked/abandoned) from `task_run_logs.outcome_state`. Runs with no
+ * outcome state recorded fall into `unknown`.
+ */
+export interface RecentTaskOutcomes {
+  total: number;
+  success: number;
+  error: number;
+  by_outcome_state: {
+    done: number;
+    blocked: number;
+    abandoned: number;
+    unknown: number;
+  };
 }
 
 export interface WebServerConfig {


### PR DESCRIPTION
## Summary

Adds a *recent task outcomes* tile to the `/system` page that rolls up `task_run_logs` from the last hour across every scheduled task. Surfaces total runs, success/error split, and a by-outcome-state breakdown (`done` / `blocked` / `abandoned` / `unknown`).

Implements one of the remaining acceptance items on the operator observability rollup tracker (#644):

> `/system` enrichments — agent state breakdown, *recent task outcomes*, peer health rollup

Today an operator has to drill into individual task pages to see whether recent runs succeeded or got blocked. The new tile makes the recent run state visible at a glance alongside the existing agent / queue / container rollups.

## What changed

- New `getRecentTaskOutcomeStats(sinceIso)` in `src/db.ts` — single grouped `SELECT` over `task_run_logs` with the `status` + `outcome_state` buckets.
- New `RecentTaskOutcomes` type and optional `getRecentTaskOutcomes` hook on `WebStateProvider`. Keeping the hook optional avoids touching the ~14 existing `FakeState` / test stubs.
- `buildHealthData` computes `recent_task_outcomes` (with `window_ms`) using a one-hour window. Falls back to zeroes when the provider does not implement the hook.
- `renderSystemContent` renders a new metric card after the existing "tasks" card, reusing the existing `reasonRollup` helper for the outcome-state breakdown.
- Orchestrator wires the SQLite function into the real provider in `src/index.ts`.

## Test plan

- [x] `bun test` — 2133 pass / 0 fail
- [x] `bun run typecheck` clean
- [x] `bunx prettier --check` clean on touched files
- [x] New `getRecentTaskOutcomeStats` tests in `src/db.test.ts` cover the empty case, the success/error split, the outcome-state buckets (including `unknown` for missing state), and the time-window filter.
- [x] New `buildHealthData` / `renderSystemContent` tests cover the optional-hook fallback path, provider integration (verifies the `sinceIso` argument is a recent ISO timestamp), and the rendered tile shape.

## Related

- Tracking: #644
- Companion docs (no change needed): #732 / `docs/OBSERVABILITY.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
