### PR TITLE
feat(slack): stay proactive in threads after a bot mention

### DIFF
--- a/src/channels/slack.test.ts
+++ b/src/channels/slack.test.ts
@@ -723,6 +723,87 @@ describe('SlackChannel.handleMessage extras', () => {
       '1700000000.000100',
     );
   });
+
+  it('stays proactive in a thread after the bot is mentioned at the root', async () => {
+    const onMessage = mock(() => {});
+    const channel = makeInboundChannel(onMessage);
+    (channel as any).client = makeInboundClient('hey <@UBOT> look at this');
+
+    // Root message mentions the bot — engages proactive mode for the thread.
+    await (channel as any).handleMessage({
+      channel: 'C123',
+      ts: '1700000000.000100',
+      text: 'hey <@UBOT> look at this',
+      user: 'UPEYTON',
+    });
+    expect(
+      (channel as any).proactiveThreads.has('C123:1700000000.000100'),
+    ).toBe(true);
+
+    // Plain follow-up reply (no mention) should be auto-triggered.
+    await (channel as any).handleMessage({
+      channel: 'C123',
+      ts: '1700000000.000200',
+      thread_ts: '1700000000.000100',
+      text: 'any update?',
+      user: 'UPEYTON',
+    });
+
+    const last = onMessage.mock.calls.at(-1) as unknown as [string, any];
+    expect(last[1].content).toBe(
+      '@bot [Thread reply to: "hey <@UBOT> look at this"] any update?',
+    );
+  });
+
+  it('does not auto-trigger plain replies in threads the bot was not mentioned in', async () => {
+    const onMessage = mock(() => {});
+    const channel = makeInboundChannel(onMessage);
+    (channel as any).client = makeInboundClient('unrelated discussion');
+
+    await (channel as any).handleMessage({
+      channel: 'C123',
+      ts: '1700000000.000200',
+      thread_ts: '1700000000.000100',
+      text: 'any update?',
+      user: 'UPEYTON',
+    });
+
+    const msg = (onMessage.mock.calls[0] as unknown as [string, any])[1];
+    expect(msg.content).toBe(
+      '[Thread reply to: "unrelated discussion"] any update?',
+    );
+  });
+
+  it('engages proactive mode when the bot is mentioned mid-thread', async () => {
+    const onMessage = mock(() => {});
+    const channel = makeInboundChannel(onMessage);
+    (channel as any).client = makeInboundClient('root');
+
+    // Reply that mentions the bot — engages without double-prepending.
+    await (channel as any).handleMessage({
+      channel: 'C123',
+      ts: '1700000000.000200',
+      thread_ts: '1700000000.000100',
+      text: '<@UBOT> can you help',
+      user: 'UPEYTON',
+    });
+    expect(
+      (channel as any).proactiveThreads.has('C123:1700000000.000100'),
+    ).toBe(true);
+    const engaged = (onMessage.mock.calls[0] as unknown as [string, any])[1];
+    expect(engaged.content).not.toStartWith('@bot ');
+
+    // Subsequent plain reply is now auto-triggered.
+    await (channel as any).handleMessage({
+      channel: 'C123',
+      ts: '1700000000.000300',
+      thread_ts: '1700000000.000100',
+      text: 'thanks',
+      user: 'UPEYTON',
+    });
+    const last = onMessage.mock.calls.at(-1) as unknown as [string, any];
+    expect(last[1].content).toStartWith('@bot ');
+  });
 });
 
 // --- Slack media download helpers ---

--- a/src/channels/slack.ts
+++ b/src/channels/slack.ts
@@ -4,6 +4,7 @@ import { App, Assistant } from '@slack/bolt';
 import { WebClient } from '@slack/web-api';
 import type { AnyChunk, KnownBlock } from '@slack/web-api';
 
