### PR TITLE
fix(reactions): drop reactions from bot/app reactors (#768 P1)

### DIFF
--- a/src/channels/discord.ts
+++ b/src/channels/discord.ts
@@ -212,6 +212,7 @@ export interface DiscordChannelOpts {
     messageId: string,
     emoji: string,
     userName: string,
+    reactor: { id: string; isBot: boolean },
   ) => void;
   onSessionCommand?: (
     command: DiscordSessionCommand,
@@ -1320,7 +1321,10 @@ export class DiscordChannel implements Channel {
     const emoji = reaction.emoji.name || '';
 
     const userName = user.displayName || user.username || 'Someone';
-    this.opts.onReaction?.(chatJid, reaction.message.id, emoji, userName);
+    this.opts.onReaction?.(chatJid, reaction.message.id, emoji, userName, {
+      id: user.id,
+      isBot: user.bot ?? false,
+    });
   }
 
   private async handleSlashCommand(

--- a/src/channels/slack.ts
+++ b/src/channels/slack.ts
@@ -67,6 +67,33 @@ async function resolveSlackUserName(
   }
 }
 
+/**
+ * Resolve both a display name and `is_bot` flag for a Slack user. The reaction
+ * handler uses `is_bot` to drop reactions from other Slack apps/bots (e.g.
+ * CodeRabbit) so they don't wake the agent or pollute the warm-container
+ * stream. Falls back to `{ name: fallback, isBot: false }` on lookup failure;
+ * treating unknown reactors as humans is the conservative choice — the
+ * downstream trigger-pattern check still gates whether a human reaction is
+ * acted on.
+ */
+async function resolveSlackUserIdentity(
+  client: WebClient,
+  userId: string,
+  fallback: string,
+): Promise<{ name: string; isBot: boolean }> {
+  try {
+    const info = await client.users.info({ user: userId });
+    const name =
+      info.user?.profile?.display_name ||
+      info.user?.profile?.real_name ||
+      info.user?.name ||
+      fallback;
+    return { name, isBot: info.user?.is_bot === true };
+  } catch {
+    return { name: fallback, isBot: false };
+  }
+}
+
 /** Resolve <@USERID> Slack mentions into display names. */
 async function resolveMentions(
   text: string,
@@ -103,6 +130,7 @@ export interface SlackChannelOpts {
     messageId: string,
     emoji: string,
     userName: string,
+    reactor: { id: string; isBot: boolean },
   ) => void;
   /** Called when a message arrives from an unregistered channel. Return true if registered. */
   autoRegister?: (chatJid: string, channelName: string) => Promise<boolean>;
@@ -152,6 +180,12 @@ export class SlackChannel implements Channel {
         event.item.type === 'message' ? event.item.channel : null;
       if (!channelId) return;
 
+      // Ignore reactions from this bot itself — Slack delivers reaction_added
+      // events for our own reactions when we use `reactions.add` from
+      // share-request approval flows, and they would otherwise re-enter
+      // the message loop as @-mention noise.
+      if (this.botUserId && event.user === this.botUserId) return;
+
       const chatJid = channelIdToJid(
         channelId,
         this.multiBotMode ? this.botId : undefined,
@@ -161,13 +195,16 @@ export class SlackChannel implements Channel {
 
       const emoji = `:${event.reaction}:`;
 
-      const userName = await resolveSlackUserName(
+      const { name: userName, isBot } = await resolveSlackUserIdentity(
         this.client,
         event.user,
         event.user,
       );
 
-      this.opts.onReaction?.(chatJid, messageId, emoji, userName);
+      this.opts.onReaction?.(chatJid, messageId, emoji, userName, {
+        id: event.user,
+        isBot,
+      });
     });
 
     // Start Socket Mode — resolves when connected

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -23,6 +23,7 @@ import {
   _setSessions,
   getAvailableGroups,
   hasWakingTrigger,
+  shouldDropBotReaction,
 } from './index.js';
 import { buildTriggerPattern, DATA_DIR } from './config.js';
 import fs from 'fs';
@@ -699,5 +700,26 @@ describe('hasWakingTrigger', () => {
         pattern,
       ),
     ).toBe(false);
+  });
+});
+
+describe('shouldDropBotReaction', () => {
+  it('drops reactions from bot/app reactors', () => {
+    expect(shouldDropBotReaction({ id: 'U_CODERABBIT', isBot: true })).toBe(
+      true,
+    );
+  });
+
+  it('keeps reactions from human reactors', () => {
+    expect(shouldDropBotReaction({ id: 'U_HUMAN', isBot: false })).toBe(false);
+  });
+
+  it('keeps reactions when isBot is missing or unknown (default-false)', () => {
+    // Mirrors the resolver fallback when users.info lookup fails — we choose
+    // to treat unresolved reactors as humans so a transient API blip can't
+    // silently swallow a real user's reaction.
+    expect(shouldDropBotReaction({ id: 'U_UNKNOWN', isBot: false })).toBe(
+      false,
+    );
   });
 });

--- a/src/index.ts
+++ b/src/index.ts
@@ -3185,6 +3185,27 @@ function buildAgentRegistry(extraFolders: string[] = []): void {
 }
 
 /**
+ * Identity of the user (or app) who added a reaction. Channel adapters resolve
+ * this from platform metadata so the orchestrator can drop noise from other
+ * bots/apps (e.g. CodeRabbit reacting `:eyes:`) before it reaches the warm
+ * container and produces a filler reply.
+ */
+export interface ReactionReactor {
+  id: string;
+  isBot: boolean;
+}
+
+/**
+ * Return true when a reaction should be dropped before any orchestrator work
+ * (group lookup, queue dispatch). Reactions from bots/apps match the synthetic
+ * `@Agent [User reacted with :emoji:]` trigger pattern and otherwise pipe
+ * straight into a warm container, producing filler replies (#768).
+ */
+export function shouldDropBotReaction(reactor: ReactionReactor): boolean {
+  return reactor.isBot;
+}
+
+/**
  * Handle a reaction notification on a bot message (non-approval reactions).
  * Pipes to the active container or stores in DB and enqueues.
  */
@@ -3194,8 +3215,24 @@ async function handleReactionNotification(
   emoji: string,
   userName: string,
   channelName: string,
+  reactor: ReactionReactor,
   discordBotId?: string,
 ): Promise<void> {
+  if (shouldDropBotReaction(reactor)) {
+    logger.debug(
+      {
+        chatJid,
+        messageId,
+        emoji,
+        userName,
+        reactorId: reactor.id,
+        channelName,
+      },
+      'Dropping reaction from bot/app reactor',
+    );
+    return;
+  }
+
   // For multi-agent Discord channels, route to the subscription whose bot
   // received the reaction rather than blindly using the primary registered group.
   // Without this, a reaction on OCPeyton's message routes to Ditto (the primary).
@@ -3862,13 +3899,20 @@ async function main(): Promise<void> {
                 slashCommandGroups: buildSlashCommandGroupsFromSubscriptions,
                 onSessionCommand: (command, chatJid, group, sessionId) =>
                   handleSessionCommand(command, chatJid, group, sessionId),
-                onReaction: async (chatJid, messageId, emoji, userName) => {
+                onReaction: async (
+                  chatJid,
+                  messageId,
+                  emoji,
+                  userName,
+                  reactor,
+                ) => {
                   await handleReactionNotification(
                     chatJid,
                     messageId,
                     emoji,
                     userName,
                     'Discord',
+                    reactor,
                     bot.id,
                   );
                 },
@@ -3963,13 +4007,20 @@ async function main(): Promise<void> {
                 registeredGroups: () => registeredGroups,
                 autoRegister: async (chatJid, channelName) =>
                   autoRegisterChannel(chatJid, channelName, 'slack', bot.id),
-                onReaction: async (chatJid, messageId, emoji, userName) => {
+                onReaction: async (
+                  chatJid,
+                  messageId,
+                  emoji,
+                  userName,
+                  reactor,
+                ) => {
                   await handleReactionNotification(
                     chatJid,
                     messageId,
                     emoji,
                     userName,
                     'Slack',
+                    reactor,
                   );
                 },
               });


### PR DESCRIPTION
## Summary

Lands the second P1 sub-item carried in #768: bots/apps reacting to bot messages should not wake or pipe into the agent.

After #767 stopped reactions from waking *idle* trigger-gated agents, the remaining noise path is the **warm-container** one — once an agent has run, its container stays warm, reactions pipe straight to stdin via `queue.sendMessage`, and a `:eyes:` from CodeRabbit (or any other Slack/Discord app) becomes `@Agent [CodeRabbit reacted with :eyes:]`, which the trigger pattern accepts and the agent then responds to with filler.

This PR plumbs reactor identity through the channel adapters and drops bot/app reactions before any group lookup or queue work.

## Changes

- **`src/index.ts`** — `handleReactionNotification` takes a new `reactor: ReactionReactor` arg (`{ id, isBot }`) and bails early via the exported `shouldDropBotReaction` predicate when `reactor.isBot` is true. Logs at debug level with reactor id for diagnostics.
- **`src/channels/discord.ts`** — Passes `{ id: user.id, isBot: user.bot ?? false }` from `MessageReactionAdd`. Self-filter (`user.id === client.user?.id`) is unchanged.
- **`src/channels/slack.ts`** — Extracts `resolveSlackUserIdentity` from the existing `users.info` lookup (no extra API call) to return both display name and `is_bot`. Also adds a missing self-filter (`event.user === botUserId`) — Slack delivers `reaction_added` for our own `reactions.add` calls used by share-request approval flows.
- **`src/index.test.ts`** — 3 new tests covering bot-drop, human-pass, and the unknown-reactor default (treats unresolved reactors as humans so a transient `users.info` blip can't swallow a real user reaction).

## Test plan

- [x] `bun run typecheck` clean
- [x] `bun test src/index.test.ts` — 28 pass (3 new)
- [x] `bun test src/channels/` — 249 pass
- [x] `bun test` — full suite 2201 pass, 0 fail
- [x] `bunx prettier --check` — clean on edited files
- [ ] Manual: confirm that a `:eyes:` reaction from CodeRabbit on a Slack agent message no longer pipes into the warm container

## Related

- Closes the P1 reactor-identity sub-item under #768
- Builds on #767 (idle-wake fix)
- PM tracker called this out as "agent-actionable, no product gate" in #801

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Bot and app reactions are now automatically filtered and ignored across Discord and Slack, preventing unnecessary processing of non-human reactions.

* **Tests**
  * Added test coverage for reaction filtering behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->