### PR TITLE
fix(web): preserve task running stats after refresh

### DIFF
--- a/src/web/dashboard.ts
+++ b/src/web/dashboard.ts
@@ -5,24 +5,10 @@ import { renderShell, escapeHtml, escapeJsonForHtml } from './shared.js';
 import { allPageScripts } from './page-scripts.js';
 import { buildAgentChannelData } from './agent-channels.js';
 import type { RemotePeerAgents } from '../discovery/types.js';
+import { formatActiveTaskStatsFromState } from './task-stats.js';
 
 function imageRev(value: string): string {
   return createHash('sha256').update(value).digest('hex').slice(0, 12);
-}
-
-export function formatDashboardActiveTasksValue(
-  state: Pick<WebStateProvider, 'getTasks' | 'getQueueDetails'>,
-): string {
-  const activeTasks = state
-    .getTasks()
-    .filter((task) => task.status === 'active').length;
-  const runningTasks = state
-    .getQueueDetails()
-    .reduce((sum, g) => sum + (g.taskLane.activeTask ? 1 : 0), 0);
-
-  return runningTasks > 0
-    ? `${activeTasks} (${runningTasks} running)`
-    : `${activeTasks}`;
 }
 
 /** Render the dashboard content (no shell wrapper). */
@@ -38,7 +24,7 @@ export function renderDashboardContent(
     0,
     stats.activeContainers - stats.idleContainers,
   );
-  const activeTasksValue = formatDashboardActiveTasksValue(state);
+  const activeTasksValue = formatActiveTaskStatsFromState(state);
   // Count local agents currently in flight on either lane (processing a
   // message or running a scheduled task). Surfaced inline on the "agents"
   // card so the operator can tell at a glance how much of the fleet is

--- a/src/web/page-scripts.test.ts
+++ b/src/web/page-scripts.test.ts
@@ -83,11 +83,18 @@ describe('tasks page script', () => {
     expect(script).toContain('sb.disabled=false;');
   });
 
