### PR TITLE
feat(web): annotate /agents/:id scheduled tasks count with paused rollup

### DIFF
--- a/src/web/agent-detail.test.ts
+++ b/src/web/agent-detail.test.ts
@@ -6,6 +6,7 @@ import type { Agent, ChannelSubscription, ScheduledTask } from '../types.js';
 import type { RemotePeerAgents } from '../discovery/types.js';
 import {
   buildAgentDetailData,
+  formatScheduledTasksCount,
   formatTaskLastRun,
   lastRunOutcomeClass,
   renderAgentDetailContent,
@@ -266,6 +267,32 @@ describe('formatTaskLastRun', () => {
   });
 });
 
+describe('formatScheduledTasksCount', () => {
+  it('returns bare total when no task is paused', () => {
+    expect(
+      formatScheduledTasksCount([
+        { status: 'active' },
+        { status: 'active' },
+        { status: 'completed' },
+      ]),
+    ).toBe('3');
+  });
+
+  it('appends paused rollup when at least one task is paused', () => {
+    expect(
+      formatScheduledTasksCount([
+        { status: 'active' },
+        { status: 'paused' },
+        { status: 'paused' },
+      ]),
+    ).toBe('3 (2 paused)');
+  });
+
+  it('returns "0" for an empty task list without a parenthetical', () => {
+    expect(formatScheduledTasksCount([])).toBe('0');
+  });
+});
+
 describe('lastRunOutcomeClass', () => {
   it('maps the done outcome state to run-success regardless of last_result', () => {
     // Schedulers write summary strings like "Completed" / "Run 1 done" /
@@ -357,6 +384,27 @@ describe('renderAgentDetailContent', () => {
     expect(html).toContain('Run the daily check');
     expect(html).toContain('status-active');
     expect(html).toContain('cron');
+  });
+
+  it('annotates the scheduled tasks count with a paused rollup when a task is paused', () => {
+    const state = makeState({
+      getTasks: () => [
+        makeTask({ id: 'task-001', status: 'active' }),
+        makeTask({ id: 'task-002', status: 'paused' }),
+      ],
+    });
+    const data = buildAgentDetailData('test-agent', state)!;
+    const html = renderAgentDetailContent(data, 'test-agent');
+    expect(html).toContain(
+      'scheduled tasks <span class="ad-count">2 (1 paused)</span>',
+    );
+  });
+
+  it('omits the paused rollup when no task is paused', () => {
+    const data = buildAgentDetailData('test-agent', makeState())!;
+    const html = renderAgentDetailContent(data, 'test-agent');
+    expect(html).toContain('scheduled tasks <span class="ad-count">1</span>');
+    expect(html).not.toContain('paused)');
   });
 
   it('renders last-run column with em-dash when task has never run', () => {

--- a/src/web/agent-detail.ts
+++ b/src/web/agent-detail.ts
@@ -63,6 +63,28 @@ export function lastRunOutcomeClass(
   return '';
 }
 
+/**
+ * Format the count shown next to the `scheduled tasks` section header,
+ * appending an inline `(N paused)` rollup when at least one of the agent's
+ * tasks is paused. Mirrors the operator observability pattern used by
+ * `/agents` local-count disabled rollup (#892), the dashboard agents working
+ * rollup (#884), and the `/network` trusted-offline rollup (#880): the bare
+ * total stays prominent, the rollup answers the cross-task "is part of this
+ * agent's task list intentionally off?" question without scanning every row.
+ *
+ * Completed tasks are excluded — paused vs active is the operator-visible
+ * decision; a completed one-shot is not "off", it's finished. Empty/all-active
+ * lists render bare so the header stays terse.
+ */
+export function formatScheduledTasksCount(
+  tasks: ReadonlyArray<{ status: string }>,
+): string {
+  const total = tasks.length;
+  let paused = 0;
+  for (const t of tasks) if (t.status === 'paused') paused++;
+  return paused > 0 ? `${total} (${paused} paused)` : `${total}`;
+}
+
 export interface AgentDetailData {
   id: string;
   name: string;
@@ -434,7 +456,7 @@ export function renderAgentDetailContent(
     `</table></div></div>` +
     // Tasks section
     `<div class="ad-section">` +
-    `<h3 class="ad-section-title">scheduled tasks <span class="ad-count">${data.tasks.length}</span></h3>` +
+    `<h3 class="ad-section-title">scheduled tasks <span class="ad-count">${formatScheduledTasksCount(data.tasks)}</span></h3>` +
     `<div class="ad-table-wrap"><table>` +
     `<thead><tr><th>status</th><th>prompt</th><th>schedule</th><th>next run</th><th>last run</th>${isLocal ? '<th></th>' : ''}</tr></thead>` +
     `<tbody>${tasksHtml}</tbody>` +


### PR DESCRIPTION
## Summary

Annotates the `/agents/:id` scheduled-tasks section header with an inline `(N paused)` rollup when at least one of the agent's tasks is paused, so the operator can spot a partially-disabled task list at a glance — without scanning every row's status badge.

Follows the same `N (M qualifier)` convention as the recent operator-observability rollups:

- `5` — all of the agent's tasks are active/completed (unchanged)
- `5 (2 paused)` — two of five tasks are paused

This mirrors:

- `/agents` local-count disabled rollup (#892)
- Dashboard agents card working rollup (#884)
- `/network` trusted-offline rollup (#880)
- `/ipc` retrying rollup

## Why

Paused tasks are a silent state. The per-row `status-paused` badge identifies a single task, but a multi-task agent can quietly have half its schedule off without the section header reflecting it. The new rollup answers the cross-task "is part of this agent's task list intentionally off?" question — the same shape PR #892 surfaced at the fleet level on `/agents`.

Completed tasks are excluded — paused vs active is the operator-visible decision; a finished one-shot is not "off", it's done. Empty and all-active lists render bare so the header stays terse for the common case.

Pure render-layer change. The new `formatScheduledTasksCount` helper reads the existing `tasks[]` already pulled by `buildAgentDetailData` for the row rendering, so the rollup and per-row badges share one source of truth. No `WebStateProvider`, schema, or SSE event changes.

## Changes

- `src/web/agent-detail.ts` — export `formatScheduledTasksCount(tasks)` returning either `"${total}"` or `"${total} (${paused} paused)"`; swap the inline `${data.tasks.length}` interpolation in the scheduled-tasks section header for the helper.
- `src/web/agent-detail.test.ts` — three unit tests on the helper (bare total, paused rollup, empty list) plus two render-level tests (annotation present with paused task, omitted with all-active).

## Test plan

- [x] `bun test src/web/agent-detail.test.ts` — 74 pass (5 new)
- [x] `bun test src/web/` — 809 pass
- [x] `bun test` — 2392 pass, 0 fail
- [x] `bun run typecheck` — clean
- [x] `bunx prettier --check src/web/agent-detail.{ts,test.ts}` — clean

Relates to #644 (operator observability rollup tracker).

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * The scheduled tasks badge now displays the count of paused tasks when applicable (e.g., "3 (2 paused)").

* **Tests**
  * Added comprehensive test coverage for scheduled task count formatting behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->