### PR TITLE
feat(slack): native streamed responses + task timeline for agent runs

### DIFF
--- a/docs/SLACK-AGENT-SETUP.md
+++ b/docs/SLACK-AGENT-SETUP.md
@@ -67,5 +67,6 @@ After install, open Slack and:
 - Clicking it opens a dedicated assistant pane with your three suggested prompts.
 - Sending a message shows the rotating "is thinking…" status below the input.
 - The reply renders rich markdown (lists, code blocks, links) instead of escaped `*literal asterisks*`.
+- Replies stream in with Slack's native AI "generating" treatment, and the agent's intermediate tool activity renders as a task timeline panel on the message (the same UI Cursor/CodeRabbit use) — not a regular message whose text gets edited over and over. This works in the assistant pane and in channel threads where the bot was mentioned; the only places that still fall back to plain messages are un-threaded sends with no one to attribute the run to (e.g. scheduled task output posted top-level into a channel).
 
 If any of those are missing, check the bot's OAuth scopes page — Slack silently drops events the bot isn't scoped for.

--- a/src/channels/slack.test.ts
+++ b/src/channels/slack.test.ts
@@ -325,8 +325,45 @@ describe('SlackChannel.sendMessage', () => {
     const startArgs = (startStream.mock.calls[0] as unknown as [any])[0];
     expect(startArgs.channel).toBe('D123');
     expect(startArgs.thread_ts).toBe('50.5');
-    expect(startArgs.markdown_text).toBe('streamed answer');
+    expect(startArgs.chunks).toEqual([
+      { type: 'markdown_text', text: 'streamed answer' },
+    ]);
     expect(stopStream).toHaveBeenCalledTimes(1);
+  });
+
+  it('streams threaded replies in regular channels with recipient info', async () => {
+    const channel = makeSendChannel();
+    const startStream = mock(() => Promise.resolve({ ts: '6.600' }));
+    const stopStream = mock(() => Promise.resolve({}));
+    const postMessage = mock(() => Promise.resolve({ ts: '9.999' }));
+    (channel as any).client = {
+      chat: { startStream, stopStream, postMessage },
+    };
+    (channel as any).teamId = 'T999';
+    (channel as any).lastHumanSenderByChannel.set('C123', 'UPEYTON');
+    (channel as any).rememberThreadRoot('100.1', '100.1');
+
+    const ts = await channel.sendMessage('slack:C123', 'answer', '100.1');
+
+    expect(ts).toBe('6.600');
+    expect(postMessage).not.toHaveBeenCalled();
+    const startArgs = (startStream.mock.calls[0] as unknown as [any])[0];
+    expect(startArgs.thread_ts).toBe('100.1');
+    expect(startArgs.recipient_user_id).toBe('UPEYTON');
+    expect(startArgs.recipient_team_id).toBe('T999');
+  });
+
+  it('does not stream in channels when the recipient is unknown', async () => {
+    const channel = makeSendChannel();
+    const startStream = mock(() => Promise.resolve({ ts: '6.600' }));
+    const postMessage = mock(() => Promise.resolve({ ts: '7.700' }));
+    (channel as any).client = { chat: { startStream, postMessage } };
+    (channel as any).teamId = 'T999'; // no lastHumanSenderByChannel entry
+
+    const ts = await channel.sendMessage('slack:C123', 'answer', '100.1');
+
+    expect(ts).toBe('7.700');
+    expect(startStream).not.toHaveBeenCalled();
   });
 
   it('falls back to postMessage when streaming is unavailable', async () => {
@@ -343,6 +380,100 @@ describe('SlackChannel.sendMessage', () => {
     expect(ts).toBe('5.500');
     const args = (postMessage.mock.calls[0] as unknown as [any])[0];
     expect(args.thread_ts).toBe('50.5');
+  });
+});
+
+describe('SlackChannel.startMessageStream', () => {
+  it('streams intermediate statuses as a task timeline and finals as markdown', async () => {
+    const channel = makeSendChannel();
+    const startStream = mock(() => Promise.resolve({ ts: '8.800' }));
+    const appendStream = mock(() => Promise.resolve({}));
+    const stopStream = mock(() => Promise.resolve({}));
+    (channel as any).client = {
+      chat: { startStream, appendStream, stopStream },
+    };
+    (channel as any).teamId = 'T999';
+    (channel as any).lastHumanSenderByChannel.set('C123', 'UPEYTON');
+
+    const stream = await channel.startMessageStream('slack:C123', '100.1');
+    expect(stream).not.toBeNull();
+
+    await stream!.appendStatus('Reading src/index.ts\nsome detail');
+    await stream!.appendStatus('Running tests');
+    await stream!.appendText('All done **bold**');
+    const ts = await stream!.stop();
+
+    expect(ts).toBe('8.800');
+    // First status opens the stream with a task in timeline mode
+    const startArgs = (startStream.mock.calls[0] as unknown as [any])[0];
+    expect(startArgs.task_display_mode).toBe('timeline');
+    expect(startArgs.chunks).toEqual([
+      {
+        type: 'task_update',
+        id: 'task-1',
+        title: 'Reading src/index.ts',
+        status: 'in_progress',
+        details: 'Reading src/index.ts\nsome detail',
+      },
+    ]);
+    // Second status completes task-1 and opens task-2
+    const append1 = (appendStream.mock.calls[0] as unknown as [any])[0];
+    expect(append1.chunks).toEqual([
+      {
+        type: 'task_update',
+        id: 'task-1',
+        title: 'Reading src/index.ts',
+        status: 'complete',
+      },
+      {
+        type: 'task_update',
+        id: 'task-2',
+        title: 'Running tests',
+        status: 'in_progress',
+      },
+    ]);
+    // Final text completes task-2 and appends markdown
+    const append2 = (appendStream.mock.calls[1] as unknown as [any])[0];
+    expect(append2.chunks).toEqual([
+      {
+        type: 'task_update',
+        id: 'task-2',
+        title: 'Running tests',
+        status: 'complete',
+      },
+      { type: 'markdown_text', text: 'All done **bold**' },
+    ]);
+    expect(stopStream).toHaveBeenCalledTimes(1);
+  });
+
+  it('returns null without a thread anchor', async () => {
+    const channel = makeSendChannel();
+    (channel as any).teamId = 'T999';
+    (channel as any).lastHumanSenderByChannel.set('C123', 'UPEYTON');
+
+    expect(await channel.startMessageStream('slack:C123')).toBeNull();
+  });
+
+  it('returns null in channels without recipient info', async () => {
+    const channel = makeSendChannel();
+    expect(await channel.startMessageStream('slack:C123', '100.1')).toBeNull();
+  });
+
+  it('uses the active assistant thread as anchor for bare DM streams', async () => {
+    const channel = makeSendChannel();
+    const startStream = mock(() => Promise.resolve({ ts: '9.900' }));
+    const stopStream = mock(() => Promise.resolve({}));
+    (channel as any).client = { chat: { startStream, stopStream } };
+    (channel as any).assistantThreads.set('D123', '50.5');
+
+    const stream = await channel.startMessageStream('slack:D123');
+    expect(stream).not.toBeNull();
+    await stream!.appendText('hi');
+    await stream!.stop();
+
+    const startArgs = (startStream.mock.calls[0] as unknown as [any])[0];
+    expect(startArgs.thread_ts).toBe('50.5');
+    expect(startArgs.recipient_user_id).toBeUndefined();
   });
 });
 

