### PR TITLE
feat(web): surface longest running message age on /system queue card

### DIFF
--- a/docs/observability.md
+++ b/docs/observability.md
@@ -37,7 +37,7 @@ Source: `src/web/system.ts` (`HealthData`, `renderSystemContent`).
 | `containers`  | active (`active/max_active`), idle (`idle/max_idle`)                                                                                                  | Agent container pool. Pinned at max → back-pressure source.                           |
 | `agents`      | total, by state, by backend, by runtime                                                                                                               | Agent inventory plus the structured exec-state breakdown (see below).                 |
 | `tasks`       | active, paused, completed, total                                                                                                                      | Scheduled-task lifecycle counts (not the running queue — see `queue` card).           |
-| `queue`       | groups, processing, running tasks, longest running, pending msgs/tasks, retrying, total retries, max retries, message lane reasons, task lane reasons | Rollup of every group's lane state. Cross-reference with `/ipc` for per-group detail. |
+| `queue`       | groups, processing, running tasks, longest running, longest message run, pending msgs/tasks, retrying, total retries, max retries, message lane reasons, task lane reasons | Rollup of every group's lane state. Cross-reference with `/ipc` for per-group detail. |
 
 ### Queue card fields
 
@@ -49,6 +49,7 @@ Source: `HealthData.queue` in `src/web/system.ts`.
 | `processing`           | groups with `messageLane.active === true`  | Lanes actively processing inbound messages right now.                     |
 | `running tasks`        | groups with `taskLane.activeTask !== null` | Scheduled tasks currently executing across all task lanes.                |
 | `longest running`      | `max(taskLane.activeTask.runningMs)`       | Age of the oldest in-flight task. Stays at `—` when no task is running.   |
+| `longest message run`  | `max(messageLane.runningMs)`               | Age of the oldest in-flight message run. Stays at `—` when `processing` is 0. |
 | `pending msgs`         | sum of `messageLane.pendingCount`          | Messages queued across all groups (back-pressure ceiling).                |
 | `pending tasks`        | sum of `taskLane.pendingCount`             | Scheduled tasks queued across all groups.                                 |
 | `retrying`             | groups with `retryCount > 0`               | Breadth of retry pressure — how many groups are currently in backoff.     |

--- a/docs/observability.md
+++ b/docs/observability.md
@@ -27,36 +27,36 @@ Source: `src/web/system.ts` (`HealthData`, `renderSystemContent`).
 
 ### Top-level cards
 
-| Card          | Fields                                                                                                                                                | What it tells you                                                                     |
-| ------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------- |
-| `server`      | version, uptime, started, sse clients                                                                                                                 | Process identity; SSE client count tracks live UI subscribers.                        |
-| `runtime`     | bun, platform, arch                                                                                                                                   | Runtime info — useful when a build is misbehaving on a specific host.                 |
-| `memory`      | rss, heap used, heap total                                                                                                                            | Orchestrator process memory; growth here points at a host-side leak.                  |
-| `cpu`         | cores, load 1m / 5m / 15m                                                                                                                             | Host load average; sustained `load > cores` means CPU-bound work.                     |
-| `host memory` | total, used (with %), free                                                                                                                            | Whole-machine memory pressure — distinct from the orchestrator's own usage.           |
-| `containers`  | active (`active/max_active`), idle (`idle/max_idle`)                                                                                                  | Agent container pool. Pinned at max → back-pressure source.                           |
-| `agents`      | total, by state, by backend, by runtime                                                                                                               | Agent inventory plus the structured exec-state breakdown (see below).                 |
-| `tasks`       | active, paused, completed, total                                                                                                                      | Scheduled-task lifecycle counts (not the running queue — see `queue` card).           |
+| Card          | Fields                                                                                                                                                                     | What it tells you                                                                     |
+| ------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------- |
+| `server`      | version, uptime, started, sse clients                                                                                                                                      | Process identity; SSE client count tracks live UI subscribers.                        |
+| `runtime`     | bun, platform, arch                                                                                                                                                        | Runtime info — useful when a build is misbehaving on a specific host.                 |
+| `memory`      | rss, heap used, heap total                                                                                                                                                 | Orchestrator process memory; growth here points at a host-side leak.                  |
+| `cpu`         | cores, load 1m / 5m / 15m                                                                                                                                                  | Host load average; sustained `load > cores` means CPU-bound work.                     |
+| `host memory` | total, used (with %), free                                                                                                                                                 | Whole-machine memory pressure — distinct from the orchestrator's own usage.           |
+| `containers`  | active (`active/max_active`), idle (`idle/max_idle`)                                                                                                                       | Agent container pool. Pinned at max → back-pressure source.                           |
+| `agents`      | total, by state, by backend, by runtime                                                                                                                                    | Agent inventory plus the structured exec-state breakdown (see below).                 |
+| `tasks`       | active, paused, completed, total                                                                                                                                           | Scheduled-task lifecycle counts (not the running queue — see `queue` card).           |
 | `queue`       | groups, processing, running tasks, longest running, longest message run, pending msgs/tasks, retrying, total retries, max retries, message lane reasons, task lane reasons | Rollup of every group's lane state. Cross-reference with `/ipc` for per-group detail. |
 
 ### Queue card fields
 
 Source: `HealthData.queue` in `src/web/system.ts`.
 
