### PR TITLE
fix(web): color /tasks and /agents/:id rows from normalized outcome state (closes #858)

### DIFF
--- a/src/web/agent-detail.test.ts
+++ b/src/web/agent-detail.test.ts
@@ -267,20 +267,49 @@ describe('formatTaskLastRun', () => {
 });
 
 describe('lastRunOutcomeClass', () => {
-  it('maps success to run-success', () => {
-    expect(lastRunOutcomeClass('success')).toBe('run-success');
+  it('maps the done outcome state to run-success regardless of last_result', () => {
+    // Schedulers write summary strings like "Completed" / "Run 1 done" /
+    // a result excerpt into last_result. The colored badge needs to follow the
+    // normalized outcome state instead, otherwise those rows render uncolored
+    // even though the run clearly succeeded (#858).
+    expect(lastRunOutcomeClass('done', 'Completed')).toBe('run-success');
+    expect(lastRunOutcomeClass('done', 'Run 1 done')).toBe('run-success');
+    expect(lastRunOutcomeClass('done')).toBe('run-success');
   });
 
-  it('maps error to run-error', () => {
-    expect(lastRunOutcomeClass('error')).toBe('run-error');
+  it('maps the blocked outcome state to run-error', () => {
+    expect(lastRunOutcomeClass('blocked', 'Error: connection refused')).toBe(
+      'run-error',
+    );
+    expect(lastRunOutcomeClass('blocked')).toBe('run-error');
   });
 
-  it('returns empty string for null', () => {
+  it('maps the abandoned outcome state to run-error', () => {
+    expect(lastRunOutcomeClass('abandoned', 'Error: Execution timed out')).toBe(
+      'run-error',
+    );
+  });
+
+  it('returns an empty class for the skipped outcome state', () => {
+    // Skipped runs are intentional no-ops — neither success nor failure — so
+    // the row should render neutral. The outcome-state badge already conveys
+    // "skipped" on its own.
+    expect(lastRunOutcomeClass('skipped', 'Skipped by preprocessor: foo')).toBe(
+      '',
+    );
+  });
+
+  it('falls back to the legacy last_result token when no outcome state is set', () => {
+    expect(lastRunOutcomeClass(null, 'success')).toBe('run-success');
+    expect(lastRunOutcomeClass(null, 'error')).toBe('run-error');
+    expect(lastRunOutcomeClass(undefined, 'success')).toBe('run-success');
+  });
+
+  it('returns an empty class when both inputs are missing or unrecognized', () => {
+    expect(lastRunOutcomeClass(null, null)).toBe('');
     expect(lastRunOutcomeClass(null)).toBe('');
-  });
-
-  it('returns empty string for unknown values', () => {
-    expect(lastRunOutcomeClass('weird')).toBe('');
+    expect(lastRunOutcomeClass(null, 'Completed')).toBe('');
+    expect(lastRunOutcomeClass(null, 'weird')).toBe('');
   });
 });
 
@@ -365,6 +394,64 @@ describe('renderAgentDetailContent', () => {
     const html = renderAgentDetailContent(data, 'test-agent');
     expect(html).toContain('run-error');
     expect(html).toContain('2h ago');
+  });
+
+  it('colors a scheduler "Completed" summary row green via last_outcome_state', () => {
+    // The scheduler writes a free-text summary into last_result
+    // (`'Completed'` for one-shots, `result.slice(0, 200)` for streamed
+    // results, `'Error: ...'` for failures — see updateTaskAfterRun in
+    // task-scheduler.ts) and the normalized state into last_outcome_state.
+    // Before #858 the row coloring keyed off last_result === 'success', so
+    // these real-world rows rendered neutral. The badge should now be
+    // green via last_outcome_state alone.
+    const state = makeState({
+      getTasks: () => [
+        makeTask({
+          last_run: new Date(Date.now() - 5 * 60_000).toISOString(),
+          last_result: 'Completed',
+          last_outcome_state: 'done',
+          last_outcome_reason: undefined,
+        }),
+      ],
+    });
+    const data = buildAgentDetailData('test-agent', state)!;
+    const html = renderAgentDetailContent(data, 'test-agent');
+    expect(html).toContain('run-success');
+    expect(html).not.toContain('run-error');
+  });
+
+  it('colors a scheduler "Error: ..." summary row red via last_outcome_state', () => {
+    const state = makeState({
+      getTasks: () => [
+        makeTask({
+          last_run: new Date(Date.now() - 2 * 3_600_000).toISOString(),
+          last_result: 'Error: container failed to start',
+          last_outcome_state: 'blocked',
+          last_outcome_reason: 'container failed to start',
+        }),
+      ],
+    });
+    const data = buildAgentDetailData('test-agent', state)!;
+    const html = renderAgentDetailContent(data, 'test-agent');
+    expect(html).toContain('run-error');
+    expect(html).not.toContain('run-success');
+  });
+
+  it('leaves a skipped row neutral so only the outcome badge conveys the state', () => {
+    const state = makeState({
+      getTasks: () => [
+        makeTask({
+          last_run: new Date(Date.now() - 10 * 60_000).toISOString(),
+          last_result: 'Skipped by preprocessor: nothing to do',
+          last_outcome_state: 'skipped',
+          last_outcome_reason: 'nothing to do',
+        }),
+      ],
+    });
+    const data = buildAgentDetailData('test-agent', state)!;
+    const html = renderAgentDetailContent(data, 'test-agent');
+    expect(html).not.toContain('run-success');
+    expect(html).not.toContain('run-error');
   });
 
   it('uses correct colspan for empty-tasks row when local agent', () => {

--- a/src/web/agent-detail.ts
+++ b/src/web/agent-detail.ts
@@ -3,6 +3,7 @@ import { createHash } from 'crypto';
 import { sanitizeTelegramAvatarUrl } from '../telegram-avatar.js';
 import type { RemotePeerAgents } from '../discovery/types.js';
 import type { MessageLaneReason } from '../group-queue.js';
+import type { TaskOutcomeState } from '../types.js';
 import type { WebStateProvider } from './types.js';
 import { renderShell, escapeHtml } from './shared.js';
 import { allPageScripts } from './page-scripts.js';
@@ -38,11 +39,25 @@ export function formatTaskLastRun(
 }
 
 /**
- * Map a task's `last_result` into the same outcome CSS class used by `/tasks`
+ * Map a task's outcome into the same CSS class used by `/tasks`
  * (`run-success` / `run-error`). Keeps the success/error colors aligned
  * across surfaces.
+ *
+ * The scheduler stores a normalized {@link TaskOutcomeState} in
+ * `last_outcome_state` *and* a free-text summary in `last_result`
+ * (e.g. `Completed`, `Error: ...`, or a result excerpt). The normalized state
+ * is the source of truth — when present it drives the color, so summary-string
+ * rows still pick up the badge. `last_result` is only consulted for older
+ * pre-normalization rows where the state was never written but the legacy
+ * `success` / `error` tokens were (see #858).
  */
-export function lastRunOutcomeClass(result: string | null): string {
+export function lastRunOutcomeClass(
+  state: TaskOutcomeState | null | undefined,
+  result?: string | null,
+): string {
+  if (state === 'done') return 'run-success';
+  if (state === 'blocked' || state === 'abandoned') return 'run-error';
+  if (state) return '';
   if (result === 'success') return 'run-success';
   if (result === 'error') return 'run-error';
   return '';
@@ -83,6 +98,7 @@ export interface AgentDetailData {
     next_run: string | null;
     last_run: string | null;
     last_result: string | null;
+    last_outcome_state: TaskOutcomeState | null;
   }>;
   recentChats: Array<{
     jid: string;
@@ -173,6 +189,7 @@ export function buildAgentDetailData(
       next_run: t.next_run,
       last_run: t.last_run,
       last_result: t.last_result,
+      last_outcome_state: t.last_outcome_state ?? null,
     }));
 
   // Find recent chats for this agent's channels
@@ -294,7 +311,10 @@ export function renderAgentDetailContent(
               ? new Date(t.next_run).toLocaleString()
               : '\u2014';
             const lastRunLabel = formatTaskLastRun(t.last_run);
-            const lastRunClass = lastRunOutcomeClass(t.last_result);
+            const lastRunClass = lastRunOutcomeClass(
+              t.last_outcome_state,
+              t.last_result,
+            );
             const lastRunTitle = t.last_run
               ? `${new Date(t.last_run).toLocaleString()}${t.last_result ? ` \u2014 ${t.last_result}` : ''}`
               : 'never run';

--- a/src/web/page-scripts.ts
+++ b/src/web/page-scripts.ts
@@ -1267,7 +1267,8 @@ function refreshTasks(){
       var sl=scheduleLabel(task.schedule_type,task.schedule_value);
       var nr=task.next_run?relTime(task.next_run):"\\u2014";
       var lr=task.last_run?relTime(task.last_run):"\\u2014";
-      var lrc=task.last_result==="success"?"run-success":task.last_result==="error"?"run-error":"";
+      var los=task.last_outcome_state;
+      var lrc=los==="done"?"run-success":(los==="blocked"||los==="abandoned")?"run-error":los?"":task.last_result==="success"?"run-success":task.last_result==="error"?"run-error":"";
       return '<tr data-task-id="'+window.__esc(task.id)+'" data-status="'+window.__esc(task.status)+'">'
         +'<td><span class="badge '+sc+'">'+window.__esc(task.status)+'</span></td>'
         +'<td class="td-agent" title="'+window.__esc(task.chat_jid)+'">'+window.__esc(task.group_folder)+'</td>'

--- a/src/web/tasks.test.ts
+++ b/src/web/tasks.test.ts
@@ -392,6 +392,71 @@ describe('renderTaskTableRows — outcome badge', () => {
     expect(html).toContain('data-outcome-state="blocked"');
     expect(html).toContain('title="awaiting user reply"');
   });
+
+  it('colors a row whose last_result is a scheduler summary string (#858)', () => {
+    // The scheduler writes free-text summary strings into last_result
+    // (`'Completed'`, `result.slice(0, 200)`, `'Error: ...'` — see
+    // updateTaskAfterRun in task-scheduler.ts). Before #858 the row coloring
+    // only fired on the exact tokens `success` / `error`, so these
+    // real-world rows rendered uncolored. The normalized last_outcome_state
+    // is now the source of truth for the row color.
+    const html = renderTaskTableRows([
+      makeTask({
+        id: 'task-summary-done',
+        last_run: '2026-05-08T11:55:00.000Z',
+        last_result: 'Completed',
+        last_outcome_state: 'done',
+      }),
+    ]);
+
+    expect(html).toContain('run-success');
+    expect(html).not.toContain('run-error');
+  });
+
+  it('colors an "Error: ..." summary row red via last_outcome_state', () => {
+    const html = renderTaskTableRows([
+      makeTask({
+        id: 'task-summary-error',
+        last_run: '2026-05-08T11:55:00.000Z',
+        last_result: 'Error: container failed to start',
+        last_outcome_state: 'blocked',
+      }),
+    ]);
+
+    expect(html).toContain('run-error');
+    expect(html).not.toContain('run-success');
+  });
+
+  it('falls back to the legacy success/error tokens when no outcome state is set', () => {
+    // Pre-normalization rows (older scheduler runs) carry the bare tokens in
+    // last_result and a null last_outcome_state. Their coloring should still
+    // work so we don't regress historical rows.
+    const html = renderTaskTableRows([
+      makeTask({
+        id: 'task-legacy-success',
+        last_run: '2026-05-08T11:55:00.000Z',
+        last_result: 'success',
+      }),
+    ]);
+
+    expect(html).toContain('run-success');
+  });
+
+  it('leaves a row whose last_result is a non-token summary uncolored when no outcome state is set', () => {
+    // Sanity check: the legacy fallback only matches the bare tokens — a
+    // free-text last_result with no normalized state shouldn't pick up a
+    // color, matching the pre-#858 behavior for that edge case.
+    const html = renderTaskTableRows([
+      makeTask({
+        id: 'task-no-state',
+        last_run: '2026-05-08T11:55:00.000Z',
+        last_result: 'Completed',
+      }),
+    ]);
+
+    expect(html).not.toContain('run-success');
+    expect(html).not.toContain('run-error');
+  });
 });
 
 describe('renderTasksContent', () => {

--- a/src/web/tasks.ts
+++ b/src/web/tasks.ts
@@ -9,6 +9,7 @@ import type { WebStateProvider } from './types.js';
 import { renderShell, escapeHtml } from './shared.js';
 import { allPageScripts } from './page-scripts.js';
 import { buildAgentChannelData } from './agent-channels.js';
+import { lastRunOutcomeClass } from './agent-detail.js';
 
 /** Render the task manager content (no shell wrapper — for SPA nav). */
 export function renderTasksContent(state: WebStateProvider): string {
@@ -145,12 +146,10 @@ export function renderTaskTableRows(tasks: ScheduledTask[]): string {
       const lastRun = task.last_run
         ? formatRelativeTime(task.last_run)
         : '\u2014';
-      const lastResultClass =
-        task.last_result === 'success'
-          ? 'run-success'
-          : task.last_result === 'error'
-            ? 'run-error'
-            : '';
+      const lastResultClass = lastRunOutcomeClass(
+        task.last_outcome_state ?? null,
+        task.last_result,
+      );
       const outcomeBadge = renderOutcomeStateBadge(
         task.last_outcome_state ?? null,
         task.last_outcome_reason ?? null,


### PR DESCRIPTION
## Summary

Closes #858. The colored `run-success` / `run-error` row classes on `/tasks` and the `/agents/:id` tasks table only fired when `scheduled_tasks.last_result` was the exact string `success` or `error`. In practice every scheduler write path stores a free-text summary into `last_result` (`'Completed'`, `result.slice(0, 200)`, `'Error: ...'` — see `updateTaskAfterRun` in `task-scheduler.ts`), so real-world rows rendered uncolored even when the run clearly succeeded or failed. The colored outcome badge (added in #843) was the only "did this run succeed" signal, and the row color was silently undercounting.

This change normalizes the row color to read from the already-populated `last_outcome_state` column (`done` / `blocked` / `abandoned` / `skipped`, via `inferOutcome` in `task-scheduler.ts`):

- `done` → `run-success`
- `blocked`, `abandoned` → `run-error`
- `skipped` → neutral — intentional no-op, the outcome badge already conveys it
- `null` last_outcome_state → fall back to the legacy `last_result === 'success' | 'error'` token check so pre-normalization rows still pick up coloring

This is the option-1 direction the issue recommends (cleaner; the read side already has the right shape, the data was just under-specified before — and `last_outcome_state` is now populated on every write path).

## Changes

- `src/web/agent-detail.ts` — `lastRunOutcomeClass(state, result?)` takes both inputs and prefers the normalized state; `AgentDetailData.tasks` now carries `last_outcome_state` through to JSON consumers.
- `src/web/tasks.ts` — call the shared helper instead of inlining the ternary.
- `src/web/page-scripts.ts` — same precedence on the SSE-driven client refresh so a live `/tasks` poll matches the SSR render.
- Test coverage in `agent-detail.test.ts` and `tasks.test.ts` for: scheduler summary strings (`'Completed'`, `'Error: container failed to start'`, `'Skipped by preprocessor: ...'`), the legacy `success` / `error` token fallback, and precedence between the two.

`last_outcome_state` has been populated on every scheduler write path since the column was added, so no backfill is required for new rows. Pre-existing rows that lack the normalized state but carry the legacy token continue to color via the fallback.

## Test plan

- [x] `bun test src/web/agent-detail.test.ts src/web/tasks.test.ts` → 96 pass, 0 fail
- [x] `bun test src/web/` → 789 pass, 0 fail
- [x] `bun test` (full suite) → 2367 pass, 0 fail
- [x] `bun run typecheck` clean


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced accuracy of task outcome status display by shifting from text-based parsing to normalized state tracking, ensuring task results display consistently and reliably across the application.

* **Tests**
  * Added comprehensive test coverage for task outcome styling across multiple result scenarios and state combinations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->