### PR TITLE
fix(security): reject Docker mount target separators

### DIFF
--- a/src/mount-security.test.ts
+++ b/src/mount-security.test.ts
@@ -232,6 +232,45 @@ describe('validateMount with allowlist', () => {
     expect(result.reason).toContain('Invalid container path');
   });
 
+  it('rejects container path with Docker volume option separator', () => {
+    writeAllowlist(baseAllowlist);
+    const result = validateMount(
+      {
+        hostPath: TEMP_ROOT + '/projects/my-app',
+        containerPath: 'my-app:rw',
+      },
+      true,
+    );
+    expect(result.allowed).toBe(false);
+    expect(result.reason).toContain('Invalid container path');
+  });
+
+  it('rejects container path with Docker mount option separator', () => {
+    writeAllowlist(baseAllowlist);
+    const result = validateMount(
+      {
+        hostPath: TEMP_ROOT + '/projects/my-app',
+        containerPath: 'my-app,readonly=false',
+      },
+      true,
+    );
+    expect(result.allowed).toBe(false);
+    expect(result.reason).toContain('Invalid container path');
+  });
+
+  it('rejects container path with control characters', () => {
+    writeAllowlist(baseAllowlist);
+    const result = validateMount(
+      {
+        hostPath: TEMP_ROOT + '/projects/my-app',
+        containerPath: 'my-app\nnext',
+      },
+      true,
+    );
+    expect(result.allowed).toBe(false);
+    expect(result.reason).toContain('Invalid container path');
+  });
+
   it('rejects absolute container path', () => {
     writeAllowlist(baseAllowlist);
     const result = validateMount(

--- a/src/mount-security.ts
+++ b/src/mount-security.ts
@@ -206,6 +206,18 @@ function isValidContainerPath(containerPath: string): boolean {
     return false;
   }
 
+  // Must not contain Docker mount option separators. These paths are rendered
+  // into --mount/-v arguments, where ':' and ',' can alter option parsing.
+  if (containerPath.includes(':') || containerPath.includes(',')) {
+    return false;
+  }
+
+  // Reject control characters to keep generated runtime arguments single-line
+  // and unambiguous for container CLIs and logs.
+  if (/[\x00-\x1f\x7f]/.test(containerPath)) {
+    return false;
+  }
+
   // Must not be absolute (it will be prefixed with /workspace/extra/)
   if (containerPath.startsWith('/')) {
     return false;
@@ -252,7 +264,7 @@ export function validateMount(
   if (!isValidContainerPath(containerPath)) {
     return {
       allowed: false,
-      reason: `Invalid container path: "${containerPath}" - must be relative, non-empty, and not contain ".."`,
+      reason: `Invalid container path: "${containerPath}" - must be relative, non-empty, and not contain traversal or Docker option separators`,
     };
   }
 


### PR DESCRIPTION
## Summary

Ports the mount target hardening from nanocoai/nanoclaw PR #1475 into OmniClaw's extra mount validator.

OmniClaw already blocks traversal and absolute extra mount targets, but configured `containerPath` values are later rendered into Docker `--mount` / `-v` arguments. This PR rejects Docker-sensitive separators and control characters before those values can reach the runtime argument builder.

Source security PR: https://github.com/nanocoai/nanoclaw/pull/1475

## What changed

- Reject `:` in extra mount `containerPath` values to avoid Docker `-v` option parsing ambiguity.
- Reject `,` in extra mount `containerPath` values to avoid Docker `--mount` option parsing ambiguity.
- Reject ASCII control characters so generated runtime args and logs stay single-line and unambiguous.
- Add regression coverage for each rejected form.

## Considered and rejected

- nanoclaw PR #171, Bash secret sanitization: already present in OmniClaw's agent runner.
- nanoclaw PR #2001, container-controlled outbox path confinement: OmniClaw does not have the same outbound outbox read/delete sink.
- nanoclaw PR #2566, scoped channel approval targets: permission module structure is not present in this codebase.
- nanoclaw PR #1475, stopContainer command injection: OmniClaw already validates orphan container names and uses `Bun.spawn` argv form.

## Validation

- `bun test src/mount-security.test.ts`
- `bun run typecheck`
- `bun run format:check src/mount-security.ts src/mount-security.test.ts`
- `git diff --check`
