### PR TITLE
fix(router): reactions must not wake idle trigger-gated agents

### DIFF
--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -22,8 +22,9 @@ import {
   _truncateIntermediateStatusBuffer,
   _setSessions,
   getAvailableGroups,
+  hasWakingTrigger,
 } from './index.js';
-import { DATA_DIR } from './config.js';
+import { buildTriggerPattern, DATA_DIR } from './config.js';
 import fs from 'fs';
 import path from 'path';
 import type {
@@ -649,5 +650,54 @@ describe('subscription selection', () => {
 
     expect(result.selectedByTrigger).toBe(true);
     expect(result.selected.map((s) => s.agentId)).toEqual(['agent-a']);
+  });
+});
+
+describe('hasWakingTrigger', () => {
+  const pattern = buildTriggerPattern('@Clayton');
+
+  it('wakes on an explicit @mention', () => {
+    expect(
+      hasWakingTrigger(
+        [{ id: 'slack-1', content: '@Clayton can you review this?' }],
+        pattern,
+      ),
+    ).toBe(true);
+  });
+
+  it('does NOT wake on a reaction notification that matches the trigger', () => {
+    // handleReactionNotification synthesizes this content + a `react-` id.
+    expect(
+      hasWakingTrigger(
+        [
+          {
+            id: 'react-1779680048436-l7zwa9',
+            content: '@Clayton [CodeRabbit reacted with :eyes:]',
+          },
+        ],
+        pattern,
+      ),
+    ).toBe(false);
+  });
+
+  it('still wakes when a real mention is batched alongside a reaction', () => {
+    expect(
+      hasWakingTrigger(
+        [
+          { id: 'react-1', content: '@Clayton [Someone reacted with :eyes:]' },
+          { id: 'slack-2', content: '@Clayton ship it' },
+        ],
+        pattern,
+      ),
+    ).toBe(true);
+  });
+
+  it('does not wake on unaddressed chatter', () => {
+    expect(
+      hasWakingTrigger(
+        [{ id: 'slack-3', content: 'https://example.com neat link' }],
+        pattern,
+      ),
+    ).toBe(false);
   });
 });

--- a/src/index.ts
+++ b/src/index.ts
@@ -1731,6 +1731,25 @@ export function _handleSessionCommandForTest(
 }
 
 /**
+ * Whether a batch of pending messages contains a real trigger that should wake
+ * a trigger-gated agent. Synthetic reaction notifications (id `react-*`) are
+ * stored with content like "@Agent [User reacted with :eyes:]" (see
+ * handleReactionNotification), which matches the trigger pattern even though no
+ * one addressed the agent. A reaction is not a mention, so it must not wake an
+ * idle agent — otherwise every emoji (e.g. a bot's :eyes:) spams a response.
+ *
+ * @internal - exported for testing
+ */
+export function hasWakingTrigger(
+  messages: Array<{ id: string; content: string }>,
+  triggerPattern: RegExp,
+): boolean {
+  return messages.some(
+    (m) => !m.id.startsWith('react-') && triggerPattern.test(m.content.trim()),
+  );
+}
+
+/**
  * Process all pending messages for a group.
  * Called by the GroupQueue when it's this group's turn.
  */
@@ -1764,10 +1783,7 @@ async function processGroupMessages(dispatchJid: string): Promise<boolean> {
   // selectSubscriptionsForMessage(). Don't re-apply trigger gating here.
   if (!agentId && !isMainGroup && group.requiresTrigger !== false) {
     const groupTriggerPattern = buildTriggerPattern(group.trigger);
-    const hasTrigger = missedMessages.some((m) =>
-      groupTriggerPattern.test(m.content.trim()),
-    );
-    if (!hasTrigger) return true;
+    if (!hasWakingTrigger(missedMessages, groupTriggerPattern)) return true;
   }
 
   const log = logger.child({


### PR DESCRIPTION
## Problem

In trigger-required channels, **emoji reactions were waking idle agents and forcing a reply.**

Root cause: `handleReactionNotification` (`src/index.ts`) synthesizes a notification message whose content is

```
@Agent [User reacted with :eyes:]
```

That string starts with `@Agent`, so it matches the per-agent trigger regex (`buildTriggerPattern`). When such a `react-*` message lands in a group's pending batch, the trigger gate in `processGroupMessages` treats it as a real mention and wakes the agent — even though nobody addressed it. With a bot like CodeRabbit repeatedly reacting `:eyes:`, this produced a stream of empty "holding"/acknowledgement replies in Slack.

## Fix

Extract the gate's trigger check into a small pure helper, `hasWakingTrigger(messages, triggerPattern)`, that **ignores synthetic `react-*` messages**. A reaction is not a mention, so it must never *independently* wake a trigger-gated agent.

```ts
export function hasWakingTrigger(messages, triggerPattern): boolean {
  return messages.some(
    (m) => !m.id.startsWith('react-') && triggerPattern.test(m.content.trim()),
  );
}
```

Behavior preserved:
- Real `@mentions` (and reactions batched alongside a real mention) still wake the agent.
- Reactions still **pipe into an actively-running container** as context (that path is unchanged) — they just no longer spawn a fresh run on an idle agent.
- Main group and `requiresTrigger: false` channels are unaffected.

## Tests

Added a `hasWakingTrigger` unit suite (mention wakes; lone reaction does not; mention+reaction wakes; unaddressed chatter does not). Full `src/index.test.ts` passes (25/25), `tsc --noEmit` clean, Prettier clean.

## Follow-ups (not in this PR — see tracking issue)

This stops idle-wake spam, but two related items deserve a product decision and are filed separately:
1. **Warm-container path**: once an agent is warm, subsequent non-mention messages still pipe in and can elicit a reply. The framework already drops empty output (`formatOutbound` -> `if (formatted)`), so the real lever is letting agents *choose silence*; worth making that an explicit, documented default.
2. **Bot/app reactions as pure noise**: reactions from non-human reactors (CodeRabbit, etc.) arguably should not notify at all. Needs reactor-identity plumbing in the Slack/Discord reaction handlers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed issue where synthetic reactions would incorrectly wake idle agents and trigger unnecessary message processing by implementing proper trigger validation.

* **Tests**
  * Added comprehensive test suite for trigger detection, verifying the system correctly identifies real triggers while ignoring reaction-synthesized content, handles batched messages, and ignores unrelated chatter.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/omniaura/omniclaw/pull/767?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->