### PR TITLE
feat(web): Run Now action for scheduled tasks

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -148,7 +148,11 @@ import {
   formatScheduledRunHandoffsForPrompt,
   readScheduledRunHandoffs,
 } from './task-handoffs.js';
-import { startSchedulerLoop } from './task-scheduler.js';
+import {
+  startSchedulerLoop,
+  triggerTaskNow,
+  type SchedulerDependencies,
+} from './task-scheduler.js';
 import {
   parseTelegramApiFileUrl,
   parseTelegramFileDescriptor,
@@ -3070,6 +3074,46 @@ async function main(): Promise<void> {
   });
   sanitizePersistedTelegramAvatarUrls();
 
+  const schedulerDeps: SchedulerDependencies = {
+    registeredGroups: () => registeredGroups,
+    getGroupForTask,
+    isAgentEnabled,
+    getSessions: () => sessions,
+    resumePositionStore,
+    queue,
+    onProcess: (groupJid, proc, containerName, groupFolder, lane) =>
+      queue.registerProcess(
+        groupJid,
+        proc,
+        containerName,
+        groupFolder,
+        undefined,
+        lane,
+      ),
+    sendMessage: async (jid, rawText, discordBotId) => {
+      const ch = findChannelForJid(
+        jid,
+        getPreferredChannelBotId(jid, discordBotId),
+      );
+      if (!ch) {
+        logger.warn({ jid }, 'No channel found for scheduled message');
+        return;
+      }
+      const group = getRegisteredGroupForJid(jid);
+      const text = formatOutbound(
+        ch,
+        rawText,
+        group ? getAgentName(group) : undefined,
+      );
+      if (text) {
+        const msgId = await ch.sendMessage(jid, text);
+        return msgId ? String(msgId) : undefined;
+      }
+    },
+    findChannel: (jid, discordBotId) =>
+      findChannelForJid(jid, getPreferredChannelBotId(jid, discordBotId)),
+  };
+
   const webState: WebStateProvider = {
     getAgents: () => agents,
     getChannelSubscriptions: () => channelSubscriptions,
@@ -3096,6 +3140,7 @@ async function main(): Promise<void> {
     createTask: (task) => dbCreateTask(task),
     updateTask: (id, updates) => dbUpdateTask(id, updates),
     deleteTask: (id) => dbDeleteTask(id),
+    runTaskNow: (id) => triggerTaskNow(id, schedulerDeps),
     calculateNextRun: (type, value) => calculateNextRun(type, value),
     readContextFile: (layerPath) => {
       const filePath = path.join(GROUPS_DIR, layerPath, 'CLAUDE.md');
@@ -3754,45 +3799,7 @@ async function main(): Promise<void> {
   });
 
   // Start subsystems (independently of connection handler)
-  startSchedulerLoop({
-    registeredGroups: () => registeredGroups,
-    getGroupForTask,
-    isAgentEnabled,
-    getSessions: () => sessions,
-    resumePositionStore,
-    queue,
-    onProcess: (groupJid, proc, containerName, groupFolder, lane) =>
-      queue.registerProcess(
-        groupJid,
-        proc,
-        containerName,
-        groupFolder,
-        undefined,
-        lane,
-      ),
-    sendMessage: async (jid, rawText, discordBotId) => {
-      const ch = findChannelForJid(
-        jid,
-        getPreferredChannelBotId(jid, discordBotId),
-      );
-      if (!ch) {
-        logger.warn({ jid }, 'No channel found for scheduled message');
-        return;
-      }
-      const group = getRegisteredGroupForJid(jid);
-      const text = formatOutbound(
-        ch,
-        rawText,
-        group ? getAgentName(group) : undefined,
-      );
-      if (text) {
-        const msgId = await ch.sendMessage(jid, text);
-        return msgId ? String(msgId) : undefined;
-      }
-    },
-    findChannel: (jid, discordBotId) =>
-      findChannelForJid(jid, getPreferredChannelBotId(jid, discordBotId)),
-  });
+  startSchedulerLoop(schedulerDeps);
   startIpcWatcher({
     sendMessage: async (jid, rawText, discordBotId) => {
       const ch = findChannelForJid(

--- a/src/web/page-scripts.ts
+++ b/src/web/page-scripts.ts
@@ -1009,6 +1009,13 @@ tbody.addEventListener("click",function(e){
     .catch(function(err){window.__toast(err.message||"Failed","error");btn.disabled=false;});
   }
 
+  if(action==="run"){
+    btn.disabled=true;
+    fetch("/api/tasks/"+encodeURIComponent(taskId)+"/run",{method:"POST"})
+    .then(function(r){if(!r.ok)return r.json().then(function(d){throw new Error(d.error);});return r.json();})
+    .then(function(){window.__toast("Task queued to run now");btn.disabled=false;})
+    .catch(function(err){window.__toast(err.message||"Failed to run task","error");btn.disabled=false;});
+  }
   if(action==="edit"){openEditModal(taskId);}
   if(action==="runs"){openRunHistory(taskId);}
   if(action==="delete"){openDeleteModal(taskId);}
@@ -1255,6 +1262,7 @@ function refreshTasks(){
       var sc=task.status==="active"?"status-active":task.status==="paused"?"status-paused":"status-completed";
       var tl=task.status==="active"?"Pause":"Resume";
       var ts2=task.status==="active"?"paused":"active";
+      var runBtn=task.status==="completed"?"":'<button class="btn btn-sm" data-tm-action="run">Run</button>';
       var ps=task.prompt.length>60?task.prompt.slice(0,57)+"\\u2026":task.prompt;
       var sl=scheduleLabel(task.schedule_type,task.schedule_value);
       var nr=task.next_run?relTime(task.next_run):"\\u2014";
@@ -1271,6 +1279,7 @@ function refreshTasks(){
         +'<td><span class="badge badge-sm">'+window.__esc(task.context_mode)+'</span></td>'
         +'<td class="td-actions">'
         +'<button class="btn btn-sm btn-toggle" data-tm-action="toggle" data-status="'+ts2+'">'+tl+'</button>'
+        +runBtn
         +'<button class="btn btn-sm" data-tm-action="edit">Edit</button>'
         +'<button class="btn btn-sm" data-tm-action="runs">Runs</button>'
         +'<button class="btn btn-sm btn-danger" data-tm-action="delete">Del</button>'

--- a/src/web/routes.test.ts
+++ b/src/web/routes.test.ts
@@ -717,6 +717,74 @@ describe('web routes unit tests', () => {
 
     expect(res.status).toBe(405);
   });
+
+  it('triggers a task to run now via the state provider', async () => {
+    const calls: string[] = [];
+    const res = await handle(
+      new Request('http://localhost/api/tasks/task-001/run', {
+        method: 'POST',
+      }),
+      makeState({
+        runTaskNow: (id) => {
+          calls.push(id);
+          return { ok: true };
+        },
+      }),
+    );
+
+    expect(res.status).toBe(200);
+    expect(calls).toEqual(['task-001']);
+    expect((await jsonBody(res)) as { ok: boolean; id: string }).toEqual({
+      ok: true,
+      id: 'task-001',
+    });
+  });
+
+  it('returns 404 when running a task that does not exist', async () => {
+    const res = await handle(
+      new Request('http://localhost/api/tasks/missing/run', {
+        method: 'POST',
+      }),
+      makeState({ runTaskNow: () => ({ ok: false, reason: 'not_found' }) }),
+    );
+
+    expect(res.status).toBe(404);
+  });
+
+  it('returns 409 when running a task in an invalid state', async () => {
+    const res = await handle(
+      new Request('http://localhost/api/tasks/task-001/run', {
+        method: 'POST',
+      }),
+      makeState({ runTaskNow: () => ({ ok: false, reason: 'invalid_state' }) }),
+    );
+
+    expect(res.status).toBe(409);
+  });
+
+  it('returns 501 when run-now is unsupported by the provider', async () => {
+    const state = makeState();
+    delete (state as { runTaskNow?: unknown }).runTaskNow;
+    const res = await handle(
+      new Request('http://localhost/api/tasks/task-001/run', {
+        method: 'POST',
+      }),
+      state,
+    );
+
+    expect(res.status).toBe(501);
+  });
+
+  it('rejects non-POST methods for run-now', async () => {
+    const res = await handle(
+      new Request('http://localhost/api/tasks/task-001/run', {
+        method: 'GET',
+      }),
+      makeState({ runTaskNow: () => ({ ok: true }) }),
+    );
+
+    expect(res.status).toBe(405);
+  });
 });
 
 describe('handleRequest task run logs', () => {

--- a/src/web/routes.ts
+++ b/src/web/routes.ts
@@ -154,6 +154,19 @@ export function handleRequest(
       return json({ error: 'Method not allowed' }, 405);
     }
 
+    // Run now: /api/tasks/{id}/run
+    if (rest.endsWith('/run')) {
+      let taskId: string;
+      try {
+        taskId = decodeURIComponent(rest.slice(0, -'/run'.length));
+      } catch {
+        return json({ error: 'Invalid task ID encoding' }, 400);
+      }
+      if (!taskId) return json({ error: 'Missing task ID' }, 400);
+      if (method === 'POST') return handleRunTaskNow(taskId, state);
+      return json({ error: 'Method not allowed' }, 405);
+    }
+
     // Task run logs: /api/tasks/{id}/runs
     if (rest.endsWith('/runs')) {
       let taskId: string;
@@ -725,6 +738,19 @@ function handleDeleteTask(taskId: string, state: WebStateProvider): Response {
   }
 
   return json({ deleted: true, id: taskId });
+}
+
+function handleRunTaskNow(taskId: string, state: WebStateProvider): Response {
+  if (!state.runTaskNow)
+    return json({ error: 'Run-now is not supported' }, 501);
+
+  const result = state.runTaskNow(taskId);
+  if (result.ok) return json({ ok: true, id: taskId });
+  if (result.reason === 'not_found')
+    return json({ error: 'Task not found' }, 404);
+  if (result.reason === 'invalid_state')
+    return json({ error: 'Task cannot be run in its current state' }, 409);
+  return json({ error: 'Failed to run task' }, 400);
 }
 
 function handleGetChats(state: WebStateProvider): Response {

--- a/src/web/tasks.test.ts
+++ b/src/web/tasks.test.ts
@@ -110,6 +110,18 @@ describe('renderTaskTableRows', () => {
     expect(html).toContain('>Resume<');
     expect(html).toContain('badge status-active');
     expect(html).toContain('badge status-paused');
+    expect(html).toContain('data-tm-action="run"');
+  });
+
+  it('omits the Run button for completed tasks', () => {
+    const html = renderTaskTableRows([
+      makeTask({ id: 'task-active', status: 'active' }),
+      makeTask({ id: 'task-done', status: 'completed' }),
+    ]);
+
+    const completedRow = html.slice(html.indexOf('data-task-id="task-done"'));
+    expect(completedRow).not.toContain('data-tm-action="run"');
+    expect(html).toContain('data-tm-action="run"');
   });
 
   it('formats interval schedule labels across millisecond, second, minute, and hour boundaries', () => {

--- a/src/web/tasks.ts
+++ b/src/web/tasks.ts
@@ -127,6 +127,10 @@ export function renderTaskTableRows(tasks: ScheduledTask[]): string {
             : 'status-completed';
       const toggleLabel = task.status === 'active' ? 'Pause' : 'Resume';
       const toggleStatus = task.status === 'active' ? 'paused' : 'active';
+      const runButton =
+        task.status === 'completed'
+          ? ''
+          : `<button class="btn btn-sm" data-tm-action="run">Run</button>`;
       const promptShort =
         task.prompt.length > 60
           ? task.prompt.slice(0, 57) + '\u2026'
@@ -160,6 +164,7 @@ export function renderTaskTableRows(tasks: ScheduledTask[]): string {
         `<td><span class="badge badge-sm">${escapeHtml(task.context_mode)}</span></td>` +
         `<td class="td-actions">` +
         `<button class="btn btn-sm btn-toggle" data-tm-action="toggle" data-status="${toggleStatus}">${toggleLabel}</button>` +
+        runButton +
         `<button class="btn btn-sm" data-tm-action="edit">Edit</button>` +
         `<button class="btn btn-sm" data-tm-action="runs">Runs</button>` +
         `<button class="btn btn-sm btn-danger" data-tm-action="delete">Del</button>` +

--- a/src/web/types.ts
+++ b/src/web/types.ts
@@ -80,6 +80,15 @@ export interface WebStateProvider {
     >,
   ): void;
   deleteTask(id: string): void;
+  /**
+   * Trigger a scheduled task to run immediately, bypassing its schedule.
+   * Returns ok=false with a reason when the task is missing or in a
+   * non-runnable state (e.g. completed/cancelled).
+   */
+  runTaskNow?(id: string): {
+    ok: boolean;
+    reason?: 'not_found' | 'invalid_state';
+  };
   /** Calculate the next run time for a schedule. Returns null on invalid input. */
   calculateNextRun(
     scheduleType: 'cron' | 'interval' | 'once',


### PR DESCRIPTION
## Summary

Adds a **Run Now** action to the Web UI task manager so a scheduled task can be triggered immediately, bypassing its schedule.

The scheduler already had `triggerTaskNow()` and the separate control-plane HTTP server exposed a `run-now` action, but the primary Web UI (`/tasks`) had no way to manually fire a task. This closes that gap as part of the Web UI work (#157), MVP item #3 (task management: view/create/edit/pause/resume/cancel — now + run-now).

## Changes

- **`WebStateProvider`**: new optional `runTaskNow(id)` returning `{ ok, reason? }` (`not_found` | `invalid_state`).
- **`src/index.ts`**: extracted the inline scheduler dependencies into a single `schedulerDeps` const reused by both `startSchedulerLoop` and the Web UI provider; wired `runTaskNow` to `triggerTaskNow`.
- **API**: `POST /api/tasks/{id}/run` — `200 { ok, id }` on success, `404` not found, `409` invalid state (e.g. completed), `501` when the provider doesn't support it, `405` for non-POST.
- **UI**: a `Run` button in the tasks table (server + client render), hidden for completed tasks; click POSTs to the new endpoint and toasts the result.

## Tests

- `routes.test.ts`: success, 404, 409, 501, and 405-method cases.
- `tasks.test.ts`: Run button rendered for active/paused, omitted for completed.
- Full suite: **2152 pass / 0 fail**. Typecheck clean. Prettier clean.

## Test plan

- [ ] `bun test`
- [ ] `bun run typecheck`
- [ ] Manually: open `/tasks`, click **Run** on an active task, confirm it enqueues and a run appears under **Runs**

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added "Run Now" action for tasks—users can trigger immediate task execution via a dedicated Run button on each task row; completed tasks exclude this action.

* **Tests**
  * Added comprehensive test coverage for the new run-now task endpoint and UI interaction.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/omniaura/omniclaw/pull/766?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->