### PR TITLE
fix(web): preserve dashboard agents working-count on live stats patch

### DIFF
--- a/src/web/dashboard.ts
+++ b/src/web/dashboard.ts
@@ -5,7 +5,11 @@ import { renderShell, escapeHtml, escapeJsonForHtml } from './shared.js';
 import { allPageScripts } from './page-scripts.js';
 import { buildAgentChannelData } from './agent-channels.js';
 import type { RemotePeerAgents } from '../discovery/types.js';
-import { formatActiveTaskStatsFromState } from './task-stats.js';
+import {
+  formatActiveTaskStatsFromState,
+  countWorkingAgents,
+  formatAgentsValue,
+} from './task-stats.js';
 
 function imageRev(value: string): string {
   return createHash('sha256').update(value).digest('hex').slice(0, 12);
@@ -31,18 +35,10 @@ export function renderDashboardContent(
   // actively doing work right now, without drilling into /agents or /system.
   // Remote peer agents are excluded because we do not track their lane state
   // locally; the bare count keeps reflecting the total fleet size.
-  const workingAgents = queueDetails.reduce(
-    (sum, g) =>
-      sum +
-      ((g.messageLane.active && !g.messageLane.idle) || g.taskLane.active
-        ? 1
-        : 0),
-    0,
+  const agentsValue = formatAgentsValue(
+    agentData.length,
+    countWorkingAgents(queueDetails),
   );
-  const agentsValue =
-    workingAgents > 0
-      ? `${agentData.length} (${workingAgents} working)`
-      : `${agentData.length}`;
 
   // Serialize agent topology data for canvas renderer
   const topoData = escapeJsonForHtml(

--- a/src/web/server.test.ts
+++ b/src/web/server.test.ts
@@ -1298,6 +1298,69 @@ describe('SSE', () => {
     reader.releaseLock();
   });
 
+  it('preserves agents working-count annotation in stats patches', async () => {
+    // Default makeState() exposes two agents; one task lane is running, so the
+    // live stats patch must show "2 (1 working)" — matching the static
+    // dashboard render — rather than resetting the card to a bare count.
+    handle = startWebServer(
+      testConfig(),
+      makeState({
+        getQueueDetails: () => [makeTaskRunningDetail()],
+      }),
+    );
+
+    const res = await authedFetch('/api/events?channels=stats', {
+      headers: { Accept: 'text/event-stream' },
+    });
+    expect(res.status).toBe(200);
+    expect(res.body).toBeTruthy();
+
+    const reader = res.body!.getReader();
+    handle.broadcast({
+      type: 'agent_status',
+      data: {
+        activeContainers: 2,
+        idleContainers: 1,
+        maxActive: 8,
+        maxIdle: 4,
+      },
+      timestamp: new Date().toISOString(),
+    });
+
+    const payload = await readUntilContains(reader, 'id="stat-agents"');
+    expect(payload).toContain('id="stat-agents">2 (1 working)</div>');
+    reader.releaseLock();
+  });
+
+  it('omits the working annotation in stats patches when no lane is active', async () => {
+    // No queue details → no agent is in flight, so the live patch must render a
+    // bare count with no "(N working)" suffix.
+    handle = startWebServer(testConfig(), makeState());
+
+    const res = await authedFetch('/api/events?channels=stats', {
+      headers: { Accept: 'text/event-stream' },
+    });
+    expect(res.status).toBe(200);
+    expect(res.body).toBeTruthy();
+
+    const reader = res.body!.getReader();
+    handle.broadcast({
+      type: 'agent_status',
+      data: {
+        activeContainers: 2,
+        idleContainers: 1,
+        maxActive: 8,
+        maxIdle: 4,
+      },
+      timestamp: new Date().toISOString(),
+    });
+
+    const payload = await readUntilContains(reader, 'id="stat-agents"');
+    expect(payload).toContain('id="stat-agents">2</div>');
+    expect(payload).not.toContain('working)');
+    reader.releaseLock();
+  });
+
   it('replays buffered logs to newly connected SSE clients', async () => {
     handle = startWebServer(testConfig(), makeState());
 

--- a/src/web/server.ts
+++ b/src/web/server.ts
@@ -44,7 +44,11 @@ import { serializeLogRecord } from './log-stream.js';
 import { renderSystemContent } from './system.js';
 import { renderSettingsContent } from './settings.js';
 import { renderTasksContent } from './tasks.js';
-import { formatActiveTaskStatsFromState } from './task-stats.js';
+import {
+  formatActiveTaskStatsFromState,
+  countWorkingAgents,
+  formatAgentsValue,
+} from './task-stats.js';
 import { renderLogsContent } from './logs.js';
 import { renderAgentsContent, buildAgentRowsHtml } from './agents-page.js';
 import {
@@ -1190,7 +1194,10 @@ function patchStats(client: SseClient, state: WebStateProvider): void {
   );
 
   client.stream.patchElements(
-    `<div class="value" id="stat-agents">${Object.keys(state.getAgents()).length}</div>`,
+    `<div class="value" id="stat-agents">${formatAgentsValue(
+      Object.keys(state.getAgents()).length,
+      countWorkingAgents(state.getQueueDetails()),
+    )}</div>`,
   );
   client.stream.patchElements(
     `<div class="value" id="stat-active">${activeContainers}/${stats.maxActive}</div>`,

--- a/src/web/task-stats.test.ts
+++ b/src/web/task-stats.test.ts
@@ -1,0 +1,95 @@
+import { describe, it, expect } from 'bun:test';
+
+import type { GroupQueueDetail } from '../group-queue.js';
+import { countWorkingAgents, formatAgentsValue } from './task-stats.js';
+
+function makeDetail(
+  overrides: {
+    message?: Partial<GroupQueueDetail['messageLane']>;
+    task?: Partial<GroupQueueDetail['taskLane']>;
+    folderKey?: string;
+  } = {},
+): GroupQueueDetail {
+  return {
+    folderKey: overrides.folderKey ?? 'agent',
+    messageLane: {
+      active: false,
+      idle: true,
+      pendingCount: 0,
+      containerName: null,
+      ...overrides.message,
+    },
+    taskLane: {
+      active: false,
+      pendingCount: 0,
+      containerName: null,
+      activeTask: null,
+      ...overrides.task,
+    },
+    retryCount: 0,
+  };
+}
+
+describe('countWorkingAgents', () => {
+  it('returns 0 when there are no queue details', () => {
+    expect(countWorkingAgents([])).toBe(0);
+  });
+
+  it('counts an agent processing a message (active, not idle)', () => {
+    expect(
+      countWorkingAgents([
+        makeDetail({ message: { active: true, idle: false } }),
+      ]),
+    ).toBe(1);
+  });
+
+  it('does not count an idle-waiting message lane', () => {
+    // active but idle means cooling down / waiting — not actively working.
+    expect(
+      countWorkingAgents([
+        makeDetail({ message: { active: true, idle: true } }),
+      ]),
+    ).toBe(0);
+  });
+
+  it('counts an agent running a scheduled task', () => {
+    expect(countWorkingAgents([makeDetail({ task: { active: true } })])).toBe(
+      1,
+    );
+  });
+
+  it('counts an agent only once when both lanes are in flight', () => {
+    expect(
+      countWorkingAgents([
+        makeDetail({
+          message: { active: true, idle: false },
+          task: { active: true },
+        }),
+      ]),
+    ).toBe(1);
+  });
+
+  it('sums working agents across multiple groups', () => {
+    expect(
+      countWorkingAgents([
+        makeDetail({ folderKey: 'a', message: { active: true, idle: false } }),
+        makeDetail({ folderKey: 'b', task: { active: true } }),
+        makeDetail({ folderKey: 'c' }),
+      ]),
+    ).toBe(2);
+  });
+});
+
+describe('formatAgentsValue', () => {
+  it('renders a bare count when no agents are working', () => {
+    expect(formatAgentsValue(3, 0)).toBe('3');
+  });
+
+  it('appends a working annotation when agents are in flight', () => {
+    expect(formatAgentsValue(3, 2)).toBe('3 (2 working)');
+  });
+
+  it('renders zero total without annotation', () => {
+    expect(formatAgentsValue(0, 0)).toBe('0');
+  });
+});

--- a/src/web/task-stats.ts
+++ b/src/web/task-stats.ts
@@ -6,6 +6,41 @@ export function countActiveTasks(tasks: readonly ScheduledTask[]): number {
   return tasks.filter((task) => task.status === 'active').length;
 }
 
+/**
+ * Count local agents currently in flight on either lane — actively processing a
+ * message (message lane active and not idle-waiting) or running a scheduled task
+ * (task lane active). Mirrors the "working" annotation on the dashboard agents
+ * card so the static render and the live SSE stats patch agree.
+ */
+export function countWorkingAgents(
+  queueDetails: readonly GroupQueueDetail[],
+): number {
+  return queueDetails.reduce(
+    (sum, g) =>
+      sum +
+      ((g.messageLane.active && !g.messageLane.idle) || g.taskLane.active
+        ? 1
+        : 0),
+    0,
+  );
+}
+
+/**
+ * Format the dashboard "agents" stat-card value: the total agent count plus a
+ * "(N working)" annotation when any agent lane is in flight. Shared by the
+ * static dashboard render and the live SSE stats patch so the two never diverge
+ * (the live patch previously dropped the annotation, resetting the card to a
+ * bare count on the first update).
+ */
+export function formatAgentsValue(
+  totalAgents: number,
+  workingAgents: number,
+): string {
+  return workingAgents > 0
+    ? `${totalAgents} (${workingAgents} working)`
+    : `${totalAgents}`;
+}
+
 export function countRunningTasks(
   queueDetails: readonly GroupQueueDetail[],
 ): number {


### PR DESCRIPTION
## Problem

The dashboard **agents** stat card renders a `(N working)` annotation on the static page (shipped in #884), telling the operator how much of the fleet is actively processing a message or running a task. But the live SSE stats patch (`patchStats` in `server.ts`) re-rendered the card with a bare count:

```ts
`<div class="value" id="stat-agents">${Object.keys(state.getAgents()).length}</div>`
```

So on the **first** `agent_status` / `task_update` event, the `(N working)` annotation silently disappeared — the static render and the live update disagreed, and the #884 feature regressed the moment anything happened on the dashboard.

## Fix

- Extract two shared helpers into `task-stats.ts`:
  - `countWorkingAgents(queueDetails)` — agents in flight on either lane (message lane active & not idle, or task lane active).
  - `formatAgentsValue(total, working)` — the `N` / `N (M working)` formatting.
- Use them from **both** the static dashboard render (`dashboard.ts`) and the live patch (`server.ts`) so the two can never diverge again.

No behavior change to the static render (logic is identical, now deduplicated). The live path now matches it.

## Tests

- `task-stats.test.ts` (new) — direct unit coverage for `countWorkingAgents` (idle-waiting lane excluded, both-lanes-counted-once, multi-group sum) and `formatAgentsValue`.
- `server.test.ts` — two SSE live-patch tests: working annotation **preserved** on `agent_status`, and **omitted** when no lane is active.

```
2516 pass / 0 fail   (bun test)
tsc --noEmit          clean
prettier --check      clean
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Dashboard and live stats now show agent counts with clearer working-agent status, such as `total (N working)` when applicable.

* **Bug Fixes**
  * Fixed inconsistent agent statistics between the dashboard and real-time updates.
  * Improved handling for cases where no queue details are available, so the agents count displays cleanly without extra wording.

* **Tests**
  * Added coverage for live stats updates and agent count formatting across active, inactive, and zero-agent scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->