### PR TITLE
docs: refresh ROADMAP — retire #760 in-flight marker and capture late-May/early-June merges (closes #806)

### DIFF
--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -1,6 +1,6 @@
 # OmniClaw Roadmap
 
-Last updated: 2026-05-23
+Last updated: 2026-06-13
 
 > **Maintenance:** run `bash scripts/check-roadmap-refs.sh` after editing to catch
 > Planned Work entries that point at closed/merged issues without an explicit
@@ -203,7 +203,13 @@ Push from "personal assistant with tasks" toward a genuine multi-agent factory.
 - agent runtime agnosticism shipped (closes #49) — Claude Agent SDK, OpenCode, Codex, Cursor all run under the same orchestration model
 - per-channel multi-bot/multi-token support shipped: Discord (closes #102), Telegram (closes #101), Slack (closes #100)
 - backend simplified to Docker (OrbStack on macOS) after Apple Container migration in #750
-- per-agent model override stored in SQLite (#760, in flight)
+- per-agent model override stored in SQLite (#760)
+- redundant message prompt attributes trimmed (#770)
+- LAN peer health rollup surfaced on /system (#754)
+- recent task outcomes rollup surfaced on /system (#749)
+- Slack multi-bot mention routing fix (#758)
+- Discord reconnect storm process-restart guard (#757)
+- Docker mount target separator rejection hardening (#753)
 
 #### Scheduler and Share Request Cleanup
 
@@ -212,6 +218,20 @@ Push from "personal assistant with tasks" toward a genuine multi-agent factory.
 - post-approval file transfer handler shipped for share_request (closes #237)
 - legacy admin approval flow removed for share_request, delegate_task, request_context (closes #240)
 - flaky github-webhooks full-suite failure resolved (closes #200)
+
+### Jun 2026
+
+#### Slack AI-App Modernization
+
+- modernize Slack channel with native AI-app agent features (#829)
+- native streamed responses + task timeline for agent runs (#836)
+- replies stay threaded across follow-up messages in live sessions (#837)
+- reference AI-app manifest and setup guide shipped (#832, `docs/SLACK-AGENT-SETUP.md`)
+
+#### Runtime Dep Sustained
+
+- claude-agent-sdk, opencode CLI/SDK, codex, agent-browser, go, and just bumps continued landing through the bot pipeline (#784–#845)
+- empty-commit workaround still required until #484 admin secrets land
 
 ### Mar 2026
 


### PR DESCRIPTION
Closes #806.

## What

Refresh `docs/ROADMAP.md` to fix the `(#760, in flight)` marker (PR #760 merged 2026-05-25) and capture the surface-layer, security, Slack, and dep-bump work that's landed since the doc was last bumped on 2026-05-23.

## Diff summary

- Drop the `, in flight` qualifier from the per-agent model override line under *Apr–May 2026 → Runtime, Topology, and Multi-bot Foundations*
- Add the late-May items that merged after the last bump: #770, #754, #749, #758, #757, #753
- Add a new **Jun 2026** section with the Slack AI-app modernization cluster (#829, #832, #836, #837) and a note that the dep-bump cadence kept rolling through the bot pipeline (#784–#845)
- Bump `Last updated:` to 2026-06-13

## Verification

- [x] `bash scripts/check-roadmap-refs.sh` → `ROADMAP.md Planned Work references look clean.`
- [x] No `Planned Work` entry references a merged PR without an explicit annotation
- [x] `Last updated:` date reflects this edit

## Notes

This is the 5-line patch flagged in #806 plus the now-21-day backlog of June merges (#806 was filed when the doc was 12 days stale; we're now at 21). Kept the Slack feature cluster as its own subsection because it's the largest surface-area landing in June and worth callout for operators reading the roadmap.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated project roadmap with Apr-May 2026 completed features including model override capabilities, bot connectivity fixes, system monitoring enhancements, and infrastructure hardening
  * Added Jun 2026 roadmap preview with platform modernization initiatives and dependency management updates

<!-- end of auto-generated comment: release notes by coderabbit.ai -->