--- a/src/channels/slack.ts
+++ b/src/channels/slack.ts
@@ -2,7 +2,7 @@ import fs from 'fs';
 import path from 'path';
 import { App, Assistant } from '@slack/bolt';
 import { WebClient } from '@slack/web-api';
-import type { KnownBlock } from '@slack/web-api';
+import type { AnyChunk, KnownBlock } from '@slack/web-api';
 
 import { logger } from '../logger.js';
 import {
@@ -22,6 +22,7 @@ import type {
   Channel,
   OnChatMetadata,
   OnInboundMessage,
+  OutboundMessageStream,
   RegisteredGroup,
 } from '../types.js';
 import { splitMessage as splitMessageShared } from './utils.js';
@@ -51,6 +52,8 @@ const MARKDOWN_BLOCK_LIMIT = 11500;
 const THREAD_ROOT_CACHE_MAX = 1000;
 const SEEN_MESSAGE_CACHE_MAX = 500;
 const THREAD_EXCERPT_MAX_CHARS = 140;
+const TASK_TITLE_MAX_CHARS = 80;
+const TASK_DETAILS_MAX_CHARS = 500;
 
 // Rotating status shown under the assistant thread while the agent works.
 const STATUS_LOADING_MESSAGES = [
@@ -119,6 +122,13 @@ async function resolveMentions(
   return { text, mentions };
 }
 
+interface SlackStreamTarget {
+  channelId: string;
+  threadTs: string;
+  /** Required by chat.startStream outside DMs. */
+  recipient?: { recipient_user_id: string; recipient_team_id: string };
+}
+
 export interface SlackChannelOpts {
   botId: string;
   token: string; // Bot token (xoxb-...)
@@ -140,12 +150,15 @@ export interface SlackChannelOpts {
 
 export class SlackChannel implements Channel {
   name = 'slack';
-  prefixAssistantName = true;
+  // Slack always shows the bot's display name on its messages — prefixing the
+  // agent name again ("Clayton: …") is redundant noise.
+  prefixAssistantName = false;
   readonly botId: string;
 
   private app: App;
   private client: WebClient;
   private botUserId: string | null = null;
+  private teamId: string | null = null;
   private connected = false;
   private multiBotMode: boolean;
   private allowLegacyJidRouting: boolean;
@@ -161,6 +174,11 @@ export class SlackChannel implements Channel {
   private threadRootExcerpts = new Map<string, string>();
   /** Dedup of processed messages (`channelId:ts`) across message/app_mention events. */
   private seenMessages = new Set<string>();
+  /**
+   * Last human sender per channel — chat.startStream needs a
+   * recipient_user_id when streaming outside a DM.
+   */
+  private lastHumanSenderByChannel = new Map<string, string>();
 
   constructor(opts: SlackChannelOpts) {
     this.opts = opts;
@@ -237,6 +255,7 @@ export class SlackChannel implements Channel {
     try {
       const authResult = await this.client.auth.test();
       this.botUserId = authResult.user_id as string;
+      this.teamId = (authResult.team_id as string) || null;
       const botName = authResult.user || 'unknown';
       logger.info(
         { botUserId: this.botUserId, botName },
@@ -268,13 +287,16 @@ export class SlackChannel implements Channel {
       : this.assistantThreads.get(channelId);
 
     try {
-      // Assistant threads get the native AI streaming treatment.
-      if (threadTs && this.assistantThreads.get(channelId) === threadTs) {
-        const ts = await this.sendStreamed(channelId, threadTs, text);
-        if (ts) {
-          this.rememberThreadRoot(ts, threadTs);
-          logger.info({ jid, length: text.length }, 'Slack message streamed');
-          return ts;
+      // Threaded sends get the native AI streaming treatment when possible
+      // (assistant threads, and channel threads where the recipient is known).
+      if (threadTs) {
+        const target = this.resolveStreamTarget(channelId, threadTs);
+        if (target) {
+          const ts = await this.trySendStreamed(target, text);
+          if (ts) {
+            logger.info({ jid, length: text.length }, 'Slack message streamed');
+            return ts;
+          }
         }
       }
 
@@ -535,50 +557,163 @@ export class SlackChannel implements Channel {
   }
 
   /**
-   * Stream a response via chat.startStream/appendStream/stopStream — renders
-   * with Slack's native AI-response treatment in assistant threads. Returns
-   * the message ts, or undefined when streaming is unavailable so the caller
-   * can fall back to chat.postMessage.
+   * Start a natively streamed message. Returns null when streaming isn't
+   * possible for this target: chat.startStream requires a thread anchor, and
+   * outside DMs also a recipient user + team.
    */
-  private async sendStreamed(
+  async startMessageStream(
+    jid: string,
+    replyToMessageId?: string,
+  ): Promise<OutboundMessageStream | null> {
+    const channelId = this.extractChannelId(jid);
+    if (!channelId) return null;
+    const threadTs = replyToMessageId
+      ? (this.threadRootByTs.get(replyToMessageId) ?? replyToMessageId)
+      : this.assistantThreads.get(channelId);
+    if (!threadTs) return null;
+    const target = this.resolveStreamTarget(channelId, threadTs);
+    if (!target) return null;
+    return this.createOutboundStream(target);
+  }
+
+  private resolveStreamTarget(
     channelId: string,
     threadTs: string,
+  ): SlackStreamTarget | null {
+    // DM channels (assistant threads included) stream without recipient info.
+    if (channelId.startsWith('D')) return { channelId, threadTs };
+    const userId = this.lastHumanSenderByChannel.get(channelId);
+    if (!userId || !this.teamId) return null;
+    return {
+      channelId,
+      threadTs,
+      recipient: {
+        recipient_user_id: userId,
+        recipient_team_id: this.teamId,
+      },
+    };
+  }
+
+  /**
+   * Streamed message session backed by chat.startStream/appendStream/
+   * stopStream. Status updates render as Slack's task-timeline panel
+   * (`task_update` chunks); final text streams as markdown. Operations are
+   * serialized through an internal chain so concurrent appends can't race
+   * the startStream call.
+   */
+  private createOutboundStream(
+    target: SlackStreamTarget,
+  ): OutboundMessageStream {
+    const { channelId, threadTs } = target;
+    let ts: string | undefined;
+    let taskSeq = 0;
+    let openTask: { id: string; title: string } | null = null;
+    let chain: Promise<unknown> = Promise.resolve();
+
+    const run = <T>(fn: () => Promise<T>): Promise<T> => {
+      const next = chain.then(fn);
+      chain = next.catch(() => undefined);
+      return next;
+    };
+
+    const send = async (chunks: AnyChunk[]): Promise<void> => {
+      if (!ts) {
+        const started = await this.client.chat.startStream({
+          channel: channelId,
+          thread_ts: threadTs,
+          ...(target.recipient ?? {}),
+          task_display_mode: 'timeline',
+          chunks,
+        });
+        ts = started.ts as string | undefined;
+        if (!ts) throw new Error('chat.startStream returned no ts');
+        this.rememberThreadRoot(ts, threadTs);
+      } else {
+        await this.client.chat.appendStream({ channel: channelId, ts, chunks });
+      }
+    };
+
+    const closeOpenTask = (): AnyChunk[] => {
+      if (!openTask) return [];
+      const closer: AnyChunk = {
+        type: 'task_update',
+        id: openTask.id,
+        title: openTask.title,
+        status: 'complete',
+      };
+      openTask = null;
+      return [closer];
+    };
+
+    return {
+      appendStatus: (text: string) =>
+        run(async () => {
+          const trimmed = text.trim();
+          const title =
+            (trimmed.split('\n')[0] || '').slice(0, TASK_TITLE_MAX_CHARS) ||
+            'Working…';
+          const id = `task-${++taskSeq}`;
+          const task: AnyChunk = {
+            type: 'task_update',
+            id,
+            title,
+            status: 'in_progress',
+            ...(trimmed.length > title.length
+              ? { details: trimmed.slice(0, TASK_DETAILS_MAX_CHARS) }
+              : {}),
+          };
+          const chunks = [...closeOpenTask(), task];
+          openTask = { id, title };
+          await send(chunks);
+        }),
+      appendText: (text: string) =>
+        run(async () => {
+          for (const chunk of splitMarkdown(text)) {
+            await send([
+              ...closeOpenTask(),
+              { type: 'markdown_text', text: chunk },
+            ]);
+          }
+        }),
+      stop: () =>
+        run(async () => {
+          if (!ts) return undefined;
+          const closers = closeOpenTask();
+          await this.client.chat.stopStream({
+            channel: channelId,
+            ts,
+            ...(closers.length > 0 ? { chunks: closers } : {}),
+          });
+          return ts;
+        }),
+    };
+  }
+
+  /**
+   * Send a complete response through the streaming APIs in one shot.
+   * Returns the message ts, or undefined when streaming is unavailable so
+   * the caller can fall back to chat.postMessage.
+   */
+  private async trySendStreamed(
+    target: SlackStreamTarget,
     text: string,
   ): Promise<string | undefined> {
-    const chunks = splitMarkdown(text);
-    let ts: string | undefined;
+    const stream = this.createOutboundStream(target);
     try {
-      const started = await this.client.chat.startStream({
-        channel: channelId,
-        thread_ts: threadTs,
-        markdown_text: chunks[0],
-      });
-      ts = started.ts as string | undefined;
-      if (!ts) return undefined;
-      for (let i = 1; i < chunks.length; i++) {
-        await this.client.chat.appendStream({
-          channel: channelId,
-          ts,
-          markdown_text: chunks[i],
-        });
-      }
-      await this.client.chat.stopStream({ channel: channelId, ts });
-      return ts;
+      await stream.appendText(text);
+      return await stream.stop();
     } catch (err) {
       logger.debug(
-        { channelId, err },
+        { channelId: target.channelId, err },
         'Slack streaming send unavailable — falling back to chat.postMessage',
       );
-      // Content already landed via startStream — finalize instead of duplicating.
-      if (ts) {
-        try {
-          await this.client.chat.stopStream({ channel: channelId, ts });
-          return ts;
-        } catch {
-          // fall through to postMessage fallback
-        }
+      // If content already landed via startStream, finalize instead of
+      // duplicating; stop() returns undefined when nothing was sent.
+      try {
+        return await stream.stop();
+      } catch {
+        return undefined;
       }
-      return undefined;
     }
   }
 
@@ -702,6 +837,9 @@ export class SlackChannel implements Channel {
     this.rememberThreadRoot(event.ts, event.thread_ts || event.ts);
 
     const senderUserId = 'user' in event ? event.user : 'unknown';
+    if (senderUserId && senderUserId !== 'unknown') {
+      this.lastHumanSenderByChannel.set(channelId, senderUserId);
+    }
     const sender = `slack:${senderUserId}`;
     const senderName = await resolveSlackUserName(
       this.client,

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -204,6 +204,103 @@ describe('intermediate status streaming', () => {
     expect(edits.at(-1)).toBe('Final response follows below.');
   });
 
+  it('streams intermediates and the final reply through a native message stream', async () => {
+    const statuses: string[] = [];
+    const texts: string[] = [];
+    let stopped = 0;
+    const sends: string[] = [];
+    const streamer = _createIntermediateStatusStreamer({
+      channel: {
+        sendMessage: async (_jid, text) => {
+          sends.push(text);
+          return 'status-1';
+        },
+        editMessage: async () => undefined,
+        startMessageStream: async (_jid, replyTo) => {
+          expect(replyTo).toBe('trigger-1');
+          return {
+            appendStatus: async (text: string) => {
+              statuses.push(text);
+            },
+            appendText: async (text: string) => {
+              texts.push(text);
+            },
+            stop: async () => {
+              stopped++;
+              return 'stream-1';
+            },
+          };
+        },
+      },
+      chatJid: 'slack:C123',
+      replyAnchor: () => 'trigger-1',
+      editDebounceMs: 1,
+    });
+
+    await streamer.append('tool call 1');
+    await streamer.append('tool call 2');
+    expect(streamer.isActive).toBe(true);
+    const edited = await streamer.editFinal('final answer');
+
+    expect(edited).toBe(true);
+    expect(statuses).toEqual(['tool call 1', 'tool call 2']);
+    expect(texts).toEqual(['final answer']);
+    expect(stopped).toBe(1);
+    // No status message was ever posted/edited — fully native
+    expect(sends).toEqual([]);
+  });
+
+  it('falls back to the edit loop when the native stream is unavailable', async () => {
+    const sends: string[] = [];
+    const streamer = _createIntermediateStatusStreamer({
+      channel: {
+        sendMessage: async (_jid, text) => {
+          sends.push(text);
+          return 'status-1';
+        },
+        editMessage: async () => undefined,
+        startMessageStream: async () => null,
+      },
+      chatJid: 'slack:C123',
+      editDebounceMs: 1,
+    });
+
+    await streamer.append('working');
+
+    expect(sends).toEqual(['working']);
+    expect(streamer.messageId).toBe('status-1');
+  });
+
+  it('falls back mid-run when a native stream append fails, keeping the buffer', async () => {
+    const sends: string[] = [];
+    let appendCalls = 0;
+    const streamer = _createIntermediateStatusStreamer({
+      channel: {
+        sendMessage: async (_jid, text) => {
+          sends.push(text);
+          return 'status-1';
+        },
+        editMessage: async () => undefined,
+        startMessageStream: async () => ({
+          appendStatus: async () => {
+            appendCalls++;
+            if (appendCalls > 1) throw new Error('stream broke');
+          },
+          appendText: async () => undefined,
+          stop: async () => undefined,
+        }),
+      },
+      chatJid: 'slack:C123',
+      editDebounceMs: 1,
+    });
+
+    await streamer.append('first');
+    await streamer.append('second');
+
+    // Fallback status message carries the full buffered context
+    expect(sends).toEqual(['first\nsecond']);
+  });
+
   it('truncates live buffers on line boundaries and strips broken fences', () => {
     const text = ['before', '```', 'secret output', '```', 'after'].join('\n');
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -170,6 +170,7 @@ import {
   type ChannelRoute,
   type ChannelSubscription,
   type NewMessage,
+  type OutboundMessageStream,
   type RegisteredGroup,
   registeredGroupToAgent,
   registeredGroupToRoute,
@@ -278,7 +279,10 @@ const INTERMEDIATE_EDIT_DEBOUNCE_MS = 750;
 const DEFAULT_SESSION_LIST_LIMIT = 10;
 const MAX_SESSION_LIST_LIMIT = 25;
 
-type IntermediateStatusChannel = Pick<Channel, 'sendMessage' | 'editMessage'>;
+type IntermediateStatusChannel = Pick<
+  Channel,
+  'sendMessage' | 'editMessage' | 'startMessageStream'
+>;
 
 export function _truncateIntermediateStatusBuffer(
   text: string,
@@ -308,6 +312,8 @@ export function _createIntermediateStatusStreamer(opts: {
   chatJid: string;
   bufferLimit?: number;
   editDebounceMs?: number;
+  /** Reply anchor for threading natively streamed messages. */
+  replyAnchor?: () => string | null | undefined;
   onDebug?: (err: unknown, message: string) => void;
 }) {
   const channel = opts.channel;
@@ -319,6 +325,38 @@ export function _createIntermediateStatusStreamer(opts: {
   let buffer = '';
   let editTimer: ReturnType<typeof setTimeout> | null = null;
   let editInFlight: Promise<void> | null = null;
+  // Native streaming (e.g. Slack chat.startStream task timeline). When the
+  // channel supports it for this target, intermediates stream as task chunks
+  // and the final reply streams as markdown — no edit loop at all.
+  let nativeStream: OutboundMessageStream | null = null;
+  let nativeStreamPromise: Promise<OutboundMessageStream | null> | null = null;
+  let nativeUnavailable = false;
+
+  const ensureNativeStream =
+    async (): Promise<OutboundMessageStream | null> => {
+      if (nativeUnavailable || !channel?.startMessageStream) return null;
+      if (!nativeStreamPromise) {
+        nativeStreamPromise = channel
+          .startMessageStream(opts.chatJid, opts.replyAnchor?.() ?? undefined)
+          .catch((err) => {
+            onDebug(err, 'Native message stream creation failed');
+            return null;
+          });
+      }
+      nativeStream = await nativeStreamPromise;
+      if (!nativeStream) nativeUnavailable = true;
+      return nativeStream;
+    };
+
+  const abandonNativeStream = (): void => {
+    const stream = nativeStream;
+    nativeStream = null;
+    nativeStreamPromise = null;
+    nativeUnavailable = true;
+    // Finalize whatever partial content was streamed so the message doesn't
+    // hang in the "generating" state.
+    stream?.stop().catch(() => undefined);
+  };
 
   const flushEdit = async (): Promise<void> => {
     if (!channel?.editMessage || !messageId) return;
@@ -365,19 +403,52 @@ export function _createIntermediateStatusStreamer(opts: {
     get buffer(): string {
       return buffer;
     },
+    /** True when a status message or native stream is open for this run. */
+    get isActive(): boolean {
+      return Boolean(messageId || creationPromise || nativeStream);
+    },
     async append(text: string): Promise<void> {
       if (!channel) return;
       const clean = text.replace(/<internal>[\s\S]*?<\/internal>/g, '').trim();
       if (!clean) return;
+      // Keep the buffer in both modes so a mid-run fallback retains context.
       buffer = _truncateIntermediateStatusBuffer(
         `${buffer}${buffer ? '\n' : ''}${clean}`,
         bufferLimit,
       );
+      if (!nativeUnavailable && channel.startMessageStream) {
+        const stream = await ensureNativeStream();
+        if (stream) {
+          try {
+            await stream.appendStatus(clean);
+            return;
+          } catch (err) {
+            onDebug(err, 'Native stream append failed — falling back to edits');
+            abandonNativeStream();
+          }
+        }
+      }
       const hadMessage = Boolean(messageId);
       const id = await ensureMessage();
       if (id && hadMessage) scheduleEdit();
     },
     async editFinal(text: string): Promise<boolean> {
+      // Wait out any in-flight native stream creation before deciding the mode.
+      if (nativeStreamPromise) await ensureNativeStream();
+      if (nativeStream) {
+        const stream = nativeStream;
+        try {
+          await stream.appendText(text);
+          await stream.stop();
+          nativeStream = null;
+          nativeStreamPromise = null;
+          return true;
+        } catch (err) {
+          onDebug(err, 'Native stream finalize failed');
+          abandonNativeStream();
+          return false;
+        }
+      }
       if (!channel?.editMessage) return false;
       if (editTimer) {
         clearTimeout(editTimer);
@@ -413,6 +484,12 @@ export function _createIntermediateStatusStreamer(opts: {
       creationPromise = null;
       messageId = null;
       buffer = '';
+      // Close any dangling native stream so it doesn't hang in "generating".
+      const stream = nativeStream;
+      nativeStream = null;
+      nativeStreamPromise = null;
+      nativeUnavailable = false;
+      stream?.stop().catch(() => undefined);
     },
   };
 }
@@ -2045,17 +2122,13 @@ async function processGroupMessages(dispatchJid: string): Promise<boolean> {
 
   let hadError = false;
   let outputSentToUser = false;
-  // Edited-message streaming: a single status message that gets updated with
-  // intermediate tool calls/logs, then replaced by the final reply.
+  // Intermediate streaming: native message streams (Slack task timeline)
+  // where supported, otherwise a single status message edited in place.
   const intermediateChannel =
-    group.containerConfig?.streamIntermediates !== false && channel?.editMessage
+    group.containerConfig?.streamIntermediates !== false &&
+    (channel?.editMessage || channel?.startMessageStream)
       ? channel
       : null;
-  const intermediateStatus = _createIntermediateStatusStreamer({
-    channel: intermediateChannel,
-    chatJid,
-    onDebug: (err, message) => log.debug({ err }, message),
-  });
 
   // Patterns that indicate system/auth errors — never send these to channels
   // Adopted from [Upstream PR #298] - Prevents infinite loops from auth failures
@@ -2106,6 +2179,12 @@ async function processGroupMessages(dispatchJid: string): Promise<boolean> {
   // Use reply threading only for the first outbound message in this run.
   // Subsequent outputs should not keep replying to the original trigger.
   let replyAnchorMessageId: string | null = triggeringMessageId;
+  const intermediateStatus = _createIntermediateStatusStreamer({
+    channel: intermediateChannel,
+    chatJid,
+    replyAnchor: () => replyAnchorMessageId,
+    onDebug: (err, message) => log.debug({ err }, message),
+  });
   const lastContent = missedMessages[missedMessages.length - 1]?.content || '';
   let output: 'success' | 'error';
   try {
@@ -2173,10 +2252,9 @@ async function processGroupMessages(dispatchJid: string): Promise<boolean> {
                   const replyId =
                     targetJid === chatJid ? replyAnchorMessageId : null;
                   if (
-                    intermediateStatus.messageId &&
+                    intermediateStatus.isActive &&
                     targetJid === chatJid &&
-                    targetChannel === intermediateChannel &&
-                    targetChannel.editMessage
+                    targetChannel === intermediateChannel
                   ) {
                     const edited =
                       await intermediateStatus.editFinal(formatted);
@@ -2243,6 +2321,9 @@ async function processGroupMessages(dispatchJid: string): Promise<boolean> {
         logger.debug({ err, chatJid }, 'Failed to clear typing indicator');
       });
     if (idleTimer) clearTimeout(idleTimer);
+    // Close any dangling native status stream (e.g. agent errored mid-run)
+    // so the streamed message doesn't hang in the "generating" state.
+    intermediateStatus.reset();
   }
 
   if (output === 'error' || hadError) {

--- a/src/types.ts
+++ b/src/types.ts
@@ -289,6 +289,24 @@ export interface FactoryWorkflowClaim {
 
 // --- Channel abstraction ---
 
+/**
+ * Handle for a natively streamed outbound message (e.g. Slack's
+ * chat.startStream/appendStream/stopStream). Created via
+ * Channel.startMessageStream; all methods may throw — callers fall back to
+ * sendMessage/editMessage on failure.
+ */
+export interface OutboundMessageStream {
+  /**
+   * Append an intermediate status update (tool call, progress note).
+   * Rendered as a task timeline on platforms that support it.
+   */
+  appendStatus(text: string): Promise<void>;
+  /** Append final response text (markdown). */
+  appendText(text: string): Promise<void>;
+  /** Finalize the stream. Returns the message id, or undefined if nothing was sent. */
+  stop(): Promise<string | undefined>;
+}
+
 export interface Channel {
   name: string;
   /** Optional channel/bot identity key for multi-bot routing (Discord/Telegram). */
@@ -310,6 +328,15 @@ export interface Channel {
   sendToThread?(thread: unknown, text: string): Promise<void>;
   // Optional: edit an existing message in-place.
   editMessage?(jid: string, messageId: string, text: string): Promise<void>;
+  /**
+   * Optional: start a natively streamed message (e.g. Slack chat.startStream).
+   * Returns null when streaming isn't possible for this target (no thread
+   * anchor, missing recipient info) so callers can fall back to sendMessage.
+   */
+  startMessageStream?(
+    jid: string,
+    replyToMessageId?: string,
+  ): Promise<OutboundMessageStream | null>;
   // Optional: add/remove emoji reactions on messages.
   addReaction?(jid: string, messageId: string, emoji: string): Promise<void>;
   removeReaction?(jid: string, messageId: string, emoji: string): Promise<void>;


### PR DESCRIPTION
## Why

#829 added `chat.startStream` support, but in practice it was dead code — users still saw the classic "post a message, edit its text over and over" loop instead of Slack's native AI streaming (the treatment Cursor/CodeRabbit get). Two reasons:

1. The native streaming path only fired in **assistant-pane DM threads**. In regular channels, `chat.startStream` requires `recipient_user_id` + `recipient_team_id`, which were never wired up.
2. Even where it could fire, it never did: #829's `editMessage` activated the orchestrator's intermediate status streamer, which delivers intermediates **and the final reply** via `chat.update` edits (`editFinal`), so `sendMessage` — the only place streaming lived — was bypassed entirely.

## What changed

**New channel streaming API** (`src/types.ts`)
- Optional `Channel.startMessageStream(jid, replyToMessageId?)` returning an `OutboundMessageStream` with `appendStatus` / `appendText` / `stop`. Returns `null` when streaming isn't possible for the target so callers fall back.

**Slack implementation** (`src/channels/slack.ts`)
- Backed by `chat.startStream` / `chat.appendStream` / `chat.stopStream` with ops serialized through an internal chain.
- Intermediate agent activity streams as `task_update` chunks with `task_display_mode: 'timeline'` — the native **task timeline panel** (each tool call becomes a task that flips `in_progress` → `complete`).
- Final replies stream as `markdown_text` chunks — native AI "generating" treatment, no `(edited)` suffix, no 4k/2k limits.
- Regular channel threads stream now too: the channel tracks `team_id` (from `auth.test`) and the last human sender per channel to satisfy the recipient requirement outside DMs.
- `sendMessage` routes threaded sends through the same streaming path, falling back to markdown-block `postMessage`.
- Dropped the redundant `Clayton: ` agent-name prefix — Slack already shows the bot's display name on every message.

**Orchestrator** (`src/index.ts`)
- `_createIntermediateStatusStreamer` prefers the native stream; the edit-loop is now only the fallback (channels without streaming, missing thread anchor/recipient, or mid-run API failures — the text buffer is maintained in both modes so a fallback keeps full context).
- Final-reply delivery gates on the new `isActive` so natively streamed runs finalize through the stream instead of `chat.update`.
- Dangling streams are closed on `reset()` and in the dispatch `finally` so errored runs don't leave messages stuck in the "generating" state.
- Discord/Telegram behavior is unchanged (no `startMessageStream` → identical legacy path, verified by existing tests).

**Docs** — verification bullet in `docs/SLACK-AGENT-SETUP.md` describing the expected streaming/task-panel behavior and the remaining fallback cases (un-threaded sends with no attributable user, e.g. top-level scheduled task output).

## Testing

- 7 new Slack tests (task-timeline chunk sequences, channel streaming with recipient info, recipient-unknown fallback, thread anchoring) + 3 new orchestrator streamer tests (native mode end-to-end, unavailable fallback, mid-run failure fallback with buffer retention).
- Full suite: 2,221 pass / 0 fail; `tsc --noEmit` and prettier clean.

## Config

No manifest changes needed — the existing manifest from #832 (with `assistant:write`, `chat:write`) covers streaming. This was purely a code-path issue.

https://claude.ai/code/session_01VWKjjWTqQvWaMgBgA6136V

---
_Generated by [Claude Code](https://claude.ai/code/session_01VWKjjWTqQvWaMgBgA6136V)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Streaming replies now leverage Slack's native "generating" UI with task timeline display showing agent intermediate tool activity in real-time.

* **Documentation**
  * Updated Slack agent setup verification guidance documenting native streaming behavior and task timeline rendering for agent responses.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->