### PR TITLE
feat(web): annotate /ipc groups tracked card with active count

### DIFF
--- a/src/web/ipc-inspector.test.ts
+++ b/src/web/ipc-inspector.test.ts
@@ -128,8 +128,83 @@ describe('renderIpcInspector', () => {
     expect(html).toContain('1/5');
     // Idle
     expect(html).toContain('1/3');
-    // Groups tracked
-    expect(html).toContain('>2<');
+    // Groups tracked = 2 total, with agent-alpha actively running
+    // (message lane active+!idle, task lane active). agent-beta's
+    // message lane is in cooldown (active+idle) so it does not count.
+    expect(html).toContain('id="stat-groups">2 (1 active)<');
+  });
+
+  it('omits groups tracked annotation when no group is active', () => {
+    const detail: GroupQueueDetail = {
+      folderKey: 'agent-quiet',
+      messageLane: {
+        active: true,
+        idle: true,
+        pendingCount: 0,
+        containerName: 'ctr-quiet-msg',
+        reason: 'cooling-down',
+      },
+      taskLane: {
+        active: false,
+        pendingCount: 0,
+        containerName: null,
+        activeTask: null,
+        reason: 'no-work',
+      },
+      retryCount: 0,
+    };
+    const html = renderIpcInspector(
+      makeState({ getQueueDetails: () => [detail] }),
+    );
+    // Exact-match closing `<` rules out any `1 (N active)` annotation;
+    // we don't `not.toContain('active)')` because unrelated CSS/JS in the
+    // shell (e.g. `:active)` selectors) can legitimately use that substring.
+    expect(html).toContain('id="stat-groups">1<');
+  });
+
+  it('does not count idle-waiting (cooldown) lanes as active', () => {
+    const cooldown: GroupQueueDetail = {
+      folderKey: 'agent-cool',
+      messageLane: {
+        // Warm container in cooldown: active=true, idle=true.
+        active: true,
+        idle: true,
+        pendingCount: 0,
+        containerName: 'ctr-cool-msg',
+        reason: 'cooling-down',
+      },
+      taskLane: {
+        active: false,
+        pendingCount: 0,
+        containerName: null,
+        activeTask: null,
+        reason: 'no-work',
+      },
+      retryCount: 0,
+    };
+    const running: GroupQueueDetail = {
+      folderKey: 'agent-run',
+      messageLane: {
+        active: true,
+        idle: false,
+        pendingCount: 1,
+        containerName: 'ctr-run-msg',
+        reason: 'running',
+      },
+      taskLane: {
+        active: false,
+        pendingCount: 0,
+        containerName: null,
+        activeTask: null,
+        reason: 'no-work',
+      },
+      retryCount: 0,
+    };
+    const html = renderIpcInspector(
+      makeState({ getQueueDetails: () => [cooldown, running] }),
+    );
+    // 2 total groups, only the running one counts as active.
+    expect(html).toContain('id="stat-groups">2 (1 active)<');
   });
 
   it('shows aggregate pending messages stat card', () => {

--- a/src/web/ipc-inspector.ts
+++ b/src/web/ipc-inspector.ts
@@ -32,12 +32,30 @@ export function renderIpcInspectorContent(state: WebStateProvider): string {
   let pendingTasks = 0;
   let retryingGroups = 0;
   let totalRetries = 0;
+  // Count groups with either lane currently in flight. Matches the
+  // dashboard "agents (N working)" definition so the two surfaces agree:
+  // - messageLane active and not idle (processing a message), or
+  // - taskLane active (running a scheduled task).
+  // Idle-waiting message lanes (active && idle — warm container in
+  // cooldown) are intentionally excluded; they are "ready" but not "doing
+  // work", mirroring getAgentExecStatus.
+  let activeGroups = 0;
   for (const g of queueDetails) {
     pendingMessages += g.messageLane.pendingCount;
     pendingTasks += g.taskLane.pendingCount;
     if (g.retryCount > 0) retryingGroups++;
     totalRetries += g.retryCount;
+    if (
+      (g.messageLane.active && !g.messageLane.idle) ||
+      g.taskLane.active
+    ) {
+      activeGroups++;
+    }
   }
+  const groupsTrackedValue =
+    activeGroups > 0
+      ? `${queueDetails.length} (${activeGroups} active)`
+      : `${queueDetails.length}`;
 
   const groupRows = queueDetails
     .map((g) => {
@@ -117,7 +135,7 @@ export function renderIpcInspectorContent(state: WebStateProvider): string {
     `<div class="stats-grid">` +
     `<div class="stat-card"><div class="label">processing</div><div class="value" id="stat-processing">${Math.max(0, stats.activeContainers - stats.idleContainers)}/${stats.maxActive}</div></div>` +
     `<div class="stat-card"><div class="label">idle</div><div class="value" id="stat-ipc-idle">${stats.idleContainers}/${stats.maxIdle}</div></div>` +
-    `<div class="stat-card"><div class="label">groups tracked</div><div class="value" id="stat-groups">${queueDetails.length}</div></div>` +
+    `<div class="stat-card"><div class="label">groups tracked</div><div class="value" id="stat-groups">${groupsTrackedValue}</div></div>` +
     `<div class="stat-card"><div class="label">pending msgs</div><div class="value" id="stat-pending-messages">${pendingMessages}</div></div>` +
     `<div class="stat-card"><div class="label">pending tasks</div><div class="value" id="stat-pending-tasks">${pendingTasks}</div></div>` +
     `<div class="stat-card"><div class="label">retrying</div><div class="value" id="stat-retrying">${retryingGroups > 0 ? `${retryingGroups} (${totalRetries})` : '0'}</div></div>` +

--- a/src/web/ipc-inspector.ts
+++ b/src/web/ipc-inspector.ts
@@ -45,10 +45,7 @@ export function renderIpcInspectorContent(state: WebStateProvider): string {
     pendingTasks += g.taskLane.pendingCount;
     if (g.retryCount > 0) retryingGroups++;
     totalRetries += g.retryCount;
-    if (
-      (g.messageLane.active && !g.messageLane.idle) ||
-      g.taskLane.active
-    ) {
+    if ((g.messageLane.active && !g.messageLane.idle) || g.taskLane.active) {
       activeGroups++;
     }
   }


### PR DESCRIPTION
## Summary

Annotates the IPC inspector's `groups tracked` stat card with an inline `(N active)` count when any tracked group has a lane in flight, so the operator can tell at a glance how much of the tracked-group set is actually doing work right now — without scanning the group queue table below.

A group is counted as active when its queue detail has either:
- `messageLane.active && !messageLane.idle` (processing a message), or
- `taskLane.active` (running a scheduled task)

Idle-waiting message lanes (`active=true, idle=true` — warm container in cooldown) are intentionally excluded, matching the dashboard `agents (N working)` definition (#884) and `getAgentExecStatus`, which classifies cooldown as `idle`. This keeps the two surfaces consistent: an operator who sees `agents: 8 (3 working)` on `/` will see the same count reflected as the active subset of groups on `/ipc`.

The annotation follows the same parenthetical `n (m qualifier)` convention already used by:
- `/ipc` `retrying` — `${groups} (${total} retries)`
- `/ipc` `recent events` severity rollup (#860)
- dashboard `agents` — `${agents} (${working} working)` (#884)
- dashboard `active tasks` — `${tasks} (${running} running)` (#875)

Pure render-layer change. `activeGroups` is computed in the existing `queueDetails` loop alongside `pendingMessages`/`retryingGroups`. No `WebStateProvider`, schema, or SSE event changes.

## Changes

- `src/web/ipc-inspector.ts` — extend the existing `queueDetails` loop to count active groups, render `${queueDetails.length} (${activeGroups} active)` when `activeGroups > 0`, otherwise the bare count as before.
- `src/web/ipc-inspector.test.ts` — update the `shows correct stats` assertion for the new annotation on the existing sample fixture (`agent-alpha` is running, `agent-beta` is in cooldown → `2 (1 active)`), plus two new cases:
  - Annotation omitted when no group is active.
  - Idle-waiting (cooldown) message lanes are not counted as active.

## Test plan

- [x] `bun test src/web/ipc-inspector.test.ts` — 33 pass.
- [x] `bun test src/web/` — 811 pass, 0 fail.
- [x] `bun test` — 2394 pass, 0 fail across the full suite.
- [x] `bun run typecheck` — clean.

Relates to #644 (operator observability rollup tracker).

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * The IPC inspector now shows richer “groups tracked” stats, including how many groups are currently active when applicable.

* **Bug Fixes**
  * Fixed active group counting so idle or cooling-down lanes no longer inflate the active total.
  * Improved the stats display to omit the active-group note when nothing is actively running.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->