### PR TITLE
test(simtest): cover discovery harness state branches

### DIFF
--- a/src/simtest/discovery-sim.test.ts
+++ b/src/simtest/discovery-sim.test.ts
@@ -222,6 +222,114 @@ describe('createSimDiscoveryEnvironment', () => {
     }
   });
 
+  it('exposes deterministic trust-store helpers for peer state transitions', () => {
+    const env = createSimDiscoveryEnvironment(new FakeState());
+    const trustStore = env.context.trustStore as unknown as {
+      completePendingEncryptedPairing: () => never;
+      getPeerSecret: (instanceId: string) => string | null;
+      getAllPeers: () => Array<{ instanceId: string; status: string }>;
+      isPeerTrusted: (instanceId: string) => boolean;
+      markPeerPending: (
+        instanceId: string,
+        name: string,
+        host: string | null,
+        port: number | null,
+      ) => { instanceId: string; status: string; sharedSecret: string | null };
+      updatePeerLastSeen: (instanceId: string) => void;
+      revokePeer: (instanceId: string) => void;
+    };
+
+    expect(trustStore.isPeerTrusted('peer-remote-1')).toBe(true);
+    expect(trustStore.getPeerSecret('peer-remote-1')).toBe(
+      'sim-secret-peer-remote-1',
+    );
+    expect(trustStore.getPeerSecret('missing-peer')).toBeNull();
+
+    const pending = trustStore.markPeerPending(
+      'peer-pending',
+      'Pending Peer',
+      null,
+      null,
+    );
+    expect(pending).toMatchObject({
+      instanceId: 'peer-pending',
+      status: 'pending',
+      sharedSecret: null,
+    });
+    expect(trustStore.isPeerTrusted('peer-pending')).toBe(false);
+
+    trustStore.updatePeerLastSeen('peer-pending');
+    trustStore.updatePeerLastSeen('missing-peer');
+
+    trustStore.revokePeer('peer-pending');
+    expect(
+      trustStore.getAllPeers().map((peer) => peer.instanceId),
+    ).not.toContain('peer-pending');
+    expect(() => trustStore.completePendingEncryptedPairing()).toThrow(
+      'Encrypted pairing callbacks are not simulated',
+    );
+  });
+
+  it('simulates remote context reads, writes, and metadata hashes', async () => {
+    const env = createSimDiscoveryEnvironment(new FakeState());
+    const createPeerClient = env.context.createPeerClient;
+    expect(createPeerClient).toBeDefined();
+    const peerClient = createPeerClient!(
+      {
+        instanceId: 'peer-remote-1',
+        host: 'remote-sim.local',
+        port: 3100,
+        sharedSecret: 'sim-secret-peer-remote-1',
+      },
+      env.context,
+    ) as unknown as {
+      getContextLayers: (params: Record<string, string>) => Promise<{
+        channel: {
+          content: string | null;
+          exists: boolean;
+          path: string | null;
+        };
+      }>;
+      listContextFiles: () => Promise<
+        Array<{ path: string; hash: string; size: number; mtime: string }>
+      >;
+      writeContextFile: (
+        layerPath: string,
+        content: string,
+      ) => Promise<{ ok: boolean }>;
+    };
+
+    const missing = await peerClient.getContextLayers({});
+    expect(missing.channel).toEqual({
+      path: null,
+      content: null,
+      exists: false,
+    });
+
+    await expect(
+      peerClient.writeContextFile('remote', '# Remote Override'),
+    ).resolves.toEqual({ ok: true });
+
+    const layers = await peerClient.getContextLayers({ folder: 'remote' });
+    expect(layers.channel).toEqual({
+      path: 'remote',
+      content: '# Remote Override',
+      exists: true,
+    });
+
+    const files = await peerClient.listContextFiles();
+    expect(files).toContainEqual(
+      expect.objectContaining({
+        path: 'remote',
+        hash: 'bcf62d8b12fdaafb34efcf83fa1acf09c396634bc8bd6173a4c790a759217ac6',
+        size: 17,
+      }),
+    );
+    expect(files.find((file) => file.path === 'remote')?.mtime).toMatch(
+      /^\d{4}-\d{2}-\d{2}T/,
+    );
+  });
+
   it('resets simulated peers and rejects mutations for missing peers', () => {
     const env = createSimDiscoveryEnvironment(new FakeState());
 

--- a/src/simtest/fake-state.test.ts
+++ b/src/simtest/fake-state.test.ts
@@ -214,4 +214,52 @@ describe('FakeState', () => {
       '# Main Agent\n\nThis is the main agent context.',
     );
   });
+
+  it('updates agent enabled/model state and handles missing agents', () => {
+    expect(state.setAgentEnabled('main', false)).toBe(true);
+    expect(state.getAgents().main?.enabled).toBe(false);
+    expect(state.setAgentEnabled('missing-agent', true)).toBe(false);
+
+    expect(state.setAgentModel('main', '  gpt-5.5  ')).toBe(true);
+    expect(state.getAgents().main?.model).toBe('gpt-5.5');
+
+    expect(state.setAgentModel('main', '   ')).toBe(true);
+    expect(state.getAgents().main?.model).toBeUndefined();
+
+    expect(state.setAgentModel('main', null)).toBe(true);
+    expect(state.getAgents().main?.model).toBeUndefined();
+    expect(state.setAgentModel('missing-agent', 'opus')).toBe(false);
+  });
+
+  it('updates existing chats and records new chat timestamps deterministically', () => {
+    state.addChat('sim:general', '#renamed-general');
+    expect(
+      state.getChats().find((chat) => chat.jid === 'sim:general'),
+    ).toMatchObject({
+      name: '#renamed-general',
+    });
+
+    state.addChat('sim:new-channel', '#new-channel');
+    expect(
+      state.getChats().find((chat) => chat.jid === 'sim:new-channel'),
+    ).toMatchObject({
+      jid: 'sim:new-channel',
+      name: '#new-channel',
+    });
+  });
+
+  it('mutates queue state and returns limited run logs for missing tasks', () => {
+    expect(state.getTaskRunLogs('missing-task')).toEqual([]);
+
+    state.setQueueStats({ activeContainers: 9, maxIdle: 2 });
+    expect(state.getQueueStats()).toMatchObject({
+      activeContainers: 9,
+      idleContainers: 1,
+      maxActive: 10,
+      maxIdle: 2,
+    });
+
+    state.setQueueDetails([]);
+    expect(state.getQueueDetails()).toEqual([]);
+  });
 });

