### PR TITLE
fix(slack): one progress card per agent run, not per action (#850)

### DIFF
--- a/src/channels/slack.test.ts
+++ b/src/channels/slack.test.ts
@@ -384,7 +384,7 @@ describe('SlackChannel.sendMessage', () => {
 });
 
 describe('SlackChannel.startMessageStream', () => {
-  it('streams intermediate statuses as a task timeline and finals as markdown', async () => {
+  it('updates a single progress card in place and streams the final as markdown', async () => {
     const channel = makeSendChannel();
     const startStream = mock(() => Promise.resolve({ ts: '8.800' }));
     const appendStream = mock(() => Promise.resolve({}));
@@ -404,46 +404,76 @@ describe('SlackChannel.startMessageStream', () => {
     const ts = await stream!.stop();
 
     expect(ts).toBe('8.800');
-    // First status opens the stream with a task in timeline mode
+    // First status opens the stream with the single progress card (#850: one
+    // evolving card per run, not one card per agent action).
     const startArgs = (startStream.mock.calls[0] as unknown as [any])[0];
     expect(startArgs.task_display_mode).toBe('timeline');
     expect(startArgs.chunks).toEqual([
       {
         type: 'task_update',
-        id: 'task-1',
+        id: 'agent-progress',
         title: 'Reading src/index.ts',
         status: 'in_progress',
         details: 'Reading src/index.ts\nsome detail',
       },
     ]);
-    // Second status completes task-1 and opens task-2
+    // Second status reuses the SAME id, updating the card in place — no new card
     const append1 = (appendStream.mock.calls[0] as unknown as [any])[0];
     expect(append1.chunks).toEqual([
       {
         type: 'task_update',
-        id: 'task-1',
-        title: 'Reading src/index.ts',
-        status: 'complete',
-      },
-      {
-        type: 'task_update',
-        id: 'task-2',
+        id: 'agent-progress',
         title: 'Running tests',
         status: 'in_progress',
       },
     ]);
-    // Final text completes task-2 and appends markdown
+    // Final text completes the progress card and appends markdown
     const append2 = (appendStream.mock.calls[1] as unknown as [any])[0];
     expect(append2.chunks).toEqual([
       {
         type: 'task_update',
-        id: 'task-2',
+        id: 'agent-progress',
         title: 'Running tests',
         status: 'complete',
       },
       { type: 'markdown_text', text: 'All done **bold**' },
     ]);
     expect(stopStream).toHaveBeenCalledTimes(1);
+  });
+
+  it('collapses many tool actions into one card and skips code-fence titles', async () => {
+    const channel = makeSendChannel();
+    const startStream = mock(() => Promise.resolve({ ts: '8.800' }));
+    const appendStream = mock(() => Promise.resolve({}));
+    const stopStream = mock(() => Promise.resolve({}));
+    (channel as any).client = {
+      chat: { startStream, appendStream, stopStream },
+    };
+    (channel as any).teamId = 'T999';
+    (channel as any).lastHumanSenderByChannel.set('C123', 'UPEYTON');
+
+    const stream = await channel.startMessageStream('slack:C123', '100.1');
+    // A tool call followed by its (code-fenced) result — both update one card.
+    await stream!.appendStatus('> **Bash**: `gh pr view 1379`');
+    await stream!.appendStatus('```\nPR #1379: Fix streaming\n```');
+    await stream!.stop();
+
+    // Exactly one startStream → one Slack message for the whole run (#850).
+    expect(startStream).toHaveBeenCalledTimes(1);
+    // Every status update reuses the single card id.
+    const allChunks = [
+      ...(startStream.mock.calls as unknown as [any][]).flatMap(
+        (c) => c[0].chunks,
+      ),
+      ...(appendStream.mock.calls as unknown as [any][]).flatMap(
+        (c) => c[0].chunks,
+      ),
+    ].filter((chunk: any) => chunk.type === 'task_update');
+    expect(allChunks.every((c: any) => c.id === 'agent-progress')).toBe(true);
+    // The code-fenced tool result surfaces its content, not a bare ```.
+    const resultUpdate = (appendStream.mock.calls[0] as unknown as [any])[0]
+      .chunks[0];
+    expect(resultUpdate.title).toBe('PR #1379: Fix streaming');
   });
 
   it('keeps the stream alive when a status append fails after start', async () => {

--- a/src/channels/slack.ts
+++ b/src/channels/slack.ts
@@ -53,7 +53,9 @@ const THREAD_ROOT_CACHE_MAX = 1000;
 const SEEN_MESSAGE_CACHE_MAX = 500;
 const THREAD_EXCERPT_MAX_CHARS = 140;
 const TASK_TITLE_MAX_CHARS = 80;
-const TASK_DETAILS_MAX_CHARS = 500;
+// Slack caps each task_update chunk at 256 chars; keep title + details under it
+// so progress updates always render instead of being silently rejected.
+const TASK_DETAILS_MAX_CHARS = 160;
 
 // Rotating status shown under the assistant thread while the agent works.
 const STATUS_LOADING_MESSAGES = [
@@ -596,17 +598,24 @@ export class SlackChannel implements Channel {
 
   /**
    * Streamed message session backed by chat.startStream/appendStream/
-   * stopStream. Status updates render as Slack's task-timeline panel
-   * (`task_update` chunks); final text streams as markdown. Operations are
-   * serialized through an internal chain so concurrent appends can't race
-   * the startStream call.
+   * stopStream — ONE Slack message per agent run.
+   *
+   * Intermediate activity updates a SINGLE live "progress" task card in place
+   * (re-sending the same `task_update` id, which Slack updates rather than
+   * appending) so a tool-heavy run shows one evolving status line instead of a
+   * card per action (#850). The final reply streams as markdown into the same
+   * message; `stop()` finalizes it in place so it persists (unlike CodeRabbit,
+   * which deletes its streamed message). Operations are serialized through an
+   * internal chain so concurrent appends can't race the startStream call.
    */
   private createOutboundStream(
     target: SlackStreamTarget,
   ): OutboundMessageStream {
     const { channelId, threadTs } = target;
+    // Stable id for the single progress card. Reusing it makes every status
+    // append update that one card in place instead of stacking a new one.
+    const PROGRESS_TASK_ID = 'agent-progress';
     let ts: string | undefined;
-    let taskSeq = 0;
     let openTask: { id: string; title: string } | null = null;
     let chain: Promise<unknown> = Promise.resolve();
 
@@ -649,23 +658,28 @@ export class SlackChannel implements Channel {
       appendStatus: (text: string) =>
         run(async () => {
           const trimmed = text.trim();
-          const title =
-            (trimmed.split('\n')[0] || '').slice(0, TASK_TITLE_MAX_CHARS) ||
-            'Working…';
-          const id = `task-${++taskSeq}`;
+          // First meaningful line becomes the card title — skip code-fence
+          // markers so tool-result updates (```…```) don't surface a bare ```.
+          const firstLine =
+            trimmed
+              .split('\n')
+              .map((l) => l.trim())
+              .find((l) => l && !/^`{3,}/.test(l)) || '';
+          const title = firstLine.slice(0, TASK_TITLE_MAX_CHARS) || 'Working…';
+          // Always reuse the same task id so each update mutates the single
+          // live card in place rather than appending a new one per action.
           const task: AnyChunk = {
             type: 'task_update',
-            id,
+            id: PROGRESS_TASK_ID,
             title,
             status: 'in_progress',
             ...(trimmed.length > title.length
               ? { details: trimmed.slice(0, TASK_DETAILS_MAX_CHARS) }
               : {}),
           };
-          const chunks = [...closeOpenTask(), task];
-          openTask = { id, title };
+          openTask = { id: PROGRESS_TASK_ID, title };
           try {
-            await send(chunks);
+            await send([task]);
           } catch (err) {
             // A dropped status update isn't worth abandoning the stream for
             // (e.g. transient rate limit) — but a failed startStream means

--- a/src/types.ts
+++ b/src/types.ts
@@ -298,7 +298,8 @@ export interface FactoryWorkflowClaim {
 export interface OutboundMessageStream {
   /**
    * Append an intermediate status update (tool call, progress note).
-   * Rendered as a task timeline on platforms that support it.
+   * Platforms that support it render this as a single live progress indicator
+   * that updates in place — one evolving status per run, not one entry per call.
    */
   appendStatus(text: string): Promise<void>;
   /** Append final response text (markdown). */


### PR DESCRIPTION
## Why

Closes #850. After #836 added native Slack streaming, a single agent run rendered as a tall stack of tiny collapsible task cards — one per agent action — instead of one coherent agent thread. The user reference is CodeRabbit, which streams **one** agent thread (but deletes it when done; we want it to stick around).

## Root cause

The code already opens **one** streamed message per run (the stream is cached in `nativeStreamPromise`, and the container emits exactly one final `result` per query — verified across `src/index.ts`, `src/backends/stream-parser.ts`, `container/agent-runner/src/index.ts`).

The defect was in rendering: `createOutboundStream.appendStatus` minted a **new** `task_update` id (`task-${++taskSeq}`) for every intermediate. Since the container emits an intermediate per tool **call** *and* per tool **result**, `task_display_mode: 'timeline'` rendered each as its own collapsible card → fragmentation.

Slack's streaming API (GA Oct 2025) updates a `task_update` **in place when the same id is reused**, and `stopStream` finalizes the message in place (so it persists — no delete needed).

## What changed (`src/channels/slack.ts`)

- `appendStatus` reuses a single stable id (`agent-progress`) so all activity updates **one live progress card** instead of one card per action. Final reply still streams as markdown into the same message; `stop()` finalizes it in place (persistent, unlike CodeRabbit).
- Card title now derives from the first non-fence line, so code-fenced tool results (```` ``` ````) don't surface a bare ```` ``` ````.
- Tightened `TASK_DETAILS_MAX_CHARS` 500→160 — Slack silently rejects `task_update` chunks over 256 chars, which previously dropped longer updates.

Result: **one agent run = one Slack message** with one evolving progress line + the streamed final reply.

## Testing

- `bun test src/channels/slack.test.ts` → 60 pass (updated the old multi-card assertion to assert single-card-in-place; added a regression test for collapse + fence stripping).
- `bun test src/index.test.ts` → 28 pass; `tsc --noEmit` clean.
- Full suite: 2221 pass; the 1 failure (`does not leak host secrets into workflow environment`) is pre-existing on `main` and unrelated.

Host-side only — no container rebuild needed. Discord/Telegram unaffected (no `startMessageStream`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Slack progress cards now display as a single evolving indicator updated in place during runs, improving message clarity and reducing clutter.
  * Refined character limits for task details to optimize status message conciseness.
  * Enhanced tool result formatting to extract and display parsed titles instead of plain code block output.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->