### PR TITLE
fix(web): block SolidStart page CSRF before proxy

### DIFF
--- a/src/web/server.test.ts
+++ b/src/web/server.test.ts
@@ -1,8 +1,6 @@
 import { createHash, createHmac, randomUUID } from 'crypto';
 
 import { describe, it, expect, afterEach, mock } from 'bun:test';
-import fs from 'fs';
-import path from 'path';
 
 import {
   isTrustedLanDiscoveryAdminRequest,
@@ -210,8 +208,6 @@ const authHeader = `Basic ${btoa(`${testAuth.username}:${testAuth.password}`)}`;
 const peerSecret = 'peer-shared-secret-32-bytes-long!';
 const originalFetch = globalThis.fetch;
 const originalWebUiSolid = process.env.WEB_UI_SOLID;
-const solidOutputDir = path.join(process.cwd(), 'webui', '.output', 'server');
-const solidOutputFile = path.join(solidOutputDir, 'index.mjs');
 
 let handle: WebServerHandle | null = null;
 
@@ -231,10 +227,6 @@ afterEach(async () => {
   } else {
     process.env.WEB_UI_SOLID = originalWebUiSolid;
   }
-  fs.rmSync(path.join(process.cwd(), 'webui', '.output'), {
-    recursive: true,
-    force: true,
-  });
   resetDiscoveryContextForTests();
 });
 
@@ -492,11 +484,6 @@ describe('basic auth', () => {
 
   it('rejects cross-site SolidStart page POSTs before proxying', async () => {
     process.env.WEB_UI_SOLID = 'true';
-    fs.mkdirSync(solidOutputDir, { recursive: true });
-    fs.writeFileSync(
-      solidOutputFile,
-      'globalThis.__solidServerLoaded = true;\n',
-    );
     const proxyFetch = mock(
       async () => new Response('proxied unsafe page mutation', { status: 299 }),
     );

--- a/src/web/server.test.ts
+++ b/src/web/server.test.ts
@@ -1,6 +1,8 @@
 import { createHash, createHmac, randomUUID } from 'crypto';
 
-import { describe, it, expect, afterEach } from 'bun:test';
+import { describe, it, expect, afterEach, mock } from 'bun:test';
+import fs from 'fs';
+import path from 'path';
 
 import {
   isTrustedLanDiscoveryAdminRequest,
@@ -206,6 +208,10 @@ function extractInlineShellScript(html: string): string {
 const testAuth = { username: 'admin', password: 'secret' };
 const authHeader = `Basic ${btoa(`${testAuth.username}:${testAuth.password}`)}`;
 const peerSecret = 'peer-shared-secret-32-bytes-long!';
+const originalFetch = globalThis.fetch;
+const originalWebUiSolid = process.env.WEB_UI_SOLID;
+const solidOutputDir = path.join(process.cwd(), 'webui', '.output', 'server');
+const solidOutputFile = path.join(solidOutputDir, 'index.mjs');
 
 let handle: WebServerHandle | null = null;
 
@@ -219,6 +225,16 @@ afterEach(async () => {
     await handle.stop();
     handle = null;
   }
+  globalThis.fetch = originalFetch;
+  if (originalWebUiSolid === undefined) {
+    delete process.env.WEB_UI_SOLID;
+  } else {
+    process.env.WEB_UI_SOLID = originalWebUiSolid;
+  }
+  fs.rmSync(path.join(process.cwd(), 'webui', '.output'), {
+    recursive: true,
+    force: true,
+  });
   resetDiscoveryContextForTests();
 });
 
@@ -472,6 +488,34 @@ describe('basic auth', () => {
       error: 'Cross-site request blocked',
     });
     expect(runCalls).toBe(0);
+  });
+
+  it('rejects cross-site SolidStart page POSTs before proxying', async () => {
+    process.env.WEB_UI_SOLID = 'true';
+    fs.mkdirSync(solidOutputDir, { recursive: true });
+    fs.writeFileSync(
+      solidOutputFile,
+      'globalThis.__solidServerLoaded = true;\n',
+    );
+    const proxyFetch = mock(
+      async () => new Response('proxied unsafe page mutation', { status: 299 }),
+    );
+    globalThis.fetch = proxyFetch as unknown as typeof fetch;
+
+    handle = startWebServer(testConfig(), makeState());
+
+    const res = await originalFetch(url('/solid-action'), {
+      method: 'POST',
+      headers: {
+        Authorization: authHeader,
+        Origin: 'https://attacker.example',
+        'Sec-Fetch-Site': 'cross-site',
+      },
+    });
+
+    expect(res.status).toBe(403);
+    expect(await res.text()).toBe('Cross-site request blocked');
+    expect(proxyFetch).not.toHaveBeenCalled();
   });
 
   it('allows same-origin browser POSTs with valid Basic credentials', async () => {

--- a/src/web/server.ts
+++ b/src/web/server.ts
@@ -442,6 +442,13 @@ export function startWebServer(
       );
     }
 
+    if (
+      !isAuthenticatedPeerRequest &&
+      isCrossSiteBrowserMutation(req, url, corsOrigin)
+    ) {
+      return makeCsrfRejection(url.pathname);
+    }
+
     // --- SolidStart mode: JSON SSE + delegate to SolidStart handler ---
     if (solidMode && url.pathname === '/api/events') {
       if (req.method !== 'GET') {
@@ -835,13 +842,6 @@ export function startWebServer(
         status: 204,
         headers: makeCorsHeaders(corsOrigin),
       });
-    }
-
-    if (
-      !isAuthenticatedPeerRequest &&
-      isCrossSiteBrowserMutation(req, url, corsOrigin)
-    ) {
-      return makeCsrfRejection(url.pathname);
     }
 
     const result = handleRequest(req, state, sseClients.size);


### PR DESCRIPTION
## Summary

- Move the Web UI cross-site unsafe-method guard before SolidStart page proxying.
- Add a regression test proving cross-site Basic Auth POSTs to SolidStart page routes are rejected before the internal proxy fetch runs.

## Security Impact

`WEB_UI_SOLID=true` previously delegated non-API page requests to SolidStart before the shared CSRF/origin guard. If the SolidStart app adds page actions or other non-API mutations, Basic Auth deployments could bypass the existing CSRF protection for those routes.

## Verification

- `bun test src/web/server.test.ts`
- `bunx prettier --check src/web/server.ts src/web/server.test.ts`
- `bun run tsc --noEmit`

## Reviewer Request

Please leave review feedback directly on this GitHub PR, using file/line comments where applicable.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Cross-site browser POST requests are now blocked earlier and more reliably, including in SolidStart-backed flows.
  * Requests that are rejected now return a clear 403 response with a “Cross-site request blocked” message.
  * Improved test isolation to prevent one request or environment setting from affecting the next.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->