### PR TITLE
feat(template): silent-by-default guidance for unaddressed Discord turns

### DIFF
--- a/src/seed-templates.test.ts
+++ b/src/seed-templates.test.ts
@@ -126,6 +126,12 @@ describe('getDiscordChannelSeed', () => {
     expect(content).toContain('secondary channel');
   });
 
+  it('includes silent-by-default guidance for unaddressed turns', () => {
+    const content = getDiscordChannelSeed();
+    expect(content).toContain('<internal>');
+    expect(content).toContain('stripInternalTags');
+  });
+
   it('matches the discord-channel template version', () => {
     const content = getDiscordChannelSeed();
     const template = SEED_TEMPLATES.get('discord-channel')!;

--- a/src/seed-templates.ts
+++ b/src/seed-templates.ts
@@ -31,12 +31,22 @@ export interface SeedTemplate {
 
 const DISCORD_CHANNEL_TEMPLATE: SeedTemplate = {
   key: 'discord-channel',
-  version: 2,
+  version: 3,
   body: `## Channel: Discord (Secondary)
 This group communicates via Discord, a secondary channel.
 You can freely answer questions and have conversations here.
 For significant actions (file changes, scheduled tasks, sending messages to other groups),
 confirm intent with the current user in this chat before proceeding.
+
+## Stay Silent When Nothing Is Addressed to You
+Not every turn deserves a reply. Reactions, ambient chatter between other people,
+and messages that don't mention or invite you are not requests for your output.
+Default to silence in those cases — don't post filler like "got it" or "looking into it".
+
+To end a turn silently, emit only \`<internal>…</internal>\` content. Anything inside
+those tags is stripped before send (see \`stripInternalTags\` in \`src/router.ts\`), and
+a turn that produces only internal-tagged text is suppressed entirely. Use this for
+private notes-to-self when the right action is no action.
 
 ## Getting Context You Don't Have
 When you need project context, repo access, credentials, or information that hasn't been shared with you:


### PR DESCRIPTION
## Summary

Adds the "silent-by-default" template guidance sub-item from #768 (the P1 item that the 2026-05-28 PM comment de-blocked as ready-to-implement, no product call needed).

- Seeded `discord-channel` CLAUDE.md gets a new **"Stay Silent When Nothing Is Addressed to You"** section that points at the existing suppression path: emit only `<internal>…</internal>` and the turn is dropped before send.
- Template version bumped `2 → 3` so the reconciler (`reconcileSeededFiles`) updates already-seeded channel CLAUDE.md files on next pass.
- New test pins both the literal `<internal>` marker and the `stripInternalTags` reference in `getDiscordChannelSeed()`, so future template edits can't silently drop the guidance.

## Why this is the right shape

The mechanism is already real:

- `src/router.ts:96` — `stripInternalTags` removes `<internal>…</internal>` content.
- `src/router.ts:110` — `formatOutbound` short-circuits on empty text after stripping (`if (!text) return ''`).
- `src/ipc.ts:413` — IPC path suppresses internal-only messages with `reason: 'internal-only'`.

So no behavioral fork: we're just teaching seeded agents the pattern at template-seed time. Pairs with #767 (P0 — reactions don't wake idle trigger-gated agents) by giving warm-container turns a documented "do nothing" exit path instead of producing the filler acknowledgements observed in Slack `#engineering`.

## Test plan

- [x] `bun test src/seed-templates.test.ts` → 32/32 pass (new assertions on `<internal>` + `stripInternalTags` strings).
- [x] `bun test` → 2199/2199 pass.
- [x] `bun run typecheck` → clean.
- [x] `bunx prettier --check src/seed-templates.ts src/seed-templates.test.ts` → clean.

Refs #768. Does **not** close the issue — the second P1 sub-item (reactor-identity plumbing in `handleReactionNotification`) and the P2 close-recommendation are still open and tracked there.
