### PR TITLE
test(backends): cover shared VM cleanup paths

### DIFF
--- a/src/backends/shared-vm.test.ts
+++ b/src/backends/shared-vm.test.ts
@@ -12,6 +12,7 @@ import os from 'os';
 import path from 'path';
 
 import { LOCAL_RUNTIME, SHARED_CLAUDE_VM_MEMORY } from '../config.js';
+import { logger } from '../logger.js';
 import { SharedVmManager } from './shared-vm.js';
 
 function makeProcess(
@@ -33,6 +34,12 @@ function makeProcess(
     exited: Promise.resolve(exitCode),
     kill: mock(() => {}),
   } as unknown as ReturnType<typeof Bun.spawn>;
+}
+
+function makeShellResult(text: string): Awaited<ReturnType<typeof Bun.$>> {
+  return {
+    text: () => text,
+  } as unknown as Awaited<ReturnType<typeof Bun.$>>;
 }
 
 describe('SharedVmManager', () => {
@@ -146,5 +153,94 @@ describe('SharedVmManager', () => {
       'stop',
       'omniclaw-shared-claude-stop-me',
     ]);
+  });
+
+  it('cleans up only running orphaned shared VMs', async () => {
+    const manager = new SharedVmManager();
+    (manager as any).containerName = 'omniclaw-shared-claude-current';
+    const shellSpy = spyOn(Bun, '$').mockImplementation(
+      (() => ({
+        quiet: async () =>
+          makeShellResult(
+            JSON.stringify([
+              {
+                status: 'running',
+                configuration: { id: 'omniclaw-shared-claude-current' },
+              },
+              {
+                status: 'running',
+                configuration: { id: 'omniclaw-shared-claude-orphan-a' },
+              },
+              {
+                status: 'stopped',
+                configuration: { id: 'omniclaw-shared-claude-stopped' },
+              },
+              {
+                status: 'running',
+                configuration: { id: 'unrelated-container' },
+              },
+              {
+                status: 'running',
+                configuration: { id: 'omniclaw-shared-claude-orphan-b' },
+              },
+            ]),
+          ),
+      })) as unknown as typeof Bun.$,
+    );
+    const spawnSpy = spyOn(Bun, 'spawn').mockImplementation((() =>
+      makeProcess(0)) as unknown as typeof Bun.spawn);
+
+    await expect(manager.cleanupOrphans()).resolves.toBeUndefined();
+
+    expect(shellSpy).toHaveBeenCalledTimes(1);
+    expect(spawnSpy.mock.calls.map((call) => call[0])).toEqual([
+      [LOCAL_RUNTIME, 'stop', 'omniclaw-shared-claude-orphan-a'],
+      [LOCAL_RUNTIME, 'stop', 'omniclaw-shared-claude-orphan-b'],
+    ]);
+  });
+
+  it('logs and continues when orphan cleanup cannot list containers', async () => {
+    const manager = new SharedVmManager();
+    const failure = new Error('runtime list failed');
+    spyOn(Bun, '$').mockImplementation(
+      (() => ({
+        quiet: async () => {
+          throw failure;
+        },
+      })) as unknown as typeof Bun.$,
+    );
+    const spawnSpy = spyOn(Bun, 'spawn');
+    const warnSpy = spyOn(logger, 'warn').mockImplementation(() => {});
+
+    await expect(manager.cleanupOrphans()).resolves.toBeUndefined();
+
+    expect(spawnSpy).not.toHaveBeenCalled();
+    expect(warnSpy).toHaveBeenCalledWith(
+      { err: failure },
+      'Failed to clean up orphaned shared VMs',
+    );
+  });
+
+  it('restarts when cached container state cannot be parsed as alive', async () => {
+    const manager = new SharedVmManager();
+    (manager as any).containerName = 'omniclaw-shared-claude-stale';
+    const nowSpy = spyOn(Date, 'now').mockReturnValue(333);
+    spyOn(Bun, '$').mockImplementation(
+      (() => ({
+        quiet: async () => makeShellResult('not-json'),
+      })) as unknown as typeof Bun.$,
+    );
+    const spawnSpy = spyOn(Bun, 'spawn').mockImplementation((() =>
+      makeProcess(0)) as unknown as typeof Bun.spawn);
+
+    try {
+      await expect(manager.ensureRunning()).resolves.toBe(
+        'omniclaw-shared-claude-333',
+      );
+      expect(spawnSpy).toHaveBeenCalledTimes(1);
+      expect(manager.getName()).toBe('omniclaw-shared-claude-333');
+    } finally {
+      nowSpy.mockRestore();
+    }
   });
 });

