### PR TITLE
feat(web): annotate /tasks active card with overdue rollup

### DIFF
--- a/src/web/page-scripts.test.ts
+++ b/src/web/page-scripts.test.ts
@@ -82,6 +82,18 @@ describe('tasks page script', () => {
     );
     expect(script).toContain('sb.disabled=false;');
   });
+
+  it('mirrors the overdue rollup on the active chip when refreshing', () => {
+    const script = allPageScripts().tasks;
+
+    expect(script).toContain(
+      "var activeLabel=overdue>0?active+' active ('+overdue+' overdue)':active+' active';",
+    );
+    expect(script).toContain(
+      '+\'<span class="tasks-stat stat-active">\'+activeLabel+\'</span>\'',
+    );
+    expect(script).toContain('if(isFinite(nr)&&nr<now)overdue++;');
+  });
 });
 
 describe('context page script', () => {

--- a/src/web/page-scripts.test.ts
+++ b/src/web/page-scripts.test.ts
@@ -90,7 +90,7 @@ describe('tasks page script', () => {
       "var activeLabel=overdue>0?active+' active ('+overdue+' overdue)':active+' active';",
     );
     expect(script).toContain(
-      '+\'<span class="tasks-stat stat-active">\'+activeLabel+\'</span>\'',
+      "+'<span class=\"tasks-stat stat-active\">'+activeLabel+'</span>'",
     );
     expect(script).toContain('if(isFinite(nr)&&nr<now)overdue++;');
   });

--- a/src/web/page-scripts.ts
+++ b/src/web/page-scripts.ts
@@ -1245,15 +1245,23 @@ function refreshTasks(){
   .then(function(r){return r.json();})
   .then(function(tasks){
     // Update stats
-    var total=tasks.length,active=0,paused=0,completed=0;
+    var total=tasks.length,active=0,paused=0,completed=0,overdue=0;
+    var now=Date.now();
     tasks.forEach(function(t){
-      if(t.status==="active")active++;
+      if(t.status==="active"){
+        active++;
+        if(t.next_run){
+          var nr=Date.parse(t.next_run);
+          if(isFinite(nr)&&nr<now)overdue++;
+        }
+      }
       else if(t.status==="paused")paused++;
       else if(t.status==="completed")completed++;
     });
+    var activeLabel=overdue>0?active+' active ('+overdue+' overdue)':active+' active';
     var stats=document.querySelector(".tasks-stats");
     if(stats)stats.innerHTML='<span class="tasks-stat">'+total+' total</span>'
-      +'<span class="tasks-stat stat-active">'+active+' active</span>'
+      +'<span class="tasks-stat stat-active">'+activeLabel+'</span>'
       +'<span class="tasks-stat stat-paused">'+paused+' paused</span>'
       +'<span class="tasks-stat stat-completed">'+completed+' completed</span>';
 

--- a/src/web/tasks.test.ts
+++ b/src/web/tasks.test.ts
@@ -561,9 +561,7 @@ describe('renderTasksContent', () => {
 
   it('ignores unparseable next_run values when computing overdue count', () => {
     const html = renderTasksContent(
-      makeState([
-        makeTask({ id: 'task-bad', next_run: 'not-a-date' }),
-      ]),
+      makeState([makeTask({ id: 'task-bad', next_run: 'not-a-date' })]),
     );
 
     expect(html).toContain('>1 active</span>');

--- a/src/web/tasks.test.ts
+++ b/src/web/tasks.test.ts
@@ -524,6 +524,51 @@ describe('renderTasksContent', () => {
 
     expect(html).not.toContain('stat-executing');
   });
+
+  it('annotates the active stat with overdue count when active tasks are past their next_run', () => {
+    const pastIso = new Date(Date.now() - 60_000).toISOString();
+    const futureIso = new Date(Date.now() + 3_600_000).toISOString();
+    const html = renderTasksContent(
+      makeState([
+        // overdue active task — counted
+        makeTask({ id: 'task-overdue', next_run: pastIso }),
+        // active task scheduled in the future — not overdue
+        makeTask({ id: 'task-future', next_run: futureIso }),
+        // paused tasks are never overdue, even if next_run is in the past
+        makeTask({ id: 'task-paused', status: 'paused', next_run: pastIso }),
+      ]),
+    );
+
+    expect(html).toContain('2 active (1 overdue)');
+    // Filter chip and paused/completed counts unchanged
+    expect(html).toContain('data-filter="active"');
+    expect(html).toContain('1 paused');
+  });
+
+  it('omits the overdue annotation when no active task is overdue', () => {
+    const futureIso = new Date(Date.now() + 3_600_000).toISOString();
+    const html = renderTasksContent(
+      makeState([
+        makeTask({ id: 'task-future', next_run: futureIso }),
+        makeTask({ id: 'task-null-next', next_run: null }),
+      ]),
+    );
+
+    // Bare count — no parenthetical
+    expect(html).toContain('>2 active</span>');
+    expect(html).not.toContain('overdue');
+  });
+
+  it('ignores unparseable next_run values when computing overdue count', () => {
+    const html = renderTasksContent(
+      makeState([
+        makeTask({ id: 'task-bad', next_run: 'not-a-date' }),
+      ]),
+    );
+
+    expect(html).toContain('>1 active</span>');
+    expect(html).not.toContain('overdue');
+  });
 });
 
 describe('renderRunningBadge', () => {

--- a/src/web/tasks.ts
+++ b/src/web/tasks.ts
@@ -22,6 +22,27 @@ export function renderTasksContent(state: WebStateProvider): string {
   const executingTasks = tasks.filter(
     (t) => t.status !== 'completed' && t.executing_since != null,
   ).length;
+  // Count active tasks whose `next_run` has already passed. The scheduler
+  // normally advances `next_run` after each tick, so an active task with a
+  // past `next_run` means the scheduler is either backed up, was offline,
+  // or the run lease hasn't been picked up yet. Surfacing the rollup on the
+  // `active` chip answers "is the scheduler keeping up?" without making the
+  // operator scan the `next run` column row-by-row.
+  //
+  // Tasks with `next_run = null` (paused/completed/once-fired) are skipped
+  // since "overdue" only makes sense relative to a scheduled time. Parse
+  // failures are treated as not-overdue to avoid noisy counts from
+  // legacy/malformed rows.
+  const now = Date.now();
+  const overdueActiveTasks = tasks.reduce((sum, t) => {
+    if (t.status !== 'active' || !t.next_run) return sum;
+    const nextRunMs = Date.parse(t.next_run);
+    return Number.isFinite(nextRunMs) && nextRunMs < now ? sum + 1 : sum;
+  }, 0);
+  const activeValue =
+    overdueActiveTasks > 0
+      ? `${activeTasks} active (${overdueActiveTasks} overdue)`
+      : `${activeTasks} active`;
 
   // Build agent/channel options for create/edit forms
   const agentOptions = agentData
@@ -47,7 +68,7 @@ export function renderTasksContent(state: WebStateProvider): string {
     // Stats row
     `<div class="tasks-stats">` +
     `<span class="tasks-stat">${tasks.length} total</span>` +
-    `<span class="tasks-stat stat-active">${activeTasks} active</span>` +
+    `<span class="tasks-stat stat-active">${activeValue}</span>` +
     (executingTasks > 0
       ? `<span class="tasks-stat stat-executing">${executingTasks} executing</span>`
       : '') +


### PR DESCRIPTION
## Summary

Annotates the `/tasks` page header's `active` stat with an inline `(N overdue)` count when one or more enabled tasks have a `next_run` in the past, so the operator can tell at a glance whether the scheduler is keeping up — without scanning the `next run` column row-by-row.

The annotation follows the existing parenthetical-rollup style already used by the dashboard `agents (N working)` chip (#884) and the `/agents` local count `(N disabled)` rollup:

- `5 active` — no overdue tasks (unchanged)
- `5 active (2 overdue)` — two of five active tasks are past `next_run`

Pure render-layer change. Counts are computed from the existing `getTasks()` already in scope — no `WebStateProvider`, schema, or SSE event changes. Tasks with `next_run = null` (paused/completed/once-fired) are skipped since "overdue" only makes sense relative to a scheduled time. Parse failures (`Date.parse` returning `NaN`) are treated as not-overdue to avoid noisy counts from legacy or malformed rows.

## Changes

- `src/web/tasks.ts` — derive `overdueActiveTasks` from `getTasks()` by counting `status === 'active'` rows whose parsed `next_run` is in the past, then render `${activeTasks} active (${overdueActiveTasks} overdue)` when `overdueActiveTasks > 0`, otherwise the bare count as before.
- `src/web/tasks.test.ts` — three new cases under `renderTasksContent`: annotation present when an active task is overdue (and paused-with-past-`next_run` is correctly ignored), annotation omitted when no active task is overdue (and `next_run: null` rows are skipped), and unparseable `next_run` values are treated as not-overdue.

## Test plan

- [x] `bun test src/web/tasks.test.ts` — 35 pass.
- [x] `bun test src/web/` — 812 pass, 0 fail.
- [x] `bun test` — 2395 pass, 0 fail across the full suite.
- [x] `bun run typecheck` — clean.

Relates to #644 (operator observability rollup tracker) and #505 (Web UI Phase 3 polish).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * The task manager now shows overdue active tasks alongside the active task count.
  * When applicable, the active stat is displayed as `X active (Y overdue)` for quicker status checks.

* **Bug Fixes**
  * Overdue counts now exclude paused tasks.
  * Invalid or unparseable scheduled times are ignored, preventing incorrect overdue totals.
  * The overdue label is hidden when no active tasks are overdue.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->