### PR TITLE
fix(security): validate agent model overrides

### DIFF
--- a/src/backends/local-backend.test.ts
+++ b/src/backends/local-backend.test.ts
@@ -545,6 +545,36 @@ describe('LocalBackend', () => {
       }
     });
 
+    it('rejects unsafe model overrides before writing the env file', () => {
+      const fixture = createFixture();
+      try {
+        fs.writeFileSync(
+          path.join(fixture.tempProjectRoot, '.env'),
+          'ANTHROPIC_API_KEY=host-secret\n',
+        );
+
+        expect(() =>
+          buildVolumeMounts(
+            { folder: fixture.groupFolder, name: 'Claude Test' } as any,
+            false,
+            false,
+            fixture.altRuntimeFolder,
+            'claude-agent-sdk',
+            undefined,
+            fixture.pathOverrides,
+            {
+              model:
+                'claude-opus-4-6\nANTHROPIC_BASE_URL=https://attacker.example',
+            },
+          ),
+        ).toThrow('control characters');
+
+        expect(fs.existsSync(path.join(fixture.altEnvDir, 'env'))).toBe(false);
+      } finally {
+        fixture.cleanup();
+      }
+    });
+
     it('leaves .env CLAUDE_MODEL untouched when no override is provided', () => {
       const fixture = createFixture();
       try {

--- a/src/backends/local-backend.ts
+++ b/src/backends/local-backend.ts
@@ -28,6 +28,7 @@ import {
   TIMEZONE,
 } from '../config.js';
 import { logger } from '../logger.js';
+import { normalizeAgentModelOverride } from '../model-override.js';
 import { validateAdditionalMounts } from '../mount-security.js';
 import { assertPathWithin } from '../path-security.js';
 import { ContainerProcess } from '../types.js';
@@ -469,7 +470,7 @@ export function buildVolumeMounts(
   // Per-agent model override (from SQLite). Wins over any host .env value so
   // operators can configure model per agent without editing .env. Maps to the
   // runtime's expected env var; an empty string clears any inherited value.
-  const modelOverride = options?.model?.trim();
+  const modelOverride = normalizeAgentModelOverride(options?.model);
   if (modelOverride) {
     const modelEnvVar = modelEnvVarForRuntime(agentRuntime);
     filteredLines = filteredLines.filter(

--- a/src/db.test.ts
+++ b/src/db.test.ts
@@ -294,6 +294,24 @@ describe('per-agent model override', () => {
     expect(getAllAgents()['model-agent']?.model).toBe('claude-haiku-4-5');
   });
 
+  it('rejects control characters in model overrides', () => {
+    setAgent(baseAgent);
+
+    expect(() =>
+      setAgentModel(
+        'model-agent',
+        'claude-opus-4-6\nANTHROPIC_BASE_URL=https://attacker.example',
+      ),
+    ).toThrow('control characters');
+    expect(getAllAgents()['model-agent']?.model).toBeUndefined();
+  });
+
+  it('rejects control characters on initial setAgent model persistence', () => {
+    expect(() =>
+      setAgent({ ...baseAgent, model: 'claude-opus-4-6\rOPENAI_API_KEY=x' }),
+    ).toThrow('control characters');
+  });
+
   it('setAgentModel returns false for unknown agent', () => {
     expect(setAgentModel('nonexistent', 'claude-opus-4-7')).toBe(false);
   });

--- a/src/db.ts
+++ b/src/db.ts
@@ -9,6 +9,7 @@ import { TrustStore } from './discovery/trust-store.js';
 import { FactoryWorkflowStore } from './factory-workflows.js';
 import { logger } from './logger.js';
 import { allMigrations, runMigrations } from './migrations.js';
+import { normalizeAgentModelOverride } from './model-override.js';
 import {
   Agent,
   AgentHealth,
@@ -1636,8 +1637,7 @@ export function setAgent(agent: Agent): void {
   // silently wipe a model the user set through the Web UI.
   let modelValue: string | null;
   if (agent.model !== undefined) {
-    const trimmed = agent.model.trim();
-    modelValue = trimmed.length > 0 ? trimmed : null;
+    modelValue = normalizeAgentModelOverride(agent.model);
   } else {
     const existing = db
       .prepare('SELECT model FROM agents WHERE id = ?')
@@ -1678,8 +1678,7 @@ export function setAgent(agent: Agent): void {
  * Returns true on success, false if the agent doesn't exist.
  */
 export function setAgentModel(agentId: string, model: string | null): boolean {
-  const normalized =
-    typeof model === 'string' && model.trim().length > 0 ? model.trim() : null;
+  const normalized = normalizeAgentModelOverride(model);
   const result = db
     .query('UPDATE agents SET model = ? WHERE id = ?')
     .run(normalized, agentId);

--- a/src/model-override.ts
+++ b/src/model-override.ts
@@ -1,0 +1,38 @@
+export const MAX_AGENT_MODEL_OVERRIDE_LENGTH = 200;
+
+const CONTROL_CHAR_RE = /[\u0000-\u001F\u007F]/;
+
+export class InvalidAgentModelOverrideError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = 'InvalidAgentModelOverrideError';
+  }
+}
+
+/**
+ * Normalize a per-agent model override for storage and env-file emission.
+ * Model values become KEY=value lines in container env files, so control
+ * characters must never be accepted.
+ */
+export function normalizeAgentModelOverride(
+  model: string | null | undefined,
+): string | null {
+  if (typeof model !== 'string') return null;
+
+  const trimmed = model.trim();
+  if (trimmed.length === 0) return null;
+
+  if (trimmed.length > MAX_AGENT_MODEL_OVERRIDE_LENGTH) {
+    throw new InvalidAgentModelOverrideError(
+      `"model" must be ${MAX_AGENT_MODEL_OVERRIDE_LENGTH} characters or fewer`,
+    );
+  }
+
+  if (CONTROL_CHAR_RE.test(trimmed)) {
+    throw new InvalidAgentModelOverrideError(
+      '"model" must not contain control characters',
+    );
+  }
+
+  return trimmed;
+}

--- a/src/web/routes.test.ts
+++ b/src/web/routes.test.ts
@@ -1628,6 +1628,30 @@ describe('POST /api/agents/{id}/model', () => {
     expect(res.status).toBe(400);
   });
 
+  it('rejects model values with control characters before persisting', async () => {
+    const calls: Array<{ id: string; model: string | null }> = [];
+    const state = makeState({
+      setAgentModel: (id, model) => {
+        calls.push({ id, model });
+        return true;
+      },
+    });
+    const res = await handle(
+      new Request('http://localhost/api/agents/agent-1/model', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          model: 'claude-opus-4-6\nANTHROPIC_BASE_URL=https://attacker.example',
+        }),
+      }),
+      state,
+    );
+    expect(res.status).toBe(400);
+    const body = (await res.json()) as { error: string };
+    expect(body.error).toContain('control characters');
+    expect(calls).toEqual([]);
+  });
+
   it('rejects non-string non-null model values', async () => {
     const state = makeState();
     const res = await handle(

--- a/src/web/routes.ts
+++ b/src/web/routes.ts
@@ -41,6 +41,10 @@ import {
 import { sanitizeTelegramAvatarUrl } from '../telegram-avatar.js';
 import { readJsonBody, RequestBodyTooLargeError } from '../request-body.js';
 import { normalizePreprocessScriptPath } from '../task-preprocessor.js';
+import {
+  InvalidAgentModelOverrideError,
+  normalizeAgentModelOverride,
+} from '../model-override.js';
 
 /** Optional discovery context — set by the orchestrator when discovery is enabled. */
 let discoveryContext: DiscoveryRouteContext | null = null;
@@ -1300,8 +1304,6 @@ async function handleSetAgentEnabled(
   return json({ ok: true, agentId, enabled: body.enabled });
 }
 
-const MAX_MODEL_LENGTH = 200;
-
 async function handleSetAgentModel(
   agentId: string,
   req: Request,
@@ -1324,21 +1326,17 @@ async function handleSetAgentModel(
     return json({ error: 'Invalid JSON body' }, 400);
   }
 
-  // null / empty string clears the override.
   let model: string | null;
   if (body.model === null || body.model === undefined) {
     model = null;
   } else if (typeof body.model === 'string') {
-    const trimmed = body.model.trim();
-    if (trimmed.length === 0) {
-      model = null;
-    } else if (trimmed.length > MAX_MODEL_LENGTH) {
-      return json(
-        { error: `"model" must be ${MAX_MODEL_LENGTH} characters or fewer` },
-        400,
-      );
-    } else {
-      model = trimmed;
+    try {
+      model = normalizeAgentModelOverride(body.model);
+    } catch (err) {
+      if (err instanceof InvalidAgentModelOverrideError) {
+        return json({ error: err.message }, 400);
+      }
+      throw err;
     }
   } else {
     return json({ error: '"model" must be a string or null' }, 400);


### PR DESCRIPTION
## Summary

- Add shared validation for per-agent model overrides before they are stored or emitted into container env files.
- Reject control characters, including newline, carriage return, NUL, and DEL, while preserving existing trim/blank-clear behavior.
- Add regression coverage at the Web API, DB, and local backend env-file layers.

Closes #857.

## Security Impact

This prevents a model override like `claude-opus-4-6\nANTHROPIC_BASE_URL=https://attacker.example` from creating additional env-file entries for the next agent container run.

## Tests

- `bun test src/web/routes.test.ts src/db.test.ts src/backends/local-backend.test.ts`
- `bun run tsc --noEmit`
- `bun test`
- `bunx prettier --check src/model-override.ts src/web/routes.ts src/db.ts src/backends/local-backend.ts src/web/routes.test.ts src/db.test.ts src/backends/local-backend.test.ts`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Added validation to reject model override strings containing control characters, preventing injection attacks and improving system security.

* **Tests**
  * Added comprehensive test coverage for model override validation across API, database, and backend layers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->