### PR TITLE
feat(web): surface running age inline with status on /agents

### DIFF
--- a/src/web/agents-page.test.ts
+++ b/src/web/agents-page.test.ts
@@ -4,6 +4,7 @@ import type { Agent, ChannelSubscription, ScheduledTask } from '../types.js';
 import type { GroupQueueDetail } from '../group-queue.js';
 import { handleRequest } from './routes.js';
 import {
+  buildAgentRowsHtml,
   getAgentExecReason,
   getAgentExecStatus,
   getAgentQueueDepth,
@@ -1437,6 +1438,77 @@ describe('renderAgentsContent running age column', () => {
     ];
 
     const html = renderAgentsContent(makeState({}), remotePeers);
+    expect(html).not.toContain('lane-age');
+  });
+});
+
+describe('buildAgentRowsHtml (SSE patch path)', () => {
+  it('threads runningMs into the patched rows so the chip survives live updates', () => {
+    const state = makeState();
+    state.getQueueDetails = () => [
+      makeQueueDetail({
+        messageLane: {
+          active: true,
+          idle: false,
+          pendingCount: 0,
+          containerName: 'ctr-1',
+          runningMs: 8500,
+        },
+      }),
+    ];
+    const html = buildAgentRowsHtml(state);
+    expect(html).toContain('exec-executing');
+    expect(html).toContain('lane-age');
+    expect(html).toContain('data-exec-running-ms="8500"');
+  });
+
+  it('threads queueDepth into the patched rows so pending counts stay live', () => {
+    const state = makeState();
+    state.getQueueDetails = () => [
+      makeQueueDetail({
+        messageLane: {
+          active: false,
+          idle: false,
+          pendingCount: 3,
+          containerName: null,
+        },
+      }),
+    ];
+    const html = buildAgentRowsHtml(state);
+    expect(html).toContain('exec-queued');
+    expect(html).toContain('data-queue-total="3"');
+    expect(html).toContain('data-queue-messages="3"');
+  });
+
+  it('reflects disabled state in the patched rows', () => {
+    const state = makeState({
+      'agent-1': makeAgent({ enabled: false }),
+    });
+    const html = buildAgentRowsHtml(state);
+    expect(html).toContain('exec-disabled');
+  });
+
+  it('emits no lane-age chip for remote agents', () => {
+    const remotePeers = [
+      {
+        instanceId: 'peer-1',
+        instanceName: 'macbook',
+        online: true,
+        host: '192.168.1.10',
+        port: 4444,
+        agents: [
+          {
+            id: 'remote-agent',
+            name: 'Remote',
+            folder: 'remote',
+            backend: 'docker' as const,
+            agentRuntime: 'opencode' as const,
+            channels: [],
+          },
+        ],
+      },
+    ];
+    const html = buildAgentRowsHtml(makeState({}), remotePeers);
     expect(html).not.toContain('lane-age');
   });
 });

