### PR TITLE
test: cover registry persistence and preprocessor edges

### DIFF
--- a/src/task-preprocessor.test.ts
+++ b/src/task-preprocessor.test.ts
@@ -222,6 +222,37 @@ it('supports explicit workflow error actions', () => {
   });
 });
 
+it('uses default skip and error messages when workflow omits details', () => {
+  fs.writeFileSync(
+    path.join(workflowsDir, 'workflow.ts'),
+    'console.log(JSON.stringify({ action: "skip" }));',
+  );
+
+  expect(runTaskPreprocessor(task(), { workflowsDir })).toEqual({
+    action: 'skip',
+    reason: 'no work',
+  });
+
+  fs.writeFileSync(
+    path.join(workflowsDir, 'workflow.ts'),
+    'console.log(JSON.stringify({ action: "error" }));',
+  );
+
+  expect(runTaskPreprocessor(task(), { workflowsDir })).toEqual({
+    action: 'error',
+    error: 'workflow error',
+  });
+});
+
+it('runs the original prompt when workflow stdout is empty', () => {
+  fs.writeFileSync(path.join(workflowsDir, 'workflow.ts'), '');
+
+  expect(runTaskPreprocessor(task(), { workflowsDir })).toEqual({
+    action: 'run',
+    prompt: 'sync connector packages',
+  });
+});
+
 it('returns a sanitized error when workflow exits nonzero with stderr', () => {
   fs.writeFileSync(
     path.join(workflowsDir, 'workflow.ts'),
@@ -265,6 +296,27 @@ it('rejects workflow paths outside the workflows directory', () => {
   const result = runTaskPreprocessor(task({ preprocess_script: '../x.ts' }), {
     workflowsDir,
   });
+
+  expect(result.action).toBe('error');
+  if (result.action !== 'error') throw new Error('expected error result');
+  expect(result.error).toContain('Path traversal detected');
+});
+
+it('rejects whitespace workflow paths as empty', () => {
+  const result = runTaskPreprocessor(task({ preprocess_script: '   ' }), {
+    workflowsDir,
+  });
+
+  expect(result).toEqual({
+    action: 'error',
+    error: 'preprocess_script must be a non-empty path',
+  });
+});
+
+it('rejects traversal in group folder when using default workflows directory', () => {
+  const result = runTaskPreprocessor(
+    task({ group_folder: '../outside', preprocess_script: 'workflow.ts' }),
+  );
 
   expect(result.action).toBe('error');
   if (result.action !== 'error') throw new Error('expected error result');

--- a/src/task-preprocessor.ts
+++ b/src/task-preprocessor.ts
@@ -208,11 +208,12 @@ export function runTaskPreprocessor(
     return { action: 'run', prompt: task.prompt };
   }
 
-  const workflowsDir = path.resolve(
-    options.workflowsDir ?? defaultWorkflowsDir(task),
-  );
+  let workflowsDir: string;
   let workflowPath: string;
   try {
+    workflowsDir = path.resolve(
+      options.workflowsDir ?? defaultWorkflowsDir(task),
+    );
     workflowPath = resolveWorkflowPath(task.preprocess_script, workflowsDir);
   } catch (err) {
     return {


### PR DESCRIPTION
## Summary

- Add deterministic disk persistence tests for `UserRegistryService.load()` and `save()` with backup/restore of `/workspace/ipc/user_registry.json`.
- Add task preprocessor edge-case tests for empty stdout, default skip/error messages, whitespace scripts, and default workflow-dir traversal handling.
- Fix `runTaskPreprocessor()` so default workflow directory resolution errors return `{ action: 'error' }` instead of throwing before the guarded path setup.

## Test Count / Coverage

- Before: `bun test` on initial scheduled branch: 2238 tests, 6012 assertions; after switching to current `origin/main`: `bun test --coverage` reported 2358 tests, 6310 assertions, 91.19% line coverage.
- After: `bun test --coverage` reports 2365 tests, 6322 assertions, 91.56% line coverage.
- `src/effect/user-registry.ts`: 69.44% -> 100.00% line coverage.
- `src/task-preprocessor.ts`: 96.41% -> 99.21% line coverage.

## Verification

- `bun test src/task-preprocessor.test.ts src/effect/user-registry.test.ts`
- `bun run typecheck`
- `bunx prettier --check src/task-preprocessor.ts src/task-preprocessor.test.ts src/effect/user-registry.test.ts`
- `bun test`
- `bun test --coverage`

## Remaining Gaps

- Large integration-heavy modules remain the main uncovered areas: channel adapters, `src/index.ts`, `src/backends/local-backend.ts`, `src/discovery/routes.ts`, `src/db.ts`, and `src/web/server.ts`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Enhanced test coverage for user registry disk persistence functionality.
  * Expanded test coverage for task preprocessor edge cases, including workflow output handling and path validation.

* **Bug Fixes**
  * Improved error handling in task preprocessing to ensure exceptions are properly caught and reported.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->