### PR TITLE
docs(roadmap): bump Slack channel maturity to Stable (#853)

### DIFF
--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -21,11 +21,11 @@ Last updated: 2026-06-21
 
 ### Channels
 
-| Channel  | Adapter     | Maturity | Notes                                       |
-| -------- | ----------- | -------- | ------------------------------------------- |
-| WhatsApp | baileys     | Stable   | Original channel, reconnect handling, auth  |
-| Discord  | discord.js  | Stable   | Mentions, threads, reactions, slash flows   |
-| Telegram | grammY      | Stable   | Multi-bot support, no trigger prefix needed |
+| Channel  | Adapter     | Maturity | Notes                                                                           |
+| -------- | ----------- | -------- | ------------------------------------------------------------------------------- |
+| WhatsApp | baileys     | Stable   | Original channel, reconnect handling, auth                                      |
+| Discord  | discord.js  | Stable   | Mentions, threads, reactions, slash flows                                       |
+| Telegram | grammY      | Stable   | Multi-bot support, no trigger prefix needed                                     |
 | Slack    | @slack/bolt | Stable   | AI-app modernization, native streamed responses, multi-bot routing, Socket Mode |
 
 ### Backends

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -1,6 +1,6 @@
 # OmniClaw Roadmap
 
-Last updated: 2026-06-13
+Last updated: 2026-06-21
 
 > **Maintenance:** run `bash scripts/check-roadmap-refs.sh` after editing to catch
 > Planned Work entries that point at closed/merged issues without an explicit
@@ -26,7 +26,7 @@ Last updated: 2026-06-13
 | WhatsApp | baileys     | Stable   | Original channel, reconnect handling, auth  |
 | Discord  | discord.js  | Stable   | Mentions, threads, reactions, slash flows   |
 | Telegram | grammY      | Stable   | Multi-bot support, no trigger prefix needed |
-| Slack    | @slack/bolt | Early    | Multi-bot routing, Socket Mode              |
+| Slack    | @slack/bolt | Stable   | AI-app modernization, native streamed responses, multi-bot routing, Socket Mode |
 
 ### Backends
 


### PR DESCRIPTION
## Summary

Closes #853 — one-line documentation fix that has been parked 6 days.

- Bump Slack channel maturity from `Early` → `Stable` in `docs/ROADMAP.md` line 29
- Refresh `Last updated:` from `2026-06-13` → `2026-06-21` (ROADMAP was 8d stale)

## Why

The Slack AI-app modernization cluster shipped in June (#829, #836, plus the streaming/threading fixes in #850). `Completed Recently` already reflects that work (line 224 onward), but the capability table at line 29 still classified Slack as `Early`. This is the classification that newcomers and #759 (Slack slash commands) planning are reading.

## Notes on the cell text

Reused the same `Stable` notes pattern as adjacent rows — short clause summarizing what's shipped. Kept "Multi-bot routing, Socket Mode" since those are still load-bearing capability descriptors.

## Verification

- `bash scripts/check-roadmap-refs.sh` → `ROADMAP.md Planned Work references look clean.`
- No other references to the `Early` tier for Slack — grepped `docs/ROADMAP.md` for "Slack" and confirmed only the capability table row used the maturity label.

## Test plan

- [x] ROADMAP refs guard script passes
- [x] Diff is contained to two lines in `docs/ROADMAP.md`

Refs #759 (Slack slash commands, gated on this classification).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated roadmap to reflect Slack channel maturity status change to Stable and expanded feature details.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->