### PR TITLE
feat(web): surface task last-run time and outcome on /agents/:id tasks table

### DIFF
--- a/src/web/agent-detail.test.ts
+++ b/src/web/agent-detail.test.ts
@@ -6,6 +6,8 @@ import type { Agent, ChannelSubscription, ScheduledTask } from '../types.js';
 import type { RemotePeerAgents } from '../discovery/types.js';
 import {
   buildAgentDetailData,
+  formatTaskLastRun,
+  lastRunOutcomeClass,
   renderAgentDetailContent,
 } from './agent-detail.js';
 
@@ -226,6 +228,62 @@ describe('buildAgentDetailData', () => {
   });
 });
 
+// ---- Unit tests for formatTaskLastRun ----
+
+describe('formatTaskLastRun', () => {
+  const NOW = Date.parse('2026-06-12T12:00:00.000Z');
+
+  it('returns em-dash when last_run is null', () => {
+    expect(formatTaskLastRun(null, NOW)).toBe('—');
+  });
+
+  it('returns "<1m ago" for sub-minute deltas', () => {
+    expect(formatTaskLastRun(new Date(NOW - 30_000).toISOString(), NOW)).toBe(
+      '<1m ago',
+    );
+  });
+
+  it('formats minutes for sub-hour deltas', () => {
+    expect(
+      formatTaskLastRun(new Date(NOW - 15 * 60_000).toISOString(), NOW),
+    ).toBe('15m ago');
+  });
+
+  it('formats hours for sub-day deltas', () => {
+    expect(
+      formatTaskLastRun(new Date(NOW - 4 * 3_600_000).toISOString(), NOW),
+    ).toBe('4h ago');
+  });
+
+  it('formats days for older deltas', () => {
+    expect(
+      formatTaskLastRun(new Date(NOW - 3 * 86_400_000).toISOString(), NOW),
+    ).toBe('3d ago');
+  });
+
+  it('returns input verbatim for unparseable input', () => {
+    expect(formatTaskLastRun('not-a-date', NOW)).toBe('not-a-date');
+  });
+});
+
+describe('lastRunOutcomeClass', () => {
+  it('maps success to run-success', () => {
+    expect(lastRunOutcomeClass('success')).toBe('run-success');
+  });
+
+  it('maps error to run-error', () => {
+    expect(lastRunOutcomeClass('error')).toBe('run-error');
+  });
+
+  it('returns empty string for null', () => {
+    expect(lastRunOutcomeClass(null)).toBe('');
+  });
+
+  it('returns empty string for unknown values', () => {
+    expect(lastRunOutcomeClass('weird')).toBe('');
+  });
+});
+
 // ---- Unit tests for renderAgentDetailContent ----
 
 describe('renderAgentDetailContent', () => {
@@ -270,6 +328,61 @@ describe('renderAgentDetailContent', () => {
     expect(html).toContain('Run the daily check');
     expect(html).toContain('status-active');
     expect(html).toContain('cron');
+  });
+
+  it('renders last-run column with em-dash when task has never run', () => {
+    const data = buildAgentDetailData('test-agent', makeState())!;
+    const html = renderAgentDetailContent(data, 'test-agent');
+    expect(html).toContain('<th>last run</th>');
+    expect(html).toContain('title="never run"');
+  });
+
+  it('renders last-run column with relative time and success class', () => {
+    const state = makeState({
+      getTasks: () => [
+        makeTask({
+          last_run: new Date(Date.now() - 5 * 60_000).toISOString(),
+          last_result: 'success',
+        }),
+      ],
+    });
+    const data = buildAgentDetailData('test-agent', state)!;
+    const html = renderAgentDetailContent(data, 'test-agent');
+    expect(html).toContain('run-success');
+    expect(html).toContain('5m ago');
+  });
+
+  it('renders last-run column with error class for failed runs', () => {
+    const state = makeState({
+      getTasks: () => [
+        makeTask({
+          last_run: new Date(Date.now() - 2 * 3_600_000).toISOString(),
+          last_result: 'error',
+        }),
+      ],
+    });
+    const data = buildAgentDetailData('test-agent', state)!;
+    const html = renderAgentDetailContent(data, 'test-agent');
+    expect(html).toContain('run-error');
+    expect(html).toContain('2h ago');
+  });
+
+  it('uses correct colspan for empty-tasks row when local agent', () => {
+    const state = makeState({ getTasks: () => [] });
+    const data = buildAgentDetailData('test-agent', state)!;
+    const html = renderAgentDetailContent(data, 'test-agent');
+    expect(html).toContain('colspan="6"');
+    expect(html).toContain('No scheduled tasks');
+  });
+
+  it('uses correct colspan for empty-tasks row when remote agent', () => {
+    const data = buildAgentDetailData(
+      'peer-1:remote:agent',
+      makeState(),
+      remotePeers,
+    )!;
+    const html = renderAgentDetailContent(data, 'peer-1:remote:agent');
+    expect(html).toContain('colspan="5"');
   });
 
   it('renders recent conversations', () => {
@@ -507,6 +620,25 @@ describe('/api/agents/:id/detail endpoint', () => {
     expect(data.channels).toHaveLength(1);
     expect(data.tasks).toHaveLength(1);
     expect(data.recentChats).toHaveLength(1);
+  });
+
+  it('includes last_run and last_result on each task in JSON response', async () => {
+    handle = startWebServer(
+      testConfig(),
+      makeState({
+        getTasks: () => [
+          makeTask({
+            last_run: '2026-06-12T11:00:00.000Z',
+            last_result: 'success',
+          }),
+        ],
+      }),
+    );
+    const res = await authedFetch('/api/agents/test-agent/detail');
+    const data = (await res.json()) as JsonObject;
+    const tasks = data.tasks as Array<JsonObject>;
+    expect(tasks[0].last_run).toBe('2026-06-12T11:00:00.000Z');
+    expect(tasks[0].last_result).toBe('success');
   });
 
   it('returns 404 for unknown agent', async () => {

--- a/src/web/agent-detail.ts
+++ b/src/web/agent-detail.ts
@@ -11,6 +11,36 @@ function imageRev(value: string): string {
   return createHash('sha256').update(value).digest('hex').slice(0, 12);
 }
 
+/**
+ * Format a past timestamp into a short relative string for the agent detail
+ * tasks table. Mirrors the unit progression used on `/tasks` so the two
+ * surfaces agree at a glance. `now` is injectable for deterministic tests.
+ */
+export function formatTaskLastRun(
+  isoStr: string | null,
+  now: number = Date.now(),
+): string {
+  if (!isoStr) return '—';
+  const t = new Date(isoStr).getTime();
+  if (Number.isNaN(t)) return isoStr;
+  const diff = Math.max(0, now - t);
+  if (diff < 60_000) return '<1m ago';
+  if (diff < 3_600_000) return `${Math.round(diff / 60_000)}m ago`;
+  if (diff < 86_400_000) return `${Math.round(diff / 3_600_000)}h ago`;
+  return `${Math.round(diff / 86_400_000)}d ago`;
+}
+
+/**
+ * Map a task's `last_result` into the same outcome CSS class used by `/tasks`
+ * (`run-success` / `run-error`). Keeps the success/error colors aligned
+ * across surfaces.
+ */
+export function lastRunOutcomeClass(result: string | null): string {
+  if (result === 'success') return 'run-success';
+  if (result === 'error') return 'run-error';
+  return '';
+}
+
 export interface AgentDetailData {
   id: string;
   name: string;
@@ -45,6 +75,7 @@ export interface AgentDetailData {
     status: string;
     next_run: string | null;
     last_run: string | null;
+    last_result: string | null;
   }>;
   recentChats: Array<{
     jid: string;
@@ -119,6 +150,7 @@ export function buildAgentDetailData(
       status: t.status,
       next_run: t.next_run,
       last_run: t.last_run,
+      last_result: t.last_result,
     }));
 
   // Find recent chats for this agent's channels
@@ -222,6 +254,11 @@ export function renderAgentDetailContent(
             const nextRun = t.next_run
               ? new Date(t.next_run).toLocaleString()
               : '\u2014';
+            const lastRunLabel = formatTaskLastRun(t.last_run);
+            const lastRunClass = lastRunOutcomeClass(t.last_result);
+            const lastRunTitle = t.last_run
+              ? `${new Date(t.last_run).toLocaleString()}${t.last_result ? ` \u2014 ${t.last_result}` : ''}`
+              : 'never run';
             const promptPreview =
               t.prompt.length > 80
                 ? t.prompt.slice(0, 80) + '\u2026'
@@ -240,12 +277,13 @@ export function renderAgentDetailContent(
               `<td class="td-prompt" title="${esc(t.prompt)}">${esc(promptPreview)}</td>` +
               `<td class="td-dim">${esc(t.schedule_type)}: ${esc(t.schedule_value)}</td>` +
               `<td class="td-dim">${nextRun}</td>` +
+              `<td class="td-dim ${lastRunClass}" title="${esc(lastRunTitle)}">${esc(lastRunLabel)}</td>` +
               actionCell +
               `</tr>`
             );
           })
           .join('')
-      : `<tr><td colspan="${isLocal ? '5' : '4'}" class="td-dim">No scheduled tasks</td></tr>`;
+      : `<tr><td colspan="${isLocal ? '6' : '5'}" class="td-dim">No scheduled tasks</td></tr>`;
 
   // --- Recent chats ---
   const chatsHtml =
@@ -337,7 +375,7 @@ export function renderAgentDetailContent(
     `<div class="ad-section">` +
     `<h3 class="ad-section-title">scheduled tasks <span class="ad-count">${data.tasks.length}</span></h3>` +
     `<div class="ad-table-wrap"><table>` +
-    `<thead><tr><th>status</th><th>prompt</th><th>schedule</th><th>next run</th>${isLocal ? '<th></th>' : ''}</tr></thead>` +
+    `<thead><tr><th>status</th><th>prompt</th><th>schedule</th><th>next run</th><th>last run</th>${isLocal ? '<th></th>' : ''}</tr></thead>` +
     `<tbody>${tasksHtml}</tbody>` +
     `</table></div></div>` +
     // Recent conversations section


### PR DESCRIPTION
## What

Add a *last run* column to the scheduled-tasks table on `/agents/:id`. Each row now shows a short relative time ("5m ago", "2h ago", "3d ago", "—" when never run) with the same `run-success` / `run-error` color classes already used on `/tasks`, and a tooltip carrying the absolute timestamp plus the outcome string.

Before vs after on a row:

```
before:  active  Run the daily check  cron: 0 9 * * *  3/2/2026, 9:00:00 AM  [pause]

after:   active  Run the daily check  cron: 0 9 * * *  3/2/2026, 9:00:00 AM  5m ago  [pause]
                                                                            (green if success, red if error)
```

## Why

The agent detail page's tasks table showed `status / prompt / schedule / next run` but nothing about *when* or *how* each task last ran. An operator investigating a slow or stalled agent had to bounce to `/tasks` to see the last-run timestamp and outcome already surfaced there. Now those signals live right next to the agent's other state — channels, conversations, exec status — closing the loop on the per-agent investigation flow.

This matches the rolling cadence of recent operator-observability work on `/agents/:id` and `/tasks` (#779 per-task last outcome, #793 currently-running tasks, #831 SSR exec status + lane reason) — small additive signals on existing pages, no new top-level routes.

## How

- *Data shape* — `AgentDetailData.tasks[]` already mapped `last_run`. This adds `last_result` so the JSON response from `/api/agents/:id/detail` also carries the outcome string (already available on `ScheduledTask` rows in the DB).
- *Render* — `renderAgentDetailContent` adds one column to the tasks table between `next run` and the action cell. Header gets `last run`. Empty-tasks colspan bumps from 5→6 (local) / 4→5 (remote).
- *Helpers* — two new exported pure functions keep the formatting deterministic and unit-testable:
  - `formatTaskLastRun(isoStr, now?)` — `<1m / Nm / Nh / Nd ago`, em-dash when null, passthrough on unparseable input. `now` is injectable for tests.
  - `lastRunOutcomeClass(result)` — `success → run-success`, `error → run-error`, otherwise empty (mirrors `/tasks`).

## Test plan

- [x] `bun test` — full suite (2238 tests) green
- [x] `bun run typecheck` clean
- [x] `bunx prettier --check` clean on touched files
- [x] 12 new tests added in `src/web/agent-detail.test.ts`:
  - 6 unit tests for `formatTaskLastRun` (null, sub-minute, minutes, hours, days, unparseable)
  - 4 unit tests for `lastRunOutcomeClass` (success, error, null, unknown)
  - 1 render test confirming the new column header + `never run` tooltip for tasks with no `last_run`
  - 1 render test confirming `run-success` class + `5m ago` for recent successful runs
  - 1 render test confirming `run-error` class + `2h ago` for recent failed runs
  - 1 colspan test for local vs remote empty-tasks row
  - 1 API integration test confirming `last_run` + `last_result` survive in the JSON response

## Scope

Single page, single column. No API contract break — `last_result` is a strict addition. No new top-level route, no new client-side script. Mobile layout untouched (column inherits existing `.ad-table-wrap` styles).

Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a "last run" column to the agent detail tasks table, displaying when each task last executed in relative time format.
  * Added visual indicators showing task outcome status (success or error) in the table.
  * Added tooltips displaying detailed last run timestamp information.

* **Tests**
  * Added comprehensive test coverage for last run formatting and task outcome display across various time ranges and states.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->