### PR TITLE
test(discovery): cover network identity failure fallbacks

### DIFF
--- a/src/discovery/network-identity.test.ts
+++ b/src/discovery/network-identity.test.ts
@@ -262,7 +262,12 @@ describe('network identity detection', () => {
       ),
     ).toBe(true);
     expect(spawnSpy).toHaveBeenCalledWith(
-      ['/usr/sbin/system_profiler', 'SPAirPortDataType', '-detailLevel', 'mini'],
+      [
+        '/usr/sbin/system_profiler',
+        'SPAirPortDataType',
+        '-detailLevel',
+        'mini',
+      ],
       expect.any(Object),
     );
     expect(spawnSpy).toHaveBeenCalledWith(
@@ -280,18 +285,20 @@ describe('network identity detection', () => {
     const hangingProcess = createHangingProcess();
     const originalSetTimeout = globalThis.setTimeout;
     let timeoutCalls = 0;
-    timeoutSpy = spyOn(globalThis, 'setTimeout').mockImplementation(
-      ((handler: TimerHandler, timeout?: number, ...args: unknown[]) => {
-        timeoutCalls += 1;
-        if (timeoutCalls === 1) {
-          queueMicrotask(() => {
-            if (typeof handler === 'function') handler(...args);
-          });
-          return 0 as unknown as ReturnType<typeof setTimeout>;
-        }
-        return originalSetTimeout(handler, timeout, ...args);
-      }) as typeof setTimeout,
-    );
+    timeoutSpy = spyOn(globalThis, 'setTimeout').mockImplementation(((
+      handler: TimerHandler,
+      timeout?: number,
+      ...args: unknown[]
+    ) => {
+      timeoutCalls += 1;
+      if (timeoutCalls === 1) {
+        queueMicrotask(() => {
+          if (typeof handler === 'function') handler(...args);
+        });
+        return 0 as unknown as ReturnType<typeof setTimeout>;
+      }
+      return originalSetTimeout(handler, timeout, ...args);
+    }) as typeof setTimeout);
     spawnSpy = spyOn(Bun, 'spawn').mockImplementation(((cmd: string[]) => {
       if (cmd[0] === 'iwgetid') {
         return hangingProcess;

--- a/src/discovery/network-identity.test.ts
+++ b/src/discovery/network-identity.test.ts
@@ -19,6 +19,7 @@ const encoder = new TextEncoder();
 describe('network identity detection', () => {
   const originalPlatform = process.platform;
   let spawnSpy: any = null;
+  let timeoutSpy: any = null;
   let warnSpy: any = null;
 
   beforeEach(() => {
@@ -34,8 +35,10 @@ describe('network identity detection', () => {
       configurable: true,
     });
     spawnSpy?.mockRestore();
+    timeoutSpy?.mockRestore();
     warnSpy?.mockRestore();
     spawnSpy = null;
+    timeoutSpy = null;
     warnSpy = null;
   });
 
@@ -231,6 +234,85 @@ describe('network identity detection', () => {
     ).toBe(true);
   });
 
+  it('logs generic spawn errors and continues through macOS fallbacks', async () => {
+    spawnSpy = spyOn(Bun, 'spawn').mockImplementation(((cmd: string[]) => {
+      if (cmd.includes('-listallhardwareports')) {
+        throw new Error('spawn failed before process creation');
+      }
+
+      if (cmd[0] === '/usr/sbin/system_profiler') {
+        return createProcess({ stdout: '' });
+      }
+
+      if (cmd[0] === '/usr/bin/wdutil') {
+        return createProcess({ stdout: '' });
+      }
+
+      throw new Error(`Unexpected command: ${cmd.join(' ')}`);
+    }) as typeof Bun.spawn);
+
+    warnSpy = spyOn(logger, 'warn');
+
+    const result = await detectCurrentNetwork();
+
+    expect(result).toBeNull();
+    expect(
+      warnSpy.mock.calls.some((call: unknown[]) =>
+        String(call[1]).includes('Network identity command failed'),
+      ),
+    ).toBe(true);
+    expect(spawnSpy).toHaveBeenCalledWith(
+      ['/usr/sbin/system_profiler', 'SPAirPortDataType', '-detailLevel', 'mini'],
+      expect.any(Object),
+    );
+    expect(spawnSpy).toHaveBeenCalledWith(
+      ['/usr/bin/wdutil', 'info'],
+      expect.any(Object),
+    );
+  });
+
+  it('kills timed-out linux probes and continues to the next detector', async () => {
+    Object.defineProperty(process, 'platform', {
+      value: 'linux',
+      configurable: true,
+    });
+
+    const hangingProcess = createHangingProcess();
+    const originalSetTimeout = globalThis.setTimeout;
+    let timeoutCalls = 0;
+    timeoutSpy = spyOn(globalThis, 'setTimeout').mockImplementation(
+      ((handler: TimerHandler, timeout?: number, ...args: unknown[]) => {
+        timeoutCalls += 1;
+        if (timeoutCalls === 1) {
+          queueMicrotask(() => {
+            if (typeof handler === 'function') handler(...args);
+          });
+          return 0 as unknown as ReturnType<typeof setTimeout>;
+        }
+        return originalSetTimeout(handler, timeout, ...args);
+      }) as typeof setTimeout,
+    );
+    spawnSpy = spyOn(Bun, 'spawn').mockImplementation(((cmd: string[]) => {
+      if (cmd[0] === 'iwgetid') {
+        return hangingProcess;
+      }
+
+      if (cmd[0] === 'nmcli') {
+        return createProcess({ stdout: 'yes:Fallback Linux\n' });
+      }
+
+      throw new Error(`Unexpected command: ${cmd.join(' ')}`);
+    }) as typeof Bun.spawn);
+
+    const result = await detectCurrentNetwork();
+
+    expect(result).toEqual({
+      id: 'wifi:Fallback Linux',
+      label: 'Fallback Linux',
+    });
+    expect(hangingProcess.kill).toHaveBeenCalledTimes(1);
+  });
+
   it('retries networksetup via PATH when the absolute macOS binary is unavailable', async () => {
     spawnSpy = spyOn(Bun, 'spawn').mockImplementation(((cmd: string[]) => {
       if (cmd[0] === '/usr/sbin/networksetup') {
@@ -339,6 +421,15 @@ function createProcess({
     stdout: createStream(stdout),
     stderr: createStream(stderr),
     exited: Promise.resolve(exitCode),
+    kill: mock(() => {}),
+  } as unknown as ReturnType<typeof Bun.spawn>;
+}
+
+function createHangingProcess() {
+  return {
+    stdout: new ReadableStream<Uint8Array>(),
+    stderr: new ReadableStream<Uint8Array>(),
+    exited: new Promise<number>(() => {}),
     kill: mock(() => {}),
   } as unknown as ReturnType<typeof Bun.spawn>;
 }

--- a/src/discovery/network-identity.test.ts
+++ b/src/discovery/network-identity.test.ts
@@ -286,7 +286,7 @@ describe('network identity detection', () => {
     const originalSetTimeout = globalThis.setTimeout;
     let timeoutCalls = 0;
     timeoutSpy = spyOn(globalThis, 'setTimeout').mockImplementation(((
-      handler: TimerHandler,
+      handler: Parameters<typeof setTimeout>[0],
       timeout?: number,
       ...args: unknown[]
     ) => {


### PR DESCRIPTION
## Summary

- Add deterministic network identity tests for generic spawn failures and command timeouts.
- Verify macOS detection continues through `system_profiler` and `wdutil` after a pre-process spawn failure.
- Verify Linux detection kills a hung `iwgetid` probe and falls back to `nmcli`.

## Test Count / Coverage

- Before: `bun test` = 2,385 pass, 0 fail, 6,370 expect calls across 104 files.
- After: `bun test` = 2,387 pass, 0 fail, 6,374 expect calls across 104 files.
- Before coverage: 91.32% lines overall; `src/discovery/network-identity.ts` 91.28% lines / 95.00% funcs.
- After coverage: 91.38% lines overall; `src/discovery/network-identity.ts` 97.44% lines / 100.00% funcs.

## Verification

- `bun test src/discovery/network-identity.test.ts`
- `bun test`
- `bun test --coverage`

## Remaining Gaps

- Large integration-heavy modules remain low coverage: channel adapters, `src/index.ts`, local backend, DB paths, and discovery routes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Expanded test coverage for network detection failure scenarios and timeout handling across macOS and Linux platforms.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->