### PR TITLE
test(logger): cover pretty color branches

### DIFF
--- a/src/logger.test.ts
+++ b/src/logger.test.ts
@@ -401,19 +401,25 @@ describe('logger', () => {
     it('uses op-based colors for non-error pretty logs', () => {
       const logger = createLogger({ group: 'main' }, 'trace');
 
+      logger.info({ op: 'containerSpawn' }, 'spawning container');
+      logger.info({ op: 'channelConnect' }, 'connecting channel');
       logger.info({ op: 'startup' }, 'booting');
       logger.info({ op: 'containerExit' }, 'stopped');
       logger.info({ op: 'ipcProcess' }, 'processing ipc');
       logger.info({ op: 'messageReceived' }, 'message in');
+      logger.info({ op: 'channelSend' }, 'message out');
       logger.info({ op: 'taskRun' }, 'running task');
       logger.info({ op: 'agentRun' }, 'running agent');
 
       expect(stderrOutput[0]).toContain('\x1b[32m');
-      expect(stderrOutput[1]).toContain('\x1b[31m');
-      expect(stderrOutput[2]).toContain('\x1b[34m');
-      expect(stderrOutput[3]).toContain('\x1b[33m');
-      expect(stderrOutput[4]).toContain('\x1b[35m');
-      expect(stderrOutput[5]).toContain('\x1b[36m');
+      expect(stderrOutput[1]).toContain('\x1b[32m');
+      expect(stderrOutput[2]).toContain('\x1b[32m');
+      expect(stderrOutput[3]).toContain('\x1b[31m');
+      expect(stderrOutput[4]).toContain('\x1b[34m');
+      expect(stderrOutput[5]).toContain('\x1b[33m');
+      expect(stderrOutput[6]).toContain('\x1b[33m');
+      expect(stderrOutput[7]).toContain('\x1b[35m');
+      expect(stderrOutput[8]).toContain('\x1b[36m');
     });
 
     it('uses level-based colors when no op is present and keeps errors red', () => {
@@ -431,6 +437,16 @@ describe('logger', () => {
       expect(stderrOutput[3]).toContain('\x1b[2m');
       expect(stderrOutput[4]).toContain('\x1b[31m');
       expect(stderrOutput[4]).toContain('ERROR');
+    });
+
+    it('renders fatal logs as red severity records in pretty mode', () => {
+      const logger = createLogger({ group: 'main' }, 'trace');
+
+      logger.fatal('fatal crash');
+
+      expect(stderrOutput[0]).toContain('\x1b[31m');
+      expect(stderrOutput[0]).toContain('FATAL');
+      expect(stderrOutput[0]).toContain('fatal crash');
     });
 
     it('falls back to dim coloring for unknown ops', () => {


### PR DESCRIPTION
## Summary

- Add deterministic pretty-output logger tests for the remaining operation color aliases.
- Add fatal pretty-output coverage to verify red severity label rendering.

## Test Count

- Before: 2504 tests, 6648 assertions.
- After: 2505 tests, 6654 assertions.

## Coverage

- `src/logger.ts` line coverage increased from 95.60% to 96.15%.
- Overall coverage remains 92.82% funcs / 92.27% lines.

## Verification

- `bun test src/logger.test.ts`
- `bun run typecheck`
- `bun test`
- `bun test --coverage`

## Remaining Coverage Gaps

- `src/logger.ts`: process-level uncaught exception handler remains untested because it exits the process.
- Larger uncovered areas remain in runtime-heavy modules such as channel adapters, `src/index.ts`, and local backend orchestration.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved pretty log color handling for a wider range of operation values.
  * Fatal logs in pretty mode now display a clear red severity indicator, including the fatal label and message text.

* **Tests**
  * Expanded automated coverage for colored log output and fatal log formatting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->