### PR TITLE
fix(security): reject control chars in agent model override (#857)

### DIFF
--- a/src/agent-model-validation.test.ts
+++ b/src/agent-model-validation.test.ts
@@ -1,0 +1,94 @@
+import { describe, expect, it } from 'bun:test';
+
+import {
+  InvalidModelOverrideError,
+  MAX_MODEL_OVERRIDE_LENGTH,
+  assertSafeModelOverride,
+  validateModelOverride,
+} from './agent-model-validation.js';
+
+describe('validateModelOverride', () => {
+  it('returns null for null / undefined / blank', () => {
+    expect(validateModelOverride(null)).toEqual({ ok: true, value: null });
+    expect(validateModelOverride(undefined)).toEqual({ ok: true, value: null });
+    expect(validateModelOverride('')).toEqual({ ok: true, value: null });
+    expect(validateModelOverride('   ')).toEqual({ ok: true, value: null });
+  });
+
+  it('trims surrounding whitespace on accept', () => {
+    expect(validateModelOverride('  claude-opus-4-6  ')).toEqual({
+      ok: true,
+      value: 'claude-opus-4-6',
+    });
+  });
+
+  it('rejects non-string non-null inputs', () => {
+    expect(validateModelOverride(42)).toEqual({
+      ok: false,
+      error: '"model" must be a string or null',
+    });
+    expect(validateModelOverride({ model: 'x' })).toEqual({
+      ok: false,
+      error: '"model" must be a string or null',
+    });
+  });
+
+  it('rejects values longer than MAX_MODEL_OVERRIDE_LENGTH after trim', () => {
+    const tooLong = 'x'.repeat(MAX_MODEL_OVERRIDE_LENGTH + 1);
+    const result = validateModelOverride(tooLong);
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.error).toContain(`${MAX_MODEL_OVERRIDE_LENGTH}`);
+    }
+  });
+
+  it('accepts a value exactly at MAX_MODEL_OVERRIDE_LENGTH', () => {
+    const exact = 'a'.repeat(MAX_MODEL_OVERRIDE_LENGTH);
+    expect(validateModelOverride(exact)).toEqual({ ok: true, value: exact });
+  });
+
+  // Core #857 regression: every byte in 0x00–0x1F plus DEL must be rejected.
+  it('rejects every ASCII control character (0x00–0x1F and 0x7F)', () => {
+    const codes: number[] = [];
+    for (let c = 0x00; c <= 0x1f; c++) codes.push(c);
+    codes.push(0x7f);
+    for (const code of codes) {
+      const ch = String.fromCharCode(code);
+      const result = validateModelOverride(`claude-opus-4-6${ch}foo`);
+      expect(result.ok).toBe(false);
+      if (!result.ok) {
+        expect(result.error).toContain('control characters');
+      }
+    }
+  });
+
+  it('rejects the exact #857 newline-injection payload', () => {
+    const result = validateModelOverride(
+      'claude-opus-4-6\nANTHROPIC_BASE_URL=https://attacker.example',
+    );
+    expect(result).toEqual({
+      ok: false,
+      error: '"model" must not contain control characters',
+    });
+  });
+});
+
+describe('assertSafeModelOverride', () => {
+  it('returns the normalized value for safe input', () => {
+    expect(assertSafeModelOverride(null)).toBeNull();
+    expect(assertSafeModelOverride('  claude-opus-4-6  ')).toBe(
+      'claude-opus-4-6',
+    );
+  });
+
+  it('throws InvalidModelOverrideError for unsafe input', () => {
+    let caught: unknown;
+    try {
+      assertSafeModelOverride('claude-opus-4-6\nFOO=bar');
+    } catch (err) {
+      caught = err;
+    }
+    expect(caught).toBeInstanceOf(InvalidModelOverrideError);
+    expect((caught as Error).message).toContain('control characters');
+  });
+});