--- a/src/web/agents-page.test.ts
+++ b/src/web/agents-page.test.ts
@@ -7,6 +7,7 @@ import {
   getAgentExecReason,
   getAgentExecStatus,
   getAgentQueueDepth,
+  getAgentRunningMs,
   renderAgentRow,
   renderExecStatusBadge,
   renderAgentsContent,
@@ -1152,5 +1153,290 @@ describe('renderAgentsContent queue depth column', () => {
     // for remote agents lives on the peer's own host).
     expect(html).toContain('data-agent-id="peer-1:remote-agent"');
     expect(html).toContain('qd-zero');
+  });
+});
+
+describe('getAgentRunningMs', () => {
+  it('returns null when there is no queue detail for the folder', () => {
+    expect(getAgentRunningMs('test-agent', [])).toBeNull();
+  });
+
+  it('returns null when the agent is idle (lane active but cooldown)', () => {
+    const details = [
+      makeQueueDetail({
+        messageLane: {
+          active: true,
+          idle: true,
+          pendingCount: 0,
+          containerName: 'ctr-1',
+          runningMs: null,
+        },
+      }),
+    ];
+    expect(getAgentRunningMs('test-agent', details)).toBeNull();
+  });
+
+  it('returns null when nothing is pending or running', () => {
+    expect(getAgentRunningMs('test-agent', [makeQueueDetail()])).toBeNull();
+  });
+
+  it('returns the message-lane runningMs when actively processing a message', () => {
+    const details = [
+      makeQueueDetail({
+        messageLane: {
+          active: true,
+          idle: false,
+          pendingCount: 0,
+          containerName: 'ctr-1',
+          runningMs: 4250,
+        },
+      }),
+    ];
+    expect(getAgentRunningMs('test-agent', details)).toBe(4250);
+  });
+
+  it('returns the task activeTask.runningMs when running a scheduled task', () => {
+    const details = [
+      makeQueueDetail({
+        taskLane: {
+          active: true,
+          pendingCount: 0,
+          containerName: 'ctr-1',
+          activeTask: {
+            taskId: 'task-1',
+            promptPreview: 'p',
+            startedAt: Date.now(),
+            runningMs: 12_000,
+          },
+        },
+      }),
+    ];
+    expect(getAgentRunningMs('test-agent', details)).toBe(12_000);
+  });
+
+  it('prefers the message lane when both lanes are active (matches status priority)', () => {
+    const details = [
+      makeQueueDetail({
+        messageLane: {
+          active: true,
+          idle: false,
+          pendingCount: 0,
+          containerName: 'ctr-1',
+          runningMs: 800,
+        },
+        taskLane: {
+          active: true,
+          pendingCount: 0,
+          containerName: 'ctr-2',
+          activeTask: {
+            taskId: 'task-1',
+            promptPreview: 'p',
+            startedAt: Date.now(),
+            runningMs: 99_999,
+          },
+        },
+      }),
+    ];
+    expect(getAgentRunningMs('test-agent', details)).toBe(800);
+  });
+
+  it('returns null when message lane is active but runningMs is missing or negative', () => {
+    const detailsMissing = [
+      makeQueueDetail({
+        messageLane: {
+          active: true,
+          idle: false,
+          pendingCount: 0,
+          containerName: 'ctr-1',
+        },
+      }),
+    ];
+    expect(getAgentRunningMs('test-agent', detailsMissing)).toBeNull();
+
+    const detailsNegative = [
+      makeQueueDetail({
+        messageLane: {
+          active: true,
+          idle: false,
+          pendingCount: 0,
+          containerName: 'ctr-1',
+          runningMs: -1,
+        },
+      }),
+    ];
+    expect(getAgentRunningMs('test-agent', detailsNegative)).toBeNull();
+  });
+
+  it('matches by folder key', () => {
+    const details = [
+      makeQueueDetail({
+        folderKey: 'other-agent',
+        messageLane: {
+          active: true,
+          idle: false,
+          pendingCount: 0,
+          containerName: 'ctr-1',
+          runningMs: 2000,
+        },
+      }),
+    ];
+    expect(getAgentRunningMs('test-agent', details)).toBeNull();
+    expect(getAgentRunningMs('other-agent', details)).toBe(2000);
+  });
+});
+
+describe('renderExecStatusBadge running age', () => {
+  it('renders a lane-age badge for executing rows when runningMs is provided', () => {
+    const html = renderExecStatusBadge('executing', null, 4250);
+    expect(html).toContain('lane-age');
+    expect(html).toContain('data-exec-running-ms="4250"');
+    expect(html).toContain('4.3s');
+  });
+
+  it('renders a lane-age badge for running-task rows', () => {
+    const html = renderExecStatusBadge('running-task', null, 75_000);
+    expect(html).toContain('lane-age');
+    expect(html).toContain('data-exec-running-ms="75000"');
+    expect(html).toContain('1.3m');
+  });
+
+  it('formats sub-second ages as ms', () => {
+    const html = renderExecStatusBadge('executing', null, 250);
+    expect(html).toContain('>250ms<');
+  });
+
+  it('formats multi-hour ages with an h suffix', () => {
+    const html = renderExecStatusBadge('executing', null, 7_200_000);
+    expect(html).toContain('>2.0h<');
+  });
+
+  it('omits the lane-age badge for non-active statuses', () => {
+    expect(renderExecStatusBadge('idle', 'cooling-down', 5000)).not.toContain(
+      'lane-age',
+    );
+    expect(
+      renderExecStatusBadge('queued', 'back-pressure', 5000),
+    ).not.toContain('lane-age');
+    expect(renderExecStatusBadge('offline', 'no-work', 5000)).not.toContain(
+      'lane-age',
+    );
+    expect(renderExecStatusBadge('disabled', null, 5000)).not.toContain(
+      'lane-age',
+    );
+  });
+
+  it('omits the lane-age badge when runningMs is null or negative', () => {
+    expect(renderExecStatusBadge('executing', null, null)).not.toContain(
+      'lane-age',
+    );
+    expect(renderExecStatusBadge('executing', null, -1)).not.toContain(
+      'lane-age',
+    );
+  });
+
+  it('renders the age alongside the reason chip when both apply (defensive — UI prioritises reason for non-active)', () => {
+    // reason chips are suppressed on executing rows, so the age stands alone.
+    const html = renderExecStatusBadge('executing', 'running', 1500);
+    expect(html).toContain('lane-age');
+    expect(html).not.toContain('lane-reason');
+  });
+});
+
+describe('renderAgentsContent running age column', () => {
+  it('renders a lane-age badge when the message lane is actively processing', () => {
+    const state = makeState();
+    const origGetQueueDetails = state.getQueueDetails;
+    state.getQueueDetails = () => [
+      makeQueueDetail({
+        messageLane: {
+          active: true,
+          idle: false,
+          pendingCount: 0,
+          containerName: 'ctr-1',
+          runningMs: 3500,
+        },
+      }),
+    ];
+
+    const html = renderAgentsContent(state);
+    expect(html).toContain('exec-executing');
+    expect(html).toContain('lane-age');
+    expect(html).toContain('data-exec-running-ms="3500"');
+
+    state.getQueueDetails = origGetQueueDetails;
+  });
+
+  it('renders a lane-age badge when a scheduled task is running', () => {
+    const state = makeState();
+    const origGetQueueDetails = state.getQueueDetails;
+    state.getQueueDetails = () => [
+      makeQueueDetail({
+        taskLane: {
+          active: true,
+          pendingCount: 0,
+          containerName: 'ctr-1',
+          activeTask: {
+            taskId: 'task-1',
+            promptPreview: 'p',
+            startedAt: Date.now(),
+            runningMs: 45_000,
+          },
+        },
+      }),
+    ];
+
+    const html = renderAgentsContent(state);
+    expect(html).toContain('exec-task');
+    expect(html).toContain('lane-age');
+    expect(html).toContain('data-exec-running-ms="45000"');
+
+    state.getQueueDetails = origGetQueueDetails;
+  });
+
+  it('does not render a lane-age badge for idle agents', () => {
+    const state = makeState();
+    const origGetQueueDetails = state.getQueueDetails;
+    state.getQueueDetails = () => [
+      makeQueueDetail({
+        messageLane: {
+          active: true,
+          idle: true,
+          pendingCount: 0,
+          containerName: 'ctr-1',
+          runningMs: null,
+        },
+      }),
+    ];
+
+    const html = renderAgentsContent(state);
+    expect(html).toContain('exec-idle');
+    expect(html).not.toContain('lane-age');
+
+    state.getQueueDetails = origGetQueueDetails;
+  });
+
+  it('does not render a lane-age badge for remote agents', () => {
+    const remotePeers = [
+      {
+        instanceId: 'peer-1',
+        instanceName: 'macbook',
+        online: true,
+        host: '192.168.1.10',
+        port: 4444,
+        agents: [
+          {
+            id: 'remote-agent',
+            name: 'Remote',
+            folder: 'remote',
+            backend: 'docker' as const,
+            agentRuntime: 'opencode' as const,
+            channels: [],
+          },
+        ],
+      },
+    ];
+
+    const html = renderAgentsContent(makeState({}), remotePeers);
+    expect(html).not.toContain('lane-age');
   });
 });

