### PR TITLE
fix(security): validate scheduled task group folders

### DIFF
--- a/src/path-security.test.ts
+++ b/src/path-security.test.ts
@@ -64,6 +64,18 @@ describe('rejectTraversalSegments', () => {
     );
   });
 
+  it('rejects traversal that normalizes within the path', () => {
+    expect(() => rejectTraversalSegments('agent/../outside', 'test')).toThrow(
+      /Path traversal/,
+    );
+  });
+
+  it('rejects trailing traversal that normalizes to current path', () => {
+    expect(() => rejectTraversalSegments('agent/..', 'test')).toThrow(
+      /Path traversal/,
+    );
+  });
+
   it('rejects traversal that normalizes to parent', () => {
     expect(() => rejectTraversalSegments('a/b/../../..', 'test')).toThrow(
       /Path traversal/,

--- a/src/path-security.ts
+++ b/src/path-security.ts
@@ -35,11 +35,9 @@ export const rejectTraversalSegmentsEffect = (
   relativePath: string,
   label: string,
 ): Effect.Effect<void, PathTraversalError> => {
-  // Normalize to handle different separators and resolve ./ segments
-  const normalized = path.normalize(relativePath);
-
-  // Split into segments and check for any '..' component
-  const segments = normalized.split(path.sep);
+  // Check raw path components before normalization so `a/../b` cannot hide
+  // traversal by canceling itself out.
+  const segments = relativePath.split(/[\\/]+/);
   if (segments.includes('..')) {
     return Effect.fail(
       new PathTraversalError({

--- a/src/task-scheduler-runner.test.ts
+++ b/src/task-scheduler-runner.test.ts
@@ -338,6 +338,7 @@ describe('startSchedulerLoop task execution', () => {
     const logTaskRunMock = mock(() => {});
     const resolveBackendMock = mock(() => ({ runAgent: mock(() => {}) }));
     const markTaskExecutingMock = mock(() => {});
+    const isAgentEnabledMock = mock(() => true);
     const enqueuedRuns: Array<Promise<void>> = [];
     const originalSetTimeout = globalThis.setTimeout;
 
@@ -369,6 +370,7 @@ describe('startSchedulerLoop task execution', () => {
           notifyIdle: mock(() => {}),
           closeStdin: mock(() => {}),
         } as unknown as SchedulerDependencies['queue'],
+        isAgentEnabled: isAgentEnabledMock,
         onProcess: mock(() => {}),
         sendMessage: mock(async () => undefined),
         findChannel: () => undefined,
@@ -402,6 +404,7 @@ describe('startSchedulerLoop task execution', () => {
 
       expect(resolveBackendMock).not.toHaveBeenCalled();
       expect(markTaskExecutingMock).not.toHaveBeenCalled();
+      expect(isAgentEnabledMock).not.toHaveBeenCalled();
       expect(logTaskRunMock).toHaveBeenCalledWith(
         expect.objectContaining({
           task_id: 'task-unsafe-folder',

--- a/src/task-scheduler-runner.test.ts
+++ b/src/task-scheduler-runner.test.ts
@@ -322,7 +322,7 @@ describe('startSchedulerLoop task execution', () => {
   it('refuses persisted tasks with traversal group folders before dispatch', async () => {
     const task: ScheduledTask = {
       id: 'task-unsafe-folder',
-      group_folder: '../outside',
+      group_folder: 'agent/../outside',
       chat_jid: 'main@g.us',
       prompt: 'unsafe folder',
       schedule_type: 'interval',

--- a/src/task-scheduler-runner.test.ts
+++ b/src/task-scheduler-runner.test.ts
@@ -319,6 +319,102 @@ describe('startSchedulerLoop task execution', () => {
     }
   });
 
+  it('refuses persisted tasks with traversal group folders before dispatch', async () => {
+    const task: ScheduledTask = {
+      id: 'task-unsafe-folder',
+      group_folder: '../outside',
+      chat_jid: 'main@g.us',
+      prompt: 'unsafe folder',
+      schedule_type: 'interval',
+      schedule_value: '300000',
+      context_mode: 'isolated',
+      next_run: '2026-01-01T00:00:00.000Z',
+      last_run: null,
+      last_result: null,
+      status: 'active',
+      created_at: '2026-01-01T00:00:00.000Z',
+      executing_since: null,
+    };
+    const logTaskRunMock = mock(() => {});
+    const resolveBackendMock = mock(() => ({ runAgent: mock(() => {}) }));
+    const markTaskExecutingMock = mock(() => {});
+    const enqueuedRuns: Array<Promise<void>> = [];
+    const originalSetTimeout = globalThis.setTimeout;
+
+    (globalThis as { setTimeout: typeof setTimeout }).setTimeout = ((
+      _fn: Parameters<typeof setTimeout>[0],
+    ) => ({ id: 'poll' })) as unknown as typeof setTimeout;
+
+    try {
+      const deps: SchedulerDependencies = {
+        registeredGroups: () => ({}),
+        getGroupForTask: () => {
+          throw new Error('should not resolve group');
+        },
+        getSessions: () => ({}),
+        resumePositionStore: {
+          get: () => undefined,
+          set: () => {},
+          getAll: () => ({}),
+          clear: () => {},
+        },
+        queue: {
+          enqueueTask: (
+            _jid: string,
+            _taskId: string,
+            run: () => Promise<void>,
+          ) => {
+            enqueuedRuns.push(run());
+          },
+          notifyIdle: mock(() => {}),
+          closeStdin: mock(() => {}),
+        } as unknown as SchedulerDependencies['queue'],
+        onProcess: mock(() => {}),
+        sendMessage: mock(async () => undefined),
+        findChannel: () => undefined,
+      };
+
+      startSchedulerLoop(deps, {
+        calculateNextRun: mock(() => '2026-01-01T00:05:00.000Z'),
+        resolveBackend: resolveBackendMock,
+        writeTasksSnapshot: mock(() => {}),
+        advanceTaskNextRun: mock(() => {}),
+        markTaskExecuting: markTaskExecutingMock,
+        clearTaskExecuting: mock(() => {}),
+        getStaleExecutingTasks: mock(() => []),
+        getOrphanedOnceTasks: mock(() => []),
+        hasSuccessfulRun: mock(() => false),
+        getAllTasks: mock(() => [task]),
+        getDueTasks: mock(() => [task]),
+        getTaskById: mock(() => task),
+        logTaskRun: logTaskRunMock,
+        appendTaskRunPhaseEvent: mock(() => {}),
+        updateTaskAfterRun: mock(() => {}),
+        writeScheduledRunHandoff: mock(() => 'handoff.json'),
+        runTaskPreprocessor: (task: ScheduledTask) => ({
+          action: 'run',
+          prompt: task.prompt,
+        }),
+        logger: createLoggerMock(),
+      } as any);
+
+      await Promise.all(enqueuedRuns);
+
+      expect(resolveBackendMock).not.toHaveBeenCalled();
+      expect(markTaskExecutingMock).not.toHaveBeenCalled();
+      expect(logTaskRunMock).toHaveBeenCalledWith(
+        expect.objectContaining({
+          task_id: 'task-unsafe-folder',
+          status: 'error',
+          outcome_state: 'abandoned',
+        }),
+      );
+    } finally {
+      (globalThis as { setTimeout: typeof setTimeout }).setTimeout =
+        originalSetTimeout;
+    }
+  });
+
   it('skips agent dispatch when a deterministic preprocessor returns skip', async () => {
     const task: ScheduledTask = {
       id: 'task-skip',

--- a/src/task-scheduler.ts
+++ b/src/task-scheduler.ts
@@ -35,6 +35,7 @@ import {
 } from './db.js';
 import { GroupQueue } from './group-queue.js';
 import { logger } from './logger.js';
+import { rejectTraversalSegments } from './path-security.js';
 import { ResumePositionStore } from './resume-position-store.js';
 import { writeScheduledRunHandoff } from './task-handoffs.js';
 import { runTaskPreprocessor } from './task-preprocessor.js';
@@ -208,6 +209,28 @@ async function runTask(
     runtime.logger.info(
       { taskId: task.id, agentFolder: task.group_folder },
       'Task skipped — agent is disabled',
+    );
+    return;
+  }
+
+  try {
+    rejectTraversalSegments(task.group_folder, 'scheduled task group folder');
+  } catch (err) {
+    const folderError = err instanceof Error ? err.message : String(err);
+    appendPhaseEvent('group_resolved', 'error', false, folderError);
+    runtime.logTaskRun({
+      task_id: task.id,
+      run_at: runAt,
+      duration_ms: 0,
+      status: 'error',
+      result: null,
+      error: folderError,
+      outcome_state: 'abandoned',
+      outcome_reason: folderError,
+    });
+    runtime.logger.warn(
+      { taskId: task.id, groupFolder: task.group_folder, err: folderError },
+      'Refusing scheduled task with unsafe group folder',
     );
     return;
   }

--- a/src/task-scheduler.ts
+++ b/src/task-scheduler.ts
@@ -202,17 +202,6 @@ async function runTask(
     return;
   }
 
-  // Skip runs when the owning agent is disabled via the web UI off-switch.
-  // next_run was already advanced before this call, so when the agent is
-  // re-enabled, future ticks pick the task up at its next scheduled time.
-  if (deps.isAgentEnabled && !deps.isAgentEnabled(task.group_folder)) {
-    runtime.logger.info(
-      { taskId: task.id, agentFolder: task.group_folder },
-      'Task skipped — agent is disabled',
-    );
-    return;
-  }
-
   try {
     rejectTraversalSegments(task.group_folder, 'scheduled task group folder');
   } catch (err) {
@@ -231,6 +220,17 @@ async function runTask(
     runtime.logger.warn(
       { taskId: task.id, groupFolder: task.group_folder, err: folderError },
       'Refusing scheduled task with unsafe group folder',
+    );
+    return;
+  }
+
+  // Skip runs when the owning agent is disabled via the web UI off-switch.
+  // next_run was already advanced before this call, so when the agent is
+  // re-enabled, future ticks pick the task up at its next scheduled time.
+  if (deps.isAgentEnabled && !deps.isAgentEnabled(task.group_folder)) {
+    runtime.logger.info(
+      { taskId: task.id, agentFolder: task.group_folder },
+      'Task skipped — agent is disabled',
     );
     return;
   }

--- a/src/web/routes.test.ts
+++ b/src/web/routes.test.ts
@@ -515,6 +515,31 @@ describe('web routes unit tests', () => {
     expect(body.context_mode).toBe('isolated');
   });
 
+  it('rejects traversal group folders on task creation', async () => {
+    const state = makeState();
+    const res = await handle(
+      new Request('http://localhost/api/tasks', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          group_folder: '../outside',
+          chat_jid: 'dc:123',
+          prompt: 'Unsafe folder',
+          schedule_type: 'interval',
+          schedule_value: '60000',
+        }),
+      }),
+      state,
+    );
+
+    expect(res.status).toBe(400);
+    const body = (await jsonBody(res)) as { error: string };
+    expect(body.error).toContain('Path traversal detected');
+    expect(
+      state.getTasks().some((task) => task.prompt === 'Unsafe folder'),
+    ).toBe(false);
+  });
+
   it('rejects invalid preprocess_script extensions on task creation', async () => {
     const res = await handle(
       new Request('http://localhost/api/tasks', {

--- a/src/web/routes.test.ts
+++ b/src/web/routes.test.ts
@@ -540,6 +540,31 @@ describe('web routes unit tests', () => {
     ).toBe(false);
   });
 
+  it('rejects group folders with embedded traversal on task creation', async () => {
+    const state = makeState();
+    const res = await handle(
+      new Request('http://localhost/api/tasks', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          group_folder: 'agent/../outside',
+          chat_jid: 'dc:123',
+          prompt: 'Unsafe embedded folder',
+          schedule_type: 'interval',
+          schedule_value: '60000',
+        }),
+      }),
+      state,
+    );
+
+    expect(res.status).toBe(400);
+    const body = (await jsonBody(res)) as { error: string };
+    expect(body.error).toContain('Path traversal detected');
+    expect(
+      state.getTasks().some((task) => task.prompt === 'Unsafe embedded folder'),
+    ).toBe(false);
+  });
+
   it('rejects invalid preprocess_script extensions on task creation', async () => {
     const res = await handle(
       new Request('http://localhost/api/tasks', {

--- a/src/web/routes.ts
+++ b/src/web/routes.ts
@@ -2,7 +2,7 @@ import fs from 'fs';
 import path from 'path';
 
 import { GROUPS_DIR } from '../config.js';
-import { assertPathWithin } from '../path-security.js';
+import { assertPathWithin, rejectTraversalSegments } from '../path-security.js';
 import type { ScheduledTask } from '../types.js';
 import type { WebStateProvider } from './types.js';
 import {
@@ -535,6 +535,14 @@ async function handleCreateTask(
   if (!group_folder || typeof group_folder !== 'string') {
     return json(
       { error: 'Missing or invalid "group_folder" (string required)' },
+      400,
+    );
+  }
+  try {
+    rejectTraversalSegments(group_folder, 'scheduled task group_folder');
+  } catch (err) {
+    return json(
+      { error: err instanceof Error ? err.message : String(err) },
       400,
     );
   }


### PR DESCRIPTION
## Summary

- Reject traversal and absolute `group_folder` values when creating scheduled tasks via the Web UI API.
- Refuse already-persisted scheduled tasks with unsafe group folders before scheduler dispatch or filesystem writes.
- Add regression coverage for both the Web API validation path and scheduler defense-in-depth path.

## Security Impact

Before this change, a crafted persisted scheduled task could use a `group_folder` such as `../outside`. The scheduler created `GROUPS_DIR/<group_folder>` before confirming the task's group exists, so the value could escape the groups root and create directories outside the intended workspace boundary.

## Testing

- `bun test src/web/routes.test.ts src/task-scheduler-runner.test.ts`
- `bunx prettier --check src/task-scheduler.ts src/web/routes.ts src/web/routes.test.ts src/task-scheduler-runner.test.ts`
- `bun run typecheck`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Added safeguards to reject unsafe task group folder paths containing traversal segments.
  * Task creation now returns a clear 400 error when an invalid folder path is submitted.
  * Scheduled tasks with unsafe group folders are stopped early and չեն’t proceed to execution or backend dispatch.
* **Tests**
  * Added coverage for rejected path traversal during task creation.
  * Added coverage to ensure unsafe scheduled tasks are abandoned before dispatch.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->