-| Field                  | Source                                     | Meaning                                                                   |
-| ---------------------- | ------------------------------------------ | ------------------------------------------------------------------------- |
-| `groups`               | `queueDetails.length`                      | Group folders the orchestrator is currently tracking.                     |
-| `processing`           | groups with `messageLane.active === true`  | Lanes actively processing inbound messages right now.                     |
-| `running tasks`        | groups with `taskLane.activeTask !== null` | Scheduled tasks currently executing across all task lanes.                |
-| `longest running`      | `max(taskLane.activeTask.runningMs)`       | Age of the oldest in-flight task. Stays at `—` when no task is running.   |
+| Field                  | Source                                     | Meaning                                                                       |
+| ---------------------- | ------------------------------------------ | ----------------------------------------------------------------------------- |
+| `groups`               | `queueDetails.length`                      | Group folders the orchestrator is currently tracking.                         |
+| `processing`           | groups with `messageLane.active === true`  | Lanes actively processing inbound messages right now.                         |
+| `running tasks`        | groups with `taskLane.activeTask !== null` | Scheduled tasks currently executing across all task lanes.                    |
+| `longest running`      | `max(taskLane.activeTask.runningMs)`       | Age of the oldest in-flight task. Stays at `—` when no task is running.       |
 | `longest message run`  | `max(messageLane.runningMs)`               | Age of the oldest in-flight message run. Stays at `—` when `processing` is 0. |
-| `pending msgs`         | sum of `messageLane.pendingCount`          | Messages queued across all groups (back-pressure ceiling).                |
-| `pending tasks`        | sum of `taskLane.pendingCount`             | Scheduled tasks queued across all groups.                                 |
-| `retrying`             | groups with `retryCount > 0`               | Breadth of retry pressure — how many groups are currently in backoff.     |
-| `total retries`        | sum of `retryCount`                        | Intensity — one group stuck retrying many times will inflate this.        |
-| `max retries`          | `max(retryCount)`                          | Highest individual retry depth, useful for spotting a single stuck group. |
-| `message lane reasons` | reason-code rollup (see below)             | Distribution of message lanes across the 5 message reason codes.          |
-| `task lane reasons`    | reason-code rollup (see below)             | Distribution of task lanes across the 3 task reason codes.                |
+| `pending msgs`         | sum of `messageLane.pendingCount`          | Messages queued across all groups (back-pressure ceiling).                    |
+| `pending tasks`        | sum of `taskLane.pendingCount`             | Scheduled tasks queued across all groups.                                     |
+| `retrying`             | groups with `retryCount > 0`               | Breadth of retry pressure — how many groups are currently in backoff.         |
+| `total retries`        | sum of `retryCount`                        | Intensity — one group stuck retrying many times will inflate this.            |
+| `max retries`          | `max(retryCount)`                          | Highest individual retry depth, useful for spotting a single stuck group.     |
+| `message lane reasons` | reason-code rollup (see below)             | Distribution of message lanes across the 5 message reason codes.              |
+| `task lane reasons`    | reason-code rollup (see below)             | Distribution of task lanes across the 3 task reason codes.                    |
 
 ### Agent exec-state breakdown
 

