### PR TITLE
Trim redundant message prompt attributes

### DIFF
--- a/docs/SPEC.md
+++ b/docs/SPEC.md
@@ -603,10 +603,10 @@ Agents support `resumeAt` persistence — the byte offset is saved so subsequent
 When a triggered message arrives, the agent receives all messages since its last interaction, formatted as XML:
 
 ```xml
-<messages participants="John, Sarah">
-<message id="msg1" sender="John" time="2026-02-23T14:32:00Z">hey everyone, should we do pizza tonight?</message>
-<message id="msg2" sender="Sarah" time="2026-02-23T14:33:00Z">sounds good to me</message>
-<message id="msg3" sender="John" time="2026-02-23T14:35:00Z">@Omni what toppings do you recommend?</message>
+<messages excerpt_participants="John, Sarah" participant_keys="discord:111, discord:222">
+<message id="msg1" sender="John" sender_id="discord:111" time="2026-02-23T14:32:00Z">hey everyone, should we do pizza tonight?</message>
+<message id="msg2" sender="Sarah" sender_id="discord:222" time="2026-02-23T14:33:00Z">sounds good to me</message>
+<message id="msg3" sender="John" sender_id="discord:111" time="2026-02-23T14:35:00Z">@Omni what toppings do you recommend?</message>
 </messages>
 ```
 

--- a/docs/sender-identity-phase0-audit.md
+++ b/docs/sender-identity-phase0-audit.md
@@ -317,7 +317,7 @@ This audit is observational only. The instrumentation counters specified in Sect
 
 ## Implementation Notes
 
-- `formatMessages()` now emits explicit immutable sender attributes (`sender_id` and `sender_key`) alongside presentation attributes, plus `participant_keys` for the deduplicated immutable roster.
+- `formatMessages()` now emits explicit immutable sender attributes (`sender_id` on each message and `participant_keys` on the batch) alongside presentation sender names.
 - Sender identity observability now logs `participant_roster_inflation` and `sender_name_changed` counters through the structured logger.
 
 _Last updated: 2026-03-18_

--- a/src/formatting.test.ts
+++ b/src/formatting.test.ts
@@ -62,8 +62,8 @@ describe('formatMessages', () => {
   it('formats a single message as XML with participant attributes', () => {
     const result = formatMessages([makeMsg()]);
     expect(result).toBe(
-      '<messages excerpt_participants="Alice" participants="Alice" participant_keys="123@s.whatsapp.net">\n' +
-        '<message id="1" sender="Alice" sender_id="123@s.whatsapp.net" sender_key="123@s.whatsapp.net" sender_label="Alice" time="2024-01-01T00:00:00.000Z">hello</message>\n' +
+      '<messages excerpt_participants="Alice" participant_keys="123@s.whatsapp.net">\n' +
+        '<message id="1" sender="Alice" sender_id="123@s.whatsapp.net" time="2024-01-01T00:00:00.000Z">hello</message>\n' +
         '</messages>',
     );
   });
@@ -102,7 +102,7 @@ describe('formatMessages', () => {
       }),
     ];
     const result = formatMessages(msgs);
-    expect(result).toContain('participants="Alice, Bob"');
+    expect(result).toContain('excerpt_participants="Alice, Bob"');
     expect(result).toContain('sender="Alice"');
     expect(result).toContain('sender="Bob"');
     expect(result).toContain('>hi</message>');
@@ -125,7 +125,7 @@ describe('formatMessages', () => {
       }),
     ];
     const result = formatMessages(msgs);
-    expect(result).toContain('participants="Alice"');
+    expect(result).toContain('excerpt_participants="Alice"');
     // Should appear once in participants, not "Alice, Alice"
     expect(result).not.toContain('Alice, Alice');
   });
@@ -148,15 +148,15 @@ describe('formatMessages', () => {
       }),
     ];
     const result = formatMessages(msgs);
