### PR TITLE
docs: reconcile ROADMAP.md Planned Work refs and add ref-check script (closes #636)

### DIFF
--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -1,6 +1,11 @@
 # OmniClaw Roadmap
 
-Last updated: 2026-05-02
+Last updated: 2026-05-23
+
+> **Maintenance:** run `bash scripts/check-roadmap-refs.sh` after editing to catch
+> Planned Work entries that point at closed/merged issues without an explicit
+> annotation. Move shipped items to _Completed Recently_ instead of leaving stale
+> trackers in Planned Work.
 
 ## Guiding Principles
 
@@ -73,25 +78,26 @@ Self-maintenance is core to the AI-native operations principle, and the dep bump
 
 - #484 needs admin secret config so GitHub App can trigger CI on dep bump PRs
 - dependent on operator action; no agent-side fix possible until secrets are configured
-- once unblocked, the auto-close superseded dep bumps (#617) and auto-merge error surfacing (#616) workflows will run cleanly
+- once unblocked, the auto-close superseded dep bumps (#617, merged) and auto-merge error surfacing (#616, merged) workflows will run cleanly
 
-#### Scheduler Reliability and Chat Cohesion (#162, #186)
+#### Scheduler Reliability and Chat Cohesion (follow-on to #162, #186; active: #725)
 
-Recovery work has landed, but the full scheduler/chat cohesion vision is still open.
+Recovery, isolation, and handoff foundations have shipped (#162 and #186 both closed). The remaining work is the chat-cohesion edges that surface when scheduled and chat runs interleave.
 
 - stale task recovery and deterministic scheduler coverage have improved the base
-- #186 remains open for shared progress, isolated execution workspaces, lease/lock semantics, and structured handoffs between scheduled and chat work
+- snapshot current chat at turn boundaries for final-output routing (#725) is the active follow-on
+- continue tightening lease/lock semantics and structured handoffs as new edge cases surface
 
-#### Share Request Security Follow-through (#237, #240)
+#### Share Request Security Follow-through (follow-on to #237, #240)
 
-Recent hardening reduced risk in approval and transfer paths, but cleanup is still in progress.
+Approval-flow removal and post-approval file transfer both shipped (#237 and #240 closed). Treat any new findings under the `security` label as the canonical follow-on rather than these closed trackers.
 
-- finish removing obsolete approval flow paths
 - keep approval, provenance, and auditability crisp for cross-agent context sharing
+- file new tracking issues for any remaining cleanup rather than reopening the closed ones
 
-#### Test Reliability and Coverage Expansion (#200 and follow-ons)
+#### Test Reliability and Coverage Expansion
 
-Coverage has improved materially, but there are still gaps in end-to-end confidence and a few brittle areas.
+Coverage has improved materially (the original flaky-suite tracker #200 closed), but there are still gaps in end-to-end confidence and a few brittle areas.
 
 - stabilize remaining flaky suites and document root causes
 - keep filling high-value gaps in orchestrator, backend, and security-sensitive paths
@@ -105,19 +111,20 @@ Effect remains a targeted tool, not a migration goal.
 
 ### Medium-term
 
-#### Agent Runtime Agnosticism (#49)
+#### Agent Runtime Polish (follow-on to #49)
 
-OmniClaw still carries Claude-first assumptions in prompt assembly, context conventions, and session handling.
+The runtime-agnostic foundation shipped (#49 closed); per-agent runtime selection works across Claude Agent SDK, OpenCode, Codex, and Cursor. Remaining work is reducing Claude-first assumptions in prompt assembly, context conventions, and session handling so non-Claude runtimes feel first-class.
 
-- keep pushing runtime abstraction so Claude Agent SDK, OpenCode, Codex, and future local runtimes fit the same orchestration model
+- continue pushing the runtime abstraction as new runtimes are added
 - preserve per-agent runtime selection without forking the orchestrator
 
-#### Multi-bot / Multi-token Maturity (#100, #101, #102)
+#### Channel Parity Across Multi-bot Surfaces (follow-on to #100, #101, #102)
 
-Telegram and Slack multi-bot support have moved forward; the remaining work is consistency and polish across all channels.
+Per-channel multi-token support has shipped for Discord (#102), Telegram (#101), and Slack (#100). The remaining work is consistency and polish across all channels.
 
 - make multi-bot routing predictable across Discord, Telegram, and Slack
 - keep channel ownership, slash flow targeting, and avatar identity aligned
+- close Slack-side gaps as they surface (e.g. slash command parity, #759)
 
 #### Codebase Simplification
 
@@ -136,10 +143,6 @@ on `/system` and `/ipc` today; the items below extend it.
 - lightweight diagnostics for why an agent is idle, blocked, retrying, or offline
 
 ### Long-term
-
-#### Declarative Agent Topology (#57)
-
-Move toward a declarative source of truth for agent/channel topology while keeping SQLite for runtime state.
 
 #### Extensible MCP / Tool Plugin Model
 
@@ -193,6 +196,22 @@ Push from "personal assistant with tasks" toward a genuine multi-agent factory.
 - control plane route and startup branch coverage (#594)
 - Web UI fallback and pairing failure coverage (#581)
 - discovery, index, logger, and path-security coverage (#566, #556)
+
+#### Runtime, Topology, and Multi-bot Foundations
+
+- declarative agent topology config shipped (closes #57; delivered via #629)
+- agent runtime agnosticism shipped (closes #49) — Claude Agent SDK, OpenCode, Codex, Cursor all run under the same orchestration model
+- per-channel multi-bot/multi-token support shipped: Discord (closes #102), Telegram (closes #101), Slack (closes #100)
+- backend simplified to Docker (OrbStack on macOS) after Apple Container migration in #750
+- per-agent model override stored in SQLite (#760, in flight)
+
+#### Scheduler and Share Request Cleanup
+
+- scheduler crash recovery for stale in-progress and orphaned tasks shipped (closes #162)
+- scheduler/chat cohesion shared-progress and isolated-execution foundations shipped (closes #186)
+- post-approval file transfer handler shipped for share_request (closes #237)
+- legacy admin approval flow removed for share_request, delegate_task, request_context (closes #240)
+- flaky github-webhooks full-suite failure resolved (closes #200)
 
 ### Mar 2026
 

--- a/scripts/check-roadmap-refs.sh
+++ b/scripts/check-roadmap-refs.sh
@@ -1,0 +1,71 @@
+#!/usr/bin/env bash
+# Warn when docs/ROADMAP.md "Planned Work" sections reference closed/merged
+# issues without an explicit `(closed; ...)` or `(follow-on ...)` annotation.
+#
+# Usage: bash scripts/check-roadmap-refs.sh
+# Requires: gh CLI authenticated against omniaura/omniclaw.
+# Non-zero exit if a stale reference is found.
+
+set -u
+
+ROADMAP="${ROADMAP:-docs/ROADMAP.md}"
+REPO="${REPO:-omniaura/omniclaw}"
+
+if [[ ! -f "$ROADMAP" ]]; then
+  echo "error: $ROADMAP not found (run from repo root or set ROADMAP=)" >&2
+  exit 2
+fi
+
+if ! command -v gh >/dev/null 2>&1; then
+  echo "error: gh CLI not found in PATH" >&2
+  exit 2
+fi
+
+# Extract the Planned Work region: between "## Planned Work" and the next "## " header.
+planned=$(awk '
+  /^## Planned Work[[:space:]]*$/ { capture=1; next }
+  capture && /^## / { exit }
+  capture { print }
+' "$ROADMAP")
+
+if [[ -z "$planned" ]]; then
+  echo "error: could not locate '## Planned Work' section in $ROADMAP" >&2
+  exit 2
+fi
+
+# Pull every #NNN reference, dedup, ignore tiny numbers (footnote-like).
+refs=$(printf '%s\n' "$planned" \
+  | grep -oE '#[0-9]+' \
+  | sort -u \
+  | sed 's/^#//' \
+  | awk '$1 >= 1')
+
+stale=()
+for n in $refs; do
+  state=$(gh issue view "$n" -R "$REPO" --json state --jq '.state' 2>/dev/null || true)
+  if [[ -z "$state" ]]; then
+    # Might be a PR ref instead of an issue.
+    state=$(gh pr view "$n" -R "$REPO" --json state --jq '.state' 2>/dev/null || true)
+  fi
+  case "$state" in
+    CLOSED|MERGED)
+      # Allow if the line containing this ref carries an explicit closed/follow-on annotation
+      # or refers to the closed item in past tense (shipped/merged/completed/delivered/closed).
+      if printf '%s\n' "$planned" \
+           | grep -E "#${n}\b" \
+           | grep -qiE '\b(closed|follow-on|merged|shipped|completed|delivered|closes)\b'; then
+        continue
+      fi
+      stale+=("#$n ($state)")
+      ;;
+  esac
+done
+
+if (( ${#stale[@]} > 0 )); then
+  echo "ROADMAP.md Planned Work references the following closed/merged items without an explicit annotation:" >&2
+  printf '  - %s\n' "${stale[@]}" >&2
+  echo "Fix: move the section to 'Completed Recently', or annotate the line with '(closed; follow-on ...)'." >&2
+  exit 1
+fi
+
+echo "ROADMAP.md Planned Work references look clean."


### PR DESCRIPTION
## Summary

Closes #636.

Eight prior product-board passes flagged that `docs/ROADMAP.md` *Planned Work* sections cite issues that have actually shipped, making the doc look like more work is in flight than it really is. This PR reconciles every stale reference and adds a small bash check so the drift does not return.

## What changed

**Move shipped themes into _Completed Recently_:**

- Declarative agent topology (closes #57; delivered via #629)
- Agent runtime agnosticism (closes #49) — Claude Agent SDK, OpenCode, Codex, Cursor all run under the same orchestration model
- Per-channel multi-bot / multi-token support: Discord (closes #102), Telegram (closes #101), Slack (closes #100)
- Scheduler crash recovery for stale/orphaned tasks (closes #162)
- Scheduler/chat cohesion shared-progress and isolated-execution foundations (closes #186)
- Share request post-approval transfer (closes #237) and legacy admin approval removal (closes #240)
- Flaky `github-webhooks` full-suite failure (closes #200)

**Rewrite the still-active Planned Work sections to point at the real open follow-on issues:**

- *Scheduler/chat cohesion* → snapshot at turn boundaries (#725)
- *Channel parity* → Slack slash command parity (#759)
- *Test reliability* → drop the closed #200 tracker reference, keep the theme

**Inline-annotate the remaining contextual mentions of merged work** (#617, #616 in the CI Health section) and refresh the `Last Updated` stamp to `2026-05-23`.

**Add `scripts/check-roadmap-refs.sh`:** greps every `#NNN` in the *Planned Work* region, asks `gh` for its state, and exits non-zero with a punch list if any closed/merged ref lacks an explicit annotation. The roadmap intro now points operators at it.

## Why this matters

A roadmap is a navigation tool. When *Planned Work* points at closed issues, readers have to re-verify everything against `gh issue view`, which defeats the point. The drift was caught and reported by the Product Manager agent on every assessment since 2026-05-03, but the diff was never picked up. This filing finally lands the diff and pairs it with a CI-style check so the next refresh catches the same drift before merge.

## Verification

- `bash scripts/check-roadmap-refs.sh` → `ROADMAP.md Planned Work references look clean.`
- `bun run format:check` → all matched files use Prettier code style
- Issue-state confirmation (all referenced as closed/merged): #162, #186, #237, #240, #200, #49, #100, #101, #102, #57, #277, #418, #616, #617

## Out of scope

- Reorganizing roadmap structure or guiding principles.
- Editing *Completed Recently* entries that already cite closed/merged work (those references are correct in context).
- Wiring the script into CI as a required check — leaving it as a doc-side helper so the next ROADMAP edit picks it up by convention; a follow-up can add a workflow if drift recurs.

## Filed by

Product Manager scheduled task, 2026-05-23.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated project roadmap with clarified near-term, medium-term, and long-term priorities and current status
  * Added completion summary documenting recently shipped features and improvements

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/omniaura/omniclaw/pull/761?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->