### PR TITLE
fix(security): harden text and Slack file downloads

### DIFF
--- a/src/channels/discord.ts
+++ b/src/channels/discord.ts
@@ -1162,7 +1162,9 @@ export class DiscordChannel implements Channel {
             (a.size ?? Infinity) <= MAX_TEXT_DOWNLOAD_BYTES
           ) {
             try {
-              const text = await downloadTextAttachment(a.url);
+              const text = await downloadTextAttachment(a.url, {
+                validateRemoteUrl: true,
+              });
               parts.push(formatTextFileMarker(safeName, text));
             } catch (err) {
               logger.error(

--- a/src/channels/slack.test.ts
+++ b/src/channels/slack.test.ts
@@ -762,6 +762,43 @@ describe('SlackChannel.downloadSlackFile', () => {
         'https://files.slack.com/files-pri/T123/download/photo.png',
       );
       expect(callArgs[1].headers.Authorization).toBe(`Bearer ${token}`);
+      expect(callArgs[1].redirect).toBe('manual');
+    } finally {
+      globalThis.fetch = originalFetch;
+    }
+  });
+
+  it('does not follow redirects with the bot token', async () => {
+    const channel = new SlackChannel({
+      botId: 'TEST',
+      token: 'xoxb-test',
+      appToken: 'xapp-test',
+      onMessage: () => {},
+      onChatMetadata: () => {},
+      registeredGroups: () => ({}),
+    });
+
+    const originalFetch = globalThis.fetch;
+    const mockFetch = mock(() =>
+      Promise.resolve(
+        new Response(null, {
+          status: 302,
+          headers: { Location: 'https://evil.test/file' },
+        }),
+      ),
+    );
+    globalThis.fetch = mockFetch as any;
+
+    try {
+      await expect(
+        (channel as any).downloadSlackFile('https://files.slack.com/x', 1024),
+      ).rejects.toThrow('302');
+      expect(mockFetch).toHaveBeenCalledTimes(1);
+      const callArgs = mockFetch.mock.calls[0] as unknown as [
+        string,
+        RequestInit,
+      ];
+      expect(callArgs[1].redirect).toBe('manual');
     } finally {
       globalThis.fetch = originalFetch;
     }

--- a/src/channels/slack.test.ts
+++ b/src/channels/slack.test.ts
@@ -790,6 +790,54 @@ describe('SlackChannel.downloadSlackFile', () => {
       globalThis.fetch = originalFetch;
     }
   });
+
+  it('rejects non-Slack hosts before sending the bot token', async () => {
+    const channel = new SlackChannel({
+      botId: 'TEST',
+      token: 'xoxb-test',
+      appToken: 'xapp-test',
+      onMessage: () => {},
+      onChatMetadata: () => {},
+      registeredGroups: () => ({}),
+    });
+
+    const originalFetch = globalThis.fetch;
+    const mockFetch = mock(() => Promise.resolve(new Response(null)));
+    globalThis.fetch = mockFetch as any;
+
+    try {
+      await expect(
+        (channel as any).downloadSlackFile('https://evil.test/file', 1024),
+      ).rejects.toThrow('Rejected non-Slack file URL');
+      expect(mockFetch).not.toHaveBeenCalled();
+    } finally {
+      globalThis.fetch = originalFetch;
+    }
+  });
+
+  it('rejects non-HTTPS Slack file URLs before fetch', async () => {
+    const channel = new SlackChannel({
+      botId: 'TEST',
+      token: 'xoxb-test',
+      appToken: 'xapp-test',
+      onMessage: () => {},
+      onChatMetadata: () => {},
+      registeredGroups: () => ({}),
+    });
+
+    const originalFetch = globalThis.fetch;
+    const mockFetch = mock(() => Promise.resolve(new Response(null)));
+    globalThis.fetch = mockFetch as any;
+
+    try {
+      await expect(
+        (channel as any).downloadSlackFile('http://files.slack.com/file', 1024),
+      ).rejects.toThrow('Rejected non-Slack file URL');
+      expect(mockFetch).not.toHaveBeenCalled();
+    } finally {
+      globalThis.fetch = originalFetch;
+    }
+  });
 });
 
 describe('SlackChannel.processFileAttachments', () => {

--- a/src/channels/slack.ts
+++ b/src/channels/slack.ts
@@ -57,6 +57,8 @@ const TASK_TITLE_MAX_CHARS = 80;
 // so progress updates always render instead of being silently rejected.
 const TASK_DETAILS_MAX_CHARS = 160;
 
+const SLACK_FILE_HOSTS = new Set(['files.slack.com']);
+
 // Rotating status shown under the assistant thread while the agent works.
 const STATUS_LOADING_MESSAGES = [
   'Thinking it through…',
@@ -76,6 +78,19 @@ function splitMarkdown(text: string): string[] {
 /** Split text at Slack's plain-text message limit (hard split, no break preference). */
 function splitMessage(text: string, maxLen = TEXT_LIMIT): string[] {
   return splitMessageShared(text, maxLen, false);
+}
+
+function assertSlackFileUrl(url: string): void {
+  let parsed: URL;
+  try {
+    parsed = new URL(url);
+  } catch {
+    throw new Error('Invalid Slack file URL');
+  }
+
+  if (parsed.protocol !== 'https:' || !SLACK_FILE_HOSTS.has(parsed.hostname)) {
+    throw new Error(`Rejected non-Slack file URL: ${parsed.hostname || url}`);
+  }
 }
 
 /** A `markdown` block renders standard markdown (GFM) instead of legacy mrkdwn. */
@@ -1046,6 +1061,8 @@ export class SlackChannel implements Channel {
     url: string,
     maxBytes: number,
   ): Promise<Buffer> {
+    assertSlackFileUrl(url);
+
     const response = await fetch(url, {
       headers: { Authorization: `Bearer ${this.opts.token}` },
       signal: AbortSignal.timeout(15_000),

--- a/src/channels/slack.ts
+++ b/src/channels/slack.ts
@@ -1065,6 +1065,7 @@ export class SlackChannel implements Channel {
 
     const response = await fetch(url, {
       headers: { Authorization: `Bearer ${this.opts.token}` },
+      redirect: 'manual',
       signal: AbortSignal.timeout(15_000),
     });
     if (!response.ok) {

--- a/src/media.test.ts
+++ b/src/media.test.ts
@@ -272,11 +272,14 @@ describe('downloadTextAttachment', () => {
         Promise.resolve(new Response(createStream(['pinned-text']))),
     );
 
-    const text = await downloadTextAttachment('https://cdn.example.test/a.txt', {
-      validateRemoteUrl: true,
-      lookupHostAddresses: async () => ['203.0.113.10'],
-      fetchWithPinnedDnsImpl: pinnedFetch,
-    });
+    const text = await downloadTextAttachment(
+      'https://cdn.example.test/a.txt',
+      {
+        validateRemoteUrl: true,
+        lookupHostAddresses: async () => ['203.0.113.10'],
+        fetchWithPinnedDnsImpl: pinnedFetch,
+      },
+    );
 
     expect(text).toBe('pinned-text');
     expect(pinnedFetch).toHaveBeenCalledWith(

--- a/src/media.test.ts
+++ b/src/media.test.ts
@@ -244,6 +244,48 @@ describe('downloadTextAttachment', () => {
       downloadTextAttachment('https://example.test/file.txt'),
     ).rejects.toThrow(`Download exceeded ${MAX_TEXT_DOWNLOAD_BYTES} bytes`);
   });
+
+  it('rejects validated remote URLs that resolve to private addresses', async () => {
+    const fetchMock = mock(() =>
+      Promise.resolve(new Response(createStream(['should-not-fetch']))),
+    ) as unknown as typeof globalThis.fetch;
+    globalThis.fetch = fetchMock;
+
+    await expect(
+      downloadTextAttachment('https://example.test/private.txt', {
+        validateRemoteUrl: true,
+        lookupHostAddresses: async () => ['127.0.0.1'],
+      }),
+    ).rejects.toThrow(
+      'Remote attachment URL rejected: resolved private address is not allowed',
+    );
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it('pins DNS when downloading validated hostname URLs', async () => {
+    const fetchMock = mock(() =>
+      Promise.resolve(new Response(createStream(['should-not-fetch']))),
+    ) as unknown as typeof globalThis.fetch;
+    globalThis.fetch = fetchMock;
+    const pinnedFetch = mock(
+      (_url: string, _address: string, _timeoutMs: number) =>
+        Promise.resolve(new Response(createStream(['pinned-text']))),
+    );
+
+    const text = await downloadTextAttachment('https://cdn.example.test/a.txt', {
+      validateRemoteUrl: true,
+      lookupHostAddresses: async () => ['203.0.113.10'],
+      fetchWithPinnedDnsImpl: pinnedFetch,
+    });
+
+    expect(text).toBe('pinned-text');
+    expect(pinnedFetch).toHaveBeenCalledWith(
+      'https://cdn.example.test/a.txt',
+      '203.0.113.10',
+      15_000,
+    );
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
 });
 
 // ---------------------------------------------------------------------------

--- a/src/media.ts
+++ b/src/media.ts
@@ -195,9 +195,9 @@ export async function downloadBinaryAttachment(
  */
 export async function downloadTextAttachment(
   url: string,
-  options?: { maxBytes?: number; timeoutMs?: number },
+  options?: AttachmentDownloadOptions,
 ): Promise<string> {
-  const response = await fetchWithTimeout(url, options);
+  const response = await fetchAttachment(url, options);
   if (!response.ok) {
     throw new Error(`Download failed with status ${response.status}`);
   }


### PR DESCRIPTION
## Summary

Fixes #894.

- routes text attachment downloads through the shared hardened attachment fetch path
- enables SSRF-safe URL validation for Discord text attachments
- rejects Slack file URLs unless they are HTTPS `files.slack.com` URLs before attaching the bot token
- adds regression coverage for text SSRF rejection, DNS-pinned text fetches, and Slack pre-fetch host rejection

## Security Impact

This closes the gap where text downloads could bypass the DNS validation and pinning available to binary attachment downloads. It also prevents Slack file downloads from sending `Authorization: Bearer <bot token>` to non-Slack hosts supplied in event file metadata.

## Areas Reviewed

- `src/media.ts` shared attachment download helpers
- `src/channels/discord.ts` text attachment ingestion
- `src/channels/slack.ts` token-bearing file downloads
- existing open security issues and PRs to avoid duplicating work

## Validation

- `bun test src/media.test.ts src/channels/slack.test.ts src/channels/discord.test.ts`
- `bun run tsc --noEmit`
- `bun test`

## Reviewer Request

Agent reviewer: please leave feedback directly on this GitHub PR, preferably as file/line comments where applicable.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Enhanced security for attachment downloads by validating URLs before transfer
  * Restricted Slack file downloads to approved sources only
  * Added remote URL security validation to prevent downloading from unauthorized sources

<!-- end of auto-generated comment: release notes by coderabbit.ai -->