### PR TITLE
fix(web): block cross-site unsafe requests

### DIFF
--- a/src/web/server.test.ts
+++ b/src/web/server.test.ts
@@ -422,6 +422,58 @@ describe('basic auth', () => {
     expect(res.status).toBe(401);
   });
 
+  it('rejects cross-site browser POSTs even with valid Basic credentials', async () => {
+    let runCalls = 0;
+    handle = startWebServer(
+      testConfig(),
+      makeState({
+        runTaskNow: () => {
+          runCalls += 1;
+          return { ok: true };
+        },
+      }),
+    );
+
+    const res = await authedFetch('/api/tasks/task-001/run', {
+      method: 'POST',
+      headers: {
+        Origin: 'https://attacker.example',
+        'Sec-Fetch-Site': 'cross-site',
+      },
+    });
+
+    expect(res.status).toBe(403);
+    await expect(res.json()).resolves.toEqual({
+      error: 'Cross-site request blocked',
+    });
+    expect(runCalls).toBe(0);
+  });
+
+  it('allows same-origin browser POSTs with valid Basic credentials', async () => {
+    let runCalls = 0;
+    handle = startWebServer(
+      testConfig(),
+      makeState({
+        runTaskNow: () => {
+          runCalls += 1;
+          return { ok: true };
+        },
+      }),
+    );
+
+    const res = await authedFetch('/api/tasks/task-001/run', {
+      method: 'POST',
+      headers: {
+        Origin: `http://localhost:${handle.port}`,
+        'Sec-Fetch-Site': 'same-origin',
+      },
+    });
+
+    expect(res.status).toBe(200);
+    await expect(res.json()).resolves.toEqual({ ok: true, id: 'task-001' });
+    expect(runCalls).toBe(1);
+  });
+
   it('skips auth when no credentials are configured', async () => {
     handle = startWebServer(testConfig({ auth: undefined }), makeState());
     const pageRes = await fetch(url('/'));

--- a/src/web/server.ts
+++ b/src/web/server.ts
@@ -60,6 +60,7 @@ const PORT_ZERO_FALLBACK_START = 40000;
 const PORT_ZERO_FALLBACK_SPAN = 20000;
 const MAX_PEER_AUTH_BODY_BYTES = 1024 * 1024;
 const MAX_LOGIN_BODY_BYTES = 1024 * 1024;
+const SAFE_WEB_METHODS = new Set(['GET', 'HEAD', 'OPTIONS']);
 
 interface RequestBodyHashResult {
   hash: string;
@@ -96,6 +97,67 @@ function randomFallbackPort(): number {
     PORT_ZERO_FALLBACK_START +
     Math.floor(Math.random() * PORT_ZERO_FALLBACK_SPAN)
   );
+}
+
+function isUnsafeWebMethod(method: string): boolean {
+  return !SAFE_WEB_METHODS.has(method.toUpperCase());
+}
+
+function isTrustedRequestOrigin(
+  requestOrigin: string,
+  url: URL,
+  corsOrigin?: string,
+): boolean {
+  let parsedOrigin: URL;
+  try {
+    parsedOrigin = new URL(requestOrigin);
+  } catch {
+    return false;
+  }
+
+  if (parsedOrigin.origin === url.origin) return true;
+  if (!corsOrigin) return false;
+
+  try {
+    return parsedOrigin.origin === new URL(corsOrigin).origin;
+  } catch {
+    return false;
+  }
+}
+
+function isCrossSiteBrowserMutation(
+  req: Request,
+  url: URL,
+  corsOrigin?: string,
+): boolean {
+  if (!isUnsafeWebMethod(req.method)) return false;
+
+  const fetchSite = req.headers.get('Sec-Fetch-Site')?.toLowerCase();
+  if (fetchSite === 'cross-site') return true;
+
+  const origin = req.headers.get('Origin');
+  if (origin && !isTrustedRequestOrigin(origin, url, corsOrigin)) {
+    return true;
+  }
+
+  return false;
+}
+
+function makeCsrfRejection(pathname: string): Response {
+  if (pathname.startsWith('/api/')) {
+    return new Response(
+      JSON.stringify({ error: 'Cross-site request blocked' }),
+      {
+        status: 403,
+        headers: { 'Content-Type': 'application/json' },
+      },
+    );
+  }
+
+  return new Response('Cross-site request blocked', {
+    status: 403,
+    headers: { 'Content-Type': 'text/plain' },
+  });
 }
 
 async function hashRequestBodyWithLimit(
@@ -207,6 +269,7 @@ export function startWebServer(
     // --- Peer auth: trusted remote OmniClaw instances bypass Basic Auth ---
     const isPeerRequest =
       isPeerRoute(url.pathname) && req.headers.has('X-OmniClaw-Instance');
+    let isAuthenticatedPeerRequest = false;
     if (isPeerRequest && trustStore) {
       // Read the body from a clone so checkPeerAuth can verify the claimed
       // body hash against the bytes actually received without consuming the
@@ -227,6 +290,7 @@ export function startWebServer(
           headers: corsOrigin ? makeCorsHeaders(corsOrigin) : {},
         });
       }
+      isAuthenticatedPeerRequest = true;
       // Peer is authenticated — skip auth, fall through to routing
     } else if (sessionStore && sessionPassword) {
       // --- Session-based auth (WEB_PASSWORD) ---
@@ -770,6 +834,13 @@ export function startWebServer(
         status: 204,
         headers: makeCorsHeaders(corsOrigin),
       });
+    }
+
+    if (
+      !isAuthenticatedPeerRequest &&
+      isCrossSiteBrowserMutation(req, url, corsOrigin)
+    ) {
+      return makeCsrfRejection(url.pathname);
     }
 
     const result = handleRequest(req, state, sseClients.size);


### PR DESCRIPTION
## Summary

- Fixes #905.
- Blocks browser cross-site unsafe Web UI requests before authenticated route dispatch.
- Keeps HMAC-authenticated peer routes, same-origin dashboard requests, configured CORS origins, and non-browser API clients working.

## Security Notes

The vulnerable path was Basic Auth plus ambient browser credentials. A malicious site could submit a cross-site form POST to routes like `/api/tasks/{id}/run`, and the browser could attach cached Basic credentials.

This patch rejects unsafe non-peer requests when browser provenance headers indicate a cross-site request:

- `Sec-Fetch-Site: cross-site`
- An `Origin` header whose origin does not match the Web UI origin or configured `corsOrigin`

Requests without browser provenance headers remain allowed so existing CLI/API automation is not broken.

## Tests

- `bun test src/web/server.test.ts`
- `bun run typecheck`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Added protection against cross-site browser requests for unsafe actions.
  * Requests from untrusted origins now receive a clear `403` response, while valid same-origin requests continue to work.
  * Improved API error responses for blocked requests, with JSON output for API routes and plain-text output for other routes.
  * Added tests covering both blocked cross-site requests and allowed same-origin task runs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->