+import { buildTriggerPattern } from '../config.js';
 import { logger } from '../logger.js';
 import {
   MAX_BINARY_DOWNLOAD_BYTES,
@@ -51,6 +52,7 @@ const TEXT_LIMIT = 4000;
 const MARKDOWN_BLOCK_LIMIT = 11500;
 const THREAD_ROOT_CACHE_MAX = 1000;
 const SEEN_MESSAGE_CACHE_MAX = 500;
+const PROACTIVE_THREAD_CACHE_MAX = 1000;
 const THREAD_EXCERPT_MAX_CHARS = 140;
 const TASK_TITLE_MAX_CHARS = 80;
 // Slack caps each task_update chunk at 256 chars; keep title + details under it
@@ -217,6 +219,13 @@ export class SlackChannel implements Channel {
   private threadRootByTs = new Map<string, string>();
   /** Cached excerpts of thread root messages, keyed by `channelId:thread_ts`. */
   private threadRootExcerpts = new Map<string, string>();
+  /**
+   * Thread roots (`channelId:thread_ts`) where this bot has been engaged via an
+   * @-mention. Once engaged, subsequent plain replies in the thread are treated
+   * as triggered so the agent stays proactive instead of going silent until the
+   * next explicit mention.
+   */
+  private proactiveThreads = new Set<string>();
   /** Dedup of processed messages (`channelId:ts`) across message/app_mention events. */
   private seenMessages = new Set<string>();
   /**
@@ -841,6 +850,18 @@ export class SlackChannel implements Channel {
     }
   }
 
+  /** Mark a thread root as one this bot is actively engaged in. */
+  private markProactiveThread(channelId: string, threadTs: string): void {
+    const key = `${channelId}:${threadTs}`;
+    // Re-insert to keep most-recently-engaged threads at the tail for eviction.
+    this.proactiveThreads.delete(key);
+    this.proactiveThreads.add(key);
+    if (this.proactiveThreads.size > PROACTIVE_THREAD_CACHE_MAX) {
+      const oldest = this.proactiveThreads.values().next().value;
+      if (oldest !== undefined) this.proactiveThreads.delete(oldest);
+    }
+  }
+
   /** Dedup across message + app_mention deliveries of the same message. */
   private markSeen(key: string): boolean {
     if (this.seenMessages.has(key)) return false;
@@ -1016,6 +1037,46 @@ export class SlackChannel implements Channel {
         'Message from unregistered Slack channel — ignoring',
       );
       return;
+    }
+
+    // Proactive threads: once this bot is @-mentioned inside a thread, keep
+    // responding to subsequent plain replies in that thread without requiring a
+    // re-mention — the thread experience stays conversational. Channel threads
+    // only; assistant threads (the AI-app pane) are already a 1:1 conversation
+    // and always proactive.
+    if (!opts.assistantThread) {
+      const threadRoot = event.thread_ts || event.ts;
+      const threadKey = `${channelId}:${threadRoot}`;
+      const triggerHandle = group.trigger
+        ? group.trigger.replace(/^@/, '').toLowerCase()
+        : null;
+      const triggerPattern = group.trigger
+        ? buildTriggerPattern(group.trigger)
+        : null;
+      const mentionsThisBot =
+        (!!this.botUserId && mentions.some((m) => m.id === this.botUserId)) ||
+        (!!triggerHandle &&
+          mentions.some((m) => m.name.toLowerCase() === triggerHandle)) ||
+        (!!triggerPattern && triggerPattern.test(content));
+
+      if (mentionsThisBot) {
+        // Engage (or refresh) proactive mode for this thread root. Marking the
+        // root ts means every reply under it resolves to the same key.
+        this.markProactiveThread(channelId, threadRoot);
+      } else if (
+        event.thread_ts &&
+        event.thread_ts !== event.ts &&
+        group.trigger &&
+        this.proactiveThreads.has(threadKey)
+      ) {
+        // Plain reply in a thread we're engaged in — prepend the trigger so the
+        // subscription filter wakes this agent just like an explicit mention.
+        content = `${group.trigger} ${content}`;
+        logger.info(
+          { chatJid, threadTs: event.thread_ts, sender: senderName },
+          'Auto-triggering in engaged Slack thread',
+        );
+      }
     }
 
     // Process file attachments (images, documents, etc.)


### PR DESCRIPTION
## Summary

When a Slack OmniClaw agent is working in a thread it was **@-mentioned** in, it now stays **proactive** — responding to subsequent plain replies in that thread without needing a re-mention every time. This makes the in-thread experience conversational instead of stop-and-start.

Requested by Peyton: _"when a slack omniclaw agent is working in a thread that started with their mention, it should default to proactive instead of only listening to mentions."_

## How it works

This mirrors the existing **Discord** adapter pattern (`isThread && channel.ownerId === botId` → auto-prepend trigger). Slack threads are identified by `thread_ts`, so:

1. Any inbound message that @-mentions this bot marks its **thread root** (`channelId:thread_ts`) as *engaged* in a bounded `Set` (max 1000, LRU-style eviction).
2. A **plain reply** (no mention) in an engaged thread gets the group trigger prepended to its content, so `selectSubscriptionsForMessage()` wakes the agent exactly as it would for an explicit mention.
3. The trigger is prepended at the **start** of content, matching both the anchored `^@Name\b` trigger pattern and the non-anchored `getMentionPatterns()` filter downstream.

### Scope / safety
- **Channel threads only** — assistant (AI-app pane) threads are skipped (`!opts.assistantThread`); they're already 1:1 and always proactive.
- **Per-bot isolation** — each `SlackChannel` instance tracks its own engaged threads, so in multi-bot channels only the mentioned bot goes proactive. Other bots still require an explicit trigger.
- Mention detection is robust: matches by `botUserId`, by resolved mention display-name vs. trigger handle, or by anchored trigger pattern.

## Tests
- `stays proactive in a thread after the bot is mentioned at the root`
- `does not auto-trigger plain replies in threads the bot was not mentioned in`
- `engages proactive mode when the bot is mentioned mid-thread` (no double-prepend on the engaging message)

All 66 Slack tests pass; full suite **2482 pass / 0 fail**. `tsc --noEmit` clean, prettier formatted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Slack thread replies can now enter a proactive mode after an initial bot mention or trigger, allowing follow-up replies in the same thread to be automatically picked up.
  * Plain replies in an engaged thread are now auto-prefixed to keep the conversation moving without requiring repeated mentions.

* **Tests**
  * Added coverage for proactive thread behavior, including root mentions, plain replies, and mid-thread activation cases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->