### PR TITLE
fix(slack): keep replies threaded across follow-up messages in live sessions

### DIFF
--- a/src/channels/slack.test.ts
+++ b/src/channels/slack.test.ts
@@ -446,6 +446,33 @@ describe('SlackChannel.startMessageStream', () => {
     expect(stopStream).toHaveBeenCalledTimes(1);
   });
 
+  it('keeps the stream alive when a status append fails after start', async () => {
+    const channel = makeSendChannel();
+    let appendCalls = 0;
+    const startStream = mock(() => Promise.resolve({ ts: '8.800' }));
+    const appendStream = mock(() => {
+      appendCalls++;
+      if (appendCalls === 1) return Promise.reject(new Error('rate_limited'));
+      return Promise.resolve({});
+    });
+    const stopStream = mock(() => Promise.resolve({}));
+    (channel as any).client = {
+      chat: { startStream, appendStream, stopStream },
+    };
+    (channel as any).teamId = 'T999';
+    (channel as any).lastHumanSenderByChannel.set('C123', 'UPEYTON');
+
+    const stream = await channel.startMessageStream('slack:C123', '100.1');
+    await stream!.appendStatus('first');
+    // This append fails transiently — must not throw or kill the stream
+    await stream!.appendStatus('second');
+    await stream!.appendText('final');
+    const ts = await stream!.stop();
+
+    expect(ts).toBe('8.800');
+    expect(stopStream).toHaveBeenCalledTimes(1);
+  });
+
   it('returns null without a thread anchor', async () => {
     const channel = makeSendChannel();
     (channel as any).teamId = 'T999';

--- a/src/channels/slack.ts
+++ b/src/channels/slack.ts
@@ -664,7 +664,19 @@ export class SlackChannel implements Channel {
           };
           const chunks = [...closeOpenTask(), task];
           openTask = { id, title };
-          await send(chunks);
+          try {
+            await send(chunks);
+          } catch (err) {
+            // A dropped status update isn't worth abandoning the stream for
+            // (e.g. transient rate limit) — but a failed startStream means
+            // streaming is unavailable, so propagate for the caller to fall
+            // back to the edit-loop.
+            if (!ts) throw err;
+            logger.debug(
+              { channelId, err },
+              'Slack task update append failed (non-fatal)',
+            );
+          }
         }),
       appendText: (text: string) =>
         run(async () => {

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -251,23 +251,25 @@ describe('intermediate status streaming', () => {
   });
 
   it('falls back to the edit loop when the native stream is unavailable', async () => {
-    const sends: string[] = [];
+    const sends: Array<{ text: string; replyTo?: string }> = [];
     const streamer = _createIntermediateStatusStreamer({
       channel: {
-        sendMessage: async (_jid, text) => {
-          sends.push(text);
+        sendMessage: async (_jid, text, replyTo) => {
+          sends.push({ text, replyTo });
           return 'status-1';
         },
         editMessage: async () => undefined,
         startMessageStream: async () => null,
       },
       chatJid: 'slack:C123',
+      replyAnchor: () => 'trigger-1',
       editDebounceMs: 1,
     });
 
     await streamer.append('working');
 
-    expect(sends).toEqual(['working']);
+    // The fallback status message threads under the trigger too
+    expect(sends).toEqual([{ text: 'working', replyTo: 'trigger-1' }]);
     expect(streamer.messageId).toBe('status-1');
   });
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -263,6 +263,19 @@ function isAgentEnabled(idOrFolder: string): boolean {
 const consecutiveErrors: Record<string, number> = {};
 const MAX_CONSECUTIVE_ERRORS = 3;
 
+// Per-dispatch reply anchor: the inbound message the next outbound reply
+// should thread under. Seeded when a run starts, refreshed by the pipe paths
+// when follow-up messages are fed into a running container, and consumed
+// (nulled) after each reply goes out. Module-level because container runs
+// outlive a single processGroupMessages batch.
+const pendingReplyAnchor: Record<string, string | null> = {};
+
+/** Reply anchor for a batch: last message id, unless synthetic. */
+function replyAnchorFromMessages(messages: NewMessage[]): string | null {
+  const id = messages[messages.length - 1]?.id || null;
+  return id && /^(synth|react|notify)-/.test(id) ? null : id;
+}
+
 let whatsapp: WhatsAppChannel | null = null;
 const channels: Channel[] = [];
 const queue = new GroupQueue();
@@ -382,7 +395,11 @@ export function _createIntermediateStatusStreamer(opts: {
     if (!creationPromise) {
       const initialBuffer = buffer;
       creationPromise = channel
-        .sendMessage(opts.chatJid, initialBuffer.slice(0, 2000))
+        .sendMessage(
+          opts.chatJid,
+          initialBuffer.slice(0, 2000),
+          opts.replyAnchor?.() ?? undefined,
+        )
         .then((id) => {
           messageId = typeof id === 'string' ? id : null;
           if (messageId && buffer !== initialBuffer) scheduleEdit();
@@ -2176,13 +2193,16 @@ async function processGroupMessages(dispatchJid: string): Promise<boolean> {
     lastMessageId && /^(synth|react|notify)-/.test(lastMessageId)
       ? null
       : lastMessageId;
-  // Use reply threading only for the first outbound message in this run.
-  // Subsequent outputs should not keep replying to the original trigger.
-  let replyAnchorMessageId: string | null = triggeringMessageId;
+  // Reply anchor: the message the next outbound reply should thread under.
+  // Kept in module state (not a closure variable) because follow-up messages
+  // are piped into the running container by a different loop iteration — the
+  // pipe paths refresh the anchor so each reply threads to what the user most
+  // recently said, then it's consumed after the reply goes out.
+  pendingReplyAnchor[dispatchJid] = triggeringMessageId;
   const intermediateStatus = _createIntermediateStatusStreamer({
     channel: intermediateChannel,
     chatJid,
-    replyAnchor: () => replyAnchorMessageId,
+    replyAnchor: () => pendingReplyAnchor[dispatchJid],
     onDebug: (err, message) => log.debug({ err }, message),
   });
   const lastContent = missedMessages[missedMessages.length - 1]?.content || '';
@@ -2248,9 +2268,11 @@ async function processGroupMessages(dispatchJid: string): Promise<boolean> {
                   getAgentName(group),
                 );
                 if (formatted) {
-                  // Don't use triggeringMessageId for cross-channel responses — it belongs to the original chat
+                  // Don't use the reply anchor for cross-channel responses — it belongs to the original chat
                   const replyId =
-                    targetJid === chatJid ? replyAnchorMessageId : null;
+                    targetJid === chatJid
+                      ? pendingReplyAnchor[dispatchJid]
+                      : null;
                   if (
                     intermediateStatus.isActive &&
                     targetJid === chatJid &&
@@ -2272,7 +2294,11 @@ async function processGroupMessages(dispatchJid: string): Promise<boolean> {
                       replyId || undefined,
                     );
                   }
-                  if (replyAnchorMessageId) replyAnchorMessageId = null;
+                  // Anchor consumed — unless a pipe already refreshed it for
+                  // a newer message while this reply was being sent.
+                  if (pendingReplyAnchor[dispatchJid] === replyId) {
+                    pendingReplyAnchor[dispatchJid] = null;
+                  }
                   outputSentToUser = true;
                   // Stop typing refresh — prevents the 8s interval from
                   // re-triggering typing AFTER the response is visible.
@@ -2954,6 +2980,10 @@ async function startMessageLoop(): Promise<void> {
               channelRosterHasRoleLabels: true,
             });
 
+            // Refresh the reply anchor before piping so the running
+            // container's next reply threads under this message.
+            pendingReplyAnchor[chatJid] =
+              replyAnchorFromMessages(messagesToSend);
             if (await queue.sendMessage(chatJid, formatted)) {
               logger.info(
                 { chatJid, count: messagesToSend.length },
@@ -3010,6 +3040,10 @@ async function startMessageLoop(): Promise<void> {
               channelRosterHasRoleLabels: true,
             });
 
+            // Refresh the reply anchor before piping so the running
+            // container's next reply threads under this message.
+            pendingReplyAnchor[dispatchJid] =
+              replyAnchorFromMessages(messagesToSend);
             if (await queue.sendMessage(dispatchJid, formatted)) {
               logger.info(
                 { chatJid, agentId: sub.agentId, count: messagesToSend.length },


### PR DESCRIPTION
## Why

Field report after #836: the first @-mention streamed correctly (task panel + threaded reply), but replying **inside that thread** regressed — the agent did the post-then-edit status loop and dropped its final reply top-level in the main channel instead of the thread.

## Root cause

The reply anchor (`replyAnchorMessageId`) lived in the `processGroupMessages` closure and was **nulled after the first outbound reply** ("only thread the first message of a run"). But follow-up messages don't start a new run — they're **piped into the already-running container** by a later message-loop iteration, while outputs keep flowing through the original closure. So on turn 2:

1. `replyAnchor()` → `null`
2. `startMessageStream(jid, undefined)` → no `thread_ts` (required by `chat.startStream`) → `null`
3. Orchestrator falls back to the legacy edit-loop, which posted its status message **un-threaded**
4. Final reply delivered by editing that top-level status message → main channel

## What changed

- **Reply anchor moved to module state** keyed by dispatch key. Both pipe paths (legacy group + multi-agent subscription) refresh it before feeding new messages to a running container; it's consumed after each reply — unless a pipe already refreshed it for a newer message while the reply was in flight, so fast back-and-forth keeps threading correctly. Every turn of a live session now streams into the right thread.
- **The fallback edit-loop status message threads under the anchor too**, so even when native streaming genuinely isn't available the conversation stays in-thread (applies to Discord/Telegram as a reply reference as well).
- **Slack stream resilience**: a single failed `task_update` append (e.g. transient rate limit) no longer abandons the live stream — the update is dropped and streaming continues. Only a failed `chat.startStream` falls back to the edit-loop.

## Testing

- Updated the streamer fallback test to assert the status message threads under the trigger; new Slack test for surviving a transient append failure mid-stream.
- Full suite: 2,222 pass / 0 fail; `tsc --noEmit` and prettier clean.

https://claude.ai/code/session_01VWKjjWTqQvWaMgBgA6136V

---
_Generated by [Claude Code](https://claude.ai/code/session_01VWKjjWTqQvWaMgBgA6136V)_