-    expect(result).toContain('participants="Alice"');
-    expect(result).not.toContain('participants="Alice, System"');
+    expect(result).toContain('excerpt_participants="Alice"');
+    expect(result).not.toContain('excerpt_participants="Alice, System"');
   });
 
   it('escapes special characters in sender names', () => {
     const result = formatMessages([makeMsg({ sender_name: 'A & B <Co>' })]);
     expect(result).toContain('sender="A &amp; B &lt;Co&gt;"');
     expect(result).toContain('sender_id="123@s.whatsapp.net"');
-    expect(result).toContain('participants="A &amp; B &lt;Co&gt;"');
+    expect(result).toContain('excerpt_participants="A &amp; B &lt;Co&gt;"');
   });
 
   it('escapes special characters in content', () => {
@@ -189,7 +189,7 @@ describe('formatMessages', () => {
     const result = formatMessages(msgs);
     // Participants header should only show the first display name (deduped by sender ID)
     const headerLine = result.split('\n')[0];
-    expect(headerLine).toContain('participants="Alice"');
+    expect(headerLine).toContain('excerpt_participants="Alice"');
     expect(headerLine).not.toContain('Alice (New Name)');
     // But both messages still show their respective sender names
     expect(result).toContain('sender="Alice"');
@@ -216,16 +216,16 @@ describe('formatMessages', () => {
     ];
     const result = formatMessages(msgs);
     // Both appear in participants because they have different sender IDs
-    expect(result).toContain('participants="Alice, Alice"');
+    expect(result).toContain('excerpt_participants="Alice, Alice"');
   });
 
-  it('includes sender_id attribute with immutable ID', () => {
+  it('includes only the canonical sender_id attribute with immutable ID', () => {
     const result = formatMessages([
       makeMsg({ sender: 'discord:456789', sender_name: 'Bob' }),
     ]);
     expect(result).toContain('sender_id="discord:456789"');
-    expect(result).toContain('sender_key="discord:456789"');
-    expect(result).toContain('sender_label="Bob"');
+    expect(result).not.toContain('sender_key=');
+    expect(result).not.toContain('sender_label=');
   });
 
   it('includes participant_keys for immutable sender roster', () => {
@@ -283,8 +283,8 @@ describe('formatMessages', () => {
     ];
     const result = formatMessages(msgs);
     // Only "Valid" should appear in participants (Ghost has no sender ID)
-    expect(result).toContain('participants="Valid"');
-    expect(result).not.toContain('participants="Ghost');
+    expect(result).toContain('excerpt_participants="Valid"');
+    expect(result).not.toContain('excerpt_participants="Ghost');
     // But Ghost's message is still rendered in the XML body
     expect(result).toContain('sender="Ghost"');
   });
@@ -314,7 +314,7 @@ describe('formatMessages', () => {
     ];
     const result = formatMessages(msgs);
     // Should show only the first name for the sender (first-name-wins dedup by sender ID)
-    expect(result).toContain('participants="Alice"');
+    expect(result).toContain('excerpt_participants="Alice"');
     expect(result).not.toContain('Alice, Alice');
   });
 
@@ -336,7 +336,7 @@ describe('formatMessages', () => {
       }),
     ];
     const result = formatMessages(msgs);
-    expect(result).toContain('participants="Alice, Bob"');
+    expect(result).toContain('excerpt_participants="Alice, Bob"');
   });
 
   it('excludes system sender from participant roster', () => {
@@ -357,9 +357,9 @@ describe('formatMessages', () => {
       }),
     ];
     const result = formatMessages(msgs);
-    expect(result).toContain('participants="Alice"');
+    expect(result).toContain('excerpt_participants="Alice"');
     // System should not appear in participants attribute (still appears as message sender)
-    expect(result).not.toContain('participants="Alice, System"');
+    expect(result).not.toContain('excerpt_participants="Alice, System"');
   });
 });
 

--- a/src/router.ts
+++ b/src/router.ts
@@ -29,8 +29,6 @@ export function formatMessages(
     return (
       `<message id="${m.id}" sender="${escapeXml(m.sender_name)}" ` +
       `sender_id="${escapeXml(m.sender)}" ` +
-      `sender_key="${escapeXml(m.sender)}" ` +
-      `sender_label="${escapeXml(m.sender_name)}" ` +
       `time="${m.timestamp}">${escapeXml(m.content)}</message>`
     );
   });