--- a/src/agent-model-validation.ts
+++ b/src/agent-model-validation.ts
@@ -1,0 +1,95 @@
+/**
+ * Shared validation for per-agent model overrides.
+ *
+ * Model overrides flow from the Web UI into the agent container env file
+ * (`data/env/<agent>/env`) where they are concatenated as `KEY=value` lines.
+ * A value containing `\r`, `\n`, NUL, or other ASCII control characters
+ * could inject additional env entries (e.g. `ANTHROPIC_BASE_URL=...`) into
+ * the next container run. See issue #857.
+ *
+ * This module is the single source of truth for accepting / rejecting a
+ * model override string. Both the HTTP handler (`handleSetAgentModel` in
+ * `src/web/routes.ts`) and the SQLite write (`setAgentModel` in `src/db.ts`)
+ * call into it, so an unsafe value cannot reach the env file even if a
+ * future caller forgets to validate upstream.
+ */
+
+export const MAX_MODEL_OVERRIDE_LENGTH = 200;
+
+/**
+ * Matches any ASCII control character (0x00–0x1F, including \r, \n, \t, NUL,
+ * and 0x7F DEL). These are forbidden in model override values because env-file
+ * writers concatenate raw `KEY=value` lines separated by `\n`.
+ */
+// eslint-disable-next-line no-control-regex
+const CONTROL_CHAR_REGEX = /[\x00-\x1F\x7F]/;
+
+export type ValidateModelOverrideResult =
+  | { ok: true; value: string | null }
+  | { ok: false; error: string };
+
+/**
+ * Normalize and validate a model override value submitted from an
+ * untrusted source (Web UI body, IPC, etc.).
+ *
+ * - `null` / `undefined` → cleared override (`{ ok: true, value: null }`).
+ * - Whitespace-only string → cleared override.
+ * - Non-string, non-null → rejected.
+ * - Longer than `MAX_MODEL_OVERRIDE_LENGTH` after trimming → rejected.
+ * - Contains any ASCII control character after trimming → rejected.
+ * - Otherwise returns the trimmed value.
+ */
+export function validateModelOverride(
+  raw: unknown,
+): ValidateModelOverrideResult {
+  if (raw === null || raw === undefined) {
+    return { ok: true, value: null };
+  }
+  if (typeof raw !== 'string') {
+    return { ok: false, error: '"model" must be a string or null' };
+  }
+  const trimmed = raw.trim();
+  if (trimmed.length === 0) {
+    return { ok: true, value: null };
+  }
+  if (trimmed.length > MAX_MODEL_OVERRIDE_LENGTH) {
+    return {
+      ok: false,
+      error: `"model" must be ${MAX_MODEL_OVERRIDE_LENGTH} characters or fewer`,
+    };
+  }
+  if (CONTROL_CHAR_REGEX.test(trimmed)) {
+    return {
+      ok: false,
+      error: '"model" must not contain control characters',
+    };
+  }
+  return { ok: true, value: trimmed };
+}
+
+/**
+ * Thrown by `assertSafeModelOverride` when a value would be rejected by
+ * `validateModelOverride`. Used as a defense-in-depth tripwire at the
+ * persistence layer so a bypassed HTTP validator cannot silently land an
+ * unsafe value in SQLite (and then in the env file).
+ */
+export class InvalidModelOverrideError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = 'InvalidModelOverrideError';
+  }
+}
+
+/**
+ * Throwing variant of {@link validateModelOverride}. Returns the normalized
+ * value (or null) on success, throws {@link InvalidModelOverrideError} on
+ * failure. Intended for the SQLite write path, where reaching the function
+ * with an unsafe value indicates an upstream bug rather than user input.
+ */
+export function assertSafeModelOverride(raw: unknown): string | null {
+  const result = validateModelOverride(raw);
+  if (!result.ok) {
+    throw new InvalidModelOverrideError(result.error);
+  }
+  return result.value;
+}

--- a/src/db.test.ts
+++ b/src/db.test.ts
@@ -297,6 +297,27 @@ describe('per-agent model override', () => {
   it('setAgentModel returns false for unknown agent', () => {
     expect(setAgentModel('nonexistent', 'claude-opus-4-7')).toBe(false);
   });
+
+  // Defense-in-depth regression for #857: even if the HTTP validator is
+  // bypassed, setAgentModel must refuse to persist control-character payloads
+  // so they cannot reach data/env/<agent>/env as injected KEY=value lines.
+  it('setAgentModel throws on model values containing control characters', () => {
+    setAgent(baseAgent);
+    const cases = [
+      'claude-opus-4-6\nANTHROPIC_BASE_URL=evil',
+      'claude-opus-4-6\rfoo',
+      'claude-opus-4-6\u0000foo',
+      'claude-opus-4-6\tfoo',
+      'claude-opus-4-6\u007Ffoo',
+    ];
+    for (const bad of cases) {
+      expect(() => setAgentModel('model-agent', bad)).toThrow(
+        /control characters/,
+      );
+    }
+    // The persisted model is unchanged (no override was ever set on baseAgent).
+    expect(getAllAgents()['model-agent']?.model).toBeUndefined();
+  });
 });
 
 // --- storeMessage (sender_missing counter) ---

