### PR TITLE
feat(web): surface last outcome state badge on /tasks rows

### DIFF
--- a/src/web/tasks.test.ts
+++ b/src/web/tasks.test.ts
@@ -3,6 +3,8 @@ import { describe, expect, it } from 'bun:test';
 import type { Agent, ChannelSubscription, ScheduledTask } from '../types.js';
 import { handleRequest } from './routes.js';
 import {
+  outcomeStateColor,
+  renderOutcomeStateBadge,
   renderTaskTableRows,
   renderTasks,
   renderTasksContent,
@@ -288,6 +290,107 @@ describe('renderTaskTableRows', () => {
     } finally {
       globalThis.Date = RealDate;
     }
+  });
+});
+
+describe('outcomeStateColor', () => {
+  it('returns green for done', () => {
+    expect(outcomeStateColor('done')).toBe('var(--green)');
+  });
+
+  it('returns dim for skipped', () => {
+    expect(outcomeStateColor('skipped')).toBe('var(--text-dim)');
+  });
+
+  it('returns yellow for blocked', () => {
+    expect(outcomeStateColor('blocked')).toBe('var(--yellow)');
+  });
+
+  it('returns red for abandoned', () => {
+    expect(outcomeStateColor('abandoned')).toBe('var(--red)');
+  });
+
+  it('returns null for null/undefined', () => {
+    expect(outcomeStateColor(null)).toBeNull();
+    expect(outcomeStateColor(undefined)).toBeNull();
+  });
+});
+
+describe('renderOutcomeStateBadge', () => {
+  it('returns empty string when no outcome state is set', () => {
+    expect(renderOutcomeStateBadge(null, null)).toBe('');
+    expect(renderOutcomeStateBadge(undefined, 'some reason')).toBe('');
+  });
+
+  it('renders a done badge with reason tooltip', () => {
+    const html = renderOutcomeStateBadge('done', 'all checks passed');
+
+    expect(html).toContain('class="task-outcome-badge"');
+    expect(html).toContain('data-outcome-state="done"');
+    expect(html).toContain('title="all checks passed"');
+    expect(html).toContain('var(--green)');
+    expect(html).toContain('>done</span>');
+  });
+
+  it('falls back to the state name as tooltip when no reason is provided', () => {
+    const html = renderOutcomeStateBadge('blocked', null);
+
+    expect(html).toContain('title="blocked"');
+    expect(html).toContain('var(--yellow)');
+    expect(html).toContain('>blocked</span>');
+  });
+
+  it('escapes reason content to prevent XSS', () => {
+    const html = renderOutcomeStateBadge(
+      'abandoned',
+      '<script>alert(1)</script>',
+    );
+
+    expect(html).not.toContain('<script>alert(1)</script>');
+    expect(html).toContain('&lt;script&gt;');
+  });
+});
+
+describe('renderTaskTableRows — outcome badge', () => {
+  it('renders the outcome badge in the last-run cell when an outcome state is set', () => {
+    const html = renderTaskTableRows([
+      makeTask({
+        last_run: '2026-05-08T11:55:00.000Z',
+        last_result: 'success',
+        last_outcome_state: 'done',
+        last_outcome_reason: 'sync complete',
+      }),
+    ]);
+
+    expect(html).toContain('task-outcome-badge');
+    expect(html).toContain('data-outcome-state="done"');
+    expect(html).toContain('title="sync complete"');
+  });
+
+  it('omits the outcome badge when last_outcome_state is null', () => {
+    const html = renderTaskTableRows([
+      makeTask({
+        last_run: '2026-05-08T11:55:00.000Z',
+        last_result: 'success',
+      }),
+    ]);
+
+    expect(html).not.toContain('task-outcome-badge');
+  });
+
+  it('renders a blocked badge alongside the run-error class for failed runs', () => {
+    const html = renderTaskTableRows([
+      makeTask({
+        last_run: '2026-05-08T11:55:00.000Z',
+        last_result: 'error',
+        last_outcome_state: 'blocked',
+        last_outcome_reason: 'awaiting user reply',
+      }),
+    ]);
+
+    expect(html).toContain('run-error');
+    expect(html).toContain('data-outcome-state="blocked"');
+    expect(html).toContain('title="awaiting user reply"');
   });
 });
 

--- a/src/web/tasks.ts
+++ b/src/web/tasks.ts
@@ -4,7 +4,7 @@
  * Supports create, edit, pause/resume, delete, and run-history viewing.
  */
 
-import type { ScheduledTask } from '../types.js';
+import type { ScheduledTask, TaskOutcomeState } from '../types.js';
 import type { WebStateProvider } from './types.js';
 import { renderShell, escapeHtml } from './shared.js';
 import { allPageScripts } from './page-scripts.js';
