### PR TITLE
fix(slack): drop reactions on non-agent messages

### DIFF
--- a/src/channels/slack.test.ts
+++ b/src/channels/slack.test.ts
@@ -158,6 +158,112 @@ describe('SlackChannel.ownsJid', () => {
   });
 });
 
+describe('SlackChannel.handleReactionAdded', () => {
+  const makeClient = () => ({
+    users: {
+      info: mock(({ user }: { user: string }) =>
+        Promise.resolve({
+          user: {
+            name: user,
+            profile: { display_name: user },
+            is_bot: false,
+          },
+        }),
+      ),
+    },
+  });
+
+  const makeChannel = (onReaction: ReturnType<typeof mock>) => {
+    const channel = new SlackChannel({
+      botId: 'CLAYTON',
+      token: 'xoxb-test',
+      appToken: 'xapp-test',
+      multiBotMode: true,
+      onMessage: () => {},
+      onChatMetadata: () => {},
+      registeredGroups: () => ({
+        'slack:CLAYTON:C123': {
+          name: 'Clayton',
+          folder: 'clayton-discord',
+          trigger: '@Clayton',
+          added_at: new Date().toISOString(),
+        },
+      }),
+      onReaction,
+    });
+    (channel as any).botUserId = 'UCLAYTON';
+    (channel as any).client = makeClient();
+    return channel;
+  };
+
+  const reactionEvent = (over: Record<string, unknown> = {}) => ({
+    type: 'reaction_added' as const,
+    user: 'UPEYTON',
+    reaction: 'fire',
+    item_user: 'UCLAYTON',
+    item: {
+      type: 'message' as const,
+      channel: 'C123',
+      ts: '1700000000.000100',
+    },
+    event_ts: '1700000000.000200',
+    ...over,
+  });
+
+  it('fires onReaction for a reaction on this bot’s own message', async () => {
+    const onReaction = mock(() => {});
+    const channel = makeChannel(onReaction);
+
+    await (channel as any).handleReactionAdded(reactionEvent());
+
+    expect(onReaction).toHaveBeenCalledTimes(1);
+    const args = (onReaction.mock.calls[0] as unknown as [
+      string,
+      string,
+      string,
+      string,
+      { id: string; isBot: boolean },
+    ]);
+    expect(args[0]).toBe('slack:CLAYTON:C123');
+    expect(args[1]).toBe('1700000000.000100');
+    expect(args[2]).toBe(':fire:');
+    expect(args[4]).toEqual({ id: 'UPEYTON', isBot: false });
+  });
+
+  it('drops reactions on messages authored by a teammate (not this bot)', async () => {
+    const onReaction = mock(() => {});
+    const channel = makeChannel(onReaction);
+
+    await (channel as any).handleReactionAdded(
+      reactionEvent({ item_user: 'UOTHERBOT' }),
+    );
+
+    expect(onReaction).not.toHaveBeenCalled();
+  });
+
+  it('drops reactions on messages authored by a human', async () => {
+    const onReaction = mock(() => {});
+    const channel = makeChannel(onReaction);
+
+    await (channel as any).handleReactionAdded(
+      reactionEvent({ item_user: 'UPEYTON' }),
+    );
+
+    expect(onReaction).not.toHaveBeenCalled();
+  });
+
+  it('drops reactions added by this bot itself', async () => {
+    const onReaction = mock(() => {});
+    const channel = makeChannel(onReaction);
+
+    await (channel as any).handleReactionAdded(
+      reactionEvent({ user: 'UCLAYTON' }),
+    );
+
+    expect(onReaction).not.toHaveBeenCalled();
+  });
+});
+
 describe('SlackChannel.handleMessage multi-bot mention routing', () => {
   const makeClient = () => ({
     users: {

--- a/src/channels/slack.test.ts
+++ b/src/channels/slack.test.ts
@@ -262,6 +262,16 @@ describe('SlackChannel.handleReactionAdded', () => {
 
     expect(onReaction).not.toHaveBeenCalled();
   });
+
+  it('fails closed and drops reactions when botUserId is unset', async () => {
+    const onReaction = mock(() => {});
+    const channel = makeChannel(onReaction);
+    (channel as any).botUserId = null;
+
+    await (channel as any).handleReactionAdded(reactionEvent());
+
+    expect(onReaction).not.toHaveBeenCalled();
+  });
 });
 
 describe('SlackChannel.handleMessage multi-bot mention routing', () => {

--- a/src/channels/slack.test.ts
+++ b/src/channels/slack.test.ts
@@ -217,13 +217,13 @@ describe('SlackChannel.handleReactionAdded', () => {
     await (channel as any).handleReactionAdded(reactionEvent());
 
     expect(onReaction).toHaveBeenCalledTimes(1);
-    const args = (onReaction.mock.calls[0] as unknown as [
+    const args = onReaction.mock.calls[0] as unknown as [
       string,
       string,
       string,
       string,
       { id: string; isBot: boolean },
-    ]);
+    ];
     expect(args[0]).toBe('slack:CLAYTON:C123');
     expect(args[1]).toBe('1700000000.000100');
     expect(args[2]).toBe(':fire:');

--- a/src/channels/slack.ts
+++ b/src/channels/slack.ts
@@ -3,6 +3,7 @@ import path from 'path';
 import { App, Assistant } from '@slack/bolt';
 import { WebClient } from '@slack/web-api';
 import type { AnyChunk, KnownBlock } from '@slack/web-api';
+import type { ReactionAddedEvent } from '@slack/types';
 
 import { logger } from '../logger.js';
 import {
@@ -262,35 +263,9 @@ export class SlackChannel implements Channel {
 
     // Register reaction handler (for share-request approvals etc.)
     this.app.event('reaction_added', async ({ event }) => {
-      const channelId =
-        event.item.type === 'message' ? event.item.channel : null;
-      if (!channelId) return;
-
-      // Ignore reactions from this bot itself — Slack delivers reaction_added
-      // events for our own reactions when we use `reactions.add` from
-      // share-request approval flows, and they would otherwise re-enter
-      // the message loop as @-mention noise.
-      if (this.botUserId && event.user === this.botUserId) return;
-
-      const chatJid = channelIdToJid(
-        channelId,
-        this.multiBotMode ? this.botId : undefined,
+      await this.handleReactionAdded(event).catch((err: unknown) =>
+        logger.error({ err }, 'Error handling Slack reaction_added'),
       );
-      const messageId = event.item.type === 'message' ? event.item.ts : null;
-      if (!messageId) return;
-
-      const emoji = `:${event.reaction}:`;
-
-      const { name: userName, isBot } = await resolveSlackUserIdentity(
-        this.client,
-        event.user,
-        event.user,
-      );
-
-      this.opts.onReaction?.(chatJid, messageId, emoji, userName, {
-        id: event.user,
-        isBot,
-      });
     });
 
     // Slack AI-app assistant threads (the "agent" split-pane experience).
@@ -877,6 +852,47 @@ export class SlackChannel implements Channel {
       this.threadRootExcerpts.set(key, '');
       return null;
     }
+  }
+
+  /**
+   * Process a `reaction_added` event. Exposed (via the public-shaped method)
+   * for tests; the bolt event handler in `connect()` delegates straight here.
+   *
+   * Filters that must precede dispatch:
+   *   1. drop reactions added by this bot itself (otherwise our own
+   *      `reactions.add` calls from approval flows would loop back in),
+   *   2. drop reactions on messages NOT authored by this bot — reactions on
+   *      human/teammate messages would wake the warm container with a
+   *      synthetic trigger that costs an inference round-trip just to no-op.
+   *      Mirrors the Discord adapter's `reaction.message.author?.id` check.
+   */
+  async handleReactionAdded(event: ReactionAddedEvent): Promise<void> {
+    const channelId =
+      event.item.type === 'message' ? event.item.channel : null;
+    if (!channelId) return;
+
+    if (this.botUserId && event.user === this.botUserId) return;
+    if (this.botUserId && event.item_user !== this.botUserId) return;
+
+    const chatJid = channelIdToJid(
+      channelId,
+      this.multiBotMode ? this.botId : undefined,
+    );
+    const messageId = event.item.type === 'message' ? event.item.ts : null;
+    if (!messageId) return;
+
+    const emoji = `:${event.reaction}:`;
+
+    const { name: userName, isBot } = await resolveSlackUserIdentity(
+      this.client,
+      event.user,
+      event.user,
+    );
+
+    this.opts.onReaction?.(chatJid, messageId, emoji, userName, {
+      id: event.user,
+      isBot,
+    });
   }
 
   // eslint-disable-next-line @typescript-eslint/no-explicit-any

--- a/src/channels/slack.ts
+++ b/src/channels/slack.ts
@@ -870,8 +870,12 @@ export class SlackChannel implements Channel {
     const channelId = event.item.type === 'message' ? event.item.channel : null;
     if (!channelId) return;
 
-    if (this.botUserId && event.user === this.botUserId) return;
-    if (this.botUserId && event.item_user !== this.botUserId) return;
+    // Fail closed: without a confirmed bot identity we cannot prove the
+    // reacted-to message belongs to this agent — drop rather than wake the
+    // container with a synthetic trigger.
+    if (!this.botUserId) return;
+    if (event.user === this.botUserId) return;
+    if (event.item_user !== this.botUserId) return;
 
     const chatJid = channelIdToJid(
       channelId,

--- a/src/channels/slack.ts
+++ b/src/channels/slack.ts
@@ -867,8 +867,7 @@ export class SlackChannel implements Channel {
    *      Mirrors the Discord adapter's `reaction.message.author?.id` check.
    */
   async handleReactionAdded(event: ReactionAddedEvent): Promise<void> {
-    const channelId =
-      event.item.type === 'message' ? event.item.channel : null;
+    const channelId = event.item.type === 'message' ? event.item.channel : null;
     if (!channelId) return;
 
     if (this.botUserId && event.user === this.botUserId) return;


### PR DESCRIPTION
## Summary
Slack's `reaction_added` event fires for every reaction in any registered channel — the handler only dropped reactions added *by* the bot itself, so a `:fire:` from a teammate on a *human* message still piped into `onReaction`, generated a synthetic `@Clayton [User reacted with :fire:]` trigger, and woke the warm container for a $0.20–$2.40 no-op reply ("Not addressed to me; staying silent.").

Adds the same author-is-this-bot check the Discord adapter already does (`reaction.message.author?.id !== this.client.user?.id`) so we only forward reactions on the bot's *own* messages.

Refactors the inline event handler into a dedicated `handleReactionAdded(event)` method so it's directly unit-testable (the bolt `app.event(...)` registration is opaque to the test harness).

## Background
Caught from logs of two back-to-back wakeups on the omniclaw channel (Clayton's container serves both Slack and Discord):
```
06:18:11 Clayton  Reaction on bot message in Slack
06:18:20 Result … cost=$0.2366 text=<internal>Reaction-only wakeup … Not addressed to me, no request to action.
06:18:50 Result … cost=$2.3929 text=<internal>Wakeup from Nicholas Allen's :fire: reaction on Peyton's "Sign in with Ditto" test screenshot. Not addressed to me; no action needed.
```
Reported by Peyton in #omniclaw.

## Changes
- `src/channels/slack.ts`
  - Add `if (this.botUserId && event.item_user !== this.botUserId) return;` — only fire on this bot's own messages.
  - Extract reaction logic into `handleReactionAdded(event: ReactionAddedEvent)`; bolt handler now delegates with `.catch(logger.error)`.
  - Import `ReactionAddedEvent` from `@slack/types`.
- `src/channels/slack.test.ts`
  - 4 new tests for the reaction handler: fires on own messages, drops teammate-bot author, drops human author, drops self-added reactions.

## Test plan
- [x] `bunx tsc --noEmit` — clean
- [x] `bun test src/channels/slack.test.ts` — 67 pass, 0 fail
- [x] `bun test` (full suite) — 2483 pass, 0 fail
- [ ] Deploy and observe: reactions from humans on human messages should produce no container wakeups in #omniclaw.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reaction handling in Slack channels so reactions are only processed for messages tied to the current bot.
  * Reactions are now ignored when added by the bot itself, by other bots, or on human-authored messages.
  * Reaction notifications now include the correct message, channel, emoji, and reacting user details when delivered.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->