-  it('mirrors the overdue rollup on the active chip when refreshing', () => {
+  it('mirrors active stat rollups when refreshing', () => {
     const script = allPageScripts().tasks;
 
     expect(script).toContain(
-      "var activeLabel=overdue>0?active+' active ('+overdue+' overdue)':active+' active';",
+      'function formatActiveTaskStats(active,running,overdue){',
+    );
+    expect(script).toContain('fetch("/api/ipc/queue")');
+    expect(script).toContain(
+      'var activeLabel=formatActiveTaskStats(active,running,overdue);',
+    );
+    expect(script).toContain(
+      "+(executing>0?'<span class=\"tasks-stat stat-executing\">'+executing+' executing</span>':'')",
     );
     expect(script).toContain(
       "+'<span class=\"tasks-stat stat-active\">'+activeLabel+'</span>'",

--- a/src/web/page-scripts.ts
+++ b/src/web/page-scripts.ts
@@ -1239,15 +1239,33 @@ document.getElementById("tm-run-close").addEventListener("click",function(){
   document.getElementById("tm-run-panel").style.display="none";
 });
 
+function countRunningTasks(queueDetails){
+  if(!Array.isArray(queueDetails))return 0;
+  return queueDetails.reduce(function(sum,detail){
+    return sum+(detail&&detail.taskLane&&detail.taskLane.activeTask?1:0);
+  },0);
+}
+
+function formatActiveTaskStats(active,running,overdue){
+  var parts=[];
+  if(overdue>0)parts.push(overdue+" overdue");
+  if(running>0)parts.push(running+" running");
+  return active+" active"+(parts.length>0?" ("+parts.join(", ")+")":"");
+}
+
 // ---- Refresh tasks from API ----
 function refreshTasks(){
-  fetch("/api/tasks")
-  .then(function(r){return r.json();})
-  .then(function(tasks){
+  Promise.all([
+    fetch("/api/tasks").then(function(r){return r.json();}),
+    fetch("/api/ipc/queue").then(function(r){return r.ok?r.json():[];}).catch(function(){return [];})
+  ])
+  .then(function(results){
+    var tasks=results[0],queueDetails=results[1];
     // Update stats
-    var total=tasks.length,active=0,paused=0,completed=0,overdue=0;
+    var total=tasks.length,active=0,paused=0,completed=0,executing=0,overdue=0,running=countRunningTasks(queueDetails);
     var now=Date.now();
     tasks.forEach(function(t){
+      if(t.status!=="completed"&&t.executing_since!=null)executing++;
       if(t.status==="active"){
         active++;
         if(t.next_run){
@@ -1258,10 +1276,11 @@ function refreshTasks(){
       else if(t.status==="paused")paused++;
       else if(t.status==="completed")completed++;
     });
-    var activeLabel=overdue>0?active+' active ('+overdue+' overdue)':active+' active';
+    var activeLabel=formatActiveTaskStats(active,running,overdue);
     var stats=document.querySelector(".tasks-stats");
     if(stats)stats.innerHTML='<span class="tasks-stat">'+total+' total</span>'
       +'<span class="tasks-stat stat-active">'+activeLabel+'</span>'
+      +(executing>0?'<span class="tasks-stat stat-executing">'+executing+' executing</span>':'')
       +'<span class="tasks-stat stat-paused">'+paused+' paused</span>'
       +'<span class="tasks-stat stat-completed">'+completed+' completed</span>';
 

--- a/src/web/server.ts
+++ b/src/web/server.ts
@@ -27,10 +27,7 @@ import {
   renderAgentDetailContent,
   buildAgentDetailData,
 } from './agent-detail.js';
-import {
-  formatDashboardActiveTasksValue,
-  renderDashboardContent,
-} from './dashboard.js';
+import { renderDashboardContent } from './dashboard.js';
 import { renderConversationsContent } from './conversations.js';
 import { renderContextViewerContent } from './context-viewer.js';
 import { renderIpcInspectorContent } from './ipc-inspector.js';
@@ -47,6 +44,7 @@ import { serializeLogRecord } from './log-stream.js';
 import { renderSystemContent } from './system.js';
 import { renderSettingsContent } from './settings.js';
 import { renderTasksContent } from './tasks.js';
+import { formatActiveTaskStatsFromState } from './task-stats.js';
 import { renderLogsContent } from './logs.js';
 import { renderAgentsContent, buildAgentRowsHtml } from './agents-page.js';
 import {
@@ -1201,7 +1199,7 @@ function patchStats(client: SseClient, state: WebStateProvider): void {
     `<div class="value" id="stat-idle">${stats.idleContainers}/${stats.maxIdle}</div>`,
   );
   client.stream.patchElements(
-    `<div class="value" id="stat-tasks">${formatDashboardActiveTasksValue(state)}</div>`,
+    `<div class="value" id="stat-tasks">${formatActiveTaskStatsFromState(state)}</div>`,
   );
 }
 

--- a/src/web/task-stats.ts
+++ b/src/web/task-stats.ts
@@ -1,0 +1,63 @@
+import type { GroupQueueDetail } from '../group-queue.js';
+import type { ScheduledTask } from '../types.js';
+import type { WebStateProvider } from './types.js';
+
+export function countActiveTasks(tasks: readonly ScheduledTask[]): number {
+  return tasks.filter((task) => task.status === 'active').length;
+}
+
+export function countRunningTasks(
+  queueDetails: readonly GroupQueueDetail[],
+): number {
+  return queueDetails.reduce(
+    (sum, detail) => sum + (detail.taskLane.activeTask ? 1 : 0),
+    0,
+  );
+}
+
+export function countOverdueActiveTasks(
+  tasks: readonly ScheduledTask[],
+  nowMs = Date.now(),
+): number {
+  return tasks.reduce((sum, task) => {
+    if (task.status !== 'active' || !task.next_run) return sum;
+    const nextRunMs = Date.parse(task.next_run);
+    return Number.isFinite(nextRunMs) && nextRunMs < nowMs ? sum + 1 : sum;
+  }, 0);
+}
+
+export function formatActiveTaskStats(
+  activeTasks: number,
+  runningTasks: number,
+  options: { includeActiveLabel?: boolean; overdueTasks?: number } = {},
+): string {
+  const base = options.includeActiveLabel
+    ? `${activeTasks} active`
+    : `${activeTasks}`;
+  const annotations: string[] = [];
+  if ((options.overdueTasks ?? 0) > 0) {
+    annotations.push(`${options.overdueTasks} overdue`);
+  }
+  if (runningTasks > 0) {
+    annotations.push(`${runningTasks} running`);
+  }
+
+  return annotations.length > 0 ? `${base} (${annotations.join(', ')})` : base;
+}
+
+export function formatActiveTaskStatsFromState(
+  state: Pick<WebStateProvider, 'getTasks' | 'getQueueDetails'>,
+  options: { includeActiveLabel?: boolean; includeOverdue?: boolean } = {},
+): string {
+  const tasks = state.getTasks();
+  return formatActiveTaskStats(
+    countActiveTasks(tasks),
+    countRunningTasks(state.getQueueDetails()),
+    {
+      includeActiveLabel: options.includeActiveLabel,
+      overdueTasks: options.includeOverdue
+        ? countOverdueActiveTasks(tasks)
+        : undefined,
+    },
+  );
+}

--- a/src/web/tasks.test.ts
+++ b/src/web/tasks.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from 'bun:test';
 
 import type { Agent, ChannelSubscription, ScheduledTask } from '../types.js';
+import type { GroupQueueDetail } from '../group-queue.js';
 import { handleRequest } from './routes.js';
 import {
   formatRunningAge,
@@ -45,7 +46,36 @@ function makeTask(overrides: Partial<ScheduledTask> = {}): ScheduledTask {
   };
 }
 
-function makeState(tasks: ScheduledTask[] = [makeTask()]): WebStateProvider {
+function makeTaskRunningDetail(
+  overrides: { folderKey?: string; taskId?: string } = {},
+): GroupQueueDetail {
+  return {
+    folderKey: overrides.folderKey ?? 'test-agent',
+    messageLane: {
+      active: false,
+      idle: true,
+      pendingCount: 0,
+      containerName: null,
+    },
+    taskLane: {
+      active: true,
+      pendingCount: 0,
+      containerName: null,
+      activeTask: {
+        taskId: overrides.taskId ?? 'task-001',
+        promptPreview: 'Run the daily check',
+        startedAt: 1_700_000_000_000,
+        runningMs: 15_000,
+      },
+    },
+    retryCount: 0,
+  };
+}
+
+function makeState(
+  tasks: ScheduledTask[] = [makeTask()],
+  queueDetails: GroupQueueDetail[] = [],
+): WebStateProvider {
   return {
     getAgents: () => ({ 'agent-1': makeAgent() }),
     getChannelSubscriptions: () => ({
@@ -77,7 +107,7 @@ function makeState(tasks: ScheduledTask[] = [makeTask()]): WebStateProvider {
       maxActive: 8,
       maxIdle: 4,
     }),
-    getQueueDetails: () => [],
+    getQueueDetails: () => queueDetails,
     getIpcEvents: () => [],
     getTaskRunLogs: () => [],
     getTaskRunPhaseEvents: () => [],
@@ -543,6 +573,26 @@ describe('renderTasksContent', () => {
     // Filter chip and paused/completed counts unchanged
     expect(html).toContain('data-filter="active"');
     expect(html).toContain('1 paused');
+  });
+
+  it('combines overdue and running annotations on the active stat', () => {
+    const pastIso = new Date(Date.now() - 60_000).toISOString();
+    const futureIso = new Date(Date.now() + 3_600_000).toISOString();
+    const html = renderTasksContent(
+      makeState(
+        [
+          makeTask({ id: 'task-overdue', next_run: pastIso }),
+          makeTask({ id: 'task-future', next_run: futureIso }),
+          makeTask({ id: 'task-unscheduled', next_run: null }),
+        ],
+        [
+          makeTaskRunningDetail({ taskId: 'task-overdue' }),
+          makeTaskRunningDetail({ folderKey: 'other-agent', taskId: 'task-2' }),
+        ],
+      ),
+    );
+
+    expect(html).toContain('3 active (1 overdue, 2 running)');
   });
 
   it('omits the overdue annotation when no active task is overdue', () => {

--- a/src/web/tasks.ts
+++ b/src/web/tasks.ts
@@ -10,39 +10,29 @@ import { renderShell, escapeHtml } from './shared.js';
 import { allPageScripts } from './page-scripts.js';
 import { buildAgentChannelData } from './agent-channels.js';
 import { lastRunOutcomeClass } from './agent-detail.js';
+import {
+  countActiveTasks,
+  countOverdueActiveTasks,
+  countRunningTasks,
+  formatActiveTaskStats,
+} from './task-stats.js';
 
 /** Render the task manager content (no shell wrapper — for SPA nav). */
 export function renderTasksContent(state: WebStateProvider): string {
   const tasks = state.getTasks();
   const agentData = buildAgentChannelData(state);
 
-  const activeTasks = tasks.filter((t) => t.status === 'active').length;
+  const activeTasks = countActiveTasks(tasks);
+  const runningTasks = countRunningTasks(state.getQueueDetails());
   const pausedTasks = tasks.filter((t) => t.status === 'paused').length;
   const completedTasks = tasks.filter((t) => t.status === 'completed').length;
   const executingTasks = tasks.filter(
     (t) => t.status !== 'completed' && t.executing_since != null,
   ).length;
-  // Count active tasks whose `next_run` has already passed. The scheduler
-  // normally advances `next_run` after each tick, so an active task with a
-  // past `next_run` means the scheduler is either backed up, was offline,
-  // or the run lease hasn't been picked up yet. Surfacing the rollup on the
-  // `active` chip answers "is the scheduler keeping up?" without making the
-  // operator scan the `next run` column row-by-row.
-  //
-  // Tasks with `next_run = null` (paused/completed/once-fired) are skipped
-  // since "overdue" only makes sense relative to a scheduled time. Parse
-  // failures are treated as not-overdue to avoid noisy counts from
-  // legacy/malformed rows.
-  const now = Date.now();
-  const overdueActiveTasks = tasks.reduce((sum, t) => {
-    if (t.status !== 'active' || !t.next_run) return sum;
-    const nextRunMs = Date.parse(t.next_run);
-    return Number.isFinite(nextRunMs) && nextRunMs < now ? sum + 1 : sum;
-  }, 0);
-  const activeValue =
-    overdueActiveTasks > 0
-      ? `${activeTasks} active (${overdueActiveTasks} overdue)`
-      : `${activeTasks} active`;
+  const activeValue = formatActiveTaskStats(activeTasks, runningTasks, {
+    includeActiveLabel: true,
+    overdueTasks: countOverdueActiveTasks(tasks),
+  });
 
   // Build agent/channel options for create/edit forms
   const agentOptions = agentData


### PR DESCRIPTION
## Summary

- Extract shared active-task stat helpers for dashboard SSR, dashboard SSE stats patches, and tasks SSR.
- Update `/tasks` `refreshTasks()` to fetch queue details and preserve running, overdue, and executing stat annotations when rebuilding `.tasks-stats`.
- Add focused regressions for the tasks SSR active stat and the client refresh script.

Follow-up to #875. The original PR was merged before this client-refresh fix landed.

## Validation

- `bun test src/web/dashboard.test.ts src/web/tasks.test.ts src/web/page-scripts.test.ts src/web/server.test.ts`
- `bunx tsc --noEmit`
- `bun run format:check`