@@ -54,8 +52,6 @@ export function formatMessages(
   if (senders.length > 0) {
     const roster = senders.map(escapeXml).join(', ');
     attrs.push(`excerpt_participants="${roster}"`);
-    // Backward-compatible alias for existing prompts/parsers.
-    attrs.push(`participants="${roster}"`);
   }
 
   if (seen.size > 0) {

--- a/src/sender-identity.test.ts
+++ b/src/sender-identity.test.ts
@@ -87,9 +87,9 @@ describe('canonical sender envelope format', () => {
     const result = formatMessages([msg]);
 
     expect(result).toContain('sender_id="discord:456789012345678"');
-    expect(result).toContain('sender_key="discord:456789012345678"');
     expect(result).toContain('sender="TestUser"');
-    expect(result).toContain('sender_label="TestUser"');
+    expect(result).not.toContain('sender_key=');
+    expect(result).not.toContain('sender_label=');
   });
 
   it('WhatsApp adapter produces whatsapp:<jid> sender format', () => {
@@ -167,7 +167,7 @@ describe('label-only spoof detection', () => {
     const result = formatMessages(msgs);
 
     // Both should appear in roster because they have different sender IDs
-    expect(result).toContain('participants="Alice, Alice"');
+    expect(result).toContain('excerpt_participants="Alice, Alice"');
     // Immutable IDs are distinct — agent can tell them apart
     expect(result).toContain('participant_keys="discord:111, discord:999"');
     // Each message carries its own immutable ID
@@ -264,7 +264,7 @@ describe('empty and missing sender identity', () => {
     const result = formatMessages(msgs);
 
     const headerLine = result.split('\n')[0];
-    expect(headerLine).toContain('participants="Valid"');
+    expect(headerLine).toContain('excerpt_participants="Valid"');
     expect(headerLine).not.toContain('Ghost');
     // Ghost message still rendered in body
     expect(result).toContain('sender="Ghost"');
@@ -277,9 +277,9 @@ describe('empty and missing sender identity', () => {
     ];
     const result = formatMessages(msgs);
 
-    expect(result).toContain('participants="Bob"');
-    expect(result).not.toContain('participants="Bob, "');
-    expect(result).not.toContain('participants=", Bob"');
+    expect(result).toContain('excerpt_participants="Bob"');
+    expect(result).not.toContain('excerpt_participants="Bob, "');
+    expect(result).not.toContain('excerpt_participants=", Bob"');
   });
 
   it('system sender is never included in participant roster', () => {
@@ -294,7 +294,7 @@ describe('empty and missing sender identity', () => {
     ];
     const result = formatMessages(msgs);
 
-    expect(result).toContain('participants="User"');
+    expect(result).toContain('excerpt_participants="User"');
     // System should not appear in participants attribute
     const headerLine = result.split('\n')[0];
     expect(headerLine).not.toContain('System');
@@ -519,7 +519,7 @@ describe('cross-platform sender identity in formatted output', () => {
       'participant_keys="discord:12345, telegram:12345"',
     );
     // Both appear in participants (same name, different IDs)
-    expect(result).toContain('participants="User, User"');
+    expect(result).toContain('excerpt_participants="User, User"');
   });
 });
 


### PR DESCRIPTION
## Summary
- remove redundant `sender_key` and `sender_label` attributes from each formatted message
- remove the duplicate batch-level `participants` alias while keeping `excerpt_participants`
- update formatter/sender identity tests and message envelope docs for the leaner contract

## Token impact
Each message now carries only `sender` and `sender_id` instead of also repeating the same values as `sender_label` and `sender_key`. Each message batch also drops the duplicate `participants` alias, leaving `excerpt_participants` plus `participant_keys` as the canonical roster metadata.

## Validation
- `bun test src/formatting.test.ts src/sender-identity.test.ts`
- `bun run build`
- `git diff --check`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated specification examples and implementation notes to reflect revised message formatting attributes and structure.

* **Tests**
  * Updated test assertions to match new message attribute names and participant roster format across multiple scenarios.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/omniaura/omniclaw/pull/770?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->