### PR TITLE
feat: auto-register Slack and Telegram channels with context layer files

### DIFF
--- a/src/channels/slack.ts
+++ b/src/channels/slack.ts
@@ -104,6 +104,8 @@ export interface SlackChannelOpts {
     emoji: string,
     userName: string,
   ) => void;
+  /** Called when a message arrives from an unregistered channel. Return true if registered. */
+  autoRegister?: (chatJid: string, channelName: string) => Promise<boolean>;
 }
 
 export class SlackChannel implements Channel {
@@ -431,11 +433,19 @@ export class SlackChannel implements Channel {
       this.opts.onChatMetadata(legacyChatJid, timestamp, channelName);
     }
 
-    // Only process registered groups
+    // Only process registered groups (auto-register if callback provided)
     const groups = this.opts.registeredGroups();
-    const group =
+    let group =
       groups[chatJid] ||
       (this.allowLegacyJidRouting ? groups[legacyChatJid] : undefined);
+    if (!group && this.opts.autoRegister) {
+      const registered = await this.opts.autoRegister(chatJid, channelName);
+      if (registered) {
+        group =
+          groups[chatJid] ||
+          (this.allowLegacyJidRouting ? groups[legacyChatJid] : undefined);
+      }
+    }
     if (!group) {
       logger.debug(
         { chatJid, legacyChatJid, channelName },

--- a/src/channels/telegram.ts
+++ b/src/channels/telegram.ts
@@ -135,6 +135,8 @@ export interface TelegramChannelOpts {
   onChatMetadata: OnChatMetadata;
   registeredGroups: () => Record<string, RegisteredGroup>;
   allowLegacyJidRouting?: boolean;
+  /** Called when a message arrives from an unregistered chat. Return true if registered. */
+  autoRegister?: (chatJid: string, chatName: string) => Promise<boolean>;
 }
 
 export class TelegramChannel implements Channel {
@@ -179,6 +181,25 @@ export class TelegramChannel implements Channel {
     const fromId = replyTo?.from?.id;
     if (fromId == null) return false;
     return String(fromId) === this.botId;
+  }
+
+  /**
+   * Look up the registered group for a chat, auto-registering if configured.
+   */
+  private async resolveGroup(
+    chatJid: string,
+    legacyChatJid: string,
+    chatName: string,
+  ): Promise<RegisteredGroup | undefined> {
+    const groups = this.opts.registeredGroups();
+    let group = groups[chatJid] || groups[legacyChatJid];
+    if (!group && this.opts.autoRegister) {
+      const registered = await this.opts.autoRegister(chatJid, chatName);
+      if (registered) {
+        group = groups[chatJid] || groups[legacyChatJid];
+      }
+    }
+    return group;
   }
 
   /**
@@ -272,8 +293,7 @@ export class TelegramChannel implements Channel {
       this.opts.onChatMetadata(legacyChatJid, timestamp, chatName);
 
       // Only deliver full message for registered groups
-      const groups = this.opts.registeredGroups();
-      const group = groups[chatJid] || groups[legacyChatJid];
+      const group = await this.resolveGroup(chatJid, legacyChatJid, chatName);
       if (!group) {
         logger.debug(
           { chatJid, legacyChatJid, chatName },
@@ -304,12 +324,17 @@ export class TelegramChannel implements Channel {
     });
 
     // Handle non-text messages with placeholders so the agent knows something was sent
-    const storeNonText = (ctx: any, placeholder: string) => {
+    const storeNonText = async (ctx: any, placeholder: string) => {
       const chatId = ctx.chat.id;
       const chatJid = `tg:${this.botId}:${chatId}`;
       const legacyChatJid = `tg:${chatId}`;
-      const groups = this.opts.registeredGroups();
-      const group = groups[chatJid] || groups[legacyChatJid];
+      const chatName =
+        ctx.chat.type === 'private'
+          ? ctx.from?.first_name || ctx.from?.username || 'Unknown'
+          : 'title' in ctx.chat
+            ? ctx.chat.title
+            : chatJid;
+      const group = await this.resolveGroup(chatJid, legacyChatJid, chatName);
       if (!group) return;
 
       const timestamp = new Date(ctx.message.date * 1000).toISOString();
@@ -344,8 +369,13 @@ export class TelegramChannel implements Channel {
       const chatId = ctx.chat.id;
       const chatJid = `tg:${this.botId}:${chatId}`;
       const legacyChatJid = `tg:${chatId}`;
-      const groups = this.opts.registeredGroups();
-      const group = groups[chatJid] || groups[legacyChatJid];
+      const chatName =
+        ctx.chat.type === 'private'
+          ? ctx.from?.first_name || ctx.from?.username || 'Unknown'
+          : 'title' in ctx.chat
+            ? ctx.chat.title
+            : chatJid;
+      const group = await this.resolveGroup(chatJid, legacyChatJid, chatName);
       if (!group) return;
 
       const msgId = ctx.message.message_id.toString();
@@ -407,8 +437,13 @@ export class TelegramChannel implements Channel {
       const chatId = ctx.chat.id;
       const chatJid = `tg:${this.botId}:${chatId}`;
       const legacyChatJid = `tg:${chatId}`;
-      const groups = this.opts.registeredGroups();
-      const group = groups[chatJid] || groups[legacyChatJid];
+      const chatName =
+        ctx.chat.type === 'private'
+          ? ctx.from?.first_name || ctx.from?.username || 'Unknown'
+          : 'title' in ctx.chat
+            ? ctx.chat.title
+            : chatJid;
+      const group = await this.resolveGroup(chatJid, legacyChatJid, chatName);
       if (!group) return;
 
       const doc = ctx.message.document;

--- a/src/config.ts
+++ b/src/config.ts
@@ -15,6 +15,8 @@ export interface SlackBotConfig {
   id: string;
   token: string;
   appToken: string;
+  /** Agent ID this bot routes unregistered channels to. */
+  agent?: string;
 }
 
 const AGENT_RUNTIME_VALUES = ['claude-agent-sdk', 'opencode', 'codex'] as const;
@@ -51,6 +53,7 @@ const configSchema = z
     DISCORD_BOT_TOKEN: z.string().optional(),
     TELEGRAM_BOT_TOKENS: z.string().optional(),
     TELEGRAM_BOT_TOKEN: z.string().optional(),
+    TELEGRAM_BOT_AGENT: z.string().optional(),
     SLACK_BOT_IDS: z.string().optional(),
     SLACK_BOT_DEFAULT: z.string().optional(),
     SLACK_BOT_TOKEN: z.string().optional(),
@@ -327,7 +330,8 @@ export function buildSlackBotConfigFromEnv(env: NodeJS.ProcessEnv): {
           `Invalid OmniClaw configuration:\nSLACK_BOT_${id}_APP_TOKEN: required when SLACK_BOT_IDS includes ${id}`,
         );
       }
-      bots.push({ id, token, appToken });
+      const agent = optionalTrimmedString(env[`SLACK_BOT_${id}_AGENT`]);
+      bots.push({ id, token, appToken, agent });
     }
     const preferredDefault = sanitizeBotId(env.SLACK_BOT_DEFAULT || '');
     const defaultBotId = bots.some((b) => b.id === preferredDefault)
@@ -354,6 +358,7 @@ export const DISCORD_BOT_IDS = DISCORD_BOTS.map((b) => b.id);
 export const DISCORD_BOT_TOKEN = DISCORD_BOTS[0]?.token || '';
 export const TELEGRAM_BOT_TOKENS = buildTelegramBotTokensFromEnv(process.env);
 export const TELEGRAM_BOT_TOKEN = TELEGRAM_BOT_TOKENS[0] || '';
+export const TELEGRAM_BOT_AGENT = CONFIG.TELEGRAM_BOT_AGENT;
 const slackEnv = buildSlackBotConfigFromEnv(process.env);
 export const SLACK_BOTS = slackEnv.bots;
 export const SLACK_DEFAULT_BOT_ID = slackEnv.defaultBotId;

--- a/src/index.ts
+++ b/src/index.ts
@@ -3751,13 +3751,16 @@ async function main(): Promise<void> {
           TELEGRAM_BOT_TOKENS,
           (token, idx) =>
             Effect.gen(function* () {
-              const telegram = new TelegramChannel(token, {
+              const telegram: TelegramChannel = new TelegramChannel(token, {
                 onMessage: (chatJid, msg) => storeAndBroadcast(msg),
                 onChatMetadata: (chatJid, timestamp, name) =>
                   storeChatMetadata(chatJid, timestamp, name),
                 registeredGroups: () => registeredGroups,
                 allowLegacyJidRouting: TELEGRAM_BOT_TOKENS.length <= 1,
-                autoRegister: async (chatJid, chatName) =>
+                autoRegister: async (
+                  chatJid: string,
+                  chatName: string,
+                ): Promise<boolean> =>
                   autoRegisterChannel(
                     chatJid,
                     chatName,

--- a/src/index.ts
+++ b/src/index.ts
@@ -1343,7 +1343,11 @@ function registerGroup(jid: string, group: RegisteredGroup): void {
  */
 function ensureContextLayerFiles(
   agent: Agent | undefined,
-  layers: { serverFolder?: string; categoryFolder?: string; channelFolder?: string },
+  layers: {
+    serverFolder?: string;
+    categoryFolder?: string;
+    channelFolder?: string;
+  },
 ): void {
   const groupsBase = path.join(DATA_DIR, '..', 'groups');
   const layerPaths: string[] = [];
@@ -1395,7 +1399,9 @@ async function autoRegisterChannel(
 
   // If no explicit mapping, try to match bot ID to an agent ID
   if (!agentId) {
-    agentId = Object.keys(agents).find((id) => id.toLowerCase() === botId.toLowerCase());
+    agentId = Object.keys(agents).find(
+      (id) => id.toLowerCase() === botId.toLowerCase(),
+    );
   }
 
   if (!agentId || !agents[agentId]) {
@@ -3800,12 +3806,7 @@ async function main(): Promise<void> {
                   storeChatMetadata(chatJid, timestamp, name),
                 registeredGroups: () => registeredGroups,
                 autoRegister: async (chatJid, channelName) =>
-                  autoRegisterChannel(
-                    chatJid,
-                    channelName,
-                    'slack',
-                    bot.id,
-                  ),
+                  autoRegisterChannel(chatJid, channelName, 'slack', bot.id),
                 onReaction: async (chatJid, messageId, emoji, userName) => {
                   await handleReactionNotification(
                     chatJid,

--- a/src/index.ts
+++ b/src/index.ts
@@ -52,6 +52,7 @@ import {
   SLACK_BOTS,
   SLACK_DEFAULT_BOT_ID,
   STARTUP_CONFIRMATIONS,
+  TELEGRAM_BOT_AGENT,
   TELEGRAM_BOT_TOKENS,
   WEB_UI_CORS_ORIGIN,
   WEB_UI_HOST,
@@ -1334,6 +1335,157 @@ function registerGroup(jid: string, group: RegisteredGroup): void {
     },
     'Group registered',
   );
+}
+
+/**
+ * Ensure empty CLAUDE.md files exist for all 4 context layers
+ * (agent → server → category → channel). Skips existing files.
+ */
+function ensureContextLayerFiles(
+  agent: Agent | undefined,
+  layers: { serverFolder?: string; categoryFolder?: string; channelFolder?: string },
+): void {
+  const groupsBase = path.join(DATA_DIR, '..', 'groups');
+  const layerPaths: string[] = [];
+
+  if (agent?.agentContextFolder) {
+    layerPaths.push(agent.agentContextFolder);
+  }
+  if (layers.serverFolder) {
+    layerPaths.push(layers.serverFolder);
+  }
+  if (layers.categoryFolder) {
+    layerPaths.push(layers.categoryFolder);
+  }
+  if (layers.channelFolder) {
+    layerPaths.push(layers.channelFolder);
+  }
+
+  for (const layerPath of layerPaths) {
+    const dir = path.join(groupsBase, layerPath);
+    const resolved = path.resolve(dir);
+    if (!resolved.startsWith(path.resolve(groupsBase) + path.sep)) {
+      logger.warn({ layerPath }, 'Skipping out-of-bounds context layer path');
+      continue;
+    }
+    fs.mkdirSync(dir, { recursive: true });
+    const claudeMdPath = path.join(dir, 'CLAUDE.md');
+    if (!fs.existsSync(claudeMdPath)) {
+      fs.writeFileSync(claudeMdPath, '', 'utf-8');
+      logger.info({ layerPath }, 'Created empty context layer CLAUDE.md');
+    }
+  }
+}
+
+/** Auto-register a channel for the given bot, creating subscriptions and context layers. */
+async function autoRegisterChannel(
+  chatJid: string,
+  channelName: string,
+  platform: 'slack' | 'telegram',
+  botId: string,
+): Promise<boolean> {
+  // Resolve the agent for this bot
+  let agentId: string | undefined;
+  if (platform === 'slack') {
+    const botConfig = SLACK_BOTS.find((b) => b.id === botId);
+    agentId = botConfig?.agent;
+  } else if (platform === 'telegram') {
+    agentId = TELEGRAM_BOT_AGENT;
+  }
+
+  // If no explicit mapping, try to match bot ID to an agent ID
+  if (!agentId) {
+    agentId = Object.keys(agents).find((id) => id.toLowerCase() === botId.toLowerCase());
+  }
+
+  if (!agentId || !agents[agentId]) {
+    logger.warn(
+      { chatJid, platform, botId, agentId },
+      'Auto-register skipped: no matching agent found for bot',
+    );
+    return false;
+  }
+
+  const agent = agents[agentId];
+  const layers = resolveContextLayers({
+    channelJid: chatJid,
+    serverFolder: agent.serverFolder,
+  });
+
+  const now = new Date().toISOString();
+  const trigger = `@${agent.name}`;
+
+  // Create a minimal legacy registered group entry
+  const group: RegisteredGroup = {
+    name: channelName,
+    folder: agent.folder,
+    trigger,
+    added_at: now,
+    requiresTrigger: true,
+    serverFolder: layers.serverFolder,
+    channelFolder: layers.channelFolder,
+    categoryFolder: layers.categoryFolder,
+    agentContextFolder: agent.agentContextFolder,
+    backend: agent.backend,
+    agentRuntime: agent.agentRuntime,
+    description: agent.description,
+  };
+
+  registeredGroups[chatJid] = group;
+  setRegisteredGroup(chatJid, group);
+
+  // Create channel route
+  const route: ChannelRoute = {
+    channelJid: chatJid,
+    agentId,
+    trigger,
+    requiresTrigger: true,
+    createdAt: now,
+  };
+  channelRoutes[chatJid] = route;
+  setChannelRoute(route);
+
+  // Create channel subscription
+  const sub: ChannelSubscription = {
+    channelJid: chatJid,
+    agentId,
+    trigger,
+    requiresTrigger: true,
+    priority: 100,
+    isPrimary: true,
+    createdAt: now,
+    channelFolder: layers.channelFolder,
+    categoryFolder: layers.categoryFolder,
+  };
+  const existingSubs = channelSubscriptions[chatJid] || [];
+  const filteredSubs = existingSubs.filter((s) => s.agentId !== agentId);
+  filteredSubs.push(sub);
+  channelSubscriptions[chatJid] = filteredSubs;
+  setChannelSubscription(sub);
+
+  // Register JID→folder mapping for container sharing
+  queue.registerJidMapping(chatJid, agent.folder);
+
+  // Refresh registeredGroups from canonical state
+  refreshRegisteredGroupsFromCanonicalState();
+
+  // Create empty context layer files
+  ensureContextLayerFiles(agent, layers);
+
+  logger.info(
+    {
+      chatJid,
+      channelName,
+      platform,
+      botId,
+      agentId,
+      folder: agent.folder,
+      layers,
+    },
+    'Channel auto-registered',
+  );
+
+  return true;
 }
 
 /** Derive a server folder slug from a guild name */
@@ -3599,6 +3751,13 @@ async function main(): Promise<void> {
                   storeChatMetadata(chatJid, timestamp, name),
                 registeredGroups: () => registeredGroups,
                 allowLegacyJidRouting: TELEGRAM_BOT_TOKENS.length <= 1,
+                autoRegister: async (chatJid, chatName) =>
+                  autoRegisterChannel(
+                    chatJid,
+                    chatName,
+                    'telegram',
+                    telegram.botId,
+                  ),
               });
               yield* Effect.tryPromise(() => telegram.connect());
               return telegram;
@@ -3640,6 +3799,13 @@ async function main(): Promise<void> {
                 onChatMetadata: (chatJid, timestamp, name) =>
                   storeChatMetadata(chatJid, timestamp, name),
                 registeredGroups: () => registeredGroups,
+                autoRegister: async (chatJid, channelName) =>
+                  autoRegisterChannel(
+                    chatJid,
+                    channelName,
+                    'slack',
+                    bot.id,
+                  ),
                 onReaction: async (chatJid, messageId, emoji, userName) => {
                   await handleReactionNotification(
                     chatJid,


### PR DESCRIPTION
When a bot receives a message from an unregistered Slack or Telegram channel, auto-register it instead of ignoring. Creates empty CLAUDE.md files across all 4 context layers (agent, server, category, channel) so agents always have a place to store context.

## Changes

- **Config**: Add \+SLACK_BOT_{ID}_AGENT\+ and `TELEGRAM_BOT_AGENT` env vars to map bots to specific agents
- **Slack channel**: Add `autoRegister` callback invoked when a message arrives from an unregistered channel
- **Telegram channel**: Add `autoRegister` callback for text, photo, document, and non-text messages
- **Orchestrator**: Implement `autoRegisterChannel()` that resolves the agent, writes DB entries (`registered_group`, `channel_route`, `channel_subscription`), and calls `ensureContextLayerFiles()`
- **Context layers**: New `ensureContextLayerFiles()` creates empty `CLAUDE.md` stubs at agent, server, category, and channel layers (skipping existing files)
- **Defaults**: Auto-registered channels use trigger-only mode (`requiresTrigger: true`)

## Usage

Add to `.env`:
```bash
SLACK_BOT_PRIMARY_AGENT=clayton
TELEGRAM_BOT_AGENT=clayton
```

If unset, falls back to matching bot ID to agent ID case-insensitively.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Slack channels and Telegram chats now automatically register upon first contact, eliminating manual setup steps
  * New agent routing configuration support enables flexible channel assignment
  * Context scaffolding and routing files are automatically created for newly registered channels

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/omniaura/omniclaw/pull/764?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->