--- a/src/simtest/fake-state.test.ts
+++ b/src/simtest/fake-state.test.ts
@@ -231,7 +231,7 @@ describe('FakeState', () => {
     expect(state.setAgentModel('missing-agent', 'opus')).toBe(false);
   });
 
-  it('updates existing chats and records new chat timestamps deterministically', () => {
+  it('updates existing chats and records new chats', () => {
     state.addChat('sim:general', '#renamed-general');
     expect(
       state.getChats().find((chat) => chat.jid === 'sim:general'),


### PR DESCRIPTION
## Summary

- Add deterministic simtest coverage for discovery harness trust-store state transitions.
- Add remote context-file read/write/hash coverage through the simulated peer client.
- Add FakeState coverage for agent enabled/model mutations, chat upserts, queue mutations, and missing task log boundaries.

## Test Count

- Before: 2379 tests, 6357 expect calls, 104 files.
- After: 2384 tests, 6385 expect calls, 104 files.

## Coverage Delta

- Overall: 92.07% funcs / 91.31% lines -> 92.29% funcs / 91.48% lines.
- `src/simtest/discovery-sim.ts`: 75.00% funcs / 81.86% lines -> 87.69% funcs / 94.62% lines.
- `src/simtest/fake-state.ts`: 82.76% funcs / 96.63% lines -> 89.66% funcs / 98.99% lines.

## Remaining Coverage Gaps

- `src/backends/local-backend.ts` still has large untested runtime/backend branches.
- Channel adapters (`discord.ts`, `telegram.ts`, `whatsapp.ts`) remain low line coverage because much of the code is integration-heavy.
- `src/discovery/routes.ts` still has many route error and edge branches suitable for future deterministic request tests.

## Verification

- `bun test src/simtest/discovery-sim.test.ts src/simtest/fake-state.test.ts`
- `bun run typecheck`
- `bun test`
- `bun test --coverage`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added coverage for simulated peer discovery environment behavior, including trust-store helper state transitions, safe handling for missing peers, revocation behavior, and remote context layer/file operations (read/write/list).
  * Expanded FakeState verification for agent enable/model updates, chat creation and renaming, and queue stats/details mutations with expected derived counters.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->