### PR TITLE
fix(agent-runner): snapshot output chat per turn

### DIFF
--- a/container/agent-runner/src/__tests__/output-routing.test.ts
+++ b/container/agent-runner/src/__tests__/output-routing.test.ts
@@ -29,4 +29,18 @@ describe('output routing', () => {
       result: null,
     });
   });
+
+  it('routes visible error outputs through the turn snapshot', () => {
+    const output = withOutputChatJid(
+      { status: 'error', result: null, error: 'runtime failed' },
+      'dc:turn-origin',
+    );
+
+    expect(output).toEqual({
+      status: 'error',
+      result: null,
+      error: 'runtime failed',
+      chatJid: 'dc:turn-origin',
+    });
+  });
 });

--- a/container/agent-runner/src/__tests__/output-routing.test.ts
+++ b/container/agent-runner/src/__tests__/output-routing.test.ts
@@ -1,0 +1,32 @@
+import { describe, expect, it } from 'bun:test';
+
+import { getOriginChatJid, withOutputChatJid } from '../output-routing.js';
+
+describe('output routing', () => {
+  it('uses origin chat over mutable current chat for turn output snapshots', () => {
+    const origin = getOriginChatJid({
+      chatJid: 'dc:mutable-current',
+      originChatJid: 'dc:turn-origin',
+    } as any);
+
+    const output = withOutputChatJid(
+      { status: 'success', result: 'final' },
+      origin,
+    );
+
+    expect(output.chatJid).toBe('dc:turn-origin');
+  });
+
+  it('falls back to initial chat when origin chat is absent', () => {
+    expect(getOriginChatJid({ chatJid: 'dc:initial' } as any)).toBe(
+      'dc:initial',
+    );
+  });
+
+  it('does not add an empty output chat jid', () => {
+    expect(withOutputChatJid({ status: 'success', result: null }, '')).toEqual({
+      status: 'success',
+      result: null,
+    });
+  });
+});

--- a/container/agent-runner/src/codex-runtime.ts
+++ b/container/agent-runner/src/codex-runtime.ts
@@ -31,6 +31,7 @@ import {
   redactActivityOutput,
   TOOL_OUTPUT_SNIPPET_CHARS,
 } from './activity-format.js';