--- a/src/web/system.test.ts
+++ b/src/web/system.test.ts
@@ -877,6 +877,83 @@ describe('renderSystemContent', () => {
     );
     // longest running task duration row is present
     expect(html).toContain('id="sys-queue-longest-running"');
+    // longest running message run row is present (mirrors the task version)
+    expect(html).toContain('id="sys-queue-longest-running-message"');
+  });
+
+  it('surfaces the longest running message age across all message lanes', () => {
+    const details: GroupQueueDetail[] = [
+      {
+        folderKey: 'g1',
+        messageLane: {
+          active: true,
+          idle: false,
+          pendingCount: 0,
+          containerName: 'g1-msg',
+          runningMs: 1500,
+        },
+        taskLane: {
+          active: false,
+          pendingCount: 0,
+          containerName: null,
+          activeTask: null,
+        },
+        retryCount: 0,
+      },
+      {
+        folderKey: 'g2',
+        messageLane: {
+          active: true,
+          idle: false,
+          pendingCount: 0,
+          containerName: 'g2-msg',
+          runningMs: 90_000,
+        },
+        taskLane: {
+          active: false,
+          pendingCount: 0,
+          containerName: null,
+          activeTask: null,
+        },
+        retryCount: 0,
+      },
+    ];
+    const health = buildHealthData(makeState([makeAgent()], details), 0);
+    expect(health.queue.longest_running_message_ms).toBe(90_000);
+    expect(health.queue.processing_groups).toBe(2);
+    const html = renderSystemContent(makeState([makeAgent()], details), 0);
+    // 90000ms => 1.5m via the shared formatter
+    expect(html).toContain(
+      '<span class="metric-value" id="sys-queue-longest-running-message">1.5m</span>',
+    );
+  });
+
+  it('renders an em-dash for longest running message when no lanes are active', () => {
+    const details: GroupQueueDetail[] = [
+      {
+        folderKey: 'g1',
+        messageLane: {
+          active: false,
+          idle: true,
+          pendingCount: 0,
+          containerName: null,
+        },
+        taskLane: {
+          active: false,
+          pendingCount: 0,
+          containerName: null,
+          activeTask: null,
+        },
+        retryCount: 0,
+      },
+    ];
+    const health = buildHealthData(makeState([makeAgent()], details), 0);
+    expect(health.queue.processing_groups).toBe(0);
+    expect(health.queue.longest_running_message_ms).toBe(0);
+    const html = renderSystemContent(makeState([makeAgent()], details), 0);
+    expect(html).toContain(
+      '<span class="metric-value" id="sys-queue-longest-running-message">—</span>',
+    );
   });
 
   it('surfaces the longest running task age across all task lanes', () => {

--- a/src/web/system.ts
+++ b/src/web/system.ts
@@ -288,7 +288,10 @@ export function buildHealthData(
       }
     }
     const msgRunningMs = g.messageLane.runningMs;
-    if (typeof msgRunningMs === 'number' && msgRunningMs > longestRunningMessageMs) {
+    if (
+      typeof msgRunningMs === 'number' &&
+      msgRunningMs > longestRunningMessageMs
+    ) {
       longestRunningMessageMs = msgRunningMs;
     }
     if (g.retryCount > 0) retryingGroups++;

--- a/src/web/system.ts
+++ b/src/web/system.ts
@@ -142,6 +142,13 @@ export interface HealthData {
      * tasks without drilling into /ipc.
      */
     longest_running_task_ms: number;
+    /**
+     * Longest currently-running message run age in milliseconds across all
+     * message lanes. Zero when no message lane is active. Operators can spot a
+     * stuck message turn from the queue rollup without drilling into /ipc, the
+     * same way {@link longest_running_task_ms} surfaces stuck task runs.
+     */
+    longest_running_message_ms: number;
     /** Number of group folders whose consecutive retry count is greater than zero. */
     retrying_groups: number;
     /**
@@ -254,6 +261,7 @@ export function buildHealthData(
   let processingGroups = 0;
   let runningTasks = 0;
   let longestRunningTaskMs = 0;
+  let longestRunningMessageMs = 0;
   let retryingGroups = 0;
   let totalRetries = 0;
   let maxRetries = 0;
@@ -278,6 +286,10 @@ export function buildHealthData(
       if (g.taskLane.activeTask.runningMs > longestRunningTaskMs) {
         longestRunningTaskMs = g.taskLane.activeTask.runningMs;
       }
+    }
+    const msgRunningMs = g.messageLane.runningMs;
+    if (typeof msgRunningMs === 'number' && msgRunningMs > longestRunningMessageMs) {
+      longestRunningMessageMs = msgRunningMs;
     }
     if (g.retryCount > 0) retryingGroups++;
     totalRetries += g.retryCount;
@@ -344,6 +356,7 @@ export function buildHealthData(
       processing_groups: processingGroups,
       running_tasks: runningTasks,
       longest_running_task_ms: longestRunningTaskMs,
+      longest_running_message_ms: longestRunningMessageMs,
       retrying_groups: retryingGroups,
       total_retries: totalRetries,
       max_retries: maxRetries,
@@ -594,6 +607,13 @@ export function renderSystemContent(
             ? formatDurationCompact(health.queue.longest_running_task_ms)
             : '\u2014',
           'sys-queue-longest-running',
+        ) +
+        metricRow(
+          'longest message run',
+          health.queue.processing_groups > 0
+            ? formatDuration(health.queue.longest_running_message_ms)
+            : '\u2014',
+          'sys-queue-longest-running-message',
         ) +
         metricRow(
           'pending msgs',

--- a/src/web/system.ts
+++ b/src/web/system.ts
@@ -614,7 +614,7 @@ export function renderSystemContent(
         metricRow(
           'longest message run',
           health.queue.processing_groups > 0
-            ? formatDuration(health.queue.longest_running_message_ms)
+            ? formatDurationCompact(health.queue.longest_running_message_ms)
             : '\u2014',
           'sys-queue-longest-running-message',
         ) +


### PR DESCRIPTION
## Summary

- Adds `longest_running_message_ms` to `HealthData.queue`, computed in
  `buildHealthData()` by taking the max of `messageLane.runningMs` across
  all queue details.
- Renders a `longest message run` row on the `/system` queue card right
  below the existing `longest running` (task) row, with the same em-dash
  fallback when no message lane is active.
- Updates `docs/observability.md` queue-card table and field reference.

## Why

`/system` already surfaces `longest running` for the task lane
(`max(taskLane.activeTask.runningMs)`), but there is no equivalent for
message lanes — even though `messageLane.runningMs` is already in
`GroupQueueDetail` and surfaced per-row on `/ipc`. Operators chasing a
stuck multi-agent turn have to drill into `/ipc` and scan the table just
to spot the worst offender, which works against the operator-observability
rollup goal in #644.

This extends the existing queue rollup so the same "stuck run" question
can be answered for messages at the `/system` level too, without
introducing any new endpoint or page.

## Test plan

- [x] Unit test: two active message lanes (1.5s + 90s running) → rollup
  reports `90_000` and the rendered row shows `1.5m`.
- [x] Unit test: no active message lanes → rollup is `0` and the row
  shows `—` (mirrors the task version).
- [x] Existing `sys-queue-*` ID coverage extended to assert the new
  `sys-queue-longest-running-message` row is present.
- [x] `bun test src/web/` — 660 pass, 0 fail.
- [x] Full suite: `bun test` — 2200 pass, 0 fail.
- [x] `bun run typecheck` — clean.

Refs #644.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added longest running message duration metric to the system queue status, displaying the age of the longest currently-running message across all lanes; shows duration when messages are active, otherwise displays a dash.

* **Documentation**
  * Updated observability documentation to describe the new longest message run metric, its meaning, and display conditions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->