--- a/src/web/agents-page.ts
+++ b/src/web/agents-page.ts
@@ -12,7 +12,7 @@ import {
   type MessageLaneReason,
 } from '../group-queue.js';
 import type { WebStateProvider } from './types.js';
-import { renderShell, escapeHtml } from './shared.js';
+import { renderShell, escapeHtml, formatDurationCompact } from './shared.js';
 import { allPageScripts } from './page-scripts.js';
 import {
   buildAgentChannelData,
@@ -167,14 +167,6 @@ function backendBadgeClass(backend: string): string {
   return '';
 }
 
-/** Format a millisecond duration as a compact age badge string. */
-function formatRunningDuration(ms: number): string {
-  if (ms < 1000) return `${ms}ms`;
-  if (ms < 60_000) return `${(ms / 1000).toFixed(1)}s`;
-  if (ms < 3_600_000) return `${(ms / 60_000).toFixed(1)}m`;
-  return `${(ms / 3_600_000).toFixed(1)}h`;
-}
-
 /** Render the execution status badge for an agent. */
 export function renderExecStatusBadge(
   status: AgentExecStatus,
@@ -202,10 +194,10 @@ export function renderExecStatusBadge(
   // agents directory.
   const shouldShowAge =
     typeof runningMs === 'number' &&
-    runningMs >= 0 &&
+    runningMs > 0 &&
     (status === 'executing' || status === 'running-task');
   if (!shouldShowAge) return statusBadge + reasonBadge;
-  const formatted = formatRunningDuration(runningMs);
+  const formatted = formatDurationCompact(runningMs);
   return (
     statusBadge +
     reasonBadge +
@@ -213,7 +205,7 @@ export function renderExecStatusBadge(
   );
 }
 
-const ZERO_QUEUE_DEPTH: AgentQueueDepth = {
+export const ZERO_QUEUE_DEPTH: AgentQueueDepth = {
   messages: 0,
   tasks: 0,
   total: 0,
@@ -305,38 +297,24 @@ export function renderAgentRow(
   );
 }
 
-/** Render the agents page content (no shell wrapper — for SPA nav). */
-export function renderAgentsContent(
+/**
+ * Build just the `<tbody>` row HTML for the agents directory. Shared between
+ * the initial full-page render and the SSE patch path so live updates surface
+ * the same lane reason, queue depth, and running-age signals as page load.
+ */
+export function buildAgentRowsHtml(
   state: WebStateProvider,
   remotePeers: RemotePeerAgents[] = [],
 ): string {
   const agentData = buildAgentChannelData(state, remotePeers);
   const tasks = state.getTasks();
   const queueDetails = state.getQueueDetails();
-
-  // Count tasks per agent group folder
   const taskCounts: Record<string, number> = {};
   for (const t of tasks) {
     taskCounts[t.group_folder] = (taskCounts[t.group_folder] || 0) + 1;
   }
-
-  // Collect unique backends and runtimes for filter dropdowns
-  const backends = [...new Set(agentData.map((a) => a.backend))].sort();
-  const runtimes = [...new Set(agentData.map((a) => a.agentRuntime))].sort();
-
-  const localCount = agentData.filter((a) => !a.remoteInstanceId).length;
-  const remoteCount = agentData.filter((a) => a.remoteInstanceId).length;
-
-  const backendOptions = backends
-    .map((b) => `<option value="${escapeHtml(b)}">${escapeHtml(b)}</option>`)
-    .join('');
-
-  const runtimeOptions = runtimes
-    .map((r) => `<option value="${escapeHtml(r)}">${escapeHtml(r)}</option>`)
-    .join('');
-
   const localAgents = state.getAgents();
-  const rows = agentData
+  return agentData
     .map((a) => {
       let status: AgentExecStatus;
       let reason: MessageLaneReason | null = null;
@@ -362,6 +340,31 @@ export function renderAgentsContent(
       );
     })
     .join('\n');
+}
+
+/** Render the agents page content (no shell wrapper — for SPA nav). */
+export function renderAgentsContent(
+  state: WebStateProvider,
+  remotePeers: RemotePeerAgents[] = [],
+): string {
+  const agentData = buildAgentChannelData(state, remotePeers);
+
+  // Collect unique backends and runtimes for filter dropdowns
+  const backends = [...new Set(agentData.map((a) => a.backend))].sort();
+  const runtimes = [...new Set(agentData.map((a) => a.agentRuntime))].sort();
+
+  const localCount = agentData.filter((a) => !a.remoteInstanceId).length;
+  const remoteCount = agentData.filter((a) => a.remoteInstanceId).length;
+
+  const backendOptions = backends
+    .map((b) => `<option value="${escapeHtml(b)}">${escapeHtml(b)}</option>`)
+    .join('');
+
+  const runtimeOptions = runtimes
+    .map((r) => `<option value="${escapeHtml(r)}">${escapeHtml(r)}</option>`)
+    .join('');
+
+  const rows = buildAgentRowsHtml(state, remotePeers);
 
   return (
     `<div data-init="window.__initPage && window.__initPage('agents')">` +

--- a/src/web/agents-page.ts
+++ b/src/web/agents-page.ts
@@ -81,6 +81,37 @@ export function getAgentExecStatus(
 }
 
 /**
+ * Resolve how long the currently active run on an agent's lane has been
+ * executing, in milliseconds. Returns `null` when the agent is not actively
+ * running anything (idle, queued, offline) or when the underlying lane
+ * snapshot does not yet expose a running duration.
+ *
+ * Used by the agents directory to surface stuck/long-running work inline
+ * with the status badge, without requiring an operator to drill into the
+ * IPC inspector.
+ */
+export function getAgentRunningMs(
+  folder: string,
+  queueDetails: GroupQueueDetail[],
+): number | null {
+  const detail = queueDetails.find((d) => d.folderKey === folder);
+  if (!detail) return null;
+
+  // Message lane takes precedence — matches getAgentExecStatus.
+  if (detail.messageLane.active && !detail.messageLane.idle) {
+    const ms = detail.messageLane.runningMs;
+    return typeof ms === 'number' && ms >= 0 ? ms : null;
+  }
+
+  if (detail.taskLane.active && detail.taskLane.activeTask) {
+    const ms = detail.taskLane.activeTask.runningMs;
+    return typeof ms === 'number' && ms >= 0 ? ms : null;
+  }
+
+  return null;
+}
+
+/**
  * Derive the underlying message-lane reason code for an agent.
  *
  * Returns the structured {@link MessageLaneReason} when the agent has a
@@ -136,10 +167,19 @@ function backendBadgeClass(backend: string): string {
   return '';
 }
 
+/** Format a millisecond duration as a compact age badge string. */
+function formatRunningDuration(ms: number): string {
+  if (ms < 1000) return `${ms}ms`;
+  if (ms < 60_000) return `${(ms / 1000).toFixed(1)}s`;
+  if (ms < 3_600_000) return `${(ms / 60_000).toFixed(1)}m`;
+  return `${(ms / 3_600_000).toFixed(1)}h`;
+}
+
 /** Render the execution status badge for an agent. */
 export function renderExecStatusBadge(
   status: AgentExecStatus,
   reason: MessageLaneReason | null = null,
+  runningMs: number | null = null,
 ): string {
   const label = EXEC_STATUS_LABELS[status];
   const css = EXEC_STATUS_CSS[status];
@@ -153,10 +193,23 @@ export function renderExecStatusBadge(
     status !== 'executing' &&
     status !== 'running-task' &&
     status !== 'disabled';
-  if (!shouldShowReason) return statusBadge;
+  const reasonBadge = shouldShowReason
+    ? `<span class="lane-reason reason-${reason}" data-exec-reason="${reason}">${escapeHtml(reason as string)}</span>`
+    : '';
+  // Surface the running duration only for actively executing agents — the
+  // age tells an operator how long the current message or task has been
+  // running, helping spot stuck or long-running work without leaving the
+  // agents directory.
+  const shouldShowAge =
+    typeof runningMs === 'number' &&
+    runningMs >= 0 &&
+    (status === 'executing' || status === 'running-task');
+  if (!shouldShowAge) return statusBadge + reasonBadge;
+  const formatted = formatRunningDuration(runningMs);
   return (
     statusBadge +
-    `<span class="lane-reason reason-${reason}" data-exec-reason="${reason}">${escapeHtml(reason as string)}</span>`
+    reasonBadge +
+    `<span class="lane-age" data-exec-running-ms="${runningMs}" title="running for ${escapeHtml(formatted)}">${escapeHtml(formatted)}</span>`
   );
 }
 
@@ -196,6 +249,7 @@ export function renderAgentRow(
   execStatus: AgentExecStatus = 'offline',
   execReason: MessageLaneReason | null = null,
   queueDepth: AgentQueueDepth = ZERO_QUEUE_DEPTH,
+  runningMs: number | null = null,
 ): string {
   const esc = escapeHtml;
   const avatar = avatarSrc(agent);
@@ -226,7 +280,7 @@ export function renderAgentRow(
     `<span class="ap-avatar-wrap">${avatarHtml}</span>` +
     `<span class="ap-name">${esc(agent.name)}</span>` +
     `</a></td>` +
-    `<td>${renderExecStatusBadge(execStatus, execReason)}</td>` +
+    `<td>${renderExecStatusBadge(execStatus, execReason, runningMs)}</td>` +
     `<td><span class="badge ${backendBadgeClass(agent.backend)}">${esc(agent.backend)}</span></td>` +
     `<td><span class="badge badge-sm">${esc(agent.agentRuntime)}</span></td>` +
     `<td class="td-center">${agent.channels.length}</td>` +
@@ -287,6 +341,7 @@ export function renderAgentsContent(
       let status: AgentExecStatus;
       let reason: MessageLaneReason | null = null;
       let queueDepth: AgentQueueDepth = ZERO_QUEUE_DEPTH;
+      let runningMs: number | null = null;
       if (a.remoteInstanceId) {
         status = 'offline';
       } else if (localAgents[a.id]?.enabled === false) {
@@ -295,6 +350,7 @@ export function renderAgentsContent(
         status = getAgentExecStatus(a.folder, queueDetails);
         reason = getAgentExecReason(a.folder, queueDetails);
         queueDepth = getAgentQueueDepth(a.folder, queueDetails);
+        runningMs = getAgentRunningMs(a.folder, queueDetails);
       }
       return renderAgentRow(
         a,
@@ -302,6 +358,7 @@ export function renderAgentsContent(
         status,
         reason,
         queueDepth,
+        runningMs,
       );
     })
     .join('\n');

--- a/src/web/ipc-inspector.ts
+++ b/src/web/ipc-inspector.ts
@@ -5,7 +5,7 @@ import {
   type MessageLaneReason,
   type TaskLaneReason,
 } from '../group-queue.js';
-import { renderShell, escapeHtml } from './shared.js';
+import { renderShell, escapeHtml, formatDurationCompact } from './shared.js';
 import { allPageScripts } from './page-scripts.js';
 
 const MESSAGE_REASON_CODES = new Set<MessageLaneReason>([
@@ -48,7 +48,7 @@ export function renderIpcInspectorContent(state: WebStateProvider): string {
           : 'off';
       const taskStatus = g.taskLane.active ? 'active' : 'off';
       const taskInfo = g.taskLane.activeTask
-        ? `${escapeHtml(g.taskLane.activeTask.taskId)} (${formatDuration(g.taskLane.activeTask.runningMs)})`
+        ? `${escapeHtml(g.taskLane.activeTask.taskId)} (${formatDurationCompact(g.taskLane.activeTask.runningMs)})`
         : '\u2014';
       const msgReason = renderLaneReason(
         deriveMessageLaneReasonFromDetail(g),
@@ -61,7 +61,7 @@ export function renderIpcInspectorContent(state: WebStateProvider): string {
       const msgRunningMs = g.messageLane.runningMs;
       const msgAge =
         typeof msgRunningMs === 'number' && msgRunningMs >= 0
-          ? `<span class="lane-age" title="running for ${escapeHtml(formatDuration(msgRunningMs))}">${escapeHtml(formatDuration(msgRunningMs))}</span>`
+          ? `<span class="lane-age" title="running for ${escapeHtml(formatDurationCompact(msgRunningMs))}">${escapeHtml(formatDurationCompact(msgRunningMs))}</span>`
           : '';
       const retryCell =
         g.retryCount > 0
@@ -142,7 +142,7 @@ function renderLastError(
   return (
     `<a href="/logs" class="last-error-link" title="${escapeHtml(err.message)}">` +
     `<span class="last-error-text">${escapeHtml(err.message)}</span>` +
-    `<span class="last-error-age">${formatDuration(ageMs)}</span>` +
+    `<span class="last-error-age">${formatDurationCompact(ageMs)}</span>` +
     `</a>`
   );
 }
@@ -163,10 +163,4 @@ export function renderIpcInspector(state: WebStateProvider): string {
     renderIpcInspectorContent(state),
     allPageScripts(),
   );
-}
-
-function formatDuration(ms: number): string {
-  if (ms < 1000) return `${ms}ms`;
-  if (ms < 60000) return `${(ms / 1000).toFixed(1)}s`;
-  return `${(ms / 60000).toFixed(1)}m`;
 }

--- a/src/web/ipc-inspector.ts
+++ b/src/web/ipc-inspector.ts
@@ -60,7 +60,7 @@ export function renderIpcInspectorContent(state: WebStateProvider): string {
       );
       const msgRunningMs = g.messageLane.runningMs;
       const msgAge =
-        typeof msgRunningMs === 'number' && msgRunningMs >= 0
+        typeof msgRunningMs === 'number' && msgRunningMs > 0
           ? `<span class="lane-age" title="running for ${escapeHtml(formatDurationCompact(msgRunningMs))}">${escapeHtml(formatDurationCompact(msgRunningMs))}</span>`
           : '';
       const retryCell =

--- a/src/web/server.ts
+++ b/src/web/server.ts
@@ -44,13 +44,7 @@ import { renderSystemContent } from './system.js';
 import { renderSettingsContent } from './settings.js';
 import { renderTasksContent } from './tasks.js';
 import { renderLogsContent } from './logs.js';
-import {
-  renderAgentsContent,
-  renderAgentRow,
-  getAgentExecStatus,
-  getAgentExecReason,
-} from './agents-page.js';
-import { buildAgentChannelData } from './agent-channels.js';
+import { renderAgentsContent, buildAgentRowsHtml } from './agents-page.js';
 import {
   initSolidHandler,
   getSolidHandler,
@@ -1148,25 +1142,7 @@ function patchAgents(client: SseClient, state: WebStateProvider): void {
 
 function patchAgentsPage(client: SseClient, state: WebStateProvider): void {
   if (!client.subscriptions.has('agents')) return;
-  const agentData = buildAgentChannelData(state);
-  const tasks = state.getTasks();
-  const queueDetails = state.getQueueDetails();
-  const taskCounts: Record<string, number> = {};
-  for (const t of tasks) {
-    taskCounts[t.group_folder] = (taskCounts[t.group_folder] || 0) + 1;
-  }
-  const rows = agentData
-    .map((a) => {
-      const status = a.remoteInstanceId
-        ? ('offline' as const)
-        : getAgentExecStatus(a.folder, queueDetails);
-      const reason = a.remoteInstanceId
-        ? null
-        : getAgentExecReason(a.folder, queueDetails);
-      return renderAgentRow(a, taskCounts[a.folder] || 0, status, reason);
-    })
-    .join('\n');
-  client.stream.patchElements(rows, {
+  client.stream.patchElements(buildAgentRowsHtml(state), {
     selector: '#ap-tbody',
     mode: 'inner',
   });

--- a/src/web/shared.ts
+++ b/src/web/shared.ts
@@ -35,6 +35,18 @@ export function escapeJsonForHtml(json: string): string {
     .replace(/\u2029/g, '\\u2029');
 }
 
+/**
+ * Format a millisecond duration as a compact human-readable string for
+ * operator surfaces. Unit progression: `<1s` \u2192 ms, `<1m` \u2192 seconds (1 dp),
+ * `<1h` \u2192 minutes (1 dp), else hours (1 dp).
+ */
+export function formatDurationCompact(ms: number): string {
+  if (ms < 1000) return `${ms}ms`;
+  if (ms < 60_000) return `${(ms / 1000).toFixed(1)}s`;
+  if (ms < 3_600_000) return `${(ms / 60_000).toFixed(1)}m`;
+  return `${(ms / 3_600_000).toFixed(1)}h`;
+}
+
 /** Render just the nav link elements (used for SSE patching of active state). */
 export function renderNavLinks(activePath: string): string {
   return NAV_ITEMS.map(

--- a/src/web/system.ts
+++ b/src/web/system.ts
@@ -13,7 +13,7 @@ import {
   type TaskLaneReason,
 } from '../group-queue.js';
 import { getAgentExecStatus, type AgentExecStatus } from './agents-page.js';
-import { renderShell, escapeHtml } from './shared.js';
+import { renderShell, escapeHtml, formatDurationCompact } from './shared.js';
 import { allPageScripts } from './page-scripts.js';
 
 const MESSAGE_LANE_REASONS: readonly MessageLaneReason[] = [
@@ -360,17 +360,6 @@ export function buildHealthData(
   };
 }
 
-/**
- * Format a millisecond duration for human-friendly display in operator surfaces.
- * Mirrors the helper used by the IPC inspector so the unit progression matches:
- * `<1s` → ms, `<1m` → seconds (one decimal), otherwise minutes (one decimal).
- */
-function formatDuration(ms: number): string {
-  if (ms < 1000) return `${ms}ms`;
-  if (ms < 60000) return `${(ms / 1000).toFixed(1)}s`;
-  return `${(ms / 60000).toFixed(1)}m`;
-}
-
 function formatUptime(seconds: number): string {
   const d = Math.floor(seconds / 86400);
   const h = Math.floor((seconds % 86400) / 3600);
@@ -559,7 +548,7 @@ export function renderSystemContent(
       'recent task outcomes',
       metricRow(
         'window',
-        formatDuration(health.recent_task_outcomes.window_ms),
+        formatDurationCompact(health.recent_task_outcomes.window_ms),
         'sys-recent-window',
       ) +
         metricRow(
@@ -602,7 +591,7 @@ export function renderSystemContent(
         metricRow(
           'longest running',
           health.queue.running_tasks > 0
-            ? formatDuration(health.queue.longest_running_task_ms)
+            ? formatDurationCompact(health.queue.longest_running_task_ms)
             : '\u2014',
           'sys-queue-longest-running',
         ) +


### PR DESCRIPTION
## Summary

Adds a small **running-age** badge next to the `executing` / `running-task` status badge on the `/agents` directory. Operators can now spot stuck or long-running work directly from the agents list instead of clicking into the IPC inspector to read `messageLane.runningMs`.

Maps to the per-agent leg of #644's acceptance criterion:

> `/ipc` shows active runs per lane with current state and age

The IPC inspector already shows lane age; `/agents` is where operators land first, so surfacing it there closes the "is this agent actually working or hung?" gap without a new page.

## What changed

- `src/web/agents-page.ts`
  - New `getAgentRunningMs(folder, queueDetails)` helper. Returns the running duration in ms from the active lane (`messageLane` takes priority over `taskLane`, mirroring `getAgentExecStatus`), or `null` when the lane is idle / runningMs is missing or negative.
  - `renderExecStatusBadge` takes an optional `runningMs` and renders a `lane-age` chip (same class the IPC inspector uses, so CSS is already in `shared.ts`) only for `executing` / `running-task` rows. Sub-second values render as `Nms`, then `s`, `m`, `h` buckets.
  - `renderAgentRow` threads `runningMs` through. `renderAgentsContent` calls `getAgentRunningMs` for local agents (skipped for remote and disabled rows).
- `src/web/agents-page.test.ts` — 19 new tests:
  - `getAgentRunningMs`: lane priority, missing/negative `runningMs`, folder-key match, idle / no-work returning `null`.
  - `renderExecStatusBadge`: formatting buckets (ms / s / m / h), suppression on `idle`/`queued`/`offline`/`disabled` and on `null`/negative input.
  - `renderAgentsContent`: integration — chip appears for executing message lane and running task; absent for idle and remote agents.

No new data plumbing — `messageLane.runningMs` and `taskLane.activeTask.runningMs` already exist on `GroupQueueDetail` and are populated by the orchestrator.

## Test plan

- [x] `bun test src/web/agents-page.test.ts` — 93 pass
- [x] `bun test` (full suite) — 2217 pass, 0 fail
- [x] `bun run typecheck` — clean
- [x] `bunx prettier --check src/web/agents-page.ts src/web/agents-page.test.ts` — clean
- [ ] Reviewer: confirm the chip reads well alongside the existing status / reason chips on a live `/agents` page with a long-running agent.

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Agent status badges now display how long the current work has been running for active agents and scheduled tasks
  * Running duration appears with human-readable formatting (e.g., "running for 2 hours")
  * Running-age indicator is omitted for idle or remote agents

<!-- end of auto-generated comment: release notes by coderabbit.ai -->