### PR TITLE
feat(web): expose preprocess script field in task create/edit forms

### DIFF
--- a/src/web/page-scripts.test.ts
+++ b/src/web/page-scripts.test.ts
@@ -101,6 +101,23 @@ describe('tasks page script', () => {
     );
     expect(script).toContain('if(isFinite(nr)&&nr<now)overdue++;');
   });
+
+  it('sends the optional preprocess script on create and edit', () => {
+    const script = allPageScripts().tasks;
+
+    // Create payload includes the trimmed preprocess field
+    expect(script).toContain(
+      'preprocess_script:document.getElementById("tmc-preprocess").value.trim()',
+    );
+    // Edit payload includes the trimmed preprocess field
+    expect(script).toContain(
+      'preprocess_script:document.getElementById("tme-preprocess").value.trim()',
+    );
+    // Edit modal hydrates the field from the loaded task (blank when unset)
+    expect(script).toContain(
+      'document.getElementById("tme-preprocess").value=t.preprocess_script||"";',
+    );
+  });
 });
 
 describe('context page script', () => {

--- a/src/web/page-scripts.ts
+++ b/src/web/page-scripts.ts
@@ -1067,7 +1067,8 @@ document.getElementById("tmc-form").addEventListener("submit",function(e){
     prompt:document.getElementById("tmc-prompt").value,
     schedule_type:document.getElementById("tmc-schedule-type").value,
     schedule_value:schedVal,
-    context_mode:document.getElementById("tmc-context-mode").value};
+    context_mode:document.getElementById("tmc-context-mode").value,
+    preprocess_script:document.getElementById("tmc-preprocess").value.trim()};
   fetch("/api/tasks",{method:"POST",headers:{"Content-Type":"application/json"},body:JSON.stringify(payload)})
   .then(function(r){if(!r.ok)return r.json().then(function(d){throw new Error(d.error);});return r.json();})
   .then(function(t){
@@ -1094,6 +1095,7 @@ function openEditModal(taskId){
     document.getElementById("tme-prompt").value=t.prompt;
     document.getElementById("tme-schedule-type").value=t.schedule_type;
     document.getElementById("tme-context-mode").value=t.context_mode;
+    document.getElementById("tme-preprocess").value=t.preprocess_script||"";
     setScheduleInputs("tme",t.schedule_type,t.schedule_value);
     editModal.classList.add("open");
   })
@@ -1134,7 +1136,8 @@ document.getElementById("tme-form").addEventListener("submit",function(e){
   var payload={
     prompt:document.getElementById("tme-prompt").value,
     schedule_type:document.getElementById("tme-schedule-type").value,
-    schedule_value:schedVal};
+    schedule_value:schedVal,
+    preprocess_script:document.getElementById("tme-preprocess").value.trim()};
   fetch("/api/tasks/"+encodeURIComponent(editingTaskId),{method:"PATCH",headers:{"Content-Type":"application/json"},body:JSON.stringify(payload)})
   .then(function(r){if(!r.ok)return r.json().then(function(d){throw new Error(d.error);});return r.json();})
   .then(function(t){

--- a/src/web/shared.ts
+++ b/src/web/shared.ts
@@ -275,6 +275,7 @@ function shellCSS(): string {
     `.badge-docker{background:rgba(52,211,153,.1);color:var(--green)}`,
     `.badge-cursor-sdk{background:rgba(245,158,11,.12);color:var(--yellow)}`,
     `.badge-sm{font-size:9px;padding:0 5px}`,
+    `.badge-preprocess{background:color-mix(in srgb,var(--accent) 22%,transparent);color:var(--accent);cursor:help}`,
     `.badge-admin{background:rgba(167,139,250,.1);color:#a78bfa}`,
     `.status-active{background:rgba(52,211,153,.1);color:var(--green)}`,
     `.status-paused{background:rgba(251,191,36,.1);color:var(--yellow)}`,
@@ -355,6 +356,8 @@ function shellCSS(): string {
     `.form-group input:focus,.form-group select:focus,.form-group textarea:focus{outline:none;border-color:var(--accent)}`,
     `.form-actions{display:flex;gap:8px;justify-content:flex-end;margin-top:.75rem}`,
     `.form-error{color:var(--red);font-size:11px;margin-top:4px}`,
+    `.form-hint{font-size:10px;color:var(--text-dim);margin-top:4px;line-height:1.4}`,
+    `.form-optional{text-transform:none;letter-spacing:0;color:var(--text-dim);font-weight:normal}`,
 
     // --- Keyboard Shortcut Help ---
     `.shortcut-modal{width:480px}`,

--- a/src/web/tasks.test.ts
+++ b/src/web/tasks.test.ts
@@ -148,6 +148,32 @@ describe('renderTaskTableRows', () => {
     expect(html).toContain('data-tm-action="run"');
   });
 
+  it('surfaces a preprocess badge only for tasks with a preprocess script', () => {
+    const html = renderTaskTableRows([
+      makeTask({ id: 'task-pre', preprocess_script: 'daily-digest.ts' }),
+      makeTask({ id: 'task-plain', preprocess_script: null }),
+    ]);
+
+    const preRow = html.slice(
+      html.indexOf('data-task-id="task-pre"'),
+      html.indexOf('data-task-id="task-plain"'),
+    );
+    const plainRow = html.slice(html.indexOf('data-task-id="task-plain"'));
+
+    expect(preRow).toContain('badge-preprocess');
+    expect(preRow).toContain('Preprocess: daily-digest.ts');
+    expect(plainRow).not.toContain('badge-preprocess');
+  });
+
+  it('escapes preprocess script paths in the badge tooltip', () => {
+    const html = renderTaskTableRows([
+      makeTask({ id: 'task-x', preprocess_script: 'a<b>&"c.ts' }),
+    ]);
+
+    expect(html).toContain('Preprocess: a&lt;b&gt;&amp;&quot;c.ts');
+    expect(html).not.toContain('Preprocess: a<b>');
+  });
+
   it('omits the Run button for completed tasks', () => {
     const html = renderTaskTableRows([
       makeTask({ id: 'task-active', status: 'active' }),
@@ -509,6 +535,18 @@ describe('renderTasksContent', () => {
     expect(html).toContain('data-filter="active"');
     expect(html).toContain('Test Agent');
     expect(html).toContain('general');
+  });
+
+  it('exposes an optional preprocess script field in both create and edit modals', () => {
+    const html = renderTasksContent(makeState([makeTask()]));
+
+    // Create modal field
+    expect(html).toContain('id="tmc-preprocess"');
+    // Edit modal field
+    expect(html).toContain('id="tme-preprocess"');
+    // Label + hint copy
+    expect(html).toContain('Preprocess Script');
+    expect(html).toContain('task workflows dir');
   });
 
   it('renders the empty state when no tasks exist', () => {

--- a/src/web/tasks.ts
+++ b/src/web/tasks.ts
@@ -182,7 +182,11 @@ export function renderTaskTableRows(tasks: ScheduledTask[]): string {
         `<span class="sched-label">${escapeHtml(schedLabel)}</span></td>` +
         `<td class="td-time" title="${escapeHtml(task.next_run ?? '')}">${escapeHtml(nextRun)}</td>` +
         `<td class="td-time ${lastResultClass}" title="${escapeHtml(task.last_run ?? '')}">${escapeHtml(lastRun)}${outcomeBadge}</td>` +
-        `<td><span class="badge badge-sm">${escapeHtml(task.context_mode)}</span></td>` +
+        `<td><span class="badge badge-sm">${escapeHtml(task.context_mode)}</span>` +
+        (task.preprocess_script
+          ? ` <span class="badge badge-sm badge-preprocess" title="Preprocess: ${escapeHtml(task.preprocess_script)}">fn</span>`
+          : '') +
+        `</td>` +
         `<td class="td-actions">` +
         `<button class="btn btn-sm btn-toggle" data-tm-action="toggle" data-status="${toggleStatus}">${toggleLabel}</button>` +
         runButton +
@@ -282,6 +286,11 @@ function renderTaskModal(
     `<option value="isolated">Isolated</option>` +
     `<option value="group">Group (with history)</option>` +
     `</select></div>` +
+    // Optional preprocess script — a relative JS/TS path in the task
+    // workflows dir that decides run/skip/error and can rewrite the prompt.
+    `<div class="form-group"><label for="${prefix}-preprocess">Preprocess Script <span class="form-optional">(optional)</span></label>` +
+    `<input id="${prefix}-preprocess" type="text" placeholder="e.g. daily-digest.ts" maxlength="512" autocomplete="off">` +
+    `<div class="form-hint">Relative path to a JS/TS file in the task workflows dir. Runs before each execution to decide run/skip/error and optionally rewrite the prompt. Leave blank for none.</div></div>` +
     `<div id="${prefix}-error" class="form-error"></div>` +
     `<div class="form-actions">` +
     `<button type="button" class="btn" id="${prefix}-cancel">Cancel</button>` +


### PR DESCRIPTION
## What

Exposes the **preprocess script** field in the web Task Manager's create and edit forms.

The task create (`POST /api/tasks`) and update (`PATCH /api/tasks/:id`) handlers have long accepted a `preprocess_script` field (validated by `normalizePreprocessScriptPath`), but the UI forms never rendered it. Until now the only way to attach a preprocessor to a scheduled task was through the raw API. This closes that gap.

A preprocess script is a relative JS/TS file in the task workflows dir that runs before each execution and returns a `run` / `skip` / `error` decision, optionally rewriting the prompt (see `src/task-preprocessor.ts`).

## Changes

- **Form field** — adds an optional *Preprocess Script* input to both the create (`tmc-preprocess`) and edit (`tme-preprocess`) task modals, with hint text describing what it does and that blank means none.
- **Client wiring** — sends `preprocess_script` (trimmed) in the create and edit payloads. An empty value clears it (the API normalizes blank → `null`). The edit modal hydrates the field from the loaded task.
- **Table indicator** — small `fn` badge in the task table's context column for tasks that have a preprocessor attached, with the path in the tooltip.
- **Styles** — new `.form-hint`, `.form-optional`, and `.badge-preprocess` rules in `shared.ts`.

## Tests

- `tasks.test.ts` — create + edit modal expose the field; table badge appears only when a preprocessor is set; tooltip path is HTML-escaped.
- `page-scripts.test.ts` — create/edit payloads include the trimmed field; edit modal hydrates it.

```
bun test        → 2520 pass, 0 fail
bun run typecheck → clean
prettier --check  → clean
```

## Notes for reviewer

Per the repo PR protocol — please leave review feedback directly in this PR as GitHub file/line comments where applicable, not only in Discord. In particular I'd value a second look at: (1) always sending `preprocess_script` on edit (so blank clears it) vs. only sending when changed, and (2) whether the `fn` table badge is the right affordance or if it adds noise.

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>

🤖 Part of the OmniClaw Web UI effort (#157)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an optional **Preprocess Script** field to task create/edit forms, with guidance text and validation-friendly input behavior.
  * Tasks can now display a preprocess badge when this value is set, helping users quickly identify tasks with extra preprocessing logic.

* **Bug Fixes**
  * Ensured preprocess script values are saved, loaded, and shown consistently across task creation, editing, and task lists.
  * Improved display safety by properly escaping script text in tooltips.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->