@@ -151,6 +151,10 @@ export function renderTaskTableRows(tasks: ScheduledTask[]): string {
           : task.last_result === 'error'
             ? 'run-error'
             : '';
+      const outcomeBadge = renderOutcomeStateBadge(
+        task.last_outcome_state ?? null,
+        task.last_outcome_reason ?? null,
+      );
 
       return (
         `<tr data-task-id="${escapeHtml(task.id)}" data-status="${escapeHtml(task.status)}">` +
@@ -160,7 +164,7 @@ export function renderTaskTableRows(tasks: ScheduledTask[]): string {
         `<td class="td-sched"><span class="sched-type badge badge-sm">${escapeHtml(task.schedule_type)}</span> ` +
         `<span class="sched-label">${escapeHtml(schedLabel)}</span></td>` +
         `<td class="td-time" title="${escapeHtml(task.next_run ?? '')}">${escapeHtml(nextRun)}</td>` +
-        `<td class="td-time ${lastResultClass}" title="${escapeHtml(task.last_run ?? '')}">${escapeHtml(lastRun)}</td>` +
+        `<td class="td-time ${lastResultClass}" title="${escapeHtml(task.last_run ?? '')}">${escapeHtml(lastRun)}${outcomeBadge}</td>` +
         `<td><span class="badge badge-sm">${escapeHtml(task.context_mode)}</span></td>` +
         `<td class="td-actions">` +
         `<button class="btn btn-sm btn-toggle" data-tm-action="toggle" data-status="${toggleStatus}">${toggleLabel}</button>` +
@@ -173,6 +177,43 @@ export function renderTaskTableRows(tasks: ScheduledTask[]): string {
       );
     })
     .join('\n');
+}
+
+/**
+ * Map a TaskOutcomeState to the CSS color variable used by the badge.
+ * Mirrors the palette in the task runs modal (page-scripts.ts).
+ */
+export function outcomeStateColor(
+  state: TaskOutcomeState | null | undefined,
+): string | null {
+  if (state === 'done') return 'var(--green)';
+  if (state === 'skipped') return 'var(--text-dim)';
+  if (state === 'blocked') return 'var(--yellow)';
+  if (state === 'abandoned') return 'var(--red)';
+  return null;
+}
+
+/**
+ * Render an inline outcome state badge for the /tasks last-run cell.
+ * Returns an empty string when no outcome state is set. The reason, if
+ * present, is surfaced as the tooltip; otherwise the badge tooltips the
+ * state name itself.
+ */
+export function renderOutcomeStateBadge(
+  state: TaskOutcomeState | null | undefined,
+  reason: string | null | undefined,
+): string {
+  const color = outcomeStateColor(state);
+  if (!color || !state) return '';
+  const tooltip = reason && reason.length > 0 ? reason : state;
+  return (
+    ` <span class="task-outcome-badge"` +
+    ` data-outcome-state="${escapeHtml(state)}"` +
+    ` title="${escapeHtml(tooltip)}"` +
+    ` style="background:color-mix(in srgb,${color} 20%,transparent);color:${color};` +
+    `padding:1px 6px;border-radius:3px;font-size:10px;margin-left:6px;` +
+    `vertical-align:middle">${escapeHtml(state)}</span>`
+  );
 }
 
 function renderTaskModal(


### PR DESCRIPTION
## What

Add a small inline badge to the *last-run* cell on `/tasks` that surfaces `ScheduledTask.last_outcome_state` (done / blocked / abandoned / skipped) with `last_outcome_reason` as the tooltip.

Before vs after on a row's last-run cell:

```
before:  5m ago

after:   5m ago  [blocked]   ← yellow pill, tooltip = "awaiting user reply"
```

## Why

`/system` already rolls up outcome-state counts (PR #749) and the per-task *Runs* modal already renders per-run outcome chips (page-scripts.ts), but the main `/tasks` table row only carries `last_result` (a binary success / error color class). The richer signal — *why* the run terminated — is available on every `ScheduledTask` row but was never surfaced.

An operator skimming `/tasks` couldn't distinguish:
- a task that completed cleanly (`done`)
- a task that ran but gave up because it was blocked waiting on a user (`blocked`)
- a task that abandoned itself (`abandoned`)
- a no-op skip (`skipped`)

All three of the non-`done` states matter for triage, and they all currently render the same in the last-run column.

This matches the rolling cadence of small additive surface signals on existing pages (#843 task last-run on `/agents/:id`, #779 outcome badges, #793 currently-running tasks, #831 SSR exec status) — one new affordance, no new top-level route, no schema change.

## How

- *Data shape* — no change. `ScheduledTask.last_outcome_state` and `last_outcome_reason` are already on the type and already flow through `GET /api/tasks`.
- *Helpers* — two new exported pure functions keep the rendering deterministic and unit-testable:
  - `outcomeStateColor(state)` → returns the CSS color variable (`var(--green)` / `var(--yellow)` / `var(--red)` / `var(--text-dim)`), or `null` when no state is set. Mirrors the palette in the task runs modal so the badge looks identical wherever an outcome state appears.
  - `renderOutcomeStateBadge(state, reason)` → returns the inline `<span class="task-outcome-badge">…</span>` snippet, or empty string when there's no state. Reason becomes the tooltip; falls back to the state name if no reason is set.
- *Render* — the last-run `<td>` now appends the badge after the relative time. Tooltip on the `<td>` itself still carries the absolute timestamp; the badge has its own tooltip with the reason.

## Test plan

- [x] `bun test` — full suite (2234 tests) green
- [x] `bun run typecheck` clean
- [x] `bunx prettier --check` clean on touched files
- [x] 12 new tests added in `src/web/tasks.test.ts`:
  - 5 unit tests for `outcomeStateColor` (done, skipped, blocked, abandoned, null/undefined)
  - 4 unit tests for `renderOutcomeStateBadge` (empty case, done-with-reason, blocked-no-reason fallback, XSS escaping)
  - 3 render tests confirming the badge appears in the row only when `last_outcome_state` is set, and composes with the existing `run-error` class

## Scope

Single page, single column. No API contract break — `last_outcome_state` / `last_outcome_reason` are already on the response. No new route, no new client-side script, no DB change. Existing `run-success` / `run-error` color class on the `<td>` is preserved.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Outcome state badges now display in the tasks table's "last run" column, showing the result of the most recent task execution with color-coded states and contextual tooltips.

* **Tests**
  * Added comprehensive unit test coverage for outcome state badge rendering, including validation of success, error, and blocked states.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->