### PR TITLE
feat(web): annotate /agents local count with disabled rollup

### DIFF
--- a/src/web/agents-page.test.ts
+++ b/src/web/agents-page.test.ts
@@ -339,6 +339,75 @@ describe('renderAgentsContent', () => {
     expect(html).toContain('>flags<');
     expect(html).toContain('>actions<');
   });
+
+  it('annotates local count with disabled rollup when an agent is disabled', () => {
+    const agents = {
+      'agent-1': makeAgent(),
+      'agent-2': makeAgent({
+        id: 'agent-2',
+        name: 'Agent 2',
+        folder: 'agent-2',
+        enabled: false,
+      }),
+      'agent-3': makeAgent({
+        id: 'agent-3',
+        name: 'Agent 3',
+        folder: 'agent-3',
+        enabled: false,
+      }),
+    };
+
+    const html = renderAgentsContent(makeState(agents));
+
+    expect(html).toContain('3 local (2 disabled)');
+    expect(html).toContain('3 total');
+  });
+
+  it('omits the disabled rollup when no local agent is disabled', () => {
+    const agents = {
+      'agent-1': makeAgent(),
+      'agent-2': makeAgent({
+        id: 'agent-2',
+        name: 'Agent 2',
+        folder: 'agent-2',
+      }),
+    };
+
+    const html = renderAgentsContent(makeState(agents));
+
+    expect(html).toContain('2 local</span>');
+    expect(html).not.toContain('disabled)');
+  });
+
+  it('excludes remote agents from the disabled rollup even when their enabled flag is false', () => {
+    const agents = {
+      'agent-1': makeAgent({ enabled: false }),
+    };
+    const remotePeers = [
+      {
+        instanceId: 'peer-1',
+        instanceName: 'remote-mac',
+        online: true,
+        host: '192.168.1.10',
+        port: 4444,
+        agents: [
+          {
+            id: 'remote-agent',
+            name: 'Remote',
+            folder: 'remote',
+            backend: 'docker' as const,
+            agentRuntime: 'opencode' as const,
+            channels: [],
+          },
+        ],
+      },
+    ];
+
+    const html = renderAgentsContent(makeState(agents), remotePeers);
+
+    expect(html).toContain('1 local (1 disabled)');
+    expect(html).toContain('1 remote');
+  });
 });
 
 describe('renderAgentsPage', () => {

--- a/src/web/agents-page.ts
+++ b/src/web/agents-page.ts
@@ -400,6 +400,25 @@ export function renderAgentsContent(
 
   const localCount = agentData.filter((a) => !a.remoteInstanceId).length;
   const remoteCount = agentData.filter((a) => a.remoteInstanceId).length;
+  // Count operator-disabled local agents. Disabled is a silent state — the
+  // agent won't dispatch messages or run scheduled tasks, but inbound messages
+  // are still persisted, so it's easy for an operator to miss when scanning
+  // the per-row status badge column. Surfacing the rollup inline on the
+  // `local` count answers "is part of my fleet intentionally dark?" without
+  // scanning the table. Remote agents are excluded because their enabled state
+  // lives on the owning host. Matches the disabled-status derivation in
+  // {@link buildAgentRowsHtml}.
+  const localAgentsMap = state.getAgents();
+  const disabledLocalCount = agentData.reduce(
+    (sum, a) =>
+      sum +
+      (!a.remoteInstanceId && localAgentsMap[a.id]?.enabled === false ? 1 : 0),
+    0,
+  );
+  const localValue =
+    disabledLocalCount > 0
+      ? `${localCount} local (${disabledLocalCount} disabled)`
+      : `${localCount} local`;
 
   const backendOptions = backends
     .map((b) => `<option value="${escapeHtml(b)}">${escapeHtml(b)}</option>`)
@@ -420,7 +439,7 @@ export function renderAgentsContent(
     `<h2>Agents</h2>` +
     `<div class="ap-counts">` +
     `<span class="ap-count">${agentData.length} total</span>` +
-    `<span class="ap-count">${localCount} local</span>` +
+    `<span class="ap-count">${localValue}</span>` +
     (remoteCount > 0
       ? `<span class="ap-count">${remoteCount} remote</span>`
       : '') +


### PR DESCRIPTION
## Summary

Annotates the `/agents` page `local` counter with `(N disabled)` when at least one local agent has been operator-disabled, so the silent dark state is visible at a glance instead of requiring a per-row badge scan.

Mirrors the observability rollup pattern already used by the dashboard agents card (#884 — `(N working)`), the `/network` trusted card (#880 — `(N offline)`), and the `/ipc` retrying card (`X (Y)`).

- `5 local` — no local agents disabled (unchanged)
- `5 local (2 disabled)` — two of five local agents are operator-disabled

Disabled agents still persist inbound messages but skip dispatch and scheduled task execution, so a misconfigured fleet looks healthy from the dashboard until messages start backing up. The per-row badge surfaces the state for a single agent; the rollup answers the cross-fleet "is part of my fleet intentionally dark?" question.

## Why now

This is the same operator-observability pattern that's been landing across the dashboard, `/network`, and `/ipc` (#860 in flight) — every silent state that requires drilling into a per-row badge to compute the fleet rollup gets surfaced inline. Disabled was the remaining silent state on `/agents` without an aggregate.

## Changes

- `src/web/agents-page.ts` — pull `state.getAgents()`, count local agents whose `enabled === false` (same predicate `buildAgentRowsHtml` uses for the per-row badge so the rollup and badges share one source of truth), render `${localCount} local (${disabledLocal} disabled)` when `disabledLocal > 0`, otherwise the bare count as before. Remote agents are excluded because their `enabled` state lives on the owning host.
- `src/web/agents-page.test.ts` — three new cases: annotation present with multiple disabled agents, annotation omitted when none are disabled, and remote agents excluded from the rollup even when a same-folder local agent is disabled.

Pure render-layer change. No new data plumbing, no `WebStateProvider` changes, no SSE event changes. Reuses `state.getAgents()` which `buildAgentRowsHtml` already calls.

## Test plan

- [x] `bun test src/web/agents-page.test.ts` — 117 pass (3 new)
- [x] `bun test src/web/` — 804 pass, 0 fail
- [x] `bun test` — 2385 pass, 0 fail
- [x] `bun run typecheck` — clean
- [x] `bunx prettier --check src/web/agents-page.ts src/web/agents-page.test.ts` — clean

Relates to #644 (operator observability rollup tracker), follows the pattern set by #884, #880, and the in-flight #860 / #875.

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Local agents count now displays disabled agents separately in the header (e.g., "X local (Y disabled)"), helping you quickly identify how many local agents are currently disabled.

* **Tests**
  * Added validation tests for disabled agent rollup display in local agent counts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->