### PR TITLE
test(backends): cover shared VM cleanup paths

### DIFF
--- a/src/backends/shared-vm.test.ts
+++ b/src/backends/shared-vm.test.ts
@@ -176,31 +176,29 @@ describe('SharedVmManager', () => {
   it('stops only running orphaned shared VMs', async () => {
     const manager = new SharedVmManager();
     (manager as any).containerName = 'omniclaw-shared-claude-current';
-    const shellSpy = spyOn(Bun, '$').mockImplementation(
-      (() => ({
-        quiet: () => ({
-          text: () =>
-            JSON.stringify([
-              {
-                status: 'running',
-                configuration: { id: 'omniclaw-shared-claude-old' },
-              },
-              {
-                status: 'stopped',
-                configuration: { id: 'omniclaw-shared-claude-stopped' },
-              },
-              {
-                status: 'running',
-                configuration: { id: 'omniclaw-shared-claude-current' },
-              },
-              {
-                status: 'running',
-                configuration: { id: 'unrelated-container' },
-              },
-            ]),
-        }),
-      })) as unknown as typeof Bun.$,
-    );
+    const shellSpy = spyOn(Bun, '$').mockImplementation((() => ({
+      quiet: () => ({
+        text: () =>
+          JSON.stringify([
+            {
+              status: 'running',
+              configuration: { id: 'omniclaw-shared-claude-old' },
+            },
+            {
+              status: 'stopped',
+              configuration: { id: 'omniclaw-shared-claude-stopped' },
+            },
+            {
+              status: 'running',
+              configuration: { id: 'omniclaw-shared-claude-current' },
+            },
+            {
+              status: 'running',
+              configuration: { id: 'unrelated-container' },
+            },
+          ]),
+      }),
+    })) as unknown as typeof Bun.$);
     const spawnSpy = spyOn(Bun, 'spawn').mockImplementation((() =>
       makeProcess(0)) as unknown as typeof Bun.spawn);
 
@@ -217,13 +215,11 @@ describe('SharedVmManager', () => {
 
   it('swallows orphan cleanup shell failures', async () => {
     const manager = new SharedVmManager();
-    const shellSpy = spyOn(Bun, '$').mockImplementation(
-      (() => ({
-        quiet: () => {
-          throw new Error('runtime unavailable');
-        },
-      })) as unknown as typeof Bun.$,
-    );
+    const shellSpy = spyOn(Bun, '$').mockImplementation((() => ({
+      quiet: () => {
+        throw new Error('runtime unavailable');
+      },
+    })) as unknown as typeof Bun.$);
     const spawnSpy = spyOn(Bun, 'spawn');
 
     await expect(manager.cleanupOrphans()).resolves.toBeUndefined();

--- a/src/backends/shared-vm.test.ts
+++ b/src/backends/shared-vm.test.ts
@@ -52,10 +52,6 @@ describe('SharedVmManager', () => {
       process.env.OMNICLAW_EXTRA_DIR = originalExtraDir;
     }
     fs.rmSync(extraDir, { recursive: true, force: true });
-    fs.rmSync(path.join(DATA_DIR, 'opencode-data'), {
-      recursive: true,
-      force: true,
-    });
   });
 
   it('returns an existing live container without spawning a new one', async () => {
@@ -155,6 +151,7 @@ describe('SharedVmManager', () => {
   it('includes the optional OpenCode data mount when the cache exists', async () => {
     const manager = new SharedVmManager();
     const opencodeDataDir = path.join(DATA_DIR, 'opencode-data');
+    const opencodeDataDirExisted = fs.existsSync(opencodeDataDir);
     fs.mkdirSync(opencodeDataDir, { recursive: true });
     const nowSpy = spyOn(Date, 'now').mockReturnValue(333);
     const spawnSpy = spyOn(Bun, 'spawn').mockImplementation((() =>
@@ -170,6 +167,9 @@ describe('SharedVmManager', () => {
       );
     } finally {
       nowSpy.mockRestore();
+      if (!opencodeDataDirExisted) {
+        fs.rmdirSync(opencodeDataDir);
+      }
     }
   });
 

--- a/src/backends/shared-vm.test.ts
+++ b/src/backends/shared-vm.test.ts
@@ -11,7 +11,7 @@ import fs from 'fs';
 import os from 'os';
 import path from 'path';
 
-import { LOCAL_RUNTIME, SHARED_CLAUDE_VM_MEMORY } from '../config.js';
+import { DATA_DIR, LOCAL_RUNTIME, SHARED_CLAUDE_VM_MEMORY } from '../config.js';
 import { SharedVmManager } from './shared-vm.js';
 
 function makeProcess(
@@ -52,6 +52,10 @@ describe('SharedVmManager', () => {
       process.env.OMNICLAW_EXTRA_DIR = originalExtraDir;
     }
     fs.rmSync(extraDir, { recursive: true, force: true });
+    fs.rmSync(path.join(DATA_DIR, 'opencode-data'), {
+      recursive: true,
+      force: true,
+    });
   });
 
   it('returns an existing live container without spawning a new one', async () => {
@@ -146,5 +150,98 @@ describe('SharedVmManager', () => {
       'stop',
       'omniclaw-shared-claude-stop-me',
     ]);
+  });
+
+  it('includes the optional OpenCode data mount when the cache exists', async () => {
+    const manager = new SharedVmManager();
+    const opencodeDataDir = path.join(DATA_DIR, 'opencode-data');
+    fs.mkdirSync(opencodeDataDir, { recursive: true });
+    const nowSpy = spyOn(Date, 'now').mockReturnValue(333);
+    const spawnSpy = spyOn(Bun, 'spawn').mockImplementation((() =>
+      makeProcess(0)) as unknown as typeof Bun.spawn);
+
+    try {
+      await expect(manager.ensureRunning()).resolves.toBe(
+        'omniclaw-shared-claude-333',
+      );
+
+      expect(spawnSpy.mock.calls[0]?.[0]).toContain(
+        `${opencodeDataDir}:/data/opencode-data`,
+      );
+    } finally {
+      nowSpy.mockRestore();
+    }
+  });
+
+  it('stops only running orphaned shared VMs', async () => {
+    const manager = new SharedVmManager();
+    (manager as any).containerName = 'omniclaw-shared-claude-current';
+    const shellSpy = spyOn(Bun, '$').mockImplementation(
+      (() => ({
+        quiet: () => ({
+          text: () =>
+            JSON.stringify([
+              {
+                status: 'running',
+                configuration: { id: 'omniclaw-shared-claude-old' },
+              },
+              {
+                status: 'stopped',
+                configuration: { id: 'omniclaw-shared-claude-stopped' },
+              },
+              {
+                status: 'running',
+                configuration: { id: 'omniclaw-shared-claude-current' },
+              },
+              {
+                status: 'running',
+                configuration: { id: 'unrelated-container' },
+              },
+            ]),
+        }),
+      })) as unknown as typeof Bun.$,
+    );
+    const spawnSpy = spyOn(Bun, 'spawn').mockImplementation((() =>
+      makeProcess(0)) as unknown as typeof Bun.spawn);
+
+    await expect(manager.cleanupOrphans()).resolves.toBeUndefined();
+
+    expect(shellSpy).toHaveBeenCalledTimes(1);
+    expect(spawnSpy).toHaveBeenCalledTimes(1);
+    expect(spawnSpy.mock.calls[0]?.[0]).toEqual([
+      LOCAL_RUNTIME,
+      'stop',
+      'omniclaw-shared-claude-old',
+    ]);
+  });
+
+  it('swallows orphan cleanup shell failures', async () => {
+    const manager = new SharedVmManager();
+    const shellSpy = spyOn(Bun, '$').mockImplementation(
+      (() => ({
+        quiet: () => {
+          throw new Error('runtime unavailable');
+        },
+      })) as unknown as typeof Bun.$,
+    );
+    const spawnSpy = spyOn(Bun, 'spawn');
+
+    await expect(manager.cleanupOrphans()).resolves.toBeUndefined();
+
+    expect(shellSpy).toHaveBeenCalledTimes(1);
+    expect(spawnSpy).not.toHaveBeenCalled();
+  });
+
+  it('swallows stop failures after clearing the current container', async () => {
+    const manager = new SharedVmManager();
+    (manager as any).containerName = 'omniclaw-shared-claude-throw-stop';
+    const spawnSpy = spyOn(Bun, 'spawn').mockImplementation((() => {
+      throw new Error('stop failed');
+    }) as unknown as typeof Bun.spawn);
+
+    await expect(manager.stop()).resolves.toBeUndefined();
+
+    expect(manager.getName()).toBeNull();
+    expect(spawnSpy).toHaveBeenCalledTimes(1);
   });
 });


### PR DESCRIPTION
## Summary

- Add deterministic `SharedVmManager` tests for optional OpenCode data mounts.
- Add monkey-patched orphan cleanup tests that avoid invoking Docker.
- Add fallback coverage for shell cleanup failures and stop failures.

## Test Count

- Before: 2505 tests, 0 failures on fresh `origin/main`.
- After: 2509 tests, 0 failures.

## Coverage

- Overall line coverage: 92.27% -> 92.54%.
- `src/backends/shared-vm.ts` line coverage: 66.67% -> 91.04%.
- `src/backends/shared-vm.ts` function coverage: 72.73% -> 86.67%.

## Files Covered

- `src/backends/shared-vm.ts`

## Remaining Gaps

- `src/backends/local-backend.ts` remains low coverage because much of it shells out to container/runtime operations.
- Channel adapters (`discord.ts`, `telegram.ts`, `whatsapp.ts`) still have large integration-heavy regions uncovered.
- `src/index.ts` still has broad orchestrator paths that would benefit from additional simulation harness coverage.

## Verification

- `bun test src/backends/shared-vm.test.ts`
- `bun test`
- `bun test --coverage`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Expanded cleanup coverage for shared VM behavior.
  * Added checks for orphan VM handling, failure tolerance, and data mount setup when available.
  * Improved test cleanup to remove leftover app data between runs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->