### PR TITLE
fix(backends): default networkMode to 'full' so agents can reach LLM API

### DIFF
--- a/docs/SECURITY.md
+++ b/docs/SECURITY.md
@@ -17,7 +17,7 @@ Agents execute in Docker containers (OrbStack on macOS, native docker on Linux),
 
 - **Process isolation** - Container processes cannot affect the host
 - **Filesystem isolation** - Only explicitly mounted directories are visible
-- **Network isolation** - Non-main containers run with `--network none`, preventing data exfiltration. Main containers retain full network access for WebFetch/WebSearch tools. Per-group override via `containerConfig.networkMode: 'full' | 'none'`
+- **Network access** - Containers default to full network so agents can reach the LLM API (`api.anthropic.com`) and use WebFetch/WebSearch tools. Per-group opt-in to outbound network isolation via `containerConfig.networkMode: 'none'`
 - **Non-root execution** - Runs as unprivileged `bun` user (uid 1000)
 - **Ephemeral containers** - Fresh environment per invocation (`--rm`)
 - **Resource limits** - `--pids-limit 256` (fork bomb prevention), `--no-new-privileges` (privilege escalation prevention)

--- a/src/backends/local-backend.ts
+++ b/src/backends/local-backend.ts
@@ -600,10 +600,11 @@ export function buildContainerArgs({
   args.push('--pids-limit', '256');
   args.push('--security-opt', 'no-new-privileges:true');
 
-  // Network isolation: non-main containers have no network access by default.
-  // Main containers retain full network (needed for WebFetch/WebSearch).
-  // Per-group override via containerConfig.networkMode.
-  const effectiveNetwork = networkMode ?? (isMain ? 'full' : 'none');
+  // Network access: default to 'full' for both main and non-main containers.
+  // Agents need outbound network for the LLM API (api.anthropic.com) and for
+  // tool calls like WebFetch / WebSearch. Per-group override via
+  // containerConfig.networkMode = 'none' opts back into isolation.
+  const effectiveNetwork = networkMode ?? 'full';
   if (effectiveNetwork === 'none') {
     args.push('--network', 'none');
   }
@@ -649,7 +650,7 @@ export function sharedVmNetworkIsolationError(
   return {
     status: 'error',
     result: null,
-    error: `${SHARED_VM_NETWORK_ISOLATION_ERROR_CODE}: Shared-VM mode does not enforce per-agent network isolation. Disable shared-VM mode for ${groupName} or set containerConfig.networkMode to 'full' explicitly.`,
+    error: `${SHARED_VM_NETWORK_ISOLATION_ERROR_CODE}: Shared-VM mode does not enforce per-agent network isolation. Disable shared-VM mode for ${groupName} or remove containerConfig.networkMode='none' (default is 'full').`,
   };
 }
 
@@ -690,8 +691,7 @@ export class LocalBackend implements AgentBackend {
       { allowGcpCredentials: !!containerCfg?.allowGcpCredentials },
     );
     const containerName = makeContainerName(folder, runtimeFolder);
-    const effectiveNetwork =
-      containerCfg?.networkMode ?? (input.isMain ? 'full' : 'none');
+    const effectiveNetwork = containerCfg?.networkMode ?? 'full';
 
     const containerArgs = buildContainerArgs({
       mounts,
@@ -1019,8 +1019,7 @@ export class LocalBackend implements AgentBackend {
       { allowGcpCredentials: !!containerCfg?.allowGcpCredentials },
     );
 
-    const effectiveNetwork =
-      containerCfg?.networkMode ?? (input.isMain ? 'full' : 'none');
+    const effectiveNetwork = containerCfg?.networkMode ?? 'full';
     if (effectiveNetwork === 'none') {
       logger.error(
         {

--- a/src/backends/network-isolation.test.ts
+++ b/src/backends/network-isolation.test.ts
@@ -1,28 +1,27 @@
 import { describe, expect, it, mock } from 'bun:test';
 
 /**
- * Tests for network isolation in container args.
+ * Tests for network configuration in container args.
  *
- * [Upstream PR #460] Non-main containers run with --network none by default
- * to prevent data exfiltration. Main containers keep full network for
- * WebFetch/WebSearch. Per-group override via containerConfig.networkMode.
+ * Default behavior: containers run with full network access so agents can
+ * reach the LLM API (api.anthropic.com) and use WebFetch / WebSearch tools.
+ * Per-group override via containerConfig.networkMode = 'none' opts back
+ * into outbound network isolation.
  */
 
 const { buildContainerArgs } = await import('./local-backend.js');
 
 mock.restore();
 
-describe('buildContainerArgs network isolation', () => {
-  it('non-main containers get --network none by default', () => {
+describe('buildContainerArgs network configuration', () => {
+  it('non-main containers get full network by default', () => {
     const args = buildContainerArgs({
       mounts: [],
       containerName: 'test-container',
       isMain: false,
       runtime: 'docker',
     });
-    expect(args).toContain('--network');
-    const networkIdx = args.indexOf('--network');
-    expect(args[networkIdx + 1]).toBe('none');
+    expect(args).not.toContain('--network');
   });
 
   it('main containers get full network by default (no --network flag)', () => {
@@ -33,6 +32,19 @@ describe('buildContainerArgs network isolation', () => {
       runtime: 'docker',
     });
     expect(args).not.toContain('--network');
+  });
+
+  it('explicit networkMode=none still isolates', () => {
+    const args = buildContainerArgs({
+      mounts: [],
+      containerName: 'test-container',
+      isMain: false,
+      networkMode: 'none',
+      runtime: 'docker',
+    });
+    expect(args).toContain('--network');
+    const networkIdx = args.indexOf('--network');
+    expect(args[networkIdx + 1]).toBe('none');
   });
 
   it('non-main containers can override to full network via networkMode', () => {

--- a/src/types.ts
+++ b/src/types.ts
@@ -38,7 +38,7 @@ export interface ContainerConfig {
   additionalMounts?: AdditionalMount[];
   timeout?: number; // Default: 300000 (5 minutes)
   memory?: number; // Container memory in MB. Default: 4096
-  networkMode?: 'full' | 'none'; // Default: 'none' for non-main, 'full' for main
+  networkMode?: 'full' | 'none'; // Default: 'full'. Set to 'none' for outbound network isolation.
   /** Extra MCP servers to inject into the agent runtime (SSE/HTTP). Keyed by server name. */
   mcpServers?: Record<string, Record<string, unknown>>;
   /** Explicitly allow Firebase/GCP credentials to flow into the local backend env mount. */


### PR DESCRIPTION
## Summary

- Non-main containers had `--network none` as a default (upstream PR #460). Under Apple's `container` framework the flag was apparently not fully enforced, so agents could still reach `api.anthropic.com`. After the OrbStack/Docker migration (#750) the flag is enforced and every non-main agent now fails its first turn with `ConnectionRefused` against the LLM API; WebFetch/WebSearch tools are equally broken.
- Flip the default to `'full'` for both main and non-main containers. Agents need outbound network for the LLM API and for tool calls like WebFetch / WebSearch.
- `containerConfig.networkMode = 'none'` remains a valid opt-in for groups that want outbound network isolation. Nothing else about the network handling changes.

## Changes

- `src/backends/local-backend.ts` — `buildContainerArgs` and both `runAgent` paths (regular + shared-VM) now default `effectiveNetwork` to `'full'`. Comment block above the default updated. Shared-VM error message updated to reflect the new default.
- `src/types.ts` — `ContainerConfig.networkMode` comment now reads `Default: 'full'. Set to 'none' for outbound network isolation.`
- `src/backends/network-isolation.test.ts` — non-main-default test flipped to assert no `--network` flag; new `explicit networkMode=none still isolates` test added; file header comment updated.
- `docs/SECURITY.md` — security boundary description updated to reflect the new default and the opt-in to isolation.

## Test plan

- [x] `bun test src/backends/network-isolation.test.ts` — 6 pass
- [x] `bun run build` — clean
- [ ] Verified manually on the reference machine (Mac mini running OrbStack on macOS 26): non-main agents complete turns and the LLM API is reachable from inside the container.