### PR TITLE
test: cover task preprocessor workflow resolution

### DIFF
--- a/src/task-preprocessor.test.ts
+++ b/src/task-preprocessor.test.ts
@@ -3,6 +3,7 @@ import fs from 'fs';
 import os from 'os';
 import path from 'path';
 
+import { GROUPS_DIR, TASK_WORKFLOWS_DIR } from './config.js';
 import {
   normalizePreprocessScriptPath,
   runTaskPreprocessor,
@@ -309,4 +310,39 @@ it('does nothing when no preprocessor is configured', () => {
     action: 'run',
     prompt: 'sync connector packages',
   });
+});
+
+it('rejects whitespace-only preprocess_script values at execution time', () => {
+  expect(
+    runTaskPreprocessor(task({ preprocess_script: '   ' }), { workflowsDir }),
+  ).toEqual({
+    action: 'error',
+    error: 'preprocess_script must be a non-empty path',
+  });
+});
+
+it('resolves the default group task-workflows directory when no override is provided', () => {
+  const groupFolder = `preprocessor-test-${process.pid}`;
+  const groupWorkflowsDir = path.join(
+    GROUPS_DIR,
+    groupFolder,
+    TASK_WORKFLOWS_DIR,
+  );
+  fs.mkdirSync(groupWorkflowsDir, { recursive: true });
+  fs.writeFileSync(
+    path.join(groupWorkflowsDir, 'workflow.ts'),
+    'console.log(JSON.stringify({ action: "skip", reason: "default dir" }));',
+  );
+
+  try {
+    expect(runTaskPreprocessor(task({ group_folder: groupFolder }))).toEqual({
+      action: 'skip',
+      reason: 'default dir',
+    });
+  } finally {
+    fs.rmSync(path.join(GROUPS_DIR, groupFolder), {
+      recursive: true,
+      force: true,
+    });
+  }
 });

--- a/src/task-preprocessor.test.ts
+++ b/src/task-preprocessor.test.ts
@@ -323,11 +323,9 @@ it('rejects whitespace-only preprocess_script values at execution time', () => {
 
 it('resolves the default group task-workflows directory when no override is provided', () => {
   const groupFolder = `preprocessor-test-${process.pid}`;
-  const groupWorkflowsDir = path.join(
-    GROUPS_DIR,
-    groupFolder,
-    TASK_WORKFLOWS_DIR,
-  );
+  const groupWorkflowsDir = path.isAbsolute(TASK_WORKFLOWS_DIR)
+    ? TASK_WORKFLOWS_DIR
+    : path.join(GROUPS_DIR, groupFolder, TASK_WORKFLOWS_DIR);
   fs.mkdirSync(groupWorkflowsDir, { recursive: true });
   fs.writeFileSync(
     path.join(groupWorkflowsDir, 'workflow.ts'),
@@ -340,9 +338,14 @@ it('resolves the default group task-workflows directory when no override is prov
       reason: 'default dir',
     });
   } finally {
-    fs.rmSync(path.join(GROUPS_DIR, groupFolder), {
-      recursive: true,
-      force: true,
-    });
+    fs.rmSync(
+      path.isAbsolute(TASK_WORKFLOWS_DIR)
+        ? groupWorkflowsDir
+        : path.join(GROUPS_DIR, groupFolder),
+      {
+        recursive: true,
+        force: true,
+      },
+    );
   }
 });


### PR DESCRIPTION
## Summary

Adds deterministic task preprocessor coverage for workflow path resolution edge cases:

- rejects whitespace-only `preprocess_script` values through `runTaskPreprocessor`
- exercises default `groups/<folder>/task-workflows` resolution when no `workflowsDir` override is provided

## Test Count

Before:

- `bun test`: 2,382 pass, 0 fail, 6,362 assertions across 104 files
- `bun test --coverage`: 2,382 pass, 0 fail; all-files coverage 92.08% functions / 91.31% lines

After:

- `bun test`: 2,384 pass, 0 fail, 6,364 assertions across 104 files
- `bun test --coverage`: 2,384 pass, 0 fail; all-files coverage 92.18% functions / 91.34% lines

## Files Covered

- `src/task-preprocessor.test.ts`
- `src/task-preprocessor.ts`: improved to 100.00% functions / 99.20% lines

## Verification

- `bun test src/task-preprocessor.test.ts`
- `bun test`
- `bun test --coverage`

## Remaining Coverage Gaps

- `src/channels/discord.ts`, `src/channels/telegram.ts`, and `src/channels/whatsapp.ts` remain low-coverage integration-heavy adapters.
- `src/backends/local-backend.ts` still has large untested runtime/container orchestration branches.
- `src/index.ts` remains mostly uncovered because it combines startup orchestration, message routing, and side-effectful channel/runtime wiring.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added test coverage for preprocessor validation (rejection of empty values) and default workflow directory resolution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->