### PR TITLE
fix(security): block remote image redirect SSRF

### DIFF
--- a/src/web/image-cache.test.ts
+++ b/src/web/image-cache.test.ts
@@ -156,6 +156,43 @@ describe('serveCachedRemoteImage', () => {
     }
   });
 
+  it('does not follow direct-IP redirects to unvalidated targets', async () => {
+    const testImageCacheDir = path.join(
+      DATA_DIR,
+      'image-cache-image-cache-test',
+      randomUUID(),
+    );
+    const fetchCalls: RequestInit[] = [];
+
+    clearTestImageCache(testImageCacheDir);
+
+    try {
+      const response = await serveCachedRemoteImage(
+        'redirect-cache-key',
+        async () => 'http://93.184.216.34/avatar.png',
+        {
+          cacheDir: testImageCacheDir,
+          fetchImpl: (async (_input, init) => {
+            fetchCalls.push(init ?? {});
+            return new Response(null, {
+              status: 302,
+              headers: {
+                location: 'http://127.0.0.1:8080/private.png',
+              },
+            });
+          }) as RemoteImageFetch,
+        },
+      );
+
+      expect(response).toBeNull();
+      expect(fetchCalls).toHaveLength(1);
+      expect(fetchCalls[0].redirect).toBe('manual');
+      expect(fs.readdirSync(testImageCacheDir)).toEqual([]);
+    } finally {
+      clearTestImageCache(testImageCacheDir);
+    }
+  });
+
   it('rejects active content types from upstream responses', async () => {
     const testImageCacheDir = path.join(
       DATA_DIR,

--- a/src/web/image-cache.ts
+++ b/src/web/image-cache.ts
@@ -467,14 +467,18 @@ export async function serveCachedRemoteImage(
       );
     } else if (options.fetchImpl) {
       // Caller-provided fetch is only safe for direct-IP URLs, where there is
-      // no hostname to re-resolve after validation.
+      // no hostname to re-resolve after validation. Keep redirects disabled so
+      // a validated public IP cannot bounce the fetch into private networks.
       upstream = await options.fetchImpl(url, {
         signal: AbortSignal.timeout(REMOTE_IMAGE_FETCH_TIMEOUT_MS),
+        redirect: 'manual',
       });
     } else {
-      // Direct-IP URL: already validated above, safe to fetch directly.
+      // Direct-IP URL: already validated above, safe to fetch directly as long
+      // as redirects cannot bypass validation.
       upstream = await fetch(url, {
         signal: AbortSignal.timeout(REMOTE_IMAGE_FETCH_TIMEOUT_MS),
+        redirect: 'manual',
       });
     }
 


### PR DESCRIPTION
## Summary

- Disable automatic redirects for direct-IP remote image fetches.
- Add a regression test for a validated public IP redirecting to loopback.

## Security Impact

Remote image URL validation rejects loopback/private addresses before fetching, and hostname URLs already use a pinned no-redirect request path. Direct-IP URLs used default `fetch`, which follows redirects automatically. A public direct-IP avatar URL could therefore redirect the server-side fetch to a private address after validation.

This change keeps direct-IP fetches on `redirect: 'manual'`, so redirects are treated as non-OK upstream responses instead of fetching unvalidated targets.

## Verification

- `bun test src/web/image-cache.test.ts`
- `bun run tsc --noEmit`
- `bun test src/web/server.test.ts src/web/routes.test.ts src/web/image-cache.test.ts`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Enhanced image cache security by disabling automatic redirect handling during image fetching, preventing untrusted redirects to potentially unsafe addresses from being followed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->