### PR TITLE
test: cover user registry persistence

### DIFF
--- a/src/effect/user-registry.test.ts
+++ b/src/effect/user-registry.test.ts
@@ -1,8 +1,13 @@
 import { describe, it, expect } from 'bun:test';
+import { mkdir, mkdtemp, readFile, rm, writeFile } from 'node:fs/promises';
+import { existsSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
 import { Effect, Layer } from 'effect';
 import {
   UserRegistryService,
   UserRegistryServiceLive,
+  makeUserRegistryServiceAtPath,
   formatMention,
   UserRegistryError,
   type UserInfo,
@@ -17,6 +22,33 @@ function runWithRegistry<E, A>(
   effect: Effect.Effect<A, E, UserRegistryService>,
 ) {
   return Effect.runPromise(Effect.provide(effect, UserRegistryServiceLive));
+}
+
+function runWithRegistryAtPath<E, A>(
+  registryPath: string,
+  effect: Effect.Effect<A, E, UserRegistryService>,
+  now?: () => Date,
+) {
+  return Effect.runPromise(
+    Effect.provide(
+      effect,
+      Layer.effect(
+        UserRegistryService,
+        makeUserRegistryServiceAtPath(registryPath, now),
+      ),
+    ),
+  );
+}
+
+async function withTempRegistry<T>(
+  callback: (registryPath: string, rootDir: string) => Promise<T>,
+): Promise<T> {
+  const rootDir = await mkdtemp(join(tmpdir(), 'omniclaw-user-registry-'));
+  try {
+    return await callback(join(rootDir, 'ipc', 'user_registry.json'), rootDir);
+  } finally {
+    await rm(rootDir, { force: true, recursive: true });
+  }
 }
 
 const alice: UserInfo = {
@@ -157,6 +189,142 @@ describe('UserRegistryService', () => {
         }),
       );
       expect(result.length).toBe(2);
+    });
+  });
+
+  describe('load/save', () => {
+    it('creates the registry directory when loading with no file', async () => {
+      await withTempRegistry(async (registryPath, rootDir) => {
+        await runWithRegistryAtPath(
+          registryPath,
+          Effect.gen(function* (_) {
+            const svc = yield* _(UserRegistryService);
+            yield* _(svc.load());
+            return yield* _(svc.getUser('Alice'));
+          }),
+        );
+
+        expect(existsSync(join(rootDir, 'ipc'))).toBe(true);
+      });
+    });
+
+    it('loads users from disk and supports normalized lookups', async () => {
+      await withTempRegistry(async (registryPath) => {
+        await mkdir(join(registryPath, '..'), { recursive: true });
+        await writeFile(
+          registryPath,
+          JSON.stringify({ alice }, null, 2),
+          'utf-8',
+        );
+
+        const result = await runWithRegistryAtPath(
+          registryPath,
+          Effect.gen(function* (_) {
+            const svc = yield* _(UserRegistryService);
+            yield* _(svc.load());
+            return yield* _(svc.getUser(' ALICE '));
+          }),
+        );
+
+        expect(result).toEqual(alice);
+      });
+    });
+
+    it('saves current users as pretty-printed JSON', async () => {
+      await withTempRegistry(async (registryPath) => {
+        const now = () => new Date('2026-06-24T12:34:56.789Z');
+
+        await runWithRegistryAtPath(
+          registryPath,
+          Effect.gen(function* (_) {
+            const svc = yield* _(UserRegistryService);
+            yield* _(svc.load());
+            yield* _(svc.upsertUser(alice));
+            yield* _(svc.save());
+          }),
+          now,
+        );
+
+        const savedData = await readFile(registryPath, 'utf-8');
+        const saved = JSON.parse(savedData);
+        expect(Object.keys(saved)).toEqual(['alice']);
+        expect(saved.alice.id).toBe('123456');
+        expect(saved.alice.lastSeen).toBe('2026-06-24T12:34:56.789Z');
+        expect(savedData).toBe(JSON.stringify(saved, null, 2));
+      });
+    });
+
+    it('wraps invalid JSON load failures', async () => {
+      await withTempRegistry(async (registryPath) => {
+        await runWithRegistryAtPath(
+          registryPath,
+          Effect.gen(function* (_) {
+            const svc = yield* _(UserRegistryService);
+            yield* _(svc.load());
+          }),
+        );
+        await writeFile(registryPath, '{ invalid json', 'utf-8');
+
+        const error = await runWithRegistryAtPath(
+          registryPath,
+          Effect.gen(function* (_) {
+            const svc = yield* _(UserRegistryService);
+            return yield* _(Effect.flip(svc.load()));
+          }),
+        );
+
+        expect(error).toMatchObject({
+          _tag: 'UserRegistryError',
+          message: 'Failed to load user registry',
+        });
+        expect(error.cause).toBeInstanceOf(SyntaxError);
+      });
+    });
+
+    it('wraps registry directory creation failures', async () => {
+      const rootDir = await mkdtemp(join(tmpdir(), 'omniclaw-user-registry-'));
+      try {
+        const blockerPath = join(rootDir, 'blocker');
+        await writeFile(blockerPath, 'not a directory', 'utf-8');
+
+        const error = await runWithRegistryAtPath(
+          join(blockerPath, 'ipc', 'user_registry.json'),
+          Effect.gen(function* (_) {
+            const svc = yield* _(UserRegistryService);
+            return yield* _(Effect.flip(svc.load()));
+          }),
+        );
+
+        expect(error).toMatchObject({
+          _tag: 'UserRegistryError',
+          message: 'Failed to load user registry',
+        });
+        expect(error.cause).toBeInstanceOf(Error);
+      } finally {
+        await rm(rootDir, { force: true, recursive: true });
+      }
+    });
+
+    it('wraps write failures', async () => {
+      const rootDir = await mkdtemp(join(tmpdir(), 'omniclaw-user-registry-'));
+      try {
+        const error = await runWithRegistryAtPath(
+          rootDir,
+          Effect.gen(function* (_) {
+            const svc = yield* _(UserRegistryService);
+            yield* _(svc.upsertUser(alice));
+            return yield* _(Effect.flip(svc.save()));
+          }),
+        );
+
+        expect(error).toMatchObject({
+          _tag: 'UserRegistryError',
+          message: 'Failed to save user registry',
+        });
+        expect(error.cause).toBeInstanceOf(Error);
+      } finally {
+        await rm(rootDir, { force: true, recursive: true });
+      }
     });
   });
 });

--- a/src/effect/user-registry.ts
+++ b/src/effect/user-registry.ts
@@ -71,91 +71,107 @@ const REGISTRY_PATH = '/workspace/ipc/user_registry.json';
 /**
  * Create the user registry service implementation
  */
-export const makeUserRegistryService = Effect.gen(function* (_) {
-  // In-memory registry ref
-  const registryRef = yield* _(Ref.make<UserRegistry>({}));
+export const makeUserRegistryServiceAtPath = (
+  registryPath: string,
+  now: () => Date = () => new Date(),
+) =>
+  Effect.gen(function* (_) {
+    // In-memory registry ref
+    const registryRef = yield* _(Ref.make<UserRegistry>({}));
 
-  const normalizeKey = (name: string) => name.toLowerCase().trim();
+    const normalizeKey = (name: string) => name.toLowerCase().trim();
 
-  const getUser = (
-    name: string,
-  ): Effect.Effect<UserInfo | null, UserRegistryError> =>
-    Effect.gen(function* (_) {
-      const registry = yield* _(Ref.get(registryRef));
-      const key = normalizeKey(name);
-      return registry[key] || null;
-    });
+    const getUser = (
+      name: string,
+    ): Effect.Effect<UserInfo | null, UserRegistryError> =>
+      Effect.gen(function* (_) {
+        const registry = yield* _(Ref.get(registryRef));
+        const key = normalizeKey(name);
+        return registry[key] || null;
+      });
 
-  const upsertUser = (user: UserInfo): Effect.Effect<void, UserRegistryError> =>
-    Effect.gen(function* (_) {
-      const key = normalizeKey(user.name);
-      yield* _(
-        Ref.update(registryRef, (registry) => ({
-          ...registry,
-          [key]: { ...user, lastSeen: new Date().toISOString() },
-        })),
-      );
-    });
-
-  const getUsersByPlatform = (
-    platform: UserInfo['platform'],
-  ): Effect.Effect<UserInfo[], UserRegistryError> =>
-    Effect.gen(function* (_) {
-      const registry = yield* _(Ref.get(registryRef));
-      return Object.values(registry).filter(
-        (user) => user.platform === platform,
-      );
-    });
-
-  const load = (): Effect.Effect<void, UserRegistryError> =>
-    Effect.gen(function* (_) {
-      try {
-        // Ensure directory exists
-        const dir = join(REGISTRY_PATH, '..');
-        if (!existsSync(dir)) {
-          yield* _(Effect.promise(() => mkdir(dir, { recursive: true })));
-        }
-
-        // Load registry if it exists
-        if (existsSync(REGISTRY_PATH)) {
-          const data = yield* _(
-            Effect.promise(() => readFile(REGISTRY_PATH, 'utf-8')),
-          );
-          const registry = JSON.parse(data) as UserRegistry;
-          yield* _(Ref.set(registryRef, registry));
-        }
-      } catch (error) {
-        return yield* _(
-          Effect.fail(
-            new UserRegistryError('Failed to load user registry', error),
-          ),
+    const upsertUser = (
+      user: UserInfo,
+    ): Effect.Effect<void, UserRegistryError> =>
+      Effect.gen(function* (_) {
+        const key = normalizeKey(user.name);
+        yield* _(
+          Ref.update(registryRef, (registry) => ({
+            ...registry,
+            [key]: { ...user, lastSeen: now().toISOString() },
+          })),
         );
-      }
-    });
+      });
 
-  const save = (): Effect.Effect<void, UserRegistryError> =>
-    Effect.gen(function* (_) {
-      try {
+    const getUsersByPlatform = (
+      platform: UserInfo['platform'],
+    ): Effect.Effect<UserInfo[], UserRegistryError> =>
+      Effect.gen(function* (_) {
+        const registry = yield* _(Ref.get(registryRef));
+        return Object.values(registry).filter(
+          (user) => user.platform === platform,
+        );
+      });
+
+    const load = (): Effect.Effect<void, UserRegistryError> =>
+      Effect.gen(function* (_) {
+        const dir = join(registryPath, '..');
+        if (!existsSync(dir)) {
+          yield* _(
+            Effect.tryPromise({
+              try: () => mkdir(dir, { recursive: true }),
+              catch: (error) =>
+                new UserRegistryError('Failed to load user registry', error),
+            }),
+          );
+        }
+
+        if (!existsSync(registryPath)) {
+          return;
+        }
+
+        const data = yield* _(
+          Effect.tryPromise({
+            try: () => readFile(registryPath, 'utf-8'),
+            catch: (error) =>
+              new UserRegistryError('Failed to load user registry', error),
+          }),
+        );
+
+        const registry = yield* _(
+          Effect.try({
+            try: () => JSON.parse(data) as UserRegistry,
+            catch: (error) =>
+              new UserRegistryError('Failed to load user registry', error),
+          }),
+        );
+        yield* _(Ref.set(registryRef, registry));
+      });
+
+    const save = (): Effect.Effect<void, UserRegistryError> =>
+      Effect.gen(function* (_) {
         const registry = yield* _(Ref.get(registryRef));
         const data = JSON.stringify(registry, null, 2);
-        yield* _(Effect.promise(() => writeFile(REGISTRY_PATH, data, 'utf-8')));
-      } catch (error) {
-        return yield* _(
-          Effect.fail(
-            new UserRegistryError('Failed to save user registry', error),
-          ),
+        yield* _(
+          Effect.tryPromise({
+            try: () => writeFile(registryPath, data, 'utf-8'),
+            catch: (error) =>
+              new UserRegistryError('Failed to save user registry', error),
+          }),
         );
-      }
-    });
+      });
 
-  return {
-    getUser,
-    upsertUser,
-    getUsersByPlatform,
-    load,
-    save,
-  } satisfies UserRegistryService;
-});
+    return {
+      getUser,
+      upsertUser,
+      getUsersByPlatform,
+      load,
+      save,
+    } satisfies UserRegistryService;
+  });
+
+export const makeUserRegistryService =
+  makeUserRegistryServiceAtPath(REGISTRY_PATH);
 
 /**
  * Layer for providing the user registry service


### PR DESCRIPTION
## Summary

- Add deterministic disk persistence coverage for `UserRegistryService`.
- Introduce `makeUserRegistryServiceAtPath()` so tests can isolate registry I/O in temp directories.
- Add an injectable clock for deterministic `lastSeen` assertions while preserving the default live behavior.
- Cover load/save happy paths plus invalid JSON, directory creation, and write failure error wrapping.

## Test Count

- Before this worktree run: `2393 pass`, `0 fail`, `6381 expect() calls` across 104 files.
- After rebase onto current `origin/main`: `2398 pass`, `0 fail`, `6388 expect() calls` across 104 files.
- Focused file: `src/effect/user-registry.test.ts` now reports `21 pass`, `0 fail`, `32 expect() calls`.

## Coverage Notes

- Covered file: `src/effect/user-registry.ts` load/save paths and error wrapping.
- Remaining broad gaps from coverage run include integration-heavy modules such as `src/channels/discord.ts`, `src/channels/telegram.ts`, `src/channels/whatsapp.ts`, `src/backends/local-backend.ts`, and `src/index.ts`.

## Verification

- `bun test src/effect/user-registry.test.ts`
- `bun run typecheck`
- `bun test`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved registry persistence so saved data is written in a consistent format and can be reloaded reliably.
  * User lookups are now more forgiving of extra whitespace.
  * Time-based user updates now use a consistent, injectable timestamp source.
  * Added clearer error handling for invalid registry data and filesystem failures.

* **Tests**
  * Expanded coverage for loading, saving, and filesystem-backed registry behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->