### PR TITLE
[codex] Fix Slack multi-bot mention routing

### DIFF
--- a/src/channels/slack.test.ts
+++ b/src/channels/slack.test.ts
@@ -151,6 +151,92 @@ describe('SlackChannel.ownsJid', () => {
   });
 });
 
+describe('SlackChannel.handleMessage multi-bot mention routing', () => {
+  const makeClient = () => ({
+    users: {
+      info: mock(({ user }: { user: string }) =>
+        Promise.resolve({
+          user: {
+            name: user === 'UOTHERBOT' ? 'otherbot' : 'peyton',
+            profile: {
+              display_name: user === 'UOTHERBOT' ? 'OtherBot' : 'Peyton',
+            },
+          },
+        }),
+      ),
+    },
+    conversations: {
+      info: mock(() => Promise.resolve({ channel: { name: 'test-channel' } })),
+    },
+  });
+
+  it('ignores messages that mention a different bot in multi-bot mode', async () => {
+    const onMessage = mock(() => {});
+    const channel = new SlackChannel({
+      botId: 'CLAYTON',
+      token: 'xoxb-test',
+      appToken: 'xapp-test',
+      multiBotMode: true,
+      onMessage,
+      onChatMetadata: () => {},
+      registeredGroups: () => ({
+        'slack:CLAYTON:C123': {
+          name: 'Clayton',
+          folder: 'clayton-discord',
+          trigger: '@Clayton',
+          added_at: new Date().toISOString(),
+        },
+      }),
+    });
+
+    (channel as any).botUserId = 'UCLAYTON';
+    (channel as any).client = makeClient();
+
+    await (channel as any).handleMessage({
+      channel: 'C123',
+      ts: '1700000000.000100',
+      text: '<@UOTHERBOT> hello',
+      user: 'UPEYTON',
+    });
+
+    expect(onMessage).not.toHaveBeenCalled();
+  });
+
+  it('stores messages that mention this bot in multi-bot mode', async () => {
+    const onMessage = mock(() => {});
+    const channel = new SlackChannel({
+      botId: 'CLAYTON',
+      token: 'xoxb-test',
+      appToken: 'xapp-test',
+      multiBotMode: true,
+      onMessage,
+      onChatMetadata: () => {},
+      registeredGroups: () => ({
+        'slack:CLAYTON:C123': {
+          name: 'Clayton',
+          folder: 'clayton-discord',
+          trigger: '@Clayton',
+          added_at: new Date().toISOString(),
+        },
+      }),
+    });
+
+    (channel as any).botUserId = 'UCLAYTON';
+    (channel as any).client = makeClient();
+
+    await (channel as any).handleMessage({
+      channel: 'C123',
+      ts: '1700000000.000100',
+      text: '<@UCLAYTON> hello',
+      user: 'UPEYTON',
+    });
+
+    expect(onMessage).toHaveBeenCalledTimes(1);
+    const calls = onMessage.mock.calls as unknown as Array<[string]>;
+    expect(calls[0][0]).toBe('slack:CLAYTON:C123');
+  });
+});
+
 // --- Slack media download helpers ---
 
 describe('SlackChannel.downloadSlackFile', () => {

--- a/src/channels/slack.ts
+++ b/src/channels/slack.ts
@@ -390,6 +390,24 @@ export class SlackChannel implements Channel {
     );
     let content = resolvedText;
 
+    if (
+      this.multiBotMode &&
+      mentions.length > 0 &&
+      this.botUserId &&
+      !mentions.some((m) => m.id === this.botUserId) &&
+      !/@allagents/i.test(content)
+    ) {
+      logger.debug(
+        {
+          channelId,
+          botId: this.botId,
+          mentionedUserIds: mentions.map((m) => m.id),
+        },
+        'Slack message mentions another bot — ignoring for this bot',
+      );
+      return;
+    }
+
     // Prepend thread context if this is a threaded reply
     if (
       'thread_ts' in event &&


### PR DESCRIPTION
## Summary

Fix Slack multi-bot routing so each bot ignores messages that explicitly mention a different Slack bot identity. `@allagents` remains a fan-out trigger.

## Root Cause

In a shared Slack channel with multiple Socket Mode apps installed, every bot receives the same user message. OmniClaw stored that message under each bot's scoped Slack JID. The message poll cursor could advance after non-target bot copies were processed, before the actually mentioned bot's scoped copy arrived, so messages like `@Clayton` could be skipped.

## Changes

- Filter multi-bot Slack events after mention resolution when the current bot is not mentioned.
- Preserve `@allagents` behavior.
- Add focused Slack adapter tests for ignoring another bot's mention and accepting this bot's mention.

## Validation

- `PATH=/Users/peyton/.bun/bin:/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin /Users/peyton/.bun/bin/bun test src/channels/slack.test.ts`
- `PATH=/Users/peyton/.bun/bin:/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin /Users/peyton/.bun/bin/bun run build`

Full `bunx tsc --noEmit` is currently blocked by existing unrelated type errors around `cursor-sdk`, `originChatJid`, `taskWorkflowsDir`, and task outcome `skipped`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved multi-bot mention routing in Slack channels. When multiple bots are enabled, each bot now correctly ignores messages intended for other bots and only responds to messages mentioning its own user ID, preventing duplicate or misdirected responses.

* **Tests**
  * Added test coverage for multi-bot mention routing behavior in Slack channels.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/omniaura/omniclaw/pull/758?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->