### PR TITLE
feat(web): annotate dashboard agents card with working count

### DIFF
--- a/src/web/dashboard.test.ts
+++ b/src/web/dashboard.test.ts
@@ -3,6 +3,7 @@ import { createHash } from 'crypto';
 import { describe, expect, it } from 'bun:test';
 
 import type { RemotePeerAgents } from '../discovery/types.js';
+import type { GroupQueueDetail } from '../group-queue.js';
 import type { Agent, ChannelSubscription, ScheduledTask } from '../types.js';
 import {
   renderDashboardContent,
@@ -63,6 +64,7 @@ function makeState(options?: {
   chats?: Array<{ jid: string; name: string; last_message_time: string }>;
   tasks?: ScheduledTask[];
   queueStats?: ReturnType<WebStateProvider['getQueueStats']>;
+  queueDetails?: GroupQueueDetail[];
 }): WebStateProvider {
   const agents = options?.agents ?? [makeAgent()];
   const agentMap = Object.fromEntries(agents.map((agent) => [agent.id, agent]));
@@ -81,7 +83,7 @@ function makeState(options?: {
         maxActive: 1,
         maxIdle: 1,
       },
-    getQueueDetails: () => [],
+    getQueueDetails: () => options?.queueDetails ?? [],
     getIpcEvents: () => [],
     getTaskRunLogs: () => [],
     getTaskRunPhaseEvents: () => [],
@@ -111,6 +113,73 @@ function makeState(options?: {
     },
     resolveChatImage: async () => null,
     resolveDiscordGuildImage: async () => null,
+  };
+}
+
+function makeMessageRunningDetail(
+  overrides: { folderKey?: string; runningMs?: number } = {},
+): GroupQueueDetail {
+  return {
+    folderKey: overrides.folderKey ?? 'groups/local-agent',
+    messageLane: {
+      active: true,
+      idle: false,
+      pendingCount: 0,
+      containerName: null,
+      runningMs: overrides.runningMs ?? 1500,
+    },
+    taskLane: {
+      active: false,
+      pendingCount: 0,
+      containerName: null,
+      activeTask: null,
+    },
+    retryCount: 0,
+  };
+}
+
+function makeTaskRunningDetail(
+  overrides: { folderKey?: string; taskId?: string; runningMs?: number } = {},
+): GroupQueueDetail {
+  return {
+    folderKey: overrides.folderKey ?? 'groups/other-agent',
+    messageLane: {
+      active: false,
+      idle: false,
+      pendingCount: 0,
+      containerName: null,
+    },
+    taskLane: {
+      active: true,
+      pendingCount: 0,
+      containerName: null,
+      activeTask: {
+        taskId: overrides.taskId ?? 'task-active',
+        promptPreview: '',
+        startedAt: 1_700_000_000_000,
+        runningMs: overrides.runningMs ?? 1000,
+      },
+    },
+    retryCount: 0,
+  };
+}
+
+function makeIdleDetail(folderKey: string): GroupQueueDetail {
+  return {
+    folderKey,
+    messageLane: {
+      active: false,
+      idle: true,
+      pendingCount: 0,
+      containerName: null,
+    },
+    taskLane: {
+      active: false,
+      pendingCount: 0,
+      containerName: null,
+      activeTask: null,
+    },
+    retryCount: 0,
   };
 }
 
@@ -147,6 +216,74 @@ describe('renderDashboardContent', () => {
     expect(html).toContain('id="stat-active">0/7</div>');
     expect(html).toContain('id="stat-idle">3/4</div>');
     expect(html).toContain('id="stat-tasks">1</div>');
+  });
+
+  it('annotates agents card with working count when any lane is in flight', () => {
+    const html = renderDashboardContent(
+      makeState({
+        agents: [
+          makeAgent({ id: 'a1', folder: 'groups/a1' }),
+          makeAgent({ id: 'a2', folder: 'groups/a2' }),
+          makeAgent({ id: 'a3', folder: 'groups/a3' }),
+        ],
+        queueDetails: [
+          makeMessageRunningDetail({ folderKey: 'groups/a1' }),
+          makeTaskRunningDetail({ folderKey: 'groups/a2' }),
+          makeIdleDetail('groups/a3'),
+        ],
+      }),
+    );
+
+    expect(html).toContain('id="stat-agents">3 (2 working)</div>');
+  });
+
+  it('omits the working annotation when no agent lane is active', () => {
+    const html = renderDashboardContent(
+      makeState({
+        agents: [
+          makeAgent({ id: 'a1', folder: 'groups/a1' }),
+          makeAgent({ id: 'a2', folder: 'groups/a2' }),
+        ],
+        queueDetails: [
+          makeIdleDetail('groups/a1'),
+          makeIdleDetail('groups/a2'),
+        ],
+      }),
+    );
+
+    expect(html).toContain('id="stat-agents">2</div>');
+    expect(html).not.toContain('working)');
+  });
+
+  it('does not count idle-waiting message lanes as working', () => {
+    // A lane with active=true but idle=true is a warm container in cooldown,
+    // not actively processing — it should not be counted as working.
+    const html = renderDashboardContent(
+      makeState({
+        agents: [makeAgent({ id: 'a1', folder: 'groups/a1' })],
+        queueDetails: [
+          {
+            folderKey: 'groups/a1',
+            messageLane: {
+              active: true,
+              idle: true,
+              pendingCount: 0,
+              containerName: 'omni-a1',
+            },
+            taskLane: {
+              active: false,
+              pendingCount: 0,
+              containerName: null,
+              activeTask: null,
+            },
+            retryCount: 0,
+          },
+        ],
+      }),
+    );
+
+    expect(html).toContain('id="stat-agents">1</div>');
+    expect(html).not.toContain('working)');
   });
 
   it('serializes local and remote topology data with stable avatar cache-busting hashes', () => {

--- a/src/web/dashboard.ts
+++ b/src/web/dashboard.ts
@@ -18,12 +18,31 @@ export function renderDashboardContent(
   const stats = state.getQueueStats();
   const agentData = buildAgentChannelData(state, remotePeers);
   const tasks = state.getTasks();
+  const queueDetails = state.getQueueDetails();
 
   const activeContainers = Math.max(
     0,
     stats.activeContainers - stats.idleContainers,
   );
   const activeTasks = tasks.filter((t) => t.status === 'active').length;
+  // Count local agents currently in flight on either lane (processing a
+  // message or running a scheduled task). Surfaced inline on the "agents"
+  // card so the operator can tell at a glance how much of the fleet is
+  // actively doing work right now, without drilling into /agents or /system.
+  // Remote peer agents are excluded because we do not track their lane state
+  // locally; the bare count keeps reflecting the total fleet size.
+  const workingAgents = queueDetails.reduce(
+    (sum, g) =>
+      sum +
+      ((g.messageLane.active && !g.messageLane.idle) || g.taskLane.active
+        ? 1
+        : 0),
+    0,
+  );
+  const agentsValue =
+    workingAgents > 0
+      ? `${agentData.length} (${workingAgents} working)`
+      : `${agentData.length}`;
 
   // Serialize agent topology data for canvas renderer
   const topoData = escapeJsonForHtml(
@@ -71,7 +90,7 @@ export function renderDashboardContent(
     // Main area: stats + topology
     `<div class="dash-main">` +
     `<div class="stats-grid">` +
-    `<div class="stat-card"><div class="label">agents</div><div class="value" id="stat-agents">${agentData.length}</div></div>` +
+    `<div class="stat-card"><div class="label">agents</div><div class="value" id="stat-agents">${agentsValue}</div></div>` +
     `<div class="stat-card"><div class="label">active containers</div><div class="value" id="stat-active">${activeContainers}/${stats.maxActive}</div></div>` +
     `<div class="stat-card"><div class="label">idle containers</div><div class="value" id="stat-idle">${stats.idleContainers}/${stats.maxIdle}</div></div>` +
     `<div class="stat-card"><div class="label">active tasks</div><div class="value" id="stat-tasks">${activeTasks}</div></div>` +


### PR DESCRIPTION
## Summary

Annotates the dashboard's `agents` stat card with an inline `(N working)` count whenever any local agent lane is in flight, so the operator can tell at a glance how much of the fleet is actively doing work right now — without switching to `/agents` or `/system`.

The annotation follows the established `n (m)` parenthetical style already used by the `/ipc` retrying card and complements the in-flight #875 (active tasks running annotation):

- `5` — no agent lane currently in flight (unchanged)
- `5 (2 working)` — two of five agents are processing a message or running a scheduled task right now

An agent is counted as working when its `GroupQueueDetail` has either:
- `messageLane.active && !messageLane.idle` (actively processing a message), or
- `taskLane.active` (running a scheduled task)

Idle-waiting message lanes (`active=true`, `idle=true` — warm container in cooldown) are intentionally excluded; this matches `getAgentExecStatus` in `agents-page.ts`, which classifies those as `idle`. Remote peer agents are excluded because we do not track their lane state locally; the bare `agents` count keeps reflecting the total fleet size including remote peers.

Pure render-layer change. `workingAgents` is derived from the existing `getQueueDetails()` snapshot — the same signal `/system` already exposes. No `WebStateProvider`, schema, or SSE event changes.

## Changes

- `src/web/dashboard.ts` — pull `getQueueDetails()`, count groups whose message or task lane is actively in flight, render `${agentData.length} (${workingAgents} working)` when `workingAgents > 0`, otherwise the bare count as before.
- `src/web/dashboard.test.ts` — three `GroupQueueDetail` fixture helpers (`makeMessageRunningDetail`, `makeTaskRunningDetail`, `makeIdleDetail`) plus three new cases:
  - working annotation present when one message lane + one task lane are in flight (3 total agents → `3 (2 working)`)
  - annotation omitted when no lane is active
  - idle-waiting (cooldown) lanes are not counted as working

## Test plan

- [x] `bun test src/web/dashboard.test.ts` — 8 pass.
- [x] `bun test src/web/` — 801 pass, 0 fail.
- [x] `bun test` — 2382 pass, 0 fail across the full suite.
- [x] `bun run typecheck` — clean.

Relates to #644 (operator observability rollup tracker). Complementary to #875 (dashboard active tasks running annotation).

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Dashboard agents stat card now displays the total number of agents and how many are currently working, shown in "X (Y working)" format when agents are active.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->