--- a/src/backends/shared-vm.test.ts
+++ b/src/backends/shared-vm.test.ts
@@ -158,35 +158,33 @@ describe('SharedVmManager', () => {
   it('cleans up only running orphaned shared VMs', async () => {
     const manager = new SharedVmManager();
     (manager as any).containerName = 'omniclaw-shared-claude-current';
-    const shellSpy = spyOn(Bun, '$').mockImplementation(
-      (() => ({
-        quiet: async () =>
-          makeShellResult(
-            JSON.stringify([
-              {
-                status: 'running',
-                configuration: { id: 'omniclaw-shared-claude-current' },
-              },
-              {
-                status: 'running',
-                configuration: { id: 'omniclaw-shared-claude-orphan-a' },
-              },
-              {
-                status: 'stopped',
-                configuration: { id: 'omniclaw-shared-claude-stopped' },
-              },
-              {
-                status: 'running',
-                configuration: { id: 'unrelated-container' },
-              },
-              {
-                status: 'running',
-                configuration: { id: 'omniclaw-shared-claude-orphan-b' },
-              },
-            ]),
-          ),
-      })) as unknown as typeof Bun.$,
-    );
+    const shellSpy = spyOn(Bun, '$').mockImplementation((() => ({
+      quiet: async () =>
+        makeShellResult(
+          JSON.stringify([
+            {
+              status: 'running',
+              configuration: { id: 'omniclaw-shared-claude-current' },
+            },
+            {
+              status: 'running',
+              configuration: { id: 'omniclaw-shared-claude-orphan-a' },
+            },
+            {
+              status: 'stopped',
+              configuration: { id: 'omniclaw-shared-claude-stopped' },
+            },
+            {
+              status: 'running',
+              configuration: { id: 'unrelated-container' },
+            },
+            {
+              status: 'running',
+              configuration: { id: 'omniclaw-shared-claude-orphan-b' },
+            },
+          ]),
+        ),
+    })) as unknown as typeof Bun.$);
     const spawnSpy = spyOn(Bun, 'spawn').mockImplementation((() =>
       makeProcess(0)) as unknown as typeof Bun.spawn);
 
@@ -202,13 +200,11 @@ describe('SharedVmManager', () => {
   it('logs and continues when orphan cleanup cannot list containers', async () => {
     const manager = new SharedVmManager();
     const failure = new Error('runtime list failed');
-    spyOn(Bun, '$').mockImplementation(
-      (() => ({
-        quiet: async () => {
-          throw failure;
-        },
-      })) as unknown as typeof Bun.$,
-    );
+    spyOn(Bun, '$').mockImplementation((() => ({
+      quiet: async () => {
+        throw failure;
+      },
+    })) as unknown as typeof Bun.$);
     const spawnSpy = spyOn(Bun, 'spawn');
     const warnSpy = spyOn(logger, 'warn').mockImplementation(() => {});
 
@@ -225,11 +221,9 @@ describe('SharedVmManager', () => {
     const manager = new SharedVmManager();
     (manager as any).containerName = 'omniclaw-shared-claude-stale';
     const nowSpy = spyOn(Date, 'now').mockReturnValue(333);
-    spyOn(Bun, '$').mockImplementation(
-      (() => ({
-        quiet: async () => makeShellResult('not-json'),
-      })) as unknown as typeof Bun.$,
-    );
+    spyOn(Bun, '$').mockImplementation((() => ({
+      quiet: async () => makeShellResult('not-json'),
+    })) as unknown as typeof Bun.$);
     const spawnSpy = spyOn(Bun, 'spawn').mockImplementation((() =>
       makeProcess(0)) as unknown as typeof Bun.spawn);
 


### PR DESCRIPTION
## Summary

- Add deterministic monkey-patch coverage for shared VM orphan cleanup.
- Cover cleanup failure logging without invoking a real container runtime.
- Cover stale cached container state when the runtime list response is unparsable.

## Test Count / Coverage

- Before: 2521 tests, 6682 assertions, 92.28% line coverage.
- After: 2524 tests, 6691 assertions, 92.64% line coverage.
- `src/backends/shared-vm.ts`: 66.67% -> 100.00% line coverage.

## Verification

- `bun test src/backends/shared-vm.test.ts`
- `bun test`
- `bun test --coverage`
- `bunx tsc --noEmit`

## Remaining Coverage Gaps

- Channel adapters still have broad low-coverage areas: Discord, Telegram, WhatsApp.
- Runtime-heavy backend code in `src/backends/local-backend.ts` remains difficult to cover without deeper process/container fakes.
- Large route/orchestrator modules (`src/discovery/routes.ts`, `src/index.ts`, `src/web/server.ts`) still have substantial uncovered branches.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Expanded coverage for container cleanup and recovery behavior.
  * Verified that only active orphaned containers are stopped, while unrelated or already stopped containers are left alone.
  * Added coverage for graceful handling when container listing fails, including warning logging.
  * Added a scenario confirming the app restarts when cached container state can’t be read as active.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->