### PR TITLE
test(simtest): cover discovery proxy endpoints

### DIFF
--- a/src/simtest/discovery-sim.test.ts
+++ b/src/simtest/discovery-sim.test.ts
@@ -130,6 +130,103 @@ describe('createSimDiscoveryEnvironment', () => {
     await reader!.cancel();
   });
 
+  it('proxies deterministic remote stats for a trusted peer', async () => {
+    const env = createSimDiscoveryEnvironment(new FakeState());
+
+    const statsReq = new Request(
+      'http://localhost/api/discovery/peers/peer-remote-1/stats',
+    );
+    const statsRes = (await handleDiscoveryRequest(
+      statsReq,
+      new URL(statsReq.url),
+      env.context,
+    )) as Response;
+    const stats = (await statsRes.json()) as {
+      agents: number;
+      activeTasks: number;
+      pausedTasks: number;
+      completedTasks: number;
+    };
+
+    expect(statsRes.status).toBe(200);
+    expect(stats.agents).toBeGreaterThan(0);
+    expect(stats.activeTasks).toBeGreaterThan(0);
+    expect(stats.pausedTasks).toBeGreaterThan(0);
+    expect(stats.completedTasks).toBeGreaterThanOrEqual(0);
+  });
+
+  it('writes and reads remote context layers through the proxy routes', async () => {
+    const env = createSimDiscoveryEnvironment(new FakeState());
+
+    const writeReq = new Request(
+      'http://localhost/api/discovery/peers/peer-remote-1/context/file',
+      {
+        method: 'PUT',
+        body: JSON.stringify({
+          path: 'remote/CLAUDE.md',
+          content: '# Remote Context\nKeep builds deterministic.',
+        }),
+      },
+    );
+    const writeRes = (await handleDiscoveryRequest(
+      writeReq,
+      new URL(writeReq.url),
+      env.context,
+    )) as Response;
+
+    expect(writeRes.status).toBe(200);
+    expect(await writeRes.json()).toEqual({ ok: true });
+
+    const layersReq = new Request(
+      'http://localhost/api/discovery/peers/peer-remote-1/context/layers?folder=remote%2FCLAUDE.md',
+    );
+    const layersRes = (await handleDiscoveryRequest(
+      layersReq,
+      new URL(layersReq.url),
+      env.context,
+    )) as Response;
+    const layers = (await layersRes.json()) as {
+      channel: { path: string; content: string; exists: boolean };
+    };
+
+    expect(layersRes.status).toBe(200);
+    expect(layers.channel).toEqual({
+      path: 'remote/CLAUDE.md',
+      content: '# Remote Context\nKeep builds deterministic.',
+      exists: true,
+    });
+  });
+
+  it('denies proxy access to peers that are not trusted', async () => {
+    const env = createSimDiscoveryEnvironment(new FakeState());
+
+    env.addRemotePeer({
+      instanceId: 'peer-pending',
+      name: 'Pending Peer',
+      host: 'pending-sim.local',
+      address: '192.168.1.83',
+      channelFolder: 'pending',
+      status: 'pending',
+    });
+
+    const agentsReq = new Request(
+      'http://localhost/api/discovery/peers/peer-pending/agents',
+    );
+    const agentsRes = (await handleDiscoveryRequest(
+      agentsReq,
+      new URL(agentsReq.url),
+      env.context,
+    )) as Response;
+
+    expect(agentsRes.status).toBe(403);
+    expect(await agentsRes.json()).toEqual({ error: 'Peer is not trusted' });
+    expect(
+      env
+        .getNetworkPageState()
+        .peers.find((peer) => peer.instanceId === 'peer-pending'),
+    ).toMatchObject({ status: 'pending', online: true });
+  });
+
   it('supports deterministic runtime toggles in network page state', () => {
     const env = createSimDiscoveryEnvironment(new FakeState());
     const runtime = env.context.runtime as unknown as {


### PR DESCRIPTION
## Summary

- Add deterministic discovery simulation coverage for trusted peer stats proxying.
- Add remote context write/read coverage through discovery proxy routes.
- Add pending peer denial coverage to assert untrusted peers cannot use proxy routes.

## Test Count

- Before: 2372 pass, 0 fail, 6345 expect() calls across 104 files.
- After: 2375 pass, 0 fail, 6357 expect() calls across 104 files.

## Coverage

- Overall line coverage: 91.31% -> 91.43%.
- `src/simtest/discovery-sim.ts` line coverage: 81.86% -> 89.69%.

## Verification

- `bun test src/simtest/discovery-sim.test.ts`
- `bun test`
- `bun test --coverage`

## Remaining Coverage Gaps

- Channel adapters remain integration-heavy and low coverage: Discord, Telegram, WhatsApp.
- `src/index.ts` remains difficult to cover directly due orchestrator-level process/runtime coupling.
- `src/backends/local-backend.ts` has substantial Docker/runtime paths still best covered with focused monkey-patch or integration tests.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Enhanced test coverage for discovery proxy functionality, including remote peer statistics handling, context layer operations, and access control policies for peer validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->