--- a/src/db.ts
+++ b/src/db.ts
@@ -3,6 +3,7 @@ import { randomUUID } from 'crypto';
 import fs from 'fs';
 import path from 'path';
 
+import { assertSafeModelOverride } from './agent-model-validation.js';
 import { discordCommandsSchema } from './agent-topology.js';
 import { DATA_DIR, STORE_DIR } from './config.js';
 import { TrustStore } from './discovery/trust-store.js';
@@ -1678,8 +1679,11 @@ export function setAgent(agent: Agent): void {
  * Returns true on success, false if the agent doesn't exist.
  */
 export function setAgentModel(agentId: string, model: string | null): boolean {
-  const normalized =
-    typeof model === 'string' && model.trim().length > 0 ? model.trim() : null;
+  // Defense-in-depth: reject control chars / NUL / over-long values even if
+  // the HTTP handler validator was bypassed. See agent-model-validation.ts
+  // and issue #857 — an unchecked override could inject extra env entries
+  // (e.g. ANTHROPIC_BASE_URL=...) when written to data/env/<agent>/env.
+  const normalized = assertSafeModelOverride(model);
   const result = db
     .query('UPDATE agents SET model = ? WHERE id = ?')
     .run(normalized, agentId);

--- a/src/web/routes.test.ts
+++ b/src/web/routes.test.ts
@@ -1641,6 +1641,66 @@ describe('POST /api/agents/{id}/model', () => {
     expect(res.status).toBe(400);
   });
 
+  // Regression for #857: a model override with a newline could inject
+  // additional env entries (e.g. ANTHROPIC_BASE_URL=...) into the agent
+  // container env file. Reject any ASCII control character before the value
+  // ever reaches the persistence layer.
+  it('rejects model values containing control characters', async () => {
+    const cases: Array<{ label: string; model: string }> = [
+      { label: 'newline', model: 'claude-opus-4-6\nANTHROPIC_BASE_URL=evil' },
+      { label: 'carriage return', model: 'claude-opus-4-6\rfoo' },
+      { label: 'NUL', model: 'claude-opus-4-6\u0000foo' },
+      { label: 'tab', model: 'claude-opus-4-6\tfoo' },
+      { label: 'DEL (0x7F)', model: 'claude-opus-4-6\u007Ffoo' },
+    ];
+
+    for (const { label, model } of cases) {
+      const calls: Array<{ id: string; model: string | null }> = [];
+      const state = makeState({
+        setAgentModel: (id, m) => {
+          calls.push({ id, model: m });
+          return true;
+        },
+      });
+      const res = await handle(
+        new Request('http://localhost/api/agents/agent-1/model', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ model }),
+        }),
+        state,
+      );
+      expect(res.status).toBe(400);
+      const body = (await res.json()) as { error: string };
+      expect(body.error).toContain('control');
+      // The unsafe value must never reach setAgentModel.
+      expect(calls).toEqual([]);
+      void label;
+    }
+  });
+
+  it('accepts a well-formed model identifier (happy path)', async () => {
+    const calls: Array<{ id: string; model: string | null }> = [];
+    const state = makeState({
+      setAgentModel: (id, model) => {
+        calls.push({ id, model });
+        return true;
+      },
+    });
+    const res = await handle(
+      new Request('http://localhost/api/agents/agent-1/model', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ model: 'anthropic/claude-opus-4-6' }),
+      }),
+      state,
+    );
+    expect(res.status).toBe(200);
+    expect(calls).toEqual([
+      { id: 'agent-1', model: 'anthropic/claude-opus-4-6' },
+    ]);
+  });
+
   it('returns 404 when the agent does not exist', async () => {
     const state = makeState();
     const res = await handle(

--- a/src/web/routes.ts
+++ b/src/web/routes.ts
@@ -1,6 +1,7 @@
 import fs from 'fs';
 import path from 'path';
 
+import { validateModelOverride } from '../agent-model-validation.js';
 import { GROUPS_DIR } from '../config.js';
 import { assertPathWithin } from '../path-security.js';
 import type { ScheduledTask } from '../types.js';
@@ -1300,8 +1301,6 @@ async function handleSetAgentEnabled(
   return json({ ok: true, agentId, enabled: body.enabled });
 }
 
-const MAX_MODEL_LENGTH = 200;
-
 async function handleSetAgentModel(
   agentId: string,
   req: Request,
@@ -1324,25 +1323,14 @@ async function handleSetAgentModel(
     return json({ error: 'Invalid JSON body' }, 400);
   }
 
-  // null / empty string clears the override.
-  let model: string | null;
-  if (body.model === null || body.model === undefined) {
-    model = null;
-  } else if (typeof body.model === 'string') {
-    const trimmed = body.model.trim();
-    if (trimmed.length === 0) {
-      model = null;
-    } else if (trimmed.length > MAX_MODEL_LENGTH) {
-      return json(
-        { error: `"model" must be ${MAX_MODEL_LENGTH} characters or fewer` },
-        400,
-      );
-    } else {
-      model = trimmed;
-    }
-  } else {
-    return json({ error: '"model" must be a string or null' }, 400);
+  // Shared validator: rejects control chars (\r, \n, NUL, …) so a model
+  // override cannot inject extra env entries when written to data/env/<agent>/env.
+  // See issue #857.
+  const validation = validateModelOverride(body.model);
+  if (!validation.ok) {
+    return json({ error: validation.error }, 400);
   }
+  const model = validation.value;
 
   const ok = state.setAgentModel(agentId, model);
   if (!ok) return json({ error: 'Agent not found' }, 404);


### PR DESCRIPTION
Closes #857.

## Summary

Per-agent model overrides flowed from the Web UI body straight into the container env file (`data/env/<agent>/env`), where `buildVolumeMounts()` in `src/backends/local-backend.ts` writes them as raw `KEY=value` lines. A value containing `\n` could append an additional env entry (e.g. `ANTHROPIC_BASE_URL=https://attacker.example`) and redirect SDK traffic on the next agent run.

Repro: `POST /api/agents/<id>/model` with `{"model":"foo\nANTHROPIC_BASE_URL=https://attacker.example"}` yielded a two-line env file on next container run.

## Fix

Adds a shared validator at `src/agent-model-validation.ts` and uses it at both call sites so neither path can ever land a control-character payload on disk:

- `src/web/routes.ts` — `handleSetAgentModel()` calls `validateModelOverride()` and returns `400 "model" must not contain control characters` for any ASCII control char in `0x00–0x1F` plus `0x7F`. Replaces the old inline length/trim block — same length cap (`MAX_MODEL_OVERRIDE_LENGTH = 200`), same null/blank-clears semantics.
- `src/db.ts` — `setAgentModel()` calls `assertSafeModelOverride()` as a defense-in-depth tripwire. A bypassed HTTP validator (future caller, IPC path, etc.) now throws `InvalidModelOverrideError` instead of silently persisting.

The validator is one file, ~95 LOC, fully covered by direct unit tests.

## Tests

All three test files are green locally; full suite passes (`bun test` → 2307 pass / 0 fail).

- `src/agent-model-validation.test.ts` *(new)*:
  - Null / undefined / blank → cleared.
  - Trim on accept.
  - Non-string rejected.
  - Length cap boundary (exact `MAX_MODEL_OVERRIDE_LENGTH` accepted, +1 rejected).
  - **Every code point in `0x00–0x1F` plus `0x7F` rejected** (33 control chars total).
  - The exact `#857` newline-injection payload rejected with the expected error string.
  - `assertSafeModelOverride` happy-path + throws `InvalidModelOverrideError`.
- `src/web/routes.test.ts`:
  - New `rejects model values containing control characters` covers newline, carriage return, NUL, tab, and DEL. Asserts the unsafe value never reaches `state.setAgentModel`.
  - New happy-path test confirms a well-formed `anthropic/claude-opus-4-6` still persists.
- `src/db.test.ts`:
  - New `setAgentModel throws on model values containing control characters` covers the persistence-layer tripwire. Asserts the stored model is unchanged.

## Notes

- No DB migration: validation is pure-code; existing rows are untouched.
- The `MAX_MODEL_OVERRIDE_LENGTH` constant moves from `routes.ts` to the validator so handler and DB agree on the cap.
- Per `CLAUDE.md`: targeted `--base main`, used `--body-file`, included `Co-Authored-By:` trailer.

## Test plan

- [x] `bun test src/agent-model-validation.test.ts` — 9 pass
- [x] `bun test src/db.test.ts` — 32 pass (incl. new control-char regression)
- [x] `bun test src/web/routes.test.ts` — 65 pass (incl. new control-char + happy-path regressions)
- [x] `bun test` — 2307 pass / 0 fail
- [x] `bunx tsc --noEmit` — clean
- [x] `bun run build` — bundles cleanly
- [x] `bunx prettier --check` on changed files — all matched files use Prettier code style


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Strengthened validation for agent model override inputs to reject strings containing control characters (newline, carriage return, null, tab, DEL) and enforce maximum length limits, preventing injection attacks and improving system security.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->