### PR TITLE
test: cover model override normalization

### DIFF
--- a/src/model-override.test.ts
+++ b/src/model-override.test.ts
@@ -1,0 +1,51 @@
+import { describe, expect, it } from 'bun:test';
+
+import {
+  InvalidAgentModelOverrideError,
+  MAX_AGENT_MODEL_OVERRIDE_LENGTH,
+  normalizeAgentModelOverride,
+} from './model-override.js';
+
+describe('normalizeAgentModelOverride', () => {
+  it('returns null for missing or blank model overrides', () => {
+    expect(normalizeAgentModelOverride(undefined)).toBeNull();
+    expect(normalizeAgentModelOverride(null)).toBeNull();
+    expect(normalizeAgentModelOverride('')).toBeNull();
+    expect(normalizeAgentModelOverride('   \t\n  ')).toBeNull();
+  });
+
+  it('trims whitespace around a model override', () => {
+    expect(normalizeAgentModelOverride('  claude-opus-4-6  ')).toBe(
+      'claude-opus-4-6',
+    );
+  });
+
+  it('accepts model overrides at the maximum allowed length', () => {
+    const model = 'a'.repeat(MAX_AGENT_MODEL_OVERRIDE_LENGTH);
+
+    expect(normalizeAgentModelOverride(model)).toBe(model);
+  });
+
+  it('rejects model overrides above the maximum allowed length', () => {
+    const model = 'a'.repeat(MAX_AGENT_MODEL_OVERRIDE_LENGTH + 1);
+
+    expect(() => normalizeAgentModelOverride(model)).toThrow(
+      InvalidAgentModelOverrideError,
+    );
+    expect(() => normalizeAgentModelOverride(model)).toThrow(
+      `${MAX_AGENT_MODEL_OVERRIDE_LENGTH} characters or fewer`,
+    );
+  });
+
+  it.each(['claude\nmodel', 'claude\rmodel', 'claude\tmodel', 'claude\0model'])(
+    'rejects control character in %p',
+    (model) => {
+      expect(() => normalizeAgentModelOverride(model)).toThrow(
+        InvalidAgentModelOverrideError,
+      );
+      expect(() => normalizeAgentModelOverride(model)).toThrow(
+        'must not contain control characters',
+      );
+    },
+  );
+});


### PR DESCRIPTION
## Summary

- Adds direct deterministic unit coverage for `normalizeAgentModelOverride`.
- Covers missing/blank inputs, whitespace trimming, maximum boundary acceptance, length rejection, and control-character rejection.

## Test Count

- Before: `2521 pass`, `0 fail`, `6690 expect() calls`, `106 files`.
- After: `2529 pass`, `0 fail`, `6706 expect() calls`, `107 files`.

## Verification

- `bun test src/model-override.test.ts`
- `bun test`

## Files Covered

- `src/model-override.ts`

## Remaining Coverage Gaps Noted

- `src/web/types.ts`, `src/discovery/types.ts`, and index barrel files are type/export-only and do not need runtime tests.
- `src/ipc.ts` has broad indirect coverage via IPC-focused tests, but still has room for more direct branch-level tests in future passes.
- `src/backends/local-backend.isolated.ts` remains a candidate for follow-up once its isolated runtime behavior can be tested without brittle environment coupling.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added coverage for model override validation, including empty and whitespace-only values, trimming behavior, maximum length handling, and invalid characters.
  * Verified that out-of-range overrides return the expected error and message.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->