+import { getOriginChatJid, withOutputChatJid } from './output-routing.js';
 
 interface JsonRpcRequest {
   id: string | number;
@@ -366,13 +367,17 @@ function handleServerRequest(
       type: `${request.method} declined`,
     });
     if (activity) {
-      writeOutput({
-        status: 'success',
-        result: activity,
-        newSessionId: session.threadId,
-        intermediate: true,
-        ...(currentChatJid ? { chatJid: currentChatJid } : {}),
-      });
+      writeOutput(
+        withOutputChatJid(
+          {
+            status: 'success',
+            result: activity,
+            newSessionId: session.threadId,
+            intermediate: true,
+          },
+          turnOutputChatJid,
+        ),
+      );
     }
     writeJsonRpcMessage(session, {
       id: request.id,
@@ -459,13 +464,17 @@ function handleNotification(
     }
     const activity = renderCodexActivity(item);
     if (activity) {
-      writeOutput({
-        status: 'success',
-        result: activity,
-        newSessionId: session.threadId,
-        intermediate: true,
-        ...(currentChatJid ? { chatJid: currentChatJid } : {}),
-      });
+      writeOutput(
+        withOutputChatJid(
+          {
+            status: 'success',
+            result: activity,
+            newSessionId: session.threadId,
+            intermediate: true,
+          },
+          turnOutputChatJid,
+        ),
+      );
     }
     return;
   }
@@ -872,6 +881,7 @@ async function runCodexTurn(
 
 let ipcInputDir = resolveIpcInputDir(false);
 let currentChatJid = '';
+let turnOutputChatJid = '';
 const currentChatFile =
   process.env.OMNICLAW_CURRENT_CHAT_FILE ||
   path.join('/tmp', `current_chat_jid-${process.pid}`);
@@ -883,6 +893,10 @@ function setCurrentChat(chatJid: string): void {
   } catch {
     /* ignore */
   }
+}
+
+function snapshotTurnOutputChat(chatJid: string): void {
+  turnOutputChatJid = chatJid;
 }
 
 function drainIpcInput(): IpcDrainResult {
@@ -1073,7 +1087,9 @@ export async function runCodexRuntime(
   ipcInputDir = resolveIpcInputDir(containerInput.isScheduledTask);
   fs.mkdirSync(ipcInputDir, { recursive: true });
 
+  const originChatJid = getOriginChatJid(containerInput);
   setCurrentChat(containerInput.chatJid);
+  snapshotTurnOutputChat(originChatJid);
 
   const codexEnv = buildCodexEnv(containerInput);
   const hasApiKey = Boolean(codexEnv.CODEX_API_KEY || codexEnv.OPENAI_API_KEY);
@@ -1123,6 +1139,7 @@ export async function runCodexRuntime(
     }
 
     while (true) {
+      snapshotTurnOutputChat(turnOutputChatJid || currentChatJid);
       const { shutdown } = drainIpcInput();
       if (shutdown) {
         log('Shutdown signal detected before prompt, exiting');
@@ -1150,12 +1167,16 @@ export async function runCodexRuntime(
         break;
       }
 
-      writeOutput({
-        status: 'success',
-        result: turn.text,
-        newSessionId: threadId,
-        ...(currentChatJid ? { chatJid: currentChatJid } : {}),
-      });
+      writeOutput(
+        withOutputChatJid(
+          {
+            status: 'success',
+            result: turn.text,
+            newSessionId: threadId,
+          },
+          turnOutputChatJid,
+        ),
+      );
 
       log('Prompt completed, waiting for next IPC message...');
       const nextMessage = await waitForIpcMessage();
@@ -1168,6 +1189,7 @@ export async function runCodexRuntime(
         `Got new message (${nextMessage.length} chars), sending follow-up prompt`,
       );
       prompt = nextMessage;
+      snapshotTurnOutputChat(currentChatJid);
     }
   } catch (err) {
     const errorMessage = err instanceof Error ? err.message : String(err);

--- a/container/agent-runner/src/codex-runtime.ts
+++ b/container/agent-runner/src/codex-runtime.ts
@@ -107,8 +107,9 @@ const RECOVERABLE_THREAD_RESUME_ERROR_SNIPPETS = [
 // ---------------------------------------------------------------------------
 
 function writeOutput(output: ContainerOutput): void {
+  const enriched = withOutputChatJid(output, turnOutputChatJid);
   console.log(OUTPUT_START_MARKER);
-  console.log(JSON.stringify(output));
+  console.log(JSON.stringify(enriched));
   console.log(OUTPUT_END_MARKER);
 }
 

--- a/container/agent-runner/src/cursor-sdk-runtime.ts
+++ b/container/agent-runner/src/cursor-sdk-runtime.ts
@@ -25,6 +25,7 @@ import type {
   IpcDrainResult,
   IpcMessage,
 } from '@omniclaw/protocol';
+import { getOriginChatJid, withOutputChatJid } from './output-routing.js';
 
 const OUTPUT_START_MARKER = '---OMNICLAW_OUTPUT_START---';
 const OUTPUT_END_MARKER = '---OMNICLAW_OUTPUT_END---';
@@ -41,7 +42,7 @@ function log(message: string): void {
 }
 
 function writeOutput(output: ContainerOutput, chatJid: string): void {
-  const enriched = chatJid ? { ...output, chatJid } : output;
+  const enriched = withOutputChatJid(output, chatJid);
   console.log(OUTPUT_START_MARKER);
   console.log(JSON.stringify(enriched));
   console.log(OUTPUT_END_MARKER);
@@ -61,6 +62,7 @@ function resolveCurrentChatFile(): string {
 
 let ipcInputDir = resolveIpcInputDir(false);
 let currentChatJid = '';
+let turnOutputChatJid = '';
 const currentChatFile = resolveCurrentChatFile();
 
 function setCurrentChat(chatJid: string): void {
@@ -70,6 +72,10 @@ function setCurrentChat(chatJid: string): void {
   } catch {
     /* ignore */
   }
+}
+
+function snapshotTurnOutputChat(chatJid: string): void {
+  turnOutputChatJid = chatJid;
 }
 
 function drainIpcInput(): IpcDrainResult {
@@ -332,7 +338,9 @@ export async function runCursorSdkRuntime(
   }
   fs.mkdirSync(ipcInputDir, { recursive: true });
 
+  const originChatJid = getOriginChatJid(containerInput);
   setCurrentChat(containerInput.chatJid);
+  snapshotTurnOutputChat(originChatJid);
 
   const apiKey =
     containerInput.secrets?.CURSOR_API_KEY?.trim() ||
@@ -345,7 +353,7 @@ export async function runCursorSdkRuntime(
         error:
           'CURSOR_API_KEY is not set (add to host .env or container secrets).',
       },
-      currentChatJid,
+      turnOutputChatJid,
     );
     process.exit(1);
   }
@@ -408,7 +416,7 @@ export async function runCursorSdkRuntime(
           result: null,
           intermediate: true,
         },
-        currentChatJid,
+        turnOutputChatJid,
       );
       log('heartbeat');
     }, HEARTBEAT_INTERVAL_MS);
@@ -460,6 +468,7 @@ export async function runCursorSdkRuntime(
     startHeartbeat();
 
     while (true) {
+      snapshotTurnOutputChat(turnOutputChatJid || currentChatJid);
       log(
         `Cursor send (session id: ${sessionId || 'new'}, cwd: ${groupFolder})`,
       );
@@ -500,7 +509,7 @@ export async function runCursorSdkRuntime(
                 intermediate: true,
                 newSessionId: sdkAgent.agentId,
               },
-              currentChatJid,
+              turnOutputChatJid,
             );
           }
         }
@@ -525,7 +534,7 @@ export async function runCursorSdkRuntime(
             error: message,
             newSessionId: sdkAgent.agentId,
           },
-          currentChatJid,
+          turnOutputChatJid,
         );
         stopHeartbeat();
         process.exit(1);
@@ -545,7 +554,7 @@ export async function runCursorSdkRuntime(
             intermediate: false,
             newSessionId: sdkAgent.agentId,
           },
-          currentChatJid,
+          turnOutputChatJid,
         );
       } else {
         const errDetail =
@@ -557,7 +566,7 @@ export async function runCursorSdkRuntime(
             error: errDetail,
             newSessionId: sdkAgent.agentId,
           },
-          currentChatJid,
+          turnOutputChatJid,
         );
         stopHeartbeat();
         process.exit(1);
@@ -569,7 +578,7 @@ export async function runCursorSdkRuntime(
           result: null,
           newSessionId: sessionId,
         },
-        currentChatJid,
+        turnOutputChatJid,
       );
 
       log('Waiting for next IPC message...');
@@ -579,6 +588,7 @@ export async function runCursorSdkRuntime(
         break;
       }
       prompt = nextMessage;
+      snapshotTurnOutputChat(currentChatJid);
     }
 
     stopHeartbeat();
@@ -591,13 +601,13 @@ export async function runCursorSdkRuntime(
           result: null,
           error: `Cursor SDK: ${err.message}`,
         },
-        currentChatJid,
+        turnOutputChatJid,
       );
     } else {
       const message = err instanceof Error ? err.message : String(err);
       writeOutput(
         { status: 'error', result: null, error: message },
-        currentChatJid,
+        turnOutputChatJid,
       );
     }
     process.exit(1);

--- a/container/agent-runner/src/index.ts
+++ b/container/agent-runner/src/index.ts
@@ -33,6 +33,7 @@ import type {
   IpcDrainResult,
   IpcMessage,
 } from '@omniclaw/protocol';
+import { getOriginChatJid, withOutputChatJid } from './output-routing.js';
 
 type ExternalMcpServerConfig =
   | {
@@ -422,10 +423,7 @@ const OUTPUT_START_MARKER = '---OMNICLAW_OUTPUT_START---';
 const OUTPUT_END_MARKER = '---OMNICLAW_OUTPUT_END---';
 
 function writeOutput(output: ContainerOutput): void {
-  // Inject current chatJid so the host can route responses to the correct channel
-  const enriched = currentChatJidValue
-    ? { ...output, chatJid: currentChatJidValue }
-    : output;
+  const enriched = withOutputChatJid(output, turnOutputChatJidValue);
   console.log(OUTPUT_START_MARKER);
   console.log(JSON.stringify(enriched));
   console.log(OUTPUT_END_MARKER);
@@ -928,6 +926,7 @@ function formatTranscriptMarkdown(
 // In shared-VM mode, multiple runner processes share /tmp, so this must be per exec.
 const CURRENT_CHAT_FILE = resolveCurrentChatFile();
 let currentChatJidValue = '';
+let turnOutputChatJidValue = '';
 
 function setCurrentChat(chatJid: string): void {
   currentChatJidValue = chatJid;
@@ -936,6 +935,10 @@ function setCurrentChat(chatJid: string): void {
   } catch {
     /* ignore */
   }
+}
+
+function snapshotTurnOutputChat(chatJid: string): void {
+  turnOutputChatJidValue = chatJid;
 }
 
 /**
@@ -1678,8 +1681,12 @@ Please review these changes to understand your new capabilities and fixes.
     );
   }
 
-  // Initialize current chat JID from container input
+  const originChatJid = getOriginChatJid(containerInput);
+
+  // Initialize current chat JID from container input. Final/intermediate output
+  // uses a per-turn snapshot so mid-turn sibling IPC cannot reroute replies.
   setCurrentChat(containerInput.chatJid);
+  snapshotTurnOutputChat(originChatJid);
 
   // Build initial prompt (drain any pending IPC messages too)
   let prompt = containerInput.prompt;
@@ -1709,6 +1716,7 @@ Please review these changes to understand your new capabilities and fixes.
   let resumeAt: string | undefined = containerInput.resumeAt;
   try {
     while (true) {
+      snapshotTurnOutputChat(turnOutputChatJidValue || currentChatJidValue);
       log(
         `Starting query (session: ${sessionId || 'new'}, resumeAt: ${resumeAt || 'latest'})...`,
       );
@@ -1771,6 +1779,7 @@ Please review these changes to understand your new capabilities and fixes.
 
       log(`Got new message (${nextMessage.length} chars), starting new query`);
       prompt = nextMessage;
+      snapshotTurnOutputChat(currentChatJidValue);
     }
   } catch (err) {
     const errorMessage = err instanceof Error ? err.message : String(err);

--- a/container/agent-runner/src/opencode-runtime.ts
+++ b/container/agent-runner/src/opencode-runtime.ts
@@ -50,8 +50,9 @@ const OUTPUT_END_MARKER = '---OMNICLAW_OUTPUT_END---';
 // ---------------------------------------------------------------------------
 
 function writeOutput(output: ContainerOutput): void {
+  const enriched = withOutputChatJid(output, turnOutputChatJid);
   console.log(OUTPUT_START_MARKER);
-  console.log(JSON.stringify(output));
+  console.log(JSON.stringify(enriched));
   console.log(OUTPUT_END_MARKER);
 }
 

--- a/container/agent-runner/src/opencode-runtime.ts
+++ b/container/agent-runner/src/opencode-runtime.ts
@@ -30,6 +30,7 @@ import {
   redactActivityOutput,
   TOOL_OUTPUT_SNIPPET_CHARS,
 } from './activity-format.js';
+import { getOriginChatJid, withOutputChatJid } from './output-routing.js';
 
 // ---------------------------------------------------------------------------
 // Constants
@@ -70,6 +71,7 @@ function resolveIpcInputDir(isScheduledTask?: boolean): string {
 
 let ipcInputDir = resolveIpcInputDir(false);
 let currentChatJid = '';
+let turnOutputChatJid = '';
 const currentChatFile =
   process.env.OMNICLAW_CURRENT_CHAT_FILE ||
   path.join('/tmp', `current_chat_jid-${process.pid}`);
@@ -81,6 +83,10 @@ function setCurrentChat(chatJid: string): void {
   } catch {
     /* ignore */
   }
+}
+
+function snapshotTurnOutputChat(chatJid: string): void {
+  turnOutputChatJid = chatJid;
 }
 
 function drainIpcInput(): IpcDrainResult {
@@ -464,25 +470,33 @@ async function runOpenCodePrompt(
           if (output) {
             const text = `▸ ${toolName}: ${input}\n\`\`\`\n${output}\n\`\`\``;
             log(`[tool] ${toolName}(${input}) -> ${output}`);
-            writeOutput({
-              status: 'success',
-              result: text,
-              newSessionId: sessionId,
-              intermediate: true,
-              ...(currentChatJid ? { chatJid: currentChatJid } : {}),
-            });
+            writeOutput(
+              withOutputChatJid(
+                {
+                  status: 'success',
+                  result: text,
+                  newSessionId: sessionId,
+                  intermediate: true,
+                },
+                turnOutputChatJid,
+              ),
+            );
             loggedToolIds.add(id);
             loggedPartCount++;
           } else if (!loggedToolIds.has(`pending:${id}`)) {
             const text = `▸ ${toolName}: ${input}`;
             log(`[tool] ${toolName}(${input}) ...`);
-            writeOutput({
-              status: 'success',
-              result: text,
-              newSessionId: sessionId,
-              intermediate: true,
-              ...(currentChatJid ? { chatJid: currentChatJid } : {}),
-            });
+            writeOutput(
+              withOutputChatJid(
+                {
+                  status: 'success',
+                  result: text,
+                  newSessionId: sessionId,
+                  intermediate: true,
+                },
+                turnOutputChatJid,
+              ),
+            );
             loggedToolIds.add(`pending:${id}`);
             loggedPartCount++;
           }
@@ -534,13 +548,16 @@ async function runOpenCodePrompt(
     // (OpenCode doesn't expose granular tool-call streaming via SDK prompt,
     //  so we just emit the final result)
 
-    const output: ContainerOutput = {
-      status: 'success',
-      result: responseText,
-      newSessionId: sessionId,
-    };
-    if (currentChatJid) output.chatJid = currentChatJid;
-    writeOutput(output);
+    writeOutput(
+      withOutputChatJid(
+        {
+          status: 'success',
+          result: responseText,
+          newSessionId: sessionId,
+        },
+        turnOutputChatJid,
+      ),
+    );
 
     return {
       sessionId,
@@ -642,8 +659,12 @@ export async function runOpenCodeRuntime(
   }
   fs.mkdirSync(ipcInputDir, { recursive: true });
 
-  // Initialize current chat JID
+  const originChatJid = getOriginChatJid(containerInput);
+
+  // Initialize current chat JID. Runtime output uses a per-turn snapshot so
+  // mid-turn sibling IPC cannot reroute the final reply.
   setCurrentChat(containerInput.chatJid);
+  snapshotTurnOutputChat(originChatJid);
 
   // Build env for the opencode server — strip secrets that OpenCode doesn't
   // need. OpenCode authenticates via auth.json, not env vars. Including
@@ -799,6 +820,7 @@ export async function runOpenCodeRuntime(
   // Query loop: send prompt → wait for IPC → repeat
   try {
     while (true) {
+      snapshotTurnOutputChat(turnOutputChatJid || currentChatJid);
       log(`Sending prompt (session: ${sessionId}, ${prompt.length} chars)...`);
 
       const result = await runOpenCodePrompt(
@@ -837,12 +859,16 @@ export async function runOpenCodeRuntime(
           continue;
         }
 
-        writeOutput({
-          status: 'success',
-          result: responsePlan.finalText,
-          newSessionId: sessionId,
-          ...(currentChatJid ? { chatJid: currentChatJid } : {}),
-        });
+        writeOutput(
+          withOutputChatJid(
+            {
+              status: 'success',
+              result: responsePlan.finalText,
+              newSessionId: sessionId,
+            },
+            turnOutputChatJid,
+          ),
+        );
       }
 
       // Emit session update so host can track it
@@ -860,6 +886,7 @@ export async function runOpenCodeRuntime(
         `Got new message (${nextMessage.length} chars), sending follow-up prompt`,
       );
       prompt = nextMessage;
+      snapshotTurnOutputChat(currentChatJid);
     }
   } catch (err) {
     const errorMessage = err instanceof Error ? err.message : String(err);

--- a/container/agent-runner/src/output-routing.ts
+++ b/container/agent-runner/src/output-routing.ts
@@ -1,0 +1,12 @@
+import type { ContainerInput, ContainerOutput } from '@omniclaw/protocol';
+
+export function getOriginChatJid(containerInput: ContainerInput): string {
+  return containerInput.originChatJid || containerInput.chatJid;
+}
+
+export function withOutputChatJid(
+  output: ContainerOutput,
+  chatJid: string,
+): ContainerOutput {
+  return chatJid ? { ...output, chatJid } : output;
+}


### PR DESCRIPTION
## Summary

- snapshot agent-runner stdout routing to the turn origin/current chat at turn boundaries
- keep mutable `current_chat_jid` updates for MCP `send_message` context without letting mid-turn sibling IPC reroute final output
- cover origin-chat output routing helper behavior

Fixes #725.

## Tests

- `bun test`
- `bun run typecheck`
- `bun run format:check`
