### PR TITLE
feat(web): annotate dashboard active tasks card with running count

### DIFF
--- a/src/web/dashboard.test.ts
+++ b/src/web/dashboard.test.ts
@@ -183,7 +183,6 @@ function makeIdleDetail(folderKey: string): GroupQueueDetail {
   };
 }
 
-
 function extractTopoData(html: string): Array<Record<string, unknown>> {
   const match = html.match(
     /<script type="application\/json" id="topo-data">([\s\S]*?)<\/script>/,

--- a/src/web/dashboard.test.ts
+++ b/src/web/dashboard.test.ts
@@ -3,6 +3,7 @@ import { createHash } from 'crypto';
 import { describe, expect, it } from 'bun:test';
 
 import type { RemotePeerAgents } from '../discovery/types.js';
+import type { GroupQueueDetail } from '../group-queue.js';
 import type { Agent, ChannelSubscription, ScheduledTask } from '../types.js';
 import {
   renderDashboardContent,
@@ -63,6 +64,7 @@ function makeState(options?: {
   chats?: Array<{ jid: string; name: string; last_message_time: string }>;
   tasks?: ScheduledTask[];
   queueStats?: ReturnType<WebStateProvider['getQueueStats']>;
+  queueDetails?: GroupQueueDetail[];
 }): WebStateProvider {
   const agents = options?.agents ?? [makeAgent()];
   const agentMap = Object.fromEntries(agents.map((agent) => [agent.id, agent]));
@@ -81,7 +83,7 @@ function makeState(options?: {
         maxActive: 1,
         maxIdle: 1,
       },
-    getQueueDetails: () => [],
+    getQueueDetails: () => options?.queueDetails ?? [],
     getIpcEvents: () => [],
     getTaskRunLogs: () => [],
     getTaskRunPhaseEvents: () => [],
@@ -111,6 +113,32 @@ function makeState(options?: {
     },
     resolveChatImage: async () => null,
     resolveDiscordGuildImage: async () => null,
+  };
+}
+
+function makeRunningTaskDetail(
+  overrides: { folderKey?: string; taskId?: string; runningMs?: number } = {},
+): GroupQueueDetail {
+  return {
+    folderKey: overrides.folderKey ?? 'groups/local-agent',
+    messageLane: {
+      active: false,
+      idle: false,
+      pendingCount: 0,
+      containerName: null,
+    },
+    taskLane: {
+      active: true,
+      pendingCount: 0,
+      containerName: null,
+      activeTask: {
+        taskId: overrides.taskId ?? 'task-active',
+        promptPreview: '',
+        startedAt: Date.now(),
+        runningMs: overrides.runningMs ?? 1000,
+      },
+    },
+    retryCount: 0,
   };
 }
 
@@ -147,6 +175,53 @@ describe('renderDashboardContent', () => {
     expect(html).toContain('id="stat-active">0/7</div>');
     expect(html).toContain('id="stat-idle">3/4</div>');
     expect(html).toContain('id="stat-tasks">1</div>');
+  });
+
+  it('annotates active tasks card with running count when tasks are in flight', () => {
+    const html = renderDashboardContent(
+      makeState({
+        tasks: [
+          makeTask({ id: 'task-a', status: 'active' }),
+          makeTask({ id: 'task-b', status: 'active' }),
+          makeTask({ id: 'task-c', status: 'active' }),
+        ],
+        queueDetails: [
+          makeRunningTaskDetail({ folderKey: 'g1', taskId: 'task-a' }),
+          makeRunningTaskDetail({ folderKey: 'g2', taskId: 'task-b' }),
+        ],
+      }),
+    );
+
+    expect(html).toContain('id="stat-tasks">3 (2 running)</div>');
+  });
+
+  it('omits the running annotation when no task lane is active', () => {
+    const html = renderDashboardContent(
+      makeState({
+        tasks: [makeTask({ status: 'active' })],
+        queueDetails: [
+          {
+            folderKey: 'g1',
+            messageLane: {
+              active: false,
+              idle: true,
+              pendingCount: 0,
+              containerName: null,
+            },
+            taskLane: {
+              active: false,
+              pendingCount: 0,
+              containerName: null,
+              activeTask: null,
+            },
+            retryCount: 0,
+          },
+        ],
+      }),
+    );
+
+    expect(html).toContain('id="stat-tasks">1</div>');
+    expect(html).not.toContain('running)');
   });
 
   it('serializes local and remote topology data with stable avatar cache-busting hashes', () => {

--- a/src/web/dashboard.ts
+++ b/src/web/dashboard.ts
@@ -10,6 +10,21 @@ function imageRev(value: string): string {
   return createHash('sha256').update(value).digest('hex').slice(0, 12);
 }
 
+export function formatDashboardActiveTasksValue(
+  state: Pick<WebStateProvider, 'getTasks' | 'getQueueDetails'>,
+): string {
+  const activeTasks = state
+    .getTasks()
+    .filter((task) => task.status === 'active').length;
+  const runningTasks = state
+    .getQueueDetails()
+    .reduce((sum, g) => sum + (g.taskLane.activeTask ? 1 : 0), 0);
+
+  return runningTasks > 0
+    ? `${activeTasks} (${runningTasks} running)`
+    : `${activeTasks}`;
+}
+
 /** Render the dashboard content (no shell wrapper). */
 export function renderDashboardContent(
   state: WebStateProvider,
@@ -17,26 +32,13 @@ export function renderDashboardContent(
 ): string {
   const stats = state.getQueueStats();
   const agentData = buildAgentChannelData(state, remotePeers);
-  const tasks = state.getTasks();
   const queueDetails = state.getQueueDetails();
 
   const activeContainers = Math.max(
     0,
     stats.activeContainers - stats.idleContainers,
   );
-  const activeTasks = tasks.filter((t) => t.status === 'active').length;
-  // Count tasks currently executing (task lane has an in-flight activeTask).
-  // Surfaced inline on the "active tasks" card so the operator can tell at a
-  // glance whether enabled tasks are sitting idle or actually running right
-  // now, without opening /ipc or /system.
-  const runningTasks = queueDetails.reduce(
-    (sum, g) => sum + (g.taskLane.activeTask ? 1 : 0),
-    0,
-  );
-  const activeTasksValue =
-    runningTasks > 0
-      ? `${activeTasks} (${runningTasks} running)`
-      : `${activeTasks}`;
+  const activeTasksValue = formatDashboardActiveTasksValue(state);
   // Count local agents currently in flight on either lane (processing a
   // message or running a scheduled task). Surfaced inline on the "agents"
   // card so the operator can tell at a glance how much of the fleet is

--- a/src/web/dashboard.ts
+++ b/src/web/dashboard.ts
@@ -18,12 +18,23 @@ export function renderDashboardContent(
   const stats = state.getQueueStats();
   const agentData = buildAgentChannelData(state, remotePeers);
   const tasks = state.getTasks();
+  const queueDetails = state.getQueueDetails();
 
   const activeContainers = Math.max(
     0,
     stats.activeContainers - stats.idleContainers,
   );
   const activeTasks = tasks.filter((t) => t.status === 'active').length;
+  // Count tasks currently executing (task lane has an in-flight activeTask).
+  // Surfaced inline on the "active tasks" card so the operator can tell at a
+  // glance whether enabled tasks are sitting idle or actually running right
+  // now, without opening /ipc or /system.
+  const runningTasks = queueDetails.reduce(
+    (sum, g) => sum + (g.taskLane.activeTask ? 1 : 0),
+    0,
+  );
+  const activeTasksValue =
+    runningTasks > 0 ? `${activeTasks} (${runningTasks} running)` : `${activeTasks}`;
 
   // Serialize agent topology data for canvas renderer
   const topoData = escapeJsonForHtml(
@@ -74,7 +85,7 @@ export function renderDashboardContent(
     `<div class="stat-card"><div class="label">agents</div><div class="value" id="stat-agents">${agentData.length}</div></div>` +
     `<div class="stat-card"><div class="label">active containers</div><div class="value" id="stat-active">${activeContainers}/${stats.maxActive}</div></div>` +
     `<div class="stat-card"><div class="label">idle containers</div><div class="value" id="stat-idle">${stats.idleContainers}/${stats.maxIdle}</div></div>` +
-    `<div class="stat-card"><div class="label">active tasks</div><div class="value" id="stat-tasks">${activeTasks}</div></div>` +
+    `<div class="stat-card"><div class="label">active tasks</div><div class="value" id="stat-tasks">${activeTasksValue}</div></div>` +
     `</div>` +
     `<div class="topo-section">` +
     `<div class="section-header"><h2>agent topology</h2>` +

--- a/src/web/dashboard.ts
+++ b/src/web/dashboard.ts
@@ -34,7 +34,9 @@ export function renderDashboardContent(
     0,
   );
   const activeTasksValue =
-    runningTasks > 0 ? `${activeTasks} (${runningTasks} running)` : `${activeTasks}`;
+    runningTasks > 0
+      ? `${activeTasks} (${runningTasks} running)`
+      : `${activeTasks}`;
 
   // Serialize agent topology data for canvas renderer
   const topoData = escapeJsonForHtml(

--- a/src/web/server.test.ts
+++ b/src/web/server.test.ts
@@ -13,6 +13,7 @@ import {
 } from './routes.js';
 import type { WebStateProvider, QueueStats } from './types.js';
 import type { Agent, ChannelSubscription, ScheduledTask } from '../types.js';
+import type { GroupQueueDetail } from '../group-queue.js';
 import { logger } from '../logger.js';
 
 // ---- Test fixtures ----
@@ -167,6 +168,30 @@ function makeState(
     setAgentEnabled: () => true,
     setAgentModel: () => true,
     ...overrides,
+  };
+}
+
+function makeTaskRunningDetail(): GroupQueueDetail {
+  return {
+    folderKey: 'test-agent',
+    messageLane: {
+      active: false,
+      idle: true,
+      pendingCount: 0,
+      containerName: null,
+    },
+    taskLane: {
+      active: true,
+      pendingCount: 0,
+      containerName: null,
+      activeTask: {
+        taskId: 'task-001',
+        promptPreview: 'Run the daily check',
+        startedAt: 1_700_000_000_000,
+        runningMs: 15_000,
+      },
+    },
+    retryCount: 0,
   };
 }
 
@@ -1187,6 +1212,37 @@ describe('SSE', () => {
     const payload = await readUntilContains(reader, 'sse log');
     expect(payload).toContain('selector #log-container');
     expect(payload).toContain('sse log');
+    reader.releaseLock();
+  });
+
+  it('preserves running task count in stats patches', async () => {
+    handle = startWebServer(
+      testConfig(),
+      makeState({
+        getQueueDetails: () => [makeTaskRunningDetail()],
+      }),
+    );
+
+    const res = await authedFetch('/api/events?channels=stats', {
+      headers: { Accept: 'text/event-stream' },
+    });
+    expect(res.status).toBe(200);
+    expect(res.body).toBeTruthy();
+
+    const reader = res.body!.getReader();
+    handle.broadcast({
+      type: 'agent_status',
+      data: {
+        activeContainers: 2,
+        idleContainers: 1,
+        maxActive: 8,
+        maxIdle: 4,
+      },
+      timestamp: new Date().toISOString(),
+    });
+
+    const payload = await readUntilContains(reader, 'id="stat-tasks"');
+    expect(payload).toContain('id="stat-tasks">1 (1 running)</div>');
     reader.releaseLock();
   });
 

--- a/src/web/server.ts
+++ b/src/web/server.ts
@@ -27,7 +27,10 @@ import {
   renderAgentDetailContent,
   buildAgentDetailData,
 } from './agent-detail.js';
-import { renderDashboardContent } from './dashboard.js';
+import {
+  formatDashboardActiveTasksValue,
+  renderDashboardContent,
+} from './dashboard.js';
 import { renderConversationsContent } from './conversations.js';
 import { renderContextViewerContent } from './context-viewer.js';
 import { renderIpcInspectorContent } from './ipc-inspector.js';
@@ -1112,12 +1115,10 @@ function patchLogs(client: SseClient): void {
 function patchStats(client: SseClient, state: WebStateProvider): void {
   if (!client.subscriptions.has('stats')) return;
   const stats = state.getQueueStats();
-  const tasks = state.getTasks();
   const activeContainers = Math.max(
     0,
     stats.activeContainers - stats.idleContainers,
   );
-  const activeTasks = tasks.filter((task) => task.status === 'active').length;
 
   client.stream.patchElements(
     `<div class="value" id="stat-agents">${Object.keys(state.getAgents()).length}</div>`,
@@ -1129,7 +1130,7 @@ function patchStats(client: SseClient, state: WebStateProvider): void {
     `<div class="value" id="stat-idle">${stats.idleContainers}/${stats.maxIdle}</div>`,
   );
   client.stream.patchElements(
-    `<div class="value" id="stat-tasks">${activeTasks}</div>`,
+    `<div class="value" id="stat-tasks">${formatDashboardActiveTasksValue(state)}</div>`,
   );
 }
 


### PR DESCRIPTION
## Summary

Annotates the dashboard's `active tasks` stat card with an inline `(N running)` count when any task lane is in flight, so the operator can tell at a glance whether enabled scheduled tasks are sitting idle or actually executing right now — without switching to `/ipc` or `/system`.

The annotation follows the existing `n (m)` parenthetical style already used by the `/ipc` retrying card and the new `/ipc` recent-events severity rollup (#860):

- `5` — no task lane currently running (unchanged)
- `5 (2 running)` — two of five enabled tasks are executing now

Pure render-layer change. `runningTasks` is computed from the existing `getQueueDetails()` snapshot by counting groups whose `taskLane.activeTask` is non-null — the same signal `/system` already exposes as `queue.running_tasks`. No `WebStateProvider`, schema, or SSE event changes.

## Changes

- `src/web/dashboard.ts` — pull `getQueueDetails()`, count groups with an active task, render `${activeTasks} (${runningTasks} running)` when `runningTasks > 0`, otherwise the bare count as before.
- `src/web/dashboard.test.ts` — `GroupQueueDetail` fixture helper plus two new cases: running-task annotation present, and annotation omitted when no lane is running. Existing zero-running case stays green.

## Test plan

- [x] `bun test src/web/dashboard.test.ts` — 7 pass.
- [x] `bun test src/web/` — 783 pass, 0 fail.
- [x] `bun test` — 2364 pass, 0 fail across the full suite.
- [x] `bun run typecheck` — clean.

Relates to #644 (operator observability rollup tracker).

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Updated the dashboard “active tasks” card to show a running-task annotation (formatted as “(N running)”) alongside the active task count when in-flight tasks exist.

* **Tests**
  * Added new dashboard content test cases to confirm the running-task annotation appears when there are active task lanes and is omitted when only idle details are present.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->