### PR TITLE
feat(web): annotate /network trusted stat card with offline count

### DIFF
--- a/src/web/network.test.ts
+++ b/src/web/network.test.ts
@@ -1,7 +1,9 @@
 import { describe, expect, it } from 'bun:test';
 
 import {
+  countTrustedOffline,
   formatPeerLastSeen,
+  formatTrustedStatValue,
   renderNetworkContent,
   renderNetworkPage,
   renderPeerOnlineCell,
@@ -396,6 +398,101 @@ describe('renderPeerOnlineCell', () => {
     expect(html).toContain('class="peer-last-seen"');
     expect(html).toContain(`title="${lastSeen}"`);
     expect(html).toContain('<span style="color:var(--text-muted)">○</span>');
+  });
+});
+
+describe('countTrustedOffline', () => {
+  it('returns 0 when no peers are trusted', () => {
+    expect(countTrustedOffline([])).toBe(0);
+    expect(
+      countTrustedOffline([
+        makePeer({ instanceId: 'a', status: 'discovered', online: false }),
+        makePeer({ instanceId: 'b', status: 'pending', online: false }),
+      ]),
+    ).toBe(0);
+  });
+
+  it('only counts trusted peers that are offline', () => {
+    expect(
+      countTrustedOffline([
+        makePeer({ instanceId: 'a', status: 'trusted', online: true }),
+        makePeer({ instanceId: 'b', status: 'trusted', online: false }),
+        makePeer({ instanceId: 'c', status: 'trusted', online: false }),
+        makePeer({ instanceId: 'd', status: 'pending', online: false }),
+        makePeer({ instanceId: 'e', status: 'discovered', online: false }),
+        makePeer({ instanceId: 'f', status: 'revoked', online: false }),
+      ]),
+    ).toBe(2);
+  });
+});
+
+describe('formatTrustedStatValue', () => {
+  it('returns the bare trusted count when none are offline', () => {
+    expect(formatTrustedStatValue([])).toBe('0');
+    expect(
+      formatTrustedStatValue([
+        makePeer({ instanceId: 'a', status: 'trusted', online: true }),
+        makePeer({ instanceId: 'b', status: 'trusted', online: true }),
+      ]),
+    ).toBe('2');
+  });
+
+  it('appends an offline annotation when trusted peers are offline', () => {
+    expect(
+      formatTrustedStatValue([
+        makePeer({ instanceId: 'a', status: 'trusted', online: true }),
+        makePeer({ instanceId: 'b', status: 'trusted', online: false }),
+        makePeer({ instanceId: 'c', status: 'trusted', online: false }),
+      ]),
+    ).toBe('3 (2 offline)');
+  });
+
+  it('ignores non-trusted peers when computing the annotation', () => {
+    expect(
+      formatTrustedStatValue([
+        makePeer({ instanceId: 'a', status: 'trusted', online: true }),
+        makePeer({ instanceId: 'b', status: 'pending', online: false }),
+        makePeer({ instanceId: 'c', status: 'discovered', online: false }),
+      ]),
+    ).toBe('1');
+  });
+});
+
+describe('renderNetworkContent trusted offline annotation', () => {
+  it('annotates the trusted stat card with offline count when any trusted peer is offline', () => {
+    const html = renderNetworkContent({
+      instanceId: 'local-id',
+      instanceName: 'Main Node',
+      discoveryAvailable: true,
+      discoveryEnabled: true,
+      runtime: makeRuntime(),
+      peers: [
+        makePeer({ instanceId: 'a', status: 'trusted', online: true }),
+        makePeer({ instanceId: 'b', status: 'trusted', online: false }),
+        makePeer({ instanceId: 'c', status: 'trusted', online: false }),
+      ],
+      pendingRequests: [],
+    });
+
+    expect(html).toContain('id="stat-peers-trusted">3 (2 offline)</div>');
+  });
+
+  it('omits the offline annotation when every trusted peer is online', () => {
+    const html = renderNetworkContent({
+      instanceId: 'local-id',
+      instanceName: 'Main Node',
+      discoveryAvailable: true,
+      discoveryEnabled: true,
+      runtime: makeRuntime(),
+      peers: [
+        makePeer({ instanceId: 'a', status: 'trusted', online: true }),
+        makePeer({ instanceId: 'b', status: 'trusted', online: true }),
+      ],
+      pendingRequests: [],
+    });
+
+    expect(html).toContain('id="stat-peers-trusted">2</div>');
+    expect(html).not.toContain('offline)');
   });
 });
 

--- a/src/web/network.ts
+++ b/src/web/network.ts
@@ -20,6 +20,31 @@ export interface NetworkPageState {
   pendingRequests: PairRequest[];
 }
 
+/**
+ * Count trusted peers that are not currently reachable. Operators care about
+ * this separately from the raw trusted total because a trusted peer that
+ * silently drops off the LAN is the kind of thing they want to notice
+ * without having to scan the discovered-peers table.
+ */
+export function countTrustedOffline(peers: PeerView[]): number {
+  let n = 0;
+  for (const p of peers) if (p.status === 'trusted' && !p.online) n++;
+  return n;
+}
+
+/**
+ * Format the value cell of the `trusted` stat card. Renders the bare trusted
+ * count by default, and appends an inline `(N offline)` annotation when any
+ * trusted peer is offline — mirroring the `N (M qualifier)` convention used
+ * by the dashboard active-tasks card and the IPC inspector recent-events
+ * rollup so the surface looks consistent across pages.
+ */
+export function formatTrustedStatValue(peers: PeerView[]): string {
+  const trusted = peers.filter((p) => p.status === 'trusted').length;
+  const offline = countTrustedOffline(peers);
+  return offline > 0 ? `${trusted} (${offline} offline)` : `${trusted}`;
+}
+
 /** Render just the network page content (no shell wrapper). */
 export function renderNetworkContent(pageState: NetworkPageState): string {
   const {
@@ -37,8 +62,8 @@ export function renderNetworkContent(pageState: NetworkPageState): string {
     ? 'Discovery controls are unavailable in this environment.'
     : 'Trusted networks gate discovery when present. Leave the list empty to allow discovery anywhere the toggle is on.';
 
-  const trustedCount = peers.filter((p) => p.status === 'trusted').length;
   const onlineCount = peers.filter((p) => p.online).length;
+  const trustedValue = formatTrustedStatValue(peers);
 
   return (
     `<div data-init="window.__initPage && window.__initPage('network')" id="network-root" data-discovery-available="${discoveryAvailable ? 'true' : 'false'}">` +
@@ -47,7 +72,7 @@ export function renderNetworkContent(pageState: NetworkPageState): string {
     `<div class="stat-card"><div class="label">instance</div><div class="value" style="font-size:0.85rem">${escapeHtml(instanceName)}</div></div>` +
     `<div class="stat-card"><div class="label">discovery</div><div class="value" id="discovery-runtime-status">${discoveryEnabled ? '<span style="color:var(--green)">active</span>' : '<span style="color:var(--text-muted)">disabled</span>'}</div></div>` +
     `<div class="stat-card"><div class="label">peers online</div><div class="value" id="stat-peers-online">${onlineCount}</div></div>` +
-    `<div class="stat-card"><div class="label">trusted</div><div class="value" id="stat-peers-trusted">${trustedCount}</div></div>` +
+    `<div class="stat-card"><div class="label">trusted</div><div class="value" id="stat-peers-trusted">${trustedValue}</div></div>` +
     `</div>` +
     // Instance ID
     `<div style="margin-bottom:1.5rem;padding:0.75rem 1rem;background:var(--surface);border-radius:8px;border:1px solid var(--border)">` +

--- a/src/web/page-scripts.ts
+++ b/src/web/page-scripts.ts
@@ -2090,8 +2090,10 @@ function refreshPeers(){
     .then(function(peers){
       var online=peers.filter(function(p){return p.online;}).length;
       var trusted=peers.filter(function(p){return p.status==="trusted";}).length;
+      var trustedOffline=peers.filter(function(p){return p.status==="trusted"&&!p.online;}).length;
+      var trustedText=trustedOffline>0?(trusted+" ("+trustedOffline+" offline)"):String(trusted);
       var oe=document.getElementById("stat-peers-online");if(oe)oe.textContent=String(online);
-      var te=document.getElementById("stat-peers-trusted");if(te)te.textContent=String(trusted);
+      var te=document.getElementById("stat-peers-trusted");if(te)te.textContent=trustedText;
       var body=document.getElementById("peers-tbody");if(body)body.innerHTML=renderPeerRows(peers);
     }).catch(function(){});
 }

--- a/src/web/server.ts
+++ b/src/web/server.ts
@@ -32,6 +32,7 @@ import { renderConversationsContent } from './conversations.js';
 import { renderContextViewerContent } from './context-viewer.js';
 import { renderIpcInspectorContent } from './ipc-inspector.js';
 import {
+  formatTrustedStatValue,
   renderNetworkContent,
   renderPeerRows,
   renderPendingRequests,
@@ -1179,7 +1180,7 @@ function patchNetwork(client: SseClient): void {
     `<div class="value" id="stat-peers-online">${pageState.peers.filter((peer) => peer.online).length}</div>`,
   );
   client.stream.patchElements(
-    `<div class="value" id="stat-peers-trusted">${pageState.peers.filter((peer) => peer.status === 'trusted').length}</div>`,
+    `<div class="value" id="stat-peers-trusted">${formatTrustedStatValue(pageState.peers)}</div>`,
   );
   client.stream.patchElements(
     `<span class="badge" id="pending-count">${pageState.pendingRequests.length}</span>`,


### PR DESCRIPTION
## Summary

Annotates the `/network` `trusted` stat card with an inline `(N offline)` count when any trusted peer is unreachable, so an operator can tell at a glance whether their trusted LAN peers are actually online — without scanning the discovered-peers table or drilling into `/system → peers`.

The annotation follows the established `N (M qualifier)` convention already used by the dashboard active-tasks card (#875) and the IPC inspector recent-events rollup (#860):

- `5` — every trusted peer is online (unchanged)
- `5 (2 offline)` — three of five trusted peers are reachable right now

Pure render-layer derivation from the existing `peers` array. No new `WebStateProvider` hooks, schema, or SSE event shape — `peers[].status` and `peers[].online` already flow through every render path.

## Changes

- `src/web/network.ts`
  - `countTrustedOffline(peers)` — exported helper, counts peers with `status === 'trusted' && !online`.
  - `formatTrustedStatValue(peers)` — exported helper, returns the bare trusted count or appends ` (N offline)` when any trusted peer is offline. Used by both the SSR and SSE patch paths so they stay in sync.
  - `renderNetworkContent` — uses the helper for the `stat-peers-trusted` value cell.
- `src/web/server.ts` — `patchNetwork` SSE patch reuses the helper instead of inlining the trusted filter, so the Datastar update agrees with the SSR markup.
- `src/web/page-scripts.ts` — `refreshPeers` (the `/api/discovery/peers` polling fallback for clients without an active SSE subscription) computes `trustedOffline` and renders the same annotation, so the polled DOM never diverges from the SSE-patched DOM.
- `src/web/network.test.ts` — three new `describe` blocks (7 new tests):
  - `countTrustedOffline` — empty list, no trusted peers, mixed statuses (only trusted + offline counted).
  - `formatTrustedStatValue` — bare count, count with annotation, non-trusted peers ignored.
  - `renderNetworkContent trusted offline annotation` — annotation present in SSR HTML when offline trusted peers exist, omitted when all trusted peers are online.

## Test plan

- [x] `bun test src/web/network.test.ts` — 32 pass (7 new).
- [x] `bun test src/web/` — 798 pass, 0 fail across 24 web files.
- [x] `bun test` — 2379 pass, 0 fail across the full suite.
- [x] `bun run typecheck` — clean.
- [x] `bunx prettier --check src/web/network.ts src/web/network.test.ts src/web/server.ts src/web/page-scripts.ts` — clean.

Relates to #644 (operator observability rollup tracker).

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced the trusted peers statistic to display the count of offline trusted peers inline (e.g., "5 (2 offline)").

* **Tests**
  * Added test coverage for new helpers that count offline trusted peers and format the trusted stat display.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->