### PR TITLE
fix(web): sanitize SolidStart proxy headers

### DIFF
--- a/src/web/solid-handler.test.ts
+++ b/src/web/solid-handler.test.ts
@@ -126,7 +126,15 @@ describe('solid-handler', () => {
       new Request('http://public.test/dashboard?tab=agents', {
         method: 'POST',
         headers: {
+          accept: 'text/html',
+          'accept-language': 'en-US',
           'accept-encoding': 'gzip',
+          authorization: 'Basic secret',
+          connection: 'keep-alive',
+          cookie: 'omniclaw_session=secret',
+          'content-type': 'text/plain',
+          te: 'trailers',
+          upgrade: 'websocket',
           'x-test': 'present',
         },
         body: 'hello world',
@@ -151,8 +159,16 @@ describe('solid-handler', () => {
 
     const headers = init.headers as Headers;
     expect(headers.get('host')).toBe(`127.0.0.1:${internalPort}`);
+    expect(headers.get('accept')).toBe('text/html');
     expect(headers.get('accept-encoding')).toBe('identity');
-    expect(headers.get('x-test')).toBe('present');
+    expect(headers.get('accept-language')).toBe('en-US');
+    expect(headers.get('content-type')).toBe('text/plain');
+    expect(headers.get('authorization')).toBeNull();
+    expect(headers.get('connection')).toBeNull();
+    expect(headers.get('cookie')).toBeNull();
+    expect(headers.get('te')).toBeNull();
+    expect(headers.get('upgrade')).toBeNull();
+    expect(headers.get('x-test')).toBeNull();
 
     const getResponse = await handler!(
       new Request('http://public.test/settings', { method: 'GET' }),

--- a/src/web/solid-handler.ts
+++ b/src/web/solid-handler.ts
@@ -21,6 +21,12 @@ type SolidHandler = (req: Request) => Promise<Response>;
 let solidHandler: SolidHandler | null = null;
 let solidPort: number | null = null;
 
+const SOLID_PROXY_REQUEST_HEADER_ALLOWLIST = new Set([
+  'accept',
+  'accept-language',
+  'content-type',
+]);
+
 /**
  * Initialize the SolidStart handler by importing the compiled output.
  * The SolidStart build (bun preset) starts its own server on an internal port.
@@ -52,7 +58,7 @@ export async function initSolidHandler(
     solidHandler = async (req: Request): Promise<Response> => {
       const url = new URL(req.url);
       const targetUrl = `http://127.0.0.1:${internalPort}${url.pathname}${url.search}`;
-      const headers = new Headers(req.headers);
+      const headers = buildSolidProxyRequestHeaders(req.headers);
       headers.set('host', `127.0.0.1:${internalPort}`);
       // Disable compression to avoid double-encoding when proxying
       headers.set('accept-encoding', 'identity');
@@ -94,6 +100,16 @@ export function isMainProcessRoute(pathname: string): boolean {
     pathname === '/ws' ||
     pathname.startsWith('/api/')
   );
+}
+
+function buildSolidProxyRequestHeaders(input: Headers): Headers {
+  const headers = new Headers();
+  for (const [key, value] of input) {
+    if (SOLID_PROXY_REQUEST_HEADER_ALLOWLIST.has(key.toLowerCase())) {
+      headers.set(key, value);
+    }
+  }
+  return headers;
 }
 
 /**


### PR DESCRIPTION
## Summary

- Build a fresh allowlisted header set for the internal SolidStart proxy instead of cloning inbound request headers.
- Preserve only page-rendering headers needed by the loopback app: `Accept`, `Accept-Language`, and `Content-Type`.
- Add regression coverage that `Authorization`, `Cookie`, hop-by-hop headers, and arbitrary caller headers are not forwarded.

Fixes #936.

## Testing

- `bun test src/web/solid-handler.test.ts`
- `bunx prettier --check src/web/solid-handler.ts src/web/solid-handler.test.ts`
- `bun run typecheck`
