### PR TITLE
feat: improve Slack thread contexts

### DIFF
--- a/container/agent-runner/src/codex-runtime.ts
+++ b/container/agent-runner/src/codex-runtime.ts
@@ -31,6 +31,7 @@ import {
   redactActivityOutput,
   TOOL_OUTPUT_SNIPPET_CHARS,
 } from './activity-format.js';
+import { CONVERSATION_THREAD_TOOLS_GUIDANCE } from './thread-tools-guidance.js';
 
 interface JsonRpcRequest {
   id: string | number;
@@ -999,6 +1000,8 @@ function buildSystemContext(containerInput: ContainerInput): string | null {
     }
     parts.push(`## Your Identity\n${identityParts.join(' ')}`);
   }
+
+  parts.push(CONVERSATION_THREAD_TOOLS_GUIDANCE);
 
   return parts.length > 0 ? parts.join('\n\n---\n\n') : null;
 }

--- a/container/agent-runner/src/cursor-sdk-runtime.ts
+++ b/container/agent-runner/src/cursor-sdk-runtime.ts
@@ -25,6 +25,7 @@ import type {
   IpcDrainResult,
   IpcMessage,
 } from '@omniclaw/protocol';
+import { CONVERSATION_THREAD_TOOLS_GUIDANCE } from './thread-tools-guidance.js';
 
 const OUTPUT_START_MARKER = '---OMNICLAW_OUTPUT_START---';
 const OUTPUT_END_MARKER = '---OMNICLAW_OUTPUT_END---';
@@ -439,7 +440,7 @@ export async function runCursorSdkRuntime(
       sdkAgent = await Agent.create(baseOptions);
     }
 
-    let prompt = containerInput.prompt;
+    let prompt = `${CONVERSATION_THREAD_TOOLS_GUIDANCE}\n\n${containerInput.prompt}`;
     if (containerInput.isScheduledTask) {
       prompt = `[SCHEDULED TASK - The following message was sent automatically and is not coming directly from the user or group.]\n\n${prompt}`;
     }

--- a/container/agent-runner/src/index.ts
+++ b/container/agent-runner/src/index.ts
@@ -33,6 +33,7 @@ import type {
   IpcDrainResult,
   IpcMessage,
 } from '@omniclaw/protocol';
+import { CONVERSATION_THREAD_TOOLS_GUIDANCE } from './thread-tools-guidance.js';
 
 type ExternalMcpServerConfig =
   | {
@@ -1163,6 +1164,11 @@ async function runQuery(
       ? globalClaudeMd + channelBlock
       : channelBlock.trim();
   }
+
+  const threadToolsBlock = `\n\n${CONVERSATION_THREAD_TOOLS_GUIDANCE}`;
+  globalClaudeMd = globalClaudeMd
+    ? globalClaudeMd + threadToolsBlock
+    : CONVERSATION_THREAD_TOOLS_GUIDANCE;
 
   // Append GitHub context (pre-fetched open PRs, issues, review comments)
   if (containerInput.githubContext) {

--- a/container/agent-runner/src/ipc-mcp-stdio.ts
+++ b/container/agent-runner/src/ipc-mcp-stdio.ts
@@ -66,7 +66,7 @@ function readCurrentChatJid(): string {
 interface UserInfo {
   id: string;
   name: string;
-  platform: 'discord' | 'whatsapp' | 'telegram';
+  platform: 'discord' | 'whatsapp' | 'telegram' | 'slack';
   lastSeen: string;
 }
 
@@ -255,6 +255,236 @@ Recommended: omit target_jid to reply in the channel that started this turn. Onl
         {
           type: 'text' as const,
           text: `Message sent${targetDesc ? ` to ${targetDesc}` : ''}. If this was your final response, stay silent — wrap any remaining text in <internal> tags to avoid a duplicate.`,
+        },
+      ],
+    };
+  },
+);
+
+server.tool(
+  'read_thread',
+  `Read locally stored messages for the current conversation scope. Use this before summarizing, filing, extracting decisions/action items, or acting on "this thread", "above", or prior conversation context. In Slack, the current scope may be one Slack thread rather than the whole channel. Do not call this for simple replies where the current message is enough.`,
+  {
+    limit: z
+      .number()
+      .int()
+      .min(1)
+      .max(100)
+      .optional()
+      .describe(
+        'Maximum number of messages to return, newest window in chronological order. Defaults to 50.',
+      ),
+  },
+  async (args) => {
+    const requestId = `read-thread-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
+    const chatJid = readCurrentChatJid();
+    writeIpcFile(MESSAGES_DIR, {
+      type: 'read_thread',
+      chatJid,
+      limit: args.limit,
+      requestId,
+      groupFolder,
+      timestamp: new Date().toISOString(),
+    });
+
+    const response = await waitForResponse(requestId, 8000);
+    if (!response) {
+      return {
+        content: [
+          {
+            type: 'text' as const,
+            text: 'Timed out waiting for thread messages.',
+          },
+        ],
+        isError: true,
+      };
+    }
+
+    if (response.ok === false) {
+      return {
+        content: [
+          {
+            type: 'text' as const,
+            text:
+              typeof response.error === 'string'
+                ? response.error
+                : 'Unable to read thread messages.',
+          },
+        ],
+        isError: true,
+      };
+    }
+
+    return {
+      content: [
+        {
+          type: 'text' as const,
+          text: JSON.stringify(response.result ?? response, null, 2),
+        },
+      ],
+    };
+  },
+);
+
+server.tool(
+  'update_thread_summary',
+  `Save a compact durable summary for the current conversation scope. Use this after meaningful state changes in a thread: decisions, open questions, owners, artifacts, next steps, or resolution status. Read the thread first unless the current turn already contains all relevant context. Do not include secrets, raw logs, or transient chatter.`,
+  {
+    summary: z
+      .string()
+      .min(1)
+      .max(4000)
+      .describe(
+        'Replacement summary for the current thread/channel: topic, decisions, open items, owners, links/artifacts, and current status.',
+      ),
+    status: z
+      .enum(['active', 'resolved', 'blocked'])
+      .optional()
+      .describe('Optional coarse status for the thread.'),
+    through_message_id: z
+      .string()
+      .optional()
+      .describe('Optional latest message id covered by this summary.'),
+    through_timestamp: z
+      .string()
+      .optional()
+      .describe('Optional latest message timestamp covered by this summary.'),
+  },
+  async (args) => {
+    const requestId = `update-thread-summary-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
+    const chatJid = readCurrentChatJid();
+    writeIpcFile(MESSAGES_DIR, {
+      type: 'update_thread_summary',
+      chatJid,
+      summary: args.summary,
+      status: args.status,
+      throughMessageId: args.through_message_id,
+      throughTimestamp: args.through_timestamp,
+      requestId,
+      groupFolder,
+      timestamp: new Date().toISOString(),
+    });
+
+    const response = await waitForResponse(requestId, 8000);
+    if (!response) {
+      return {
+        content: [
+          {
+            type: 'text' as const,
+            text: 'Timed out waiting for thread summary update.',
+          },
+        ],
+        isError: true,
+      };
+    }
+
+    if (response.ok === false) {
+      return {
+        content: [
+          {
+            type: 'text' as const,
+            text:
+              typeof response.error === 'string'
+                ? response.error
+                : 'Unable to update thread summary.',
+          },
+        ],
+        isError: true,
+      };
+    }
+
+    return {
+      content: [
+        {
+          type: 'text' as const,
+          text: 'Thread summary updated.',
+        },
+      ],
+    };
+  },
+);
+
+server.tool(
+  'request_confirmation',
+  `Ask the current conversation for explicit approval before a write, external side effect, irreversible action, or risky change. This posts a confirmation request in the current thread/channel and, where supported, adds approve/deny reactions. After calling this tool, stop and wait for the user to approve, deny, or request changes; do not perform the action until a later turn contains approval.`,
+  {
+    action: z
+      .string()
+      .min(1)
+      .max(240)
+      .describe(
+        'Brief title for the proposed action, such as "Create the Linear issue" or "Push the release branch".',
+      ),
+    details: z
+      .string()
+      .max(4000)
+      .optional()
+      .describe(
+        'Specific details the human should approve: target, scope, consequences, commands, or data that will be written.',
+      ),
+    approve_emoji: z
+      .string()
+      .max(64)
+      .optional()
+      .describe(
+        'Emoji name for approval, without surrounding colons. Defaults to white_check_mark.',
+      ),
+    deny_emoji: z
+      .string()
+      .max(64)
+      .optional()
+      .describe(
+        'Emoji name for denial, without surrounding colons. Defaults to x.',
+      ),
+  },
+  async (args) => {
+    const requestId = `request-confirmation-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
+    const chatJid = readCurrentChatJid();
+    writeIpcFile(MESSAGES_DIR, {
+      type: 'request_confirmation',
+      chatJid,
+      action: args.action,
+      details: args.details,
+      approveEmoji: args.approve_emoji,
+      denyEmoji: args.deny_emoji,
+      requestId,
+      groupFolder,
+      timestamp: new Date().toISOString(),
+    });
+
+    const response = await waitForResponse(requestId, 8000);
+    if (!response) {
+      return {
+        content: [
+          {
+            type: 'text' as const,
+            text: 'Timed out waiting for confirmation request result.',
+          },
+        ],
+        isError: true,
+      };
+    }
+
+    if (response.ok === false) {
+      return {
+        content: [
+          {
+            type: 'text' as const,
+            text:
+              typeof response.error === 'string'
+                ? response.error
+                : 'Unable to request confirmation.',
+          },
+        ],
+        isError: true,
+      };
+    }
+
+    return {
+      content: [
+        {
+          type: 'text' as const,
+          text: `${JSON.stringify(response.result ?? response, null, 2)}\n\nConfirmation request posted. Stop now and wait for a later user reply or approval reaction before taking the action.`,
         },
       ],
     };
@@ -956,7 +1186,7 @@ if (chatJid.startsWith('dc:') || chatJid.startsWith('tg:')) {
   if (!isTelegram)
     server.tool(
       'format_mention',
-      'Format a user mention for Discord using their display name. Returns the proper <@USER_ID> format for Discord mentions.',
+      'Format a user mention for platforms that support native mentions using their display name. Returns <@USER_ID> for Discord and Slack when the user is known.',
       {
         user_name: z
           .string()
@@ -971,8 +1201,11 @@ if (chatJid.startsWith('dc:') || chatJid.startsWith('tg:')) {
         const key = args.user_name.toLowerCase().trim();
         const user = userRegistry[key];
 
-        if (user && user.platform === 'discord') {
-          // Return properly formatted Discord mention
+        if (
+          user &&
+          (user.platform === 'discord' || user.platform === 'slack')
+        ) {
+          // Discord and Slack both use <@USER_ID> for user mentions.
           return {
             content: [
               {

--- a/container/agent-runner/src/opencode-runtime.ts
+++ b/container/agent-runner/src/opencode-runtime.ts
@@ -30,6 +30,7 @@ import {
   redactActivityOutput,
   TOOL_OUTPUT_SNIPPET_CHARS,
 } from './activity-format.js';
+import { CONVERSATION_THREAD_TOOLS_GUIDANCE } from './thread-tools-guidance.js';
 
 // ---------------------------------------------------------------------------
 // Constants
@@ -621,6 +622,8 @@ function buildSystemContext(containerInput: ContainerInput): string | null {
     }
     parts.push(`## Your Identity\n${identityParts.join(' ')}`);
   }
+
+  parts.push(CONVERSATION_THREAD_TOOLS_GUIDANCE);
 
   if (parts.length === 0) return null;
   return parts.join('\n\n---\n\n');

--- a/container/agent-runner/src/thread-tools-guidance.ts
+++ b/container/agent-runner/src/thread-tools-guidance.ts
@@ -1,0 +1,9 @@
+export const CONVERSATION_THREAD_TOOLS_GUIDANCE = `## Conversation Thread Tools
+
+The current conversation may be a channel, DM, or platform thread. Treat phrases like "this thread", "above", "what did we decide", "file this", "summarize this", and "follow up on this" as referring to the current conversation scope.
+
+Use \`mcp__omniclaw__read_thread\` before summarizing, filing, extracting decisions or action items, updating durable thread state, or taking action that depends on prior messages. Do not call it for simple replies where the current message is enough.
+
+When stable thread state changes, use \`mcp__omniclaw__update_thread_summary\` to save a compact neutral summary. Include the topic, decisions, open questions, owners, artifacts, and next steps. Do not include secrets, raw transcripts, or transient chatter.
+
+Before a write, external side effect, irreversible action, or risky change that needs human approval, use \`mcp__omniclaw__request_confirmation\`. After requesting confirmation, stop and wait for a later user reply or approval reaction before taking the action.`;

--- a/docs/SLACK-AGENT-SETUP.md
+++ b/docs/SLACK-AGENT-SETUP.md
@@ -20,6 +20,20 @@ The new agent capabilities require three coupled things on the Slack side:
 
 Without all three, the code paths in `src/channels/slack.ts` (`registerAssistant`, `setStatus`, suggested prompts, streaming) compile and run but Slack never invokes them. Same binary, no visible agent UI.
 
+## Thread context model
+
+Slack channel threads are treated as first-class OmniClaw conversations. When a user mentions a bot or uses the bot's configured trigger in a top-level channel message, OmniClaw stores that message under a durable thread JID:
+
+```text
+slack:<bot-id>:<channel-id>:thread:<root-ts>
+```
+
+That gives each Slack thread its own runtime folder, active session, reply anchor, and local message history while still inheriting the parent channel registration and shared context layers. If the parent channel already has an active agent session, the first agent turn in the new Slack thread starts as a fork of that parent session and then diverges under the thread runtime. Ordinary unmentioned channel chatter stays on the parent channel JID so it can be remembered without waking every subscribed agent.
+
+When the bot is explicitly summoned inside an existing Slack thread, OmniClaw fetches a small Slack transcript with `conversations.replies` and injects it into the current prompt as context only. It does not backfill those Slack messages into the local queue, which avoids duplicate wakeups and cursor drift. The fetch limit is intentionally 15 messages to match Slack's current non-Marketplace `conversations.replies` cap; if the API is unavailable or rate limited, OmniClaw falls back to the thread-root excerpt.
+
+Agents also get thread-scoped MCP tools in the container. `read_thread` reads locally stored messages for the current Slack thread or channel, which is useful before summarizing, filing tickets, or acting on "this thread." `update_thread_summary` saves a compact durable summary for the same scope so future turns can start from the thread's decisions, open questions, owners, artifacts, and next steps. `request_confirmation` posts an OpenTag-style approval request in the same Slack thread before risky writes or external side effects; OmniClaw adds approve/deny reactions when Slack returns a message id, and a human reaction wakes the same thread context. Summaries are state, not transcripts; they should never include secrets or raw logs.
+
 ## Manifest walkthrough
 
 The file at `config-examples/slack-app-manifest.json` is the reference. Highlights:

--- a/docs/SPEC.md
+++ b/docs/SPEC.md
@@ -701,7 +701,7 @@ The heartbeat reads `## Goals` and `## Heartbeat` sections from the agent's CLAU
 
 ## MCP Tools
 
-The `omniclaw` MCP server runs inside each container via stdio, providing 16 tools:
+The `omniclaw` MCP server runs inside each container via stdio, providing task, messaging, routing, context, and coordination tools:
 
 ### Task Management
 
@@ -721,6 +721,14 @@ The `omniclaw` MCP server runs inside each container via stdio, providing 16 too
 | `send_message`     | Send a message to the current channel       |
 | `react_to_message` | Add/remove emoji reaction on a message      |
 | `format_mention`   | Format an @mention for the current platform |
+
+### Conversation Context
+
+| Tool                    | Purpose                                                      |
+| ----------------------- | ------------------------------------------------------------ |
+| `read_thread`           | Read locally stored messages for the current conversation    |
+| `update_thread_summary` | Save compact durable state for the current thread or channel |
+| `request_confirmation`  | Ask for human approval before risky writes or side effects   |
 
 ### Heartbeat & Groups
 

--- a/groups/global/CLAUDE.md.template
+++ b/groups/global/CLAUDE.md.template
@@ -22,6 +22,14 @@ Use `mcp__omniclaw__send_message` to send a message **mid-task**, before you're 
 
 When working as a sub-agent or teammate, only use `send_message` if instructed to by the main agent.
 
+## Conversation Thread Context
+
+Use `mcp__omniclaw__read_thread` before summarizing, filing, extracting decisions or action items, updating durable thread state, or taking action that depends on prior messages in "this thread" or "above".
+
+When stable thread state changes, use `mcp__omniclaw__update_thread_summary` to save a compact neutral summary for the current conversation scope. Include the topic, decisions, open questions, owners, artifacts, and next steps. Do not include secrets, raw transcripts, or transient chatter.
+
+Before risky writes, external side effects, or irreversible actions that need human approval, use `mcp__omniclaw__request_confirmation`. After requesting confirmation, stop and wait for a later user reply or approval reaction before taking the action.
+
 ## Requesting Context
 
 If you need information from outside your workspace (files from another project, context from another group, credentials, etc.), ask directly in the current chat with exactly what you need and why.
@@ -35,6 +43,7 @@ Files you create are saved in `/workspace/group/`. Use this for notes, research,
 The `conversations/` folder contains searchable history of past conversations. Use this to recall context from previous sessions.
 
 When you learn something important:
+
 - Create files for structured data (e.g., `customers.md`, `preferences.md`)
 - Split files larger than 500 lines into folders
 - Keep an index in your memory for the files you create
@@ -50,10 +59,11 @@ When you learn something important:
 ## Message Formatting
 
 NEVER use markdown. Only use WhatsApp/Telegram formatting:
-- *single asterisks* for bold (NEVER **double asterisks**)
+
+- _single asterisks_ for bold (NEVER **double asterisks**)
 - _underscores_ for italic
 - • bullet points
-- ```triple backticks``` for code
+- `triple backticks` for code
 
 No ## headings. No [links](url). No **double stars**.
 
@@ -68,6 +78,7 @@ When running as a heartbeat (scheduled background task):
 5. If nothing is actionable, complete silently — do not send "nothing to report"
 
 You have permission to proactively:
+
 - Create PRs for issues in `ditto/` and `omniaura/` repos
 - Triage existing issues (check if still valid, add context)
 - Work on issues and open PRs without explicit instruction

--- a/groups/main/CLAUDE.md.template
+++ b/groups/main/CLAUDE.md.template
@@ -22,11 +22,20 @@ Use `mcp__omniclaw__send_message` to send a message **mid-task**, before you're 
 
 When working as a sub-agent or teammate, only use `send_message` if instructed to by the main agent.
 
+## Conversation Thread Context
+
+Use `mcp__omniclaw__read_thread` before summarizing, filing, extracting decisions or action items, updating durable thread state, or taking action that depends on prior messages in "this thread" or "above".
+
+When stable thread state changes, use `mcp__omniclaw__update_thread_summary` to save a compact neutral summary for the current conversation scope. Include the topic, decisions, open questions, owners, artifacts, and next steps. Do not include secrets, raw transcripts, or transient chatter.
+
+Before risky writes, external side effects, or irreversible actions that need human approval, use `mcp__omniclaw__request_confirmation`. After requesting confirmation, stop and wait for a later user reply or approval reaction before taking the action.
+
 ## Memory
 
 The `conversations/` folder contains searchable history of past conversations. Use this to recall context from previous sessions.
 
 When you learn something important:
+
 - Create files for structured data (e.g., `customers.md`, `preferences.md`)
 - Split files larger than 500 lines into folders
 - Keep an index in your memory for the files you create
@@ -34,10 +43,11 @@ When you learn something important:
 ## WhatsApp Formatting (and other messaging apps)
 
 Do NOT use markdown headings (##) in WhatsApp messages. Only use:
-- *Bold* (single asterisks) (NEVER **double asterisks**)
+
+- _Bold_ (single asterisks) (NEVER **double asterisks**)
 - _Italic_ (underscores)
 - • Bullets (bullet points)
-- ```Code blocks``` (triple backticks)
+- `Code blocks` (triple backticks)
 
 Keep messages clean and readable for WhatsApp.
 
@@ -51,12 +61,13 @@ This is the **main channel**, which has elevated privileges.
 
 Main has access to the entire project:
 
-| Container Path | Host Path | Access |
-|----------------|-----------|--------|
-| `/workspace/project` | Project root | read-write |
-| `/workspace/group` | `groups/main/` | read-write |
+| Container Path       | Host Path      | Access     |
+| -------------------- | -------------- | ---------- |
+| `/workspace/project` | Project root   | read-write |
+| `/workspace/group`   | `groups/main/` | read-write |
 
 Key paths inside the container:
+
 - `/workspace/project/store/messages.db` - SQLite database
 - `/workspace/project/store/messages.db` (registered_groups table) - Group config
 - `/workspace/project/groups/` - All group folders
@@ -141,6 +152,7 @@ Example:
 ```
 
 Example folder name conventions:
+
 - "Family Chat" → `family-chat`
 - "Work Team" → `work-team`
 - Use lowercase, hyphens instead of spaces
@@ -196,6 +208,7 @@ You can read and write to `/workspace/project/groups/global/CLAUDE.md` for facts
 ## Scheduling for Other Groups
 
 When scheduling tasks for other groups, use the `target_group_jid` parameter with the group's JID from `available_groups.json` (or `registered_groups` in SQLite):
+
 - `schedule_task(prompt: "...", schedule_type: "cron", schedule_value: "0 9 * * 1", target_group_jid: "120363336345536173@g.us")`
 
 The task will run in that group's context with access to their files and memory.

--- a/src/channels/slack.test.ts
+++ b/src/channels/slack.test.ts
@@ -152,6 +152,18 @@ describe('SlackChannel.ownsJid', () => {
     expect(ownsJid('slack:C123', 'OPS', false)).toBe(false);
   });
 
+  it('matches thread JIDs for the same bot', () => {
+    expect(ownsJid('slack:OPS:C123:thread:1700000000.000100', 'OPS')).toBe(
+      true,
+    );
+  });
+
+  it('does not match thread JIDs for a different bot', () => {
+    expect(ownsJid('slack:SUPPORT:C123:thread:1700000000.000100', 'OPS')).toBe(
+      false,
+    );
+  });
+
   it('does not match non-Slack JIDs', () => {
     expect(ownsJid('dc:123')).toBe(false);
     expect(ownsJid('tg:456')).toBe(false);
@@ -357,7 +369,7 @@ describe('SlackChannel.handleMessage multi-bot mention routing', () => {
 
     expect(onMessage).toHaveBeenCalledTimes(1);
     const calls = onMessage.mock.calls as unknown as Array<[string]>;
-    expect(calls[0][0]).toBe('slack:CLAYTON:C123');
+    expect(calls[0][0]).toBe('slack:CLAYTON:C123:thread:1700000000.000100');
   });
 });
 
@@ -421,6 +433,21 @@ describe('SlackChannel.sendMessage', () => {
     await channel.sendMessage('slack:C123', 'reply', '200.2');
 
     const args = (postMessage.mock.calls[0] as unknown as [any])[0];
+    expect(args.thread_ts).toBe('100.1');
+  });
+
+  it('threads replies from durable thread JIDs without an in-memory root cache', async () => {
+    const channel = makeSendChannel();
+    const postMessage = mock(() => Promise.resolve({ ts: '3.301' }));
+    (channel as any).client = { chat: { postMessage } };
+
+    await channel.sendMessage(
+      'slack:TEST:C123:thread:100.1',
+      'reply from thread jid',
+    );
+
+    const args = (postMessage.mock.calls[0] as unknown as [any])[0];
+    expect(args.channel).toBe('C123');
     expect(args.thread_ts).toBe('100.1');
   });
 
@@ -628,6 +655,27 @@ describe('SlackChannel.startMessageStream', () => {
     expect(await channel.startMessageStream('slack:C123')).toBeNull();
   });
 
+  it('starts streams from durable thread JIDs', async () => {
+    const channel = makeSendChannel();
+    const startStream = mock(() => Promise.resolve({ ts: '8.801' }));
+    const stopStream = mock(() => Promise.resolve({}));
+    (channel as any).client = { chat: { startStream, stopStream } };
+    (channel as any).teamId = 'T999';
+    (channel as any).lastHumanSenderByThread.set('C123:100.1', 'UPEYTON');
+
+    const stream = await channel.startMessageStream(
+      'slack:TEST:C123:thread:100.1',
+    );
+    expect(stream).not.toBeNull();
+    await stream!.appendText('hi');
+    await stream!.stop();
+
+    const startArgs = (startStream.mock.calls[0] as unknown as [any])[0];
+    expect(startArgs.channel).toBe('C123');
+    expect(startArgs.thread_ts).toBe('100.1');
+    expect(startArgs.recipient_user_id).toBe('UPEYTON');
+  });
+
   it('returns null in channels without recipient info', async () => {
     const channel = makeSendChannel();
     expect(await channel.startMessageStream('slack:C123', '100.1')).toBeNull();
@@ -798,9 +846,198 @@ describe('SlackChannel.handleMessage extras', () => {
 
     expect(onMessage).toHaveBeenCalledTimes(1);
     const msg = (onMessage.mock.calls[0] as unknown as [string, any])[1];
+    expect((onMessage.mock.calls[0] as unknown as [string, any])[0]).toBe(
+      'slack:TEST:C123:thread:1700000000.000100',
+    );
+    expect(msg.chat_jid).toBe('slack:TEST:C123:thread:1700000000.000100');
     expect(msg.content).toBe(
       '[Thread reply to: "What is the deploy status?"] any update?',
     );
+  });
+
+  it('hydrates existing Slack thread context into explicit threaded bot mentions', async () => {
+    const onMessage = mock(() => {});
+    const replies = mock(() =>
+      Promise.resolve({
+        messages: [
+          {
+            ts: '1700000000.000100',
+            text: 'root request',
+            user: 'UOMAR',
+          },
+          {
+            ts: '1700000000.000150',
+            text: 'prior reply with <@UPEYTON>',
+            user: 'UOMAR',
+          },
+          {
+            ts: '1700000000.000200',
+            text: '<@UBOT> summarize this',
+            user: 'UPEYTON',
+          },
+        ],
+      }),
+    );
+    const channel = makeInboundChannel(onMessage);
+    (channel as any).client = {
+      users: {
+        info: mock(({ user }: { user: string }) =>
+          Promise.resolve({
+            user: {
+              name: user.toLowerCase(),
+              profile: {
+                display_name:
+                  user === 'UOMAR'
+                    ? 'Omar'
+                    : user === 'UBOT'
+                      ? 'Bot'
+                      : 'Peyton',
+              },
+            },
+          }),
+        ),
+      },
+      conversations: {
+        info: mock(() => Promise.resolve({ channel: { name: 'general' } })),
+        replies,
+      },
+    };
+
+    await (channel as any).handleMessage({
+      channel: 'C123',
+      ts: '1700000000.000200',
+      thread_ts: '1700000000.000100',
+      text: '<@UBOT> summarize this',
+      user: 'UPEYTON',
+    });
+
+    expect(onMessage).toHaveBeenCalledTimes(1);
+    expect(replies).toHaveBeenCalledTimes(1);
+    const [chatJid, msg] = onMessage.mock.calls[0] as unknown as [string, any];
+    expect(chatJid).toBe('slack:TEST:C123:thread:1700000000.000100');
+    expect(msg.content).toContain(
+      'Slack thread context before this message (thread_ts 1700000000.000100):',
+    );
+    expect(msg.content).toContain('Omar: root request');
+    expect(msg.content).toContain('Omar: prior reply with @Peyton');
+    expect(msg.content).toContain('Current Slack message: @Bot summarize this');
+  });
+
+  it('falls back to the root excerpt when thread context hydration fails', async () => {
+    const onMessage = mock(() => {});
+    let replyCalls = 0;
+    const replies = mock(() => {
+      replyCalls++;
+      if (replyCalls === 1) {
+        return Promise.reject(new Error('rate limited'));
+      }
+      return Promise.resolve({
+        messages: [{ text: 'fallback root message' }],
+      });
+    });
+    const channel = makeInboundChannel(onMessage);
+    (channel as any).client = {
+      users: {
+        info: mock(({ user }: { user: string }) =>
+          Promise.resolve({
+            user: {
+              name: user.toLowerCase(),
+              profile: { display_name: user === 'UBOT' ? 'Bot' : 'Peyton' },
+            },
+          }),
+        ),
+      },
+      conversations: {
+        info: mock(() => Promise.resolve({ channel: { name: 'general' } })),
+        replies,
+      },
+    };
+
+    await (channel as any).handleMessage({
+      channel: 'C123',
+      ts: '1700000000.000250',
+      thread_ts: '1700000000.000100',
+      text: '<@UBOT> summarize this',
+      user: 'UPEYTON',
+    });
+
+    expect(replies).toHaveBeenCalledTimes(2);
+    const msg = (onMessage.mock.calls[0] as unknown as [string, any])[1];
+    expect(msg.content).toBe(
+      '[Thread reply to: "fallback root message"] @Bot summarize this',
+    );
+  });
+
+  it('stores top-level bot mentions under a Slack thread conversation JID', async () => {
+    const onMessage = mock(() => {});
+    const metadata: Array<{ jid: string; name?: string }> = [];
+    const channel = new SlackChannel({
+      botId: 'TEST',
+      token: 'xoxb-test',
+      appToken: 'xapp-test',
+      onMessage,
+      onChatMetadata: (jid, _timestamp, name) => metadata.push({ jid, name }),
+      registeredGroups: () => ({
+        'slack:C123': {
+          name: 'general',
+          folder: 'general',
+          trigger: '@bot',
+          added_at: new Date().toISOString(),
+        },
+      }),
+    });
+    (channel as any).botUserId = 'UBOT';
+    (channel as any).client = makeInboundClient();
+
+    await (channel as any).handleMessage({
+      channel: 'C123',
+      ts: '1700000000.000500',
+      text: '<@UBOT> please handle this',
+      user: 'UPEYTON',
+    });
+
+    expect(onMessage).toHaveBeenCalledTimes(1);
+    const [chatJid, msg] = onMessage.mock.calls[0] as unknown as [string, any];
+    expect(chatJid).toBe('slack:TEST:C123:thread:1700000000.000500');
+    expect(msg.chat_jid).toBe('slack:TEST:C123:thread:1700000000.000500');
+    expect(metadata.map((m) => m.jid)).toContain('slack:C123');
+    expect(metadata.map((m) => m.jid)).toContain(
+      'slack:TEST:C123:thread:1700000000.000500',
+    );
+  });
+
+  it('keeps unmentioned top-level channel messages on the parent channel JID', async () => {
+    const onMessage = mock(() => {});
+    const channel = makeInboundChannel(onMessage);
+    (channel as any).client = makeInboundClient();
+
+    await (channel as any).handleMessage({
+      channel: 'C123',
+      ts: '1700000000.000600',
+      text: 'ordinary channel chatter',
+      user: 'UPEYTON',
+    });
+
+    const [chatJid, msg] = onMessage.mock.calls[0] as unknown as [string, any];
+    expect(chatJid).toBe('slack:C123');
+    expect(msg.chat_jid).toBe('slack:C123');
+  });
+
+  it('stores top-level configured trigger messages under a Slack thread conversation JID', async () => {
+    const onMessage = mock(() => {});
+    const channel = makeInboundChannel(onMessage);
+    (channel as any).client = makeInboundClient();
+
+    await (channel as any).handleMessage({
+      channel: 'C123',
+      ts: '1700000000.000700',
+      text: '@bot please handle this',
+      user: 'UPEYTON',
+    });
+
+    const [chatJid, msg] = onMessage.mock.calls[0] as unknown as [string, any];
+    expect(chatJid).toBe('slack:TEST:C123:thread:1700000000.000700');
+    expect(msg.chat_jid).toBe('slack:TEST:C123:thread:1700000000.000700');
   });
 
   it('skips the thread annotation in assistant threads', async () => {
@@ -820,6 +1057,9 @@ describe('SlackChannel.handleMessage extras', () => {
     );
 
     const msg = (onMessage.mock.calls[0] as unknown as [string, any])[1];
+    expect((onMessage.mock.calls[0] as unknown as [string, any])[0]).toBe(
+      'slack:TEST:C123:thread:1700000000.000100',
+    );
     expect(msg.content).toBe('assistant question');
   });
 

--- a/src/channels/slack.ts
+++ b/src/channels/slack.ts
@@ -26,7 +26,12 @@ import {
   type DiscordFlowDefinition,
   type DiscordSessionCommand,
 } from '../discord-command-flows.js';
-import { parseScopedSlackJid } from '../slack-jid.js';
+import {
+  channelIdToSlackJid,
+  parseSlackJid,
+  parseScopedSlackJid,
+  slackThreadIdToJid,
+} from '../slack-jid.js';
 import { parseSlackCommandText } from '../slack-command-flows.js';
 import type {
   Channel,
@@ -45,15 +50,14 @@ export { parseScopedSlackJid };
 // Multi-bot format: "slack:{botId}:{channelId}"
 
 export function jidToChannelId(jid: string): string | null {
-  const scoped = parseScopedSlackJid(jid);
-  if (scoped) return scoped.channelId;
+  const parsed = parseSlackJid(jid);
+  if (parsed) return parsed.channelId;
   if (!jid.startsWith('slack:')) return null;
   return jid.slice('slack:'.length);
 }
 
 export function channelIdToJid(channelId: string, botId?: string): string {
-  if (botId) return `slack:${botId}:${channelId}`;
-  return `slack:${channelId}`;
+  return channelIdToSlackJid(channelId, botId);
 }
 
 // Slack limits: plain `text` messages cap at 4,000 chars; `markdown` blocks
@@ -63,6 +67,8 @@ const MARKDOWN_BLOCK_LIMIT = 11500;
 const THREAD_ROOT_CACHE_MAX = 1000;
 const SEEN_MESSAGE_CACHE_MAX = 500;
 const THREAD_EXCERPT_MAX_CHARS = 140;
+const THREAD_CONTEXT_FETCH_LIMIT = 15;
+const THREAD_CONTEXT_MAX_CHARS = 6000;
 const TASK_TITLE_MAX_CHARS = 80;
 // Slack caps each task_update chunk at 256 chars; keep title + details under it
 // so progress updates always render instead of being silently rejected.
@@ -102,6 +108,18 @@ function assertSlackFileUrl(url: string): void {
   if (parsed.protocol !== 'https:' || !SLACK_FILE_HOSTS.has(parsed.hostname)) {
     throw new Error(`Rejected non-Slack file URL: ${parsed.hostname || url}`);
   }
+}
+
+function slackTriggerMatches(content: string, trigger?: string): boolean {
+  if (!trigger) return false;
+  const name = trigger.replace(/^@/, '').trim();
+  if (!name) return false;
+  const escaped = name.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+  return new RegExp(`^@${escaped}\\b`, 'i').test(content.trim());
+}
+
+function slackTsToIso(ts: string): string {
+  return new Date(parseFloat(ts) * 1000).toISOString();
 }
 
 /** A `markdown` block renders standard markdown (GFM) instead of legacy mrkdwn. */
@@ -270,6 +288,8 @@ export class SlackChannel implements Channel {
    * recipient_user_id when streaming outside a DM.
    */
   private lastHumanSenderByChannel = new Map<string, string>();
+  /** Last human sender per Slack thread (`channelId:thread_ts`). */
+  private lastHumanSenderByThread = new Map<string, string>();
 
   constructor(opts: SlackChannelOpts) {
     this.opts = opts;
@@ -373,7 +393,8 @@ export class SlackChannel implements Channel {
     text: string,
     replyToMessageId?: string,
   ): Promise<string | void> {
-    const channelId = this.extractChannelId(jid);
+    const parsedJid = parseSlackJid(jid);
+    const channelId = parsedJid?.channelId ?? this.extractChannelId(jid);
     if (!channelId) {
       logger.warn({ jid }, 'Invalid Slack JID — cannot send message');
       return;
@@ -382,9 +403,11 @@ export class SlackChannel implements Channel {
     // Slack requires threading on the root ts — map reply targets through the
     // thread-root cache. Bare sends to a DM with an active assistant thread go
     // into that thread so they show up in the agent pane.
-    const threadTs = replyToMessageId
-      ? (this.threadRootByTs.get(replyToMessageId) ?? replyToMessageId)
-      : this.assistantThreads.get(channelId);
+    const threadTs =
+      parsedJid?.threadTs ??
+      (replyToMessageId
+        ? (this.threadRootByTs.get(replyToMessageId) ?? replyToMessageId)
+        : this.assistantThreads.get(channelId));
 
     try {
       // Threaded sends get the native AI streaming treatment when possible
@@ -425,7 +448,8 @@ export class SlackChannel implements Channel {
     messageId: string,
     text: string,
   ): Promise<void> {
-    const channelId = this.extractChannelId(jid);
+    const parsedJid = parseSlackJid(jid);
+    const channelId = parsedJid?.channelId ?? this.extractChannelId(jid);
     if (!channelId) return;
     const chunk = text.slice(0, MARKDOWN_BLOCK_LIMIT);
     try {
@@ -460,9 +484,11 @@ export class SlackChannel implements Channel {
    * status automatically when the reply lands in the thread.
    */
   async setTyping(jid: string, isTyping: boolean): Promise<void> {
-    const channelId = this.extractChannelId(jid);
+    const parsedJid = parseSlackJid(jid);
+    const channelId = parsedJid?.channelId ?? this.extractChannelId(jid);
     if (!channelId) return;
-    const threadTs = this.assistantThreads.get(channelId);
+    const threadTs =
+      parsedJid?.threadTs ?? this.assistantThreads.get(channelId);
     if (!threadTs) return;
     try {
       await this.client.assistant.threads.setStatus({
@@ -494,8 +520,9 @@ export class SlackChannel implements Channel {
   }
 
   ownsJid(jid: string): boolean {
-    const scoped = parseScopedSlackJid(jid);
-    if (scoped) return scoped.botId === this.botId;
+    const parsed = parseSlackJid(jid);
+    if (parsed?.botId) return parsed.botId === this.botId;
+    if (parsed && !parsed.botId) return this.allowLegacyJidRouting;
     return this.allowLegacyJidRouting && /^slack:[^:]+$/.test(jid);
   }
 
@@ -510,7 +537,8 @@ export class SlackChannel implements Channel {
     messageId: string,
     emoji: string,
   ): Promise<void> {
-    const channelId = this.extractChannelId(jid);
+    const parsedJid = parseSlackJid(jid);
+    const channelId = parsedJid?.channelId ?? this.extractChannelId(jid);
     if (!channelId) return;
     // Strip surrounding colons if passed as :emoji:
     const name = emoji.replace(/^:|:$/g, '');
@@ -533,7 +561,8 @@ export class SlackChannel implements Channel {
     messageId: string,
     emoji: string,
   ): Promise<void> {
-    const channelId = this.extractChannelId(jid);
+    const parsedJid = parseSlackJid(jid);
+    const channelId = parsedJid?.channelId ?? this.extractChannelId(jid);
     if (!channelId) return;
     const name = emoji.replace(/^:|:$/g, '');
     try {
@@ -559,10 +588,15 @@ export class SlackChannel implements Channel {
     messageId: string,
     _name: string,
   ): Promise<{ channelId: string; ts: string } | null> {
-    const channelId = this.extractChannelId(jid);
+    const parsedJid = parseSlackJid(jid);
+    const channelId = parsedJid?.channelId ?? this.extractChannelId(jid);
     if (!channelId) return null;
     // In Slack, a thread is created implicitly on first reply — just return the anchor info
-    return { channelId, ts: this.threadRootByTs.get(messageId) ?? messageId };
+    return {
+      channelId,
+      ts:
+        parsedJid?.threadTs ?? this.threadRootByTs.get(messageId) ?? messageId,
+    };
   }
 
   async sendToThread(
@@ -1074,11 +1108,14 @@ export class SlackChannel implements Channel {
     jid: string,
     replyToMessageId?: string,
   ): Promise<OutboundMessageStream | null> {
-    const channelId = this.extractChannelId(jid);
+    const parsedJid = parseSlackJid(jid);
+    const channelId = parsedJid?.channelId ?? this.extractChannelId(jid);
     if (!channelId) return null;
-    const threadTs = replyToMessageId
-      ? (this.threadRootByTs.get(replyToMessageId) ?? replyToMessageId)
-      : this.assistantThreads.get(channelId);
+    const threadTs =
+      parsedJid?.threadTs ??
+      (replyToMessageId
+        ? (this.threadRootByTs.get(replyToMessageId) ?? replyToMessageId)
+        : this.assistantThreads.get(channelId));
     if (!threadTs) return null;
     const target = this.resolveStreamTarget(channelId, threadTs);
     if (!target) return null;
@@ -1091,7 +1128,10 @@ export class SlackChannel implements Channel {
   ): SlackStreamTarget | null {
     // DM channels (assistant threads included) stream without recipient info.
     if (channelId.startsWith('D')) return { channelId, threadTs };
-    const userId = this.lastHumanSenderByChannel.get(channelId);
+    const threadKey = `${channelId}:${threadTs}`;
+    const userId =
+      this.lastHumanSenderByThread.get(threadKey) ||
+      this.lastHumanSenderByChannel.get(channelId);
     if (!userId || !this.teamId) return null;
     return {
       channelId,
@@ -1334,6 +1374,73 @@ export class SlackChannel implements Channel {
     }
   }
 
+  private async getThreadContextBlock(
+    channelId: string,
+    threadTs: string,
+    currentTs: string,
+  ): Promise<string | null> {
+    try {
+      const result = await this.client.conversations.replies({
+        channel: channelId,
+        ts: threadTs,
+        limit: THREAD_CONTEXT_FETCH_LIMIT,
+      });
+      const messages = Array.isArray(result.messages) ? result.messages : [];
+      const lines: string[] = [];
+
+      for (const raw of messages) {
+        const message = raw as {
+          ts?: string;
+          text?: string;
+          user?: string;
+          username?: string;
+          bot_profile?: { name?: string };
+          subtype?: string;
+        };
+        if (!message.ts || message.ts === currentTs) continue;
+        if (message.subtype === 'message_deleted') continue;
+        const rawText = typeof message.text === 'string' ? message.text : '';
+        if (!rawText.trim()) continue;
+
+        const { text } = await resolveMentions(rawText, this.client);
+        const senderName = message.user
+          ? await resolveSlackUserName(this.client, message.user, message.user)
+          : message.username || message.bot_profile?.name || 'Slack';
+        lines.push(`- ${slackTsToIso(message.ts)} ${senderName}: ${text}`);
+      }
+
+      const rootText =
+        typeof (messages[0] as { text?: string } | undefined)?.text === 'string'
+          ? (messages[0] as { text?: string }).text || ''
+          : '';
+      const excerpt = rootText
+        .replace(/\s+/g, ' ')
+        .trim()
+        .slice(0, THREAD_EXCERPT_MAX_CHARS);
+      this.threadRootExcerpts.set(`${channelId}:${threadTs}`, excerpt);
+
+      if (lines.length === 0) return null;
+      const suffix = result.has_more
+        ? '\n- [More Slack thread messages omitted by fetch limit]'
+        : '';
+      const block = [
+        `Slack thread context before this message (thread_ts ${threadTs}):`,
+        ...lines,
+      ].join('\n');
+      const truncated =
+        block.length > THREAD_CONTEXT_MAX_CHARS
+          ? `${block.slice(0, THREAD_CONTEXT_MAX_CHARS)}\n[Slack thread context truncated]`
+          : block;
+      return `${truncated}${suffix}`;
+    } catch (err) {
+      logger.debug(
+        { err, channelId, threadTs },
+        'Slack thread context hydration failed',
+      );
+      return null;
+    }
+  }
+
   /**
    * Process a `reaction_added` event. Exposed (via the public-shaped method)
    * for tests; the bolt event handler in `connect()` delegates straight here.
@@ -1357,12 +1464,13 @@ export class SlackChannel implements Channel {
     if (event.user === this.botUserId) return;
     if (event.item_user !== this.botUserId) return;
 
-    const chatJid = channelIdToJid(
-      channelId,
-      this.multiBotMode ? this.botId : undefined,
-    );
     const messageId = event.item.type === 'message' ? event.item.ts : null;
     if (!messageId) return;
+
+    const rootTs = this.threadRootByTs.get(messageId);
+    const chatJid = rootTs
+      ? slackThreadIdToJid(channelId, rootTs, this.botId)
+      : channelIdToJid(channelId, this.multiBotMode ? this.botId : undefined);
 
     const emoji = `:${event.reaction}:`;
 
@@ -1401,21 +1509,26 @@ export class SlackChannel implements Channel {
     // routing) — process it once.
     if (!this.markSeen(`${channelId}:${event.ts}`)) return;
 
-    const chatJid = channelIdToJid(
+    const parentChatJid = channelIdToJid(
       channelId,
       this.multiBotMode ? this.botId : undefined,
     );
     const legacyChatJid = channelIdToJid(channelId);
     // Slack ts is the unique message timestamp, doubles as message ID
     const msgId = event.ts;
-    const timestamp = new Date(parseFloat(event.ts) * 1000).toISOString();
+    const threadRootTs = event.thread_ts || event.ts;
+    const timestamp = slackTsToIso(event.ts);
 
     // Replies to this message must thread under the root ts.
-    this.rememberThreadRoot(event.ts, event.thread_ts || event.ts);
+    this.rememberThreadRoot(event.ts, threadRootTs);
 
     const senderUserId = 'user' in event ? event.user : 'unknown';
     if (senderUserId && senderUserId !== 'unknown') {
       this.lastHumanSenderByChannel.set(channelId, senderUserId);
+      this.lastHumanSenderByThread.set(
+        `${channelId}:${threadRootTs}`,
+        senderUserId,
+      );
     }
     const sender = `slack:${senderUserId}`;
     const senderName = await resolveSlackUserName(
@@ -1442,6 +1555,7 @@ export class SlackChannel implements Channel {
       this.client,
     );
     let content = resolvedText;
+    const resolvedMessageContent = content;
 
     if (
       this.multiBotMode &&
@@ -1461,24 +1575,11 @@ export class SlackChannel implements Channel {
       return;
     }
 
-    // Annotate threaded replies with the root message so the agent has
-    // context. Assistant threads skip this — the whole conversation IS the
-    // thread, and history comes from the message store.
-    if (
-      !opts.assistantThread &&
-      'thread_ts' in event &&
-      event.thread_ts &&
-      event.thread_ts !== event.ts
-    ) {
-      const excerpt = await this.getThreadRootExcerpt(
-        channelId,
-        event.thread_ts,
-      );
-      content = excerpt
-        ? `[Thread reply to: "${excerpt}"] ${content}`
-        : `[Thread reply] ${content}`;
-    }
-
+    const mentionsThisBot = Boolean(
+      this.botUserId && mentions.some((m) => m.id === this.botUserId),
+    );
+    const isThreadReply =
+      'thread_ts' in event && event.thread_ts && event.thread_ts !== event.ts;
     // Store channel metadata for group discovery
     let channelName = channelId;
     try {
@@ -1491,7 +1592,7 @@ export class SlackChannel implements Channel {
     } catch {
       // Fall back to channel ID
     }
-    this.opts.onChatMetadata(chatJid, timestamp, channelName);
+    this.opts.onChatMetadata(parentChatJid, timestamp, channelName);
     if (this.allowLegacyJidRouting) {
       this.opts.onChatMetadata(legacyChatJid, timestamp, channelName);
     }
@@ -1499,22 +1600,66 @@ export class SlackChannel implements Channel {
     // Only process registered groups (auto-register if callback provided)
     const groups = this.opts.registeredGroups();
     let group =
-      groups[chatJid] ||
+      groups[parentChatJid] ||
       (this.allowLegacyJidRouting ? groups[legacyChatJid] : undefined);
     if (!group && this.opts.autoRegister) {
-      const registered = await this.opts.autoRegister(chatJid, channelName);
+      const registered = await this.opts.autoRegister(
+        parentChatJid,
+        channelName,
+      );
       if (registered) {
         group =
-          groups[chatJid] ||
+          groups[parentChatJid] ||
           (this.allowLegacyJidRouting ? groups[legacyChatJid] : undefined);
       }
     }
     if (!group) {
       logger.debug(
-        { chatJid, legacyChatJid, channelName },
+        { chatJid: parentChatJid, legacyChatJid, channelName },
         'Message from unregistered Slack channel — ignoring',
       );
       return;
+    }
+
+    const explicitlyTriggeredThread = Boolean(
+      mentionsThisBot ||
+      slackTriggerMatches(resolvedMessageContent, group.trigger),
+    );
+    const shouldUseThreadContext = Boolean(
+      opts.assistantThread ||
+      isThreadReply ||
+      (!channelId.startsWith('D') && explicitlyTriggeredThread),
+    );
+    const chatJid = shouldUseThreadContext
+      ? slackThreadIdToJid(channelId, threadRootTs, this.botId)
+      : parentChatJid;
+
+    if (chatJid !== parentChatJid) {
+      this.opts.onChatMetadata(
+        chatJid,
+        timestamp,
+        `${channelName} thread ${threadRootTs}`,
+      );
+    }
+
+    // OpenTag-style grounding: when the bot is explicitly summoned inside an
+    // existing Slack thread, fetch the current Slack transcript as prompt
+    // context instead of storing old replies as new inbound messages.
+    if (!opts.assistantThread && isThreadReply) {
+      const threadContext = explicitlyTriggeredThread
+        ? await this.getThreadContextBlock(channelId, threadRootTs, event.ts)
+        : null;
+      if (threadContext) {
+        content = `${threadContext}\n\nCurrent Slack message: ${content}`;
+      } else {
+        const excerpt = await this.getThreadRootExcerpt(
+          channelId,
+          threadRootTs,
+        );
+        content = excerpt
+          ? `[Thread reply to: "${excerpt}"] ${content}`
+          : `[Thread reply] ${content}`;
+      }
     }
 
     // Process file attachments (images, documents, etc.)
@@ -1637,10 +1782,11 @@ export class SlackChannel implements Channel {
   }
 
   private extractChannelId(jid: string): string | null {
-    const scoped = parseScopedSlackJid(jid);
-    if (scoped) {
-      if (scoped.botId !== this.botId) return null;
-      return scoped.channelId;
+    const parsed = parseSlackJid(jid);
+    if (parsed) {
+      if (parsed.botId && parsed.botId !== this.botId) return null;
+      if (!parsed.botId && !this.allowLegacyJidRouting) return null;
+      return parsed.channelId;
     }
     if (this.allowLegacyJidRouting && /^slack:[^:]+$/.test(jid)) {
       return jidToChannelId(jid);

--- a/src/context-layers.test.ts
+++ b/src/context-layers.test.ts
@@ -58,6 +58,16 @@ describe('resolveContextLayers', () => {
     expect(layers.channelFolder).toBe('servers/slack-OPS/channels/C123ABC');
   });
 
+  it('keeps Slack thread contexts on the parent channel layer', () => {
+    const layers = resolveContextLayers({
+      channelJid: 'slack:OPS:C123ABC:thread:1700000000.000100',
+    });
+
+    expect(layers.serverFolder).toBe('servers/slack-OPS');
+    expect(layers.categoryFolder).toBe('servers/slack-OPS/channels');
+    expect(layers.channelFolder).toBe('servers/slack-OPS/channels/C123ABC');
+  });
+
   it('does not auto-derive layers for legacy Slack JID', () => {
     const layers = resolveContextLayers({
       channelJid: 'slack:C123ABC',

--- a/src/context-layers.ts
+++ b/src/context-layers.ts
@@ -1,4 +1,4 @@
-import { parseScopedSlackJid } from './slack-jid.js';
+import { parseSlackJid } from './slack-jid.js';
 
 export interface ContextLayerInput {
   channelJid: string;
@@ -45,8 +45,8 @@ export function resolveContextLayers(
     return { serverFolder, categoryFolder, channelFolder };
   }
 
-  const slack = parseScopedSlackJid(input.channelJid);
-  if (slack) {
+  const slack = parseSlackJid(input.channelJid);
+  if (slack?.botId) {
     const serverFolder = input.serverFolder || `servers/slack-${slack.botId}`;
     const categoryFolder = input.categoryFolder || `${serverFolder}/channels`;
     const channelSegment = slack.channelId.replace(/[^a-zA-Z0-9_-]/g, '-');

--- a/src/db.migrations.test.ts
+++ b/src/db.migrations.test.ts
@@ -159,6 +159,12 @@ describe('db migrations (bun:sqlite)', () => {
       'fork_from',
     );
     expect(getTableColumns(db, 'pending_session_intents')).toContain('name');
+    expect(getTableColumns(db, 'thread_summaries')).toContain('chat_jid');
+    expect(getTableColumns(db, 'thread_summaries')).toContain('summary');
+    expect(getTableColumns(db, 'thread_summaries')).toContain('status');
+    expect(getTableColumns(db, 'thread_summaries')).toContain(
+      'through_timestamp',
+    );
 
     // Verify default values applied to existing rows
     const agents = db
@@ -199,6 +205,12 @@ describe('db migrations (bun:sqlite)', () => {
       'fork_from',
     );
     expect(getTableColumns(db, 'pending_session_intents')).toContain('name');
+    expect(getTableColumns(db, 'thread_summaries')).toContain('chat_jid');
+    expect(getTableColumns(db, 'thread_summaries')).toContain('summary');
+    expect(getTableColumns(db, 'thread_summaries')).toContain('status');
+    expect(getTableColumns(db, 'thread_summaries')).toContain(
+      'through_timestamp',
+    );
 
     // Write an agent with opencode runtime
     db.query(

--- a/src/db.test.ts
+++ b/src/db.test.ts
@@ -18,6 +18,7 @@ import {
   getMessagesSince,
   getNewMessages,
   getTaskById,
+  getThreadSummary,
   loadAllDeltaCursors,
   recordGitHubWebhookDelivery,
   setAgent,
@@ -25,6 +26,7 @@ import {
   setDeltaCursorInDb,
   setAgentHealth,
   setRegisteredGroup,
+  setThreadSummary,
   storeChatMetadata,
   storeMessage,
   updateTask,
@@ -617,6 +619,66 @@ describe('getMessagesSince', () => {
     const msgs = getMessagesSince('group@g.us', '');
     // 3 user messages (bot message excluded)
     expect(msgs).toHaveLength(3);
+  });
+});
+
+// --- thread summaries ---
+
+describe('thread summaries', () => {
+  it('persists and reads a rolling thread summary', () => {
+    const updated = setThreadSummary({
+      chat_jid: 'slack:TEST:C123:thread:1700000000.000100',
+      summary: 'Thread is about launch readiness. Peyton owns the checklist.',
+      status: 'active',
+      updated_by: 'team-agent',
+      through_message_id: '1700000000.000200',
+      through_timestamp: '2024-01-01T00:00:02.000Z',
+      updated_at: '2024-01-01T00:00:03.000Z',
+    });
+
+    expect(updated).toBe(true);
+    expect(
+      getThreadSummary('slack:TEST:C123:thread:1700000000.000100'),
+    ).toEqual({
+      chat_jid: 'slack:TEST:C123:thread:1700000000.000100',
+      summary: 'Thread is about launch readiness. Peyton owns the checklist.',
+      status: 'active',
+      updated_by: 'team-agent',
+      through_message_id: '1700000000.000200',
+      through_timestamp: '2024-01-01T00:00:02.000Z',
+      updated_at: '2024-01-01T00:00:03.000Z',
+    });
+  });
+
+  it('keys Slack thread summaries by exact thread JID', () => {
+    setThreadSummary({
+      chat_jid: 'slack:TEST:C123:thread:1700000000.000100',
+      summary: 'Thread-level summary.',
+    });
+
+    expect(getThreadSummary('slack:C123')).toBeUndefined();
+    expect(
+      getThreadSummary('slack:TEST:C123:thread:1700000000.000100')?.summary,
+    ).toBe('Thread-level summary.');
+  });
+
+  it('does not overwrite newer summaries with older covered timestamps', () => {
+    setThreadSummary({
+      chat_jid: 'slack:TEST:C123:thread:1700000000.000100',
+      summary: 'Newer summary.',
+      through_timestamp: '2024-01-01T00:00:10.000Z',
+    });
+
+    const updated = setThreadSummary({
+      chat_jid: 'slack:TEST:C123:thread:1700000000.000100',
+      summary: 'Older summary.',
+      through_timestamp: '2024-01-01T00:00:05.000Z',
+    });
+
+    expect(updated).toBe(false);
+    expect(
+      getThreadSummary('slack:TEST:C123:thread:1700000000.000100')?.summary,
+    ).toBe('Newer summary.');
   });
 });
 

--- a/src/db.ts
+++ b/src/db.ts
@@ -20,6 +20,7 @@ import {
   ScheduledTask,
   TaskRunPhaseEvent,
   TaskRunLog,
+  ThreadSummary,
   registeredGroupToAgent,
   registeredGroupToRoute,
 } from './types.js';
@@ -690,6 +691,34 @@ type MessageRow = NewMessage & {
   sender_platform: string | null;
 };
 
+interface ThreadSummaryRow {
+  chat_jid: string;
+  summary: string;
+  status: string | null;
+  updated_at: string;
+  updated_by: string | null;
+  through_message_id: string | null;
+  through_timestamp: string | null;
+}
+
+function mapThreadSummaryRow(row: ThreadSummaryRow): ThreadSummary {
+  const status =
+    row.status === 'active' ||
+    row.status === 'resolved' ||
+    row.status === 'blocked'
+      ? row.status
+      : undefined;
+  return {
+    chat_jid: row.chat_jid,
+    summary: row.summary,
+    status,
+    updated_at: row.updated_at,
+    updated_by: row.updated_by || undefined,
+    through_message_id: row.through_message_id || undefined,
+    through_timestamp: row.through_timestamp || undefined,
+  };
+}
+
 const VALID_SENDER_PLATFORMS = new Set<
   NonNullable<NewMessage['sender_platform']>
 >(['discord', 'whatsapp', 'telegram', 'slack', 'ipc', 'system']);
@@ -786,6 +815,59 @@ export function getMessagesSince(
   `;
   const rows = db.prepare(sql).all(chatJid, sinceTimestamp) as MessageRow[];
   return rows.map(mapMessageRow);
+}
+
+export function getThreadSummary(chatJid: string): ThreadSummary | undefined {
+  const row = db
+    .prepare('SELECT * FROM thread_summaries WHERE chat_jid = ?')
+    .get(chatJid) as ThreadSummaryRow | undefined;
+  return row ? mapThreadSummaryRow(row) : undefined;
+}
+
+export function setThreadSummary(
+  summary: Omit<ThreadSummary, 'updated_at'> & { updated_at?: string },
+): boolean {
+  const trimmed = summary.summary.trim();
+  if (!trimmed) {
+    clearThreadSummary(summary.chat_jid);
+    return true;
+  }
+
+  const existing = getThreadSummary(summary.chat_jid);
+  if (
+    existing?.through_timestamp &&
+    summary.through_timestamp &&
+    summary.through_timestamp < existing.through_timestamp
+  ) {
+    return false;
+  }
+
+  const updatedAt = summary.updated_at ?? new Date().toISOString();
+  const status =
+    summary.status === 'active' ||
+    summary.status === 'resolved' ||
+    summary.status === 'blocked'
+      ? summary.status
+      : undefined;
+
+  db.query(
+    `INSERT OR REPLACE INTO thread_summaries
+      (chat_jid, summary, status, updated_at, updated_by, through_message_id, through_timestamp)
+      VALUES (?, ?, ?, ?, ?, ?, ?)`,
+  ).run(
+    summary.chat_jid,
+    trimmed,
+    status ?? null,
+    updatedAt,
+    summary.updated_by ?? null,
+    summary.through_message_id ?? null,
+    summary.through_timestamp ?? null,
+  );
+  return true;
+}
+
+export function clearThreadSummary(chatJid: string): void {
+  db.query('DELETE FROM thread_summaries WHERE chat_jid = ?').run(chatJid);
 }
 
 /**

--- a/src/effect/user-registry.test.ts
+++ b/src/effect/user-registry.test.ts
@@ -72,6 +72,13 @@ const charlie: UserInfo = {
   lastSeen: '2024-01-01T00:00:00.000Z',
 };
 
+const dana: UserInfo = {
+  id: 'U123SLACK',
+  name: 'Dana',
+  platform: 'slack',
+  lastSeen: '2024-01-01T00:00:00.000Z',
+};
+
 describe('UserRegistryService', () => {
   describe('getUser', () => {
     it('returns null for unknown user', async () => {
@@ -348,6 +355,17 @@ describe('formatMention', () => {
       }),
     );
     expect(result).toBe('<@123456>');
+  });
+
+  it('formats Slack mention as <@id>', async () => {
+    const result = await runWithRegistry(
+      Effect.gen(function* (_) {
+        const svc = yield* _(UserRegistryService);
+        yield* _(svc.upsertUser(dana));
+        return yield* _(formatMention('Dana'));
+      }),
+    );
+    expect(result).toBe('<@U123SLACK>');
   });
 
   it('formats WhatsApp mention as @id', async () => {

--- a/src/effect/user-registry.ts
+++ b/src/effect/user-registry.ts
@@ -12,8 +12,8 @@ export interface UserInfo {
   id: string;
   /** Display name or username */
   name: string;
-  /** Platform identifier (discord, whatsapp, telegram) */
-  platform: 'discord' | 'whatsapp' | 'telegram';
+  /** Platform identifier. */
+  platform: 'discord' | 'whatsapp' | 'telegram' | 'slack';
   /** Last seen timestamp */
   lastSeen: string;
 }
@@ -199,6 +199,7 @@ export const formatMention = (
     // Format based on platform
     switch (user.platform) {
       case 'discord':
+      case 'slack':
         return `<@${user.id}>`;
       case 'whatsapp':
         // WhatsApp uses @<phone_number> format

--- a/src/formatting.test.ts
+++ b/src/formatting.test.ts
@@ -6,6 +6,7 @@ import {
   escapeXml,
   formatMessages,
   formatOutbound,
+  formatThreadSummary,
   stripInternalTags,
 } from './router.js';
 import type { Channel, NewMessage } from './types.js';
@@ -57,6 +58,26 @@ describe('escapeXml', () => {
 });
 
 // --- formatMessages ---
+
+describe('formatThreadSummary', () => {
+  it('formats a thread summary outside the messages block with escaped content', () => {
+    const result = formatThreadSummary({
+      chat_jid: 'slack:TEST:C123:thread:1700000000.000100',
+      summary: 'Decision: use A & B <carefully>.',
+      status: 'active',
+      updated_at: '2024-01-01T00:00:03.000Z',
+      updated_by: 'team-agent',
+      through_message_id: '1700000000.000200',
+      through_timestamp: '2024-01-01T00:00:02.000Z',
+    });
+
+    expect(result).toBe(
+      '<conversation_summary chat_jid="slack:TEST:C123:thread:1700000000.000100" updated_at="2024-01-01T00:00:03.000Z" status="active" updated_by="team-agent" through_message_id="1700000000.000200" through_timestamp="2024-01-01T00:00:02.000Z">\n' +
+        'Decision: use A &amp; B &lt;carefully&gt;.\n' +
+        '</conversation_summary>',
+    );
+  });
+});
 
 describe('formatMessages', () => {
   it('formats a single message as XML with participant attributes', () => {

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -2,6 +2,7 @@ import { beforeEach, describe, expect, it } from 'bun:test';
 
 import {
   _initTestDatabase,
+  getSession,
   getPendingSessionIntent,
   setChannelSubscription,
   setSession,
@@ -9,10 +10,12 @@ import {
 } from './db.js';
 import {
   _createIntermediateStatusStreamer,
+  _getRuntimeGroupFolderForTest,
   _handleSessionCommandForTest,
   _getSlashCommandGroupsFromSubscriptions,
   _getEnabledStartupConfirmationTargets,
   _isAgentEnabled,
+  _prepareSlackThreadSessionForkForTest,
   _markChannelSubscriptionsDirty,
   _selectEnabledSubscriptionsForMessage,
   _selectSubscriptionsForMessage,
@@ -503,6 +506,96 @@ describe('Discord session command state', () => {
   });
 });
 
+describe('runtime group folder selection', () => {
+  beforeEach(() => {
+    _initTestDatabase();
+    _setSessions({});
+  });
+
+  it('keeps legacy channel runs on the base group folder', () => {
+    expect(_getRuntimeGroupFolderForTest('support', 'slack:C123')).toBe(
+      'support',
+    );
+  });
+
+  it('isolates legacy Slack thread runs from the parent group session', () => {
+    const parent = _getRuntimeGroupFolderForTest('support', 'slack:TEST:C123');
+    const thread = _getRuntimeGroupFolderForTest(
+      'support',
+      'slack:TEST:C123:thread:1700000000.000100',
+    );
+    const siblingThread = _getRuntimeGroupFolderForTest(
+      'support',
+      'slack:TEST:C123:thread:1700000000.000200',
+    );
+
+    expect(parent).toBe('support');
+    expect(thread).toMatch(/^support__dispatch__[a-f0-9]{16}$/);
+    expect(siblingThread).toMatch(/^support__dispatch__[a-f0-9]{16}$/);
+    expect(thread).not.toBe(parent);
+    expect(siblingThread).not.toBe(thread);
+  });
+
+  it('prepares a new Slack thread session as a fork of the parent channel session', () => {
+    const parentSession = '11111111-1111-4111-8111-111111111111';
+    const threadJid = 'slack:TEST:C123:thread:1700000000.000100';
+    const threadRuntime = _getRuntimeGroupFolderForTest('support', threadJid);
+
+    setSession('support', parentSession);
+    _setSessions({ support: parentSession });
+
+    expect(
+      _prepareSlackThreadSessionForkForTest('support', threadJid, threadJid),
+    ).toBe(parentSession);
+    expect(getSession(threadRuntime)).toBe(parentSession);
+    expect(getPendingSessionIntent(threadRuntime)).toEqual({
+      forkFrom: parentSession,
+      name: undefined,
+    });
+  });
+
+  it('uses the matching subscribed-agent parent session for Slack thread forks', () => {
+    const parentSession = '22222222-2222-4222-8222-222222222222';
+    const parentKey = 'slack:TEST:C123::agent::team-agent';
+    const threadKey =
+      'slack:TEST:C123:thread:1700000000.000100::agent::team-agent';
+    const parentRuntime = _getRuntimeGroupFolderForTest('support', parentKey);
+    const threadRuntime = _getRuntimeGroupFolderForTest('support', threadKey);
+
+    setSession(parentRuntime, parentSession);
+    _setSessions({ [parentRuntime]: parentSession });
+
+    expect(
+      _prepareSlackThreadSessionForkForTest(
+        'support',
+        'slack:TEST:C123:thread:1700000000.000100',
+        threadKey,
+      ),
+    ).toBe(parentSession);
+    expect(getSession(threadRuntime)).toBe(parentSession);
+    expect(getPendingSessionIntent(threadRuntime)?.forkFrom).toBe(
+      parentSession,
+    );
+  });
+
+  it('does not overwrite an existing Slack thread session fork state', () => {
+    const parentSession = '33333333-3333-4333-8333-333333333333';
+    const threadSession = '44444444-4444-4444-8444-444444444444';
+    const threadJid = 'slack:TEST:C123:thread:1700000000.000100';
+    const threadRuntime = _getRuntimeGroupFolderForTest('support', threadJid);
+
+    setSession('support', parentSession);
+    setSession(threadRuntime, threadSession);
+    _setSessions({ support: parentSession, [threadRuntime]: threadSession });
+
+    expect(
+      _prepareSlackThreadSessionForkForTest('support', threadJid, threadJid),
+    ).toBeUndefined();
+    expect(getSession(threadRuntime)).toBe(threadSession);
+    expect(getPendingSessionIntent(threadRuntime)).toBeUndefined();
+  });
+});
+
 describe('slash command subscription groups', () => {
   beforeEach(() => {
     _initTestDatabase();
@@ -684,6 +777,65 @@ describe('subscription selection', () => {
     ]);
 
     expect(result.selectedByTrigger).toBe(true);
+    expect(result.selected.map((s) => s.agentId)).toEqual(['agent-a']);
+  });
+
+  it('inherits parent Slack subscriptions for thread-scoped conversations', () => {
+    _setChannelSubscriptions({
+      'slack:TEST:C123': [
+        {
+          ...BASE_SUBSCRIPTION,
+          channelJid: 'slack:TEST:C123',
+          agentId: 'agent-a',
+          trigger: '@Clayton',
+          priority: 0,
+        },
+      ],
+    });
+
+    const result = _selectSubscriptionsForMessage(
+      'slack:TEST:C123:thread:1700000000.000100',
+      [
+        makeMessage({
+          chat_jid: 'slack:TEST:C123:thread:1700000000.000100',
+          sender_platform: 'slack',
+          sender: 'slack:UPEYTON',
+          sender_user_id: 'UPEYTON',
+          content: '@Clayton please handle this thread',
+        }),
+      ],
+    );
+
+    expect(result.selectedByTrigger).toBe(true);
+    expect(result.selected.map((s) => s.agentId)).toEqual(['agent-a']);
+  });
+
+  it('falls back to legacy Slack parent subscriptions for thread conversations', () => {
+    _setChannelSubscriptions({
+      'slack:C123': [
+        {
+          ...BASE_SUBSCRIPTION,
+          channelJid: 'slack:C123',
+          agentId: 'agent-a',
+          trigger: '@Clayton',
+          priority: 0,
+        },
+      ],
+    });
+
+    const result = _selectSubscriptionsForMessage(
+      'slack:TEST:C123:thread:1700000000.000100',
+      [
+        makeMessage({
+          chat_jid: 'slack:TEST:C123:thread:1700000000.000100',
+          sender_platform: 'slack',
+          sender: 'slack:UPEYTON',
+          sender_user_id: 'UPEYTON',
+          content: '@Clayton please handle this thread',
+        }),
+      ],
+    );
+
     expect(result.selected.map((s) => s.agentId)).toEqual(['agent-a']);
   });
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -94,6 +94,7 @@ import {
   getRecentTaskOutcomeStats,
   getTaskRunLogs,
   getTaskRunPhaseEvents,
+  getThreadSummary,
   initDatabase,
   setAgent,
   setAgentHealth,
@@ -103,6 +104,7 @@ import {
   setRegisteredGroup,
   setRouterState,
   setSession,
+  setThreadSummary,
   storeChatMetadata,
   storeGuildRoster,
   storeMessage,
@@ -136,13 +138,15 @@ import { createResumePositionStore } from './resume-position-store.js';
 import { getDiscordChannelSeed, getServerSeed } from './seed-templates.js';
 import {
   findChannel,
+  type FormatMessagesOptions,
   formatMessages,
   formatOutbound,
+  formatThreadSummary,
   getAgentName,
 } from './router.js';
 import { calculateNextRun } from './schedule-utils.js';
 import { redactSensitiveData } from './security/redaction.js';
-import { parseScopedSlackJid } from './slack-jid.js';
+import { parseSlackJid } from './slack-jid.js';
 import {
   buildStartupConfirmationTargets,
   hasPriorRuntimeState,
@@ -565,8 +569,9 @@ function getRuntimeGroupFolder(
   baseFolder: string,
   processKeyJid: string,
 ): string {
-  const { agentId } = parseDispatchKey(processKeyJid);
-  if (!agentId) return baseFolder;
+  const { channelJid, agentId } = parseDispatchKey(processKeyJid);
+  const slack = parseSlackJid(channelJid);
+  if (!agentId && !slack?.threadTs) return baseFolder;
   const digest = createHash('sha1')
     .update(processKeyJid)
     .digest('hex')
@@ -879,6 +884,13 @@ function getSubscriptionsForChannelInMemory(
 ): ChannelSubscription[] {
   const exact = channelSubscriptions[channelJid];
   if (exact && exact.length > 0) return exact;
+  const slack = parseSlackJid(channelJid);
+  if (slack) {
+    const parent = channelSubscriptions[slack.parentJid];
+    if (parent && parent.length > 0) return parent;
+    const legacyParent = channelSubscriptions[slack.legacyParentJid];
+    if (legacyParent && legacyParent.length > 0) return legacyParent;
+  }
   const legacyJid = toLegacyTelegramJid(channelJid);
   if (legacyJid) return channelSubscriptions[legacyJid] || [];
   return [];
@@ -899,6 +911,13 @@ function buildMessagePollJids(): string[] {
     if (legacyJid && jids.has(legacyJid)) {
       jids.add(chat.jid);
     }
+    const slack = parseSlackJid(chat.jid);
+    if (
+      slack?.threadTs &&
+      (jids.has(slack.parentJid) || jids.has(slack.legacyParentJid))
+    ) {
+      jids.add(chat.jid);
+    }
   }
 
   return Array.from(jids);
@@ -909,7 +928,7 @@ function buildRegisteredGroupFromSubscription(
   sub: ChannelSubscription,
 ): RegisteredGroup | undefined {
   const agent = agents[sub.agentId];
-  const fallback = registeredGroups[channelJid];
+  const fallback = getRegisteredGroupForJid(channelJid);
   if (!agent && !fallback) return undefined;
 
   const resolvedBotId = sub.discordBotId || fallback?.discordBotId;
@@ -981,8 +1000,8 @@ function toLegacyTelegramJid(jid: string): string | undefined {
 }
 
 function toLegacySlackJid(jid: string): string | undefined {
-  const parsed = parseScopedSlackJid(jid);
-  return parsed ? `slack:${parsed.channelId}` : undefined;
+  const parsed = parseSlackJid(jid);
+  return parsed?.botId ? parsed.legacyParentJid : undefined;
 }
 
 function getRegisteredGroupForJid(jid: string): RegisteredGroup | undefined {
@@ -990,8 +1009,12 @@ function getRegisteredGroupForJid(jid: string): RegisteredGroup | undefined {
   if (exact) return exact;
   const legacyTelegramJid = toLegacyTelegramJid(jid);
   if (legacyTelegramJid) return registeredGroups[legacyTelegramJid];
-  const legacySlackJid = toLegacySlackJid(jid);
-  if (legacySlackJid) return registeredGroups[legacySlackJid];
+  const slack = parseSlackJid(jid);
+  if (slack) {
+    const parent = registeredGroups[slack.parentJid];
+    if (parent) return parent;
+    return registeredGroups[slack.legacyParentJid];
+  }
   return undefined;
 }
 
@@ -1001,8 +1024,8 @@ function getPreferredChannelBotId(
 ): string | undefined {
   if (jid.startsWith('dc:')) return discordBotId || getDiscordBotIdForJid(jid);
   if (jid.startsWith('slack:')) {
-    const scopedSlack = parseScopedSlackJid(jid);
-    return scopedSlack?.botId || SLACK_DEFAULT_BOT_ID;
+    const slack = parseSlackJid(jid);
+    return slack?.botId || SLACK_DEFAULT_BOT_ID;
   }
   const scopedTelegram = parseScopedTelegramJid(jid);
   if (scopedTelegram) return scopedTelegram.botId;
@@ -1989,6 +2012,14 @@ export function _handleSessionCommandForTest(
   return handleSessionCommand(command, chatJid, group, options);
 }
 
+/** @internal - exported for testing */
+export function _getRuntimeGroupFolderForTest(
+  baseFolder: string,
+  processKeyJid: string,
+): string {
+  return getRuntimeGroupFolder(baseFolder, processKeyJid);
+}
+
 /**
  * Whether a batch of pending messages contains a real trigger that should wake
  * a trigger-gated agent. Synthetic reaction notifications (id `react-*`) are
@@ -2053,7 +2084,7 @@ async function processGroupMessages(dispatchJid: string): Promise<boolean> {
     messageCount: missedMessages.length,
   });
 
-  let prompt = formatMessages(missedMessages, {
+  let prompt = formatMessagesForPrompt(chatJid, missedMessages, {
     channelRosterNames: await getChannelRosterNames(
       chatJid,
       group.discordGuildId,
@@ -2468,6 +2499,90 @@ function buildAgentDiscoveryCapabilities(agent: Agent): string[] {
   ];
 }
 
+function formatMessagesForPrompt(
+  chatJid: string,
+  messages: NewMessage[],
+  options: FormatMessagesOptions = {},
+): string {
+  const formatted = formatMessages(messages, options);
+  const threadSummary = getThreadSummary(chatJid);
+  if (!threadSummary) return formatted;
+  return `${formatThreadSummary(threadSummary)}\n\n${formatted}`;
+}
+
+function getSlackParentProcessKeys(
+  chatJid: string,
+  processKeyJid: string,
+): string[] {
+  const slack = parseSlackJid(chatJid);
+  if (!slack?.threadTs) return [];
+
+  const { agentId } = parseDispatchKey(processKeyJid);
+  const parentJids = Array.from(
+    new Set([slack.parentJid, slack.legacyParentJid]),
+  );
+  return agentId
+    ? parentJids.map((parentJid) => makeDispatchKey(parentJid, agentId))
+    : parentJids;
+}
+
+function prepareSlackThreadSessionFork(
+  baseFolder: string,
+  chatJid: string,
+  processKeyJid: string,
+  runtimeGroupFolder: string,
+): string | undefined {
+  if (sessions[runtimeGroupFolder]) return undefined;
+  if (getPendingSessionIntent(runtimeGroupFolder)?.forkFrom) {
+    return undefined;
+  }
+
+  for (const parentProcessKey of getSlackParentProcessKeys(
+    chatJid,
+    processKeyJid,
+  )) {
+    const parentRuntimeFolder = getRuntimeGroupFolder(
+      baseFolder,
+      parentProcessKey,
+    );
+    if (parentRuntimeFolder === runtimeGroupFolder) continue;
+
+    const parentSessionId = sessions[parentRuntimeFolder];
+    if (!parentSessionId) continue;
+
+    sessions[runtimeGroupFolder] = parentSessionId;
+    setSession(runtimeGroupFolder, parentSessionId);
+    resumePositionStore.set(runtimeGroupFolder, '');
+    setPendingSessionIntent(runtimeGroupFolder, { forkFrom: parentSessionId });
+    logger.info(
+      {
+        chatJid,
+        runtimeGroupFolder,
+        parentRuntimeFolder,
+        parentSessionId,
+      },
+      'Prepared Slack thread runtime to fork from parent channel session',
+    );
+    return parentSessionId;
+  }
+
+  return undefined;
+}
+
+/** @internal - exported for testing */
+export function _prepareSlackThreadSessionForkForTest(
+  baseFolder: string,
+  chatJid: string,
+  processKeyJid: string,
+): string | undefined {
+  return prepareSlackThreadSessionFork(
+    baseFolder,
+    chatJid,
+    processKeyJid,
+    getRuntimeGroupFolder(baseFolder, processKeyJid),
+  );
+}
+
 async function runAgent(
   group: RegisteredGroup,
   prompt: string,
@@ -2491,6 +2606,13 @@ async function runAgent(
       'Expired stale sessions before agent run',
     );
   }
+
+  prepareSlackThreadSessionFork(
+    group.folder,
+    chatJid,
+    processKeyJid,
+    runtimeGroupFolder,
+  );
 
   const sessionId = sessions[runtimeGroupFolder];
   const pendingSessionIntent = getPendingSessionIntent(runtimeGroupFolder);
@@ -2969,7 +3091,7 @@ async function startMessageLoop(): Promise<void> {
             );
             if (allPending.length === 0) continue;
             const messagesToSend = allPending;
-            const formatted = formatMessages(messagesToSend, {
+            const formatted = formatMessagesForPrompt(chatJid, messagesToSend, {
               channelRosterNames: await getChannelRosterNames(
                 chatJid,
                 group.discordGuildId,
@@ -3029,7 +3151,7 @@ async function startMessageLoop(): Promise<void> {
             );
             if (filteredPending.length === 0) continue;
             const messagesToSend = filteredPending;
-            const formatted = formatMessages(messagesToSend, {
+            const formatted = formatMessagesForPrompt(chatJid, messagesToSend, {
               channelRosterNames: await getChannelRosterNames(
                 chatJid,
                 sub.discordGuildId,
@@ -4309,11 +4431,17 @@ async function main(): Promise<void> {
     agentFolders: () => new Set(Object.values(agents).map((a) => a.folder)),
     getSubscriptions: (jid) => {
       refreshChannelSubscriptions();
-      return (channelSubscriptions[jid] ?? []).map((s) => ({
+      return getSubscriptionsForChannelInMemory(jid).map((s) => ({
         agentId: s.agentId,
         agentFolder: agents[s.agentId]?.folder ?? s.agentId,
       }));
     },
+    getMessages: (jid, since, limit) => {
+      const msgs = getMessagesSince(jid, since);
+      return limit ? msgs.slice(-limit) : msgs;
+    },
+    getThreadSummary,
+    setThreadSummary,
     onIpcEvent: (kind: IpcEventKind, sourceGroup, summary, details) => {
       const event = ipcEvents.push(kind, sourceGroup, summary, details);
       webServer?.broadcast({

--- a/src/ipc-messages.test.ts
+++ b/src/ipc-messages.test.ts
@@ -361,6 +361,125 @@ describe('processMessageIpc: react_to_message', () => {
 });
 
 // =============================================================================
+// request_confirmation
+// =============================================================================
+
+describe('processMessageIpc: request_confirmation', () => {
+  function readResponse(sourceGroup: string, requestId: string) {
+    const responsePath = path.join(
+      tmpDir,
+      sourceGroup,
+      'responses',
+      `${requestId}.json`,
+    );
+    return JSON.parse(fs.readFileSync(responsePath, 'utf8'));
+  }
+
+  it('posts a confirmation request and seeds approve/deny reactions', async () => {
+    const result = await processMsg({
+      type: 'request_confirmation',
+      chatJid: 'other@g.us',
+      action: 'Push the release branch',
+      details: 'Branch: codex/slack-thread-context\nRemote: origin',
+      requestId: 'confirm-1',
+    });
+
+    expect(result).toEqual({ action: 'handled' });
+    expect(sentMessages).toHaveLength(1);
+    expect(sentMessages[0]?.jid).toBe('other@g.us');
+    expect(sentMessages[0]?.text).toContain(
+      '*Confirmation needed:* Push the release branch',
+    );
+    expect(sentMessages[0]?.text).toContain(
+      'Branch: codex/slack-thread-context',
+    );
+    expect(sentMessages[0]?.text).toContain(
+      'React with :white_check_mark: to approve or :x: to deny.',
+    );
+    expect(reactions).toEqual([
+      {
+        action: 'add',
+        jid: 'other@g.us',
+        messageId: 'sent-1',
+        emoji: ':white_check_mark:',
+      },
+      {
+        action: 'add',
+        jid: 'other@g.us',
+        messageId: 'sent-1',
+        emoji: ':x:',
+      },
+    ]);
+    expect(readResponse('main', 'confirm-1')).toEqual({
+      type: 'request_confirmation_response',
+      requestId: 'confirm-1',
+      ok: true,
+      result: {
+        chatJid: 'other@g.us',
+        messageId: 'sent-1',
+        approveEmoji: ':white_check_mark:',
+        denyEmoji: ':x:',
+        reactionsAdded: [':white_check_mark:', ':x:'],
+        reactionErrors: [],
+      },
+    });
+  });
+
+  it('inherits Slack thread authorization from the parent channel registration', async () => {
+    const threadJid = 'slack:TEST:C123:thread:1700000000.000100';
+    groups = {
+      ...groups,
+      'slack:C123': OTHER_GROUP,
+    };
+
+    const result = await processMsg(
+      {
+        type: 'request_confirmation',
+        chatJid: threadJid,
+        action: 'Create the ticket',
+        details: 'Project: Support',
+        approveEmoji: ':thumbsup:',
+        denyEmoji: ':no_entry:',
+        requestId: 'confirm-slack',
+      },
+      'other-group',
+      false,
+    );
+
+    expect(result).toEqual({ action: 'handled' });
+    expect(sentMessages[0]?.jid).toBe(threadJid);
+    expect(sentMessages[0]?.text).toContain(
+      'React with :thumbsup: to approve or :no_entry: to deny.',
+    );
+    expect(reactions).toEqual([
+      {
+        action: 'add',
+        jid: threadJid,
+        messageId: 'sent-1',
+        emoji: ':thumbsup:',
+      },
+      {
+        action: 'add',
+        jid: threadJid,
+        messageId: 'sent-1',
+        emoji: ':no_entry:',
+      },
+    ]);
+    expect(readResponse('other-group', 'confirm-slack')).toMatchObject({
+      type: 'request_confirmation_response',
+      requestId: 'confirm-slack',
+      ok: true,
+      result: {
+        chatJid: threadJid,
+        messageId: 'sent-1',
+        approveEmoji: ':thumbsup:',
+        denyEmoji: ':no_entry:',
+      },
+    });
+  });
+});
+
+// =============================================================================
 // format_mention
 // =============================================================================
 

--- a/src/ipc-processing.test.ts
+++ b/src/ipc-processing.test.ts
@@ -1,3 +1,6 @@
+import fs from 'fs';
+import path from 'path';
+
 import { describe, it, expect, beforeEach } from 'bun:test';
 
 import {
@@ -31,6 +34,7 @@ import {
   Agent,
   ChannelRoute,
   ChannelSubscription,
+  NewMessage,
 } from './types.js';
 
 // --- Shared test fixtures ---
@@ -206,6 +210,312 @@ describe('processMessageIpc: send_message routing audit', () => {
       currentChatJid: 'dc:sibling',
       targetWasExplicit: true,
     });
+  });
+
+  it('sends messages to Slack thread JIDs through parent registration', async () => {
+    const threadJid = 'slack:TEST:C123:thread:1700000000.000100';
+    const slackGroups = {
+      ...groups,
+      'slack:C123': OTHER_GROUP,
+    };
+
+    const result = await processMessageIpc(
+      {
+        type: 'message',
+        chatJid: threadJid,
+        originChatJid: threadJid,
+        currentChatJid: threadJid,
+        targetWasExplicit: false,
+        text: 'progress in the thread',
+      },
+      'other-group',
+      false,
+      '/tmp/omniclaw-ipc-test',
+      slackGroups,
+      deps,
+    );
+
+    expect(result).toEqual({ action: 'handled' });
+    expect(sentMessages).toEqual([
+      { jid: threadJid, text: 'progress in the thread' },
+    ]);
+    expect(ipcEvents[0]?.details).toMatchObject({
+      chatJid: threadJid,
+      originChatJid: threadJid,
+      currentChatJid: threadJid,
+      targetWasExplicit: false,
+    });
+  });
+
+  it('returns locally stored messages for read_thread on Slack thread JIDs', async () => {
+    const threadJid = 'slack:TEST:C123:thread:1700000000.000100';
+    const ipcDir = path.join(
+      '/tmp',
+      `omniclaw-read-thread-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`,
+    );
+    const message: NewMessage = {
+      id: '1700000000.000100',
+      chat_jid: threadJid,
+      sender: 'slack:UPEYTON',
+      sender_name: 'Peyton',
+      content: 'please summarize this',
+      timestamp: '2023-11-14T22:13:20.000Z',
+      sender_platform: 'slack',
+      sender_user_id: 'UPEYTON',
+    };
+    deps.getMessages = (jid, since, limit) => {
+      expect(jid).toBe(threadJid);
+      expect(since).toBe('');
+      expect(limit).toBe(25);
+      return [message];
+    };
+    deps.getThreadSummary = (jid) => {
+      expect(jid).toBe(threadJid);
+      return {
+        chat_jid: threadJid,
+        summary: 'Thread is about launch readiness.',
+        status: 'active',
+        updated_at: '2024-01-01T00:00:03.000Z',
+      };
+    };
+
+    try {
+      const result = await processMessageIpc(
+        {
+          type: 'read_thread',
+          chatJid: threadJid,
+          limit: 25,
+          requestId: 'read-thread-test',
+        },
+        'other-group',
+        false,
+        ipcDir,
+        {
+          ...groups,
+          'slack:C123': OTHER_GROUP,
+        },
+        deps,
+      );
+
+      expect(result).toEqual({ action: 'handled' });
+      const response = JSON.parse(
+        fs.readFileSync(
+          path.join(
+            ipcDir,
+            'other-group',
+            'responses',
+            'read-thread-test.json',
+          ),
+          'utf-8',
+        ),
+      );
+      expect(response).toMatchObject({
+        requestId: 'read-thread-test',
+        type: 'read_thread_response',
+        ok: true,
+        result: {
+          chatJid: threadJid,
+          count: 1,
+          summary: {
+            chat_jid: threadJid,
+            summary: 'Thread is about launch readiness.',
+            status: 'active',
+            updated_at: '2024-01-01T00:00:03.000Z',
+          },
+          messages: [
+            {
+              id: '1700000000.000100',
+              sender: 'Peyton',
+              sender_id: 'slack:UPEYTON',
+              timestamp: '2023-11-14T22:13:20.000Z',
+              content: 'please summarize this',
+            },
+          ],
+        },
+      });
+    } finally {
+      fs.rmSync(ipcDir, { recursive: true, force: true });
+    }
+  });
+
+  it('blocks read_thread for Slack threads owned by another group', async () => {
+    const threadJid = 'slack:TEST:C123:thread:1700000000.000100';
+    const ipcDir = path.join(
+      '/tmp',
+      `omniclaw-read-thread-blocked-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`,
+    );
+    deps.getMessages = () => {
+      throw new Error('read_thread should not reach getMessages');
+    };
+
+    try {
+      const result = await processMessageIpc(
+        {
+          type: 'read_thread',
+          chatJid: threadJid,
+          requestId: 'read-thread-blocked-test',
+        },
+        'third-group',
+        false,
+        ipcDir,
+        {
+          ...groups,
+          'slack:C123': OTHER_GROUP,
+        },
+        deps,
+      );
+
+      expect(result).toEqual({
+        action: 'blocked',
+        reason: 'not authorized',
+      });
+      const response = JSON.parse(
+        fs.readFileSync(
+          path.join(
+            ipcDir,
+            'third-group',
+            'responses',
+            'read-thread-blocked-test.json',
+          ),
+          'utf-8',
+        ),
+      );
+      expect(response).toMatchObject({
+        requestId: 'read-thread-blocked-test',
+        type: 'read_thread_response',
+        ok: false,
+        error: `Not authorized to read ${threadJid}.`,
+      });
+    } finally {
+      fs.rmSync(ipcDir, { recursive: true, force: true });
+    }
+  });
+
+  it('updates thread summaries for the current Slack thread', async () => {
+    const threadJid = 'slack:TEST:C123:thread:1700000000.000100';
+    const ipcDir = path.join(
+      '/tmp',
+      `omniclaw-update-thread-summary-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`,
+    );
+    let saved:
+      | {
+          chat_jid: string;
+          summary: string;
+          status?: 'active' | 'resolved' | 'blocked';
+          updated_by?: string;
+          through_message_id?: string;
+          through_timestamp?: string;
+        }
+      | undefined;
+    deps.setThreadSummary = (summary) => {
+      saved = summary;
+      return true;
+    };
+
+    try {
+      const result = await processMessageIpc(
+        {
+          type: 'update_thread_summary',
+          chatJid: threadJid,
+          summary: 'Decision: ship the thread routing fix. Owner: Peyton.',
+          status: 'active',
+          throughMessageId: '1700000000.000200',
+          throughTimestamp: '2024-01-01T00:00:02.000Z',
+          requestId: 'update-thread-summary-test',
+        },
+        'other-group',
+        false,
+        ipcDir,
+        {
+          ...groups,
+          'slack:C123': OTHER_GROUP,
+        },
+        deps,
+      );
+
+      expect(result).toEqual({ action: 'handled' });
+      expect(saved).toEqual({
+        chat_jid: threadJid,
+        summary: 'Decision: ship the thread routing fix. Owner: Peyton.',
+        status: 'active',
+        updated_by: 'other-group',
+        through_message_id: '1700000000.000200',
+        through_timestamp: '2024-01-01T00:00:02.000Z',
+      });
+      const response = JSON.parse(
+        fs.readFileSync(
+          path.join(
+            ipcDir,
+            'other-group',
+            'responses',
+            'update-thread-summary-test.json',
+          ),
+          'utf-8',
+        ),
+      );
+      expect(response).toMatchObject({
+        requestId: 'update-thread-summary-test',
+        type: 'update_thread_summary_response',
+        ok: true,
+        result: {
+          chatJid: threadJid,
+          updated: true,
+        },
+      });
+    } finally {
+      fs.rmSync(ipcDir, { recursive: true, force: true });
+    }
+  });
+
+  it('reports stale thread summary updates without overwriting', async () => {
+    const threadJid = 'slack:TEST:C123:thread:1700000000.000100';
+    const ipcDir = path.join(
+      '/tmp',
+      `omniclaw-update-thread-summary-stale-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`,
+    );
+    deps.setThreadSummary = () => false;
+
+    try {
+      const result = await processMessageIpc(
+        {
+          type: 'update_thread_summary',
+          chatJid: threadJid,
+          summary: 'Older summary.',
+          requestId: 'update-thread-summary-stale-test',
+        },
+        'other-group',
+        false,
+        ipcDir,
+        {
+          ...groups,
+          'slack:C123': OTHER_GROUP,
+        },
+        deps,
+      );
+
+      expect(result).toEqual({
+        action: 'blocked',
+        reason: 'stale summary',
+      });
+      const response = JSON.parse(
+        fs.readFileSync(
+          path.join(
+            ipcDir,
+            'other-group',
+            'responses',
+            'update-thread-summary-stale-test.json',
+          ),
+          'utf-8',
+        ),
+      );
+      expect(response).toMatchObject({
+        requestId: 'update-thread-summary-stale-test',
+        type: 'update_thread_summary_response',
+        ok: false,
+      });
+    } finally {
+      fs.rmSync(ipcDir, { recursive: true, force: true });
+    }
   });
 });
 

--- a/src/ipc.ts
+++ b/src/ipc.ts
@@ -209,10 +209,7 @@ function clampReadThreadLimit(limit: unknown): number {
   return Math.max(1, Math.min(100, Math.floor(limit)));
 }
 
-function normalizeConfirmationEmoji(
-  value: unknown,
-  fallback: string,
-): string {
+function normalizeConfirmationEmoji(value: unknown, fallback: string): string {
   const raw = typeof value === 'string' ? value.trim() : '';
   const stripped = raw.replace(/^:+|:+$/g, '');
   if (!stripped || !/^[a-zA-Z0-9_+-]+$/.test(stripped)) return fallback;

--- a/src/ipc.ts
+++ b/src/ipc.ts
@@ -32,9 +32,12 @@ import {
   Channel,
   IpcMessagePayload,
   IpcTaskPayload,
+  NewMessage,
   RegisteredGroup,
+  ThreadSummary,
 } from './types.js';
 import { normalizePreprocessScriptPath } from './task-preprocessor.js';
+import { parseSlackJid } from './slack-jid.js';
 import type { IpcEventKind } from './web/ipc-events.js';
 
 export const MAX_IPC_FILES_PER_SOURCE_PER_POLL = 50;
@@ -73,6 +76,14 @@ export interface IpcDeps {
   getSubscriptions?: (
     jid: string,
   ) => Array<{ agentId: string; agentFolder: string }>;
+  /** Read locally stored chat/thread messages for tools like read_thread. */
+  getMessages?: (jid: string, since: string, limit?: number) => NewMessage[];
+  /** Read the durable rolling summary for a chat/thread. */
+  getThreadSummary?: (jid: string) => ThreadSummary | undefined;
+  /** Update the durable rolling summary for a chat/thread. */
+  setThreadSummary?: (
+    summary: Omit<ThreadSummary, 'updated_at'> & { updated_at?: string },
+  ) => boolean;
   /** Called when an IPC event occurs (for the web UI inspector). */
   onIpcEvent?: (
     kind: IpcEventKind,
@@ -130,6 +141,117 @@ function safeEmitIpcEvent(
       );
     }
   });
+}
+
+function getRegisteredGroupForIpcJid(
+  jid: string,
+  registeredGroups: Record<string, RegisteredGroup>,
+): RegisteredGroup | undefined {
+  const exact = registeredGroups[jid];
+  if (exact) return exact;
+  const slack = parseSlackJid(jid);
+  if (!slack) return undefined;
+  return (
+    registeredGroups[slack.parentJid] || registeredGroups[slack.legacyParentJid]
+  );
+}
+
+function sourceCanAccessJid(
+  jid: string,
+  sourceGroup: string,
+  isMain: boolean,
+  registeredGroups: Record<string, RegisteredGroup>,
+  deps: IpcDeps,
+): {
+  allowed: boolean;
+  targetGroup: RegisteredGroup | undefined;
+  isSelf: boolean;
+} {
+  const targetGroup = getRegisteredGroupForIpcJid(jid, registeredGroups);
+  const channelSubs = deps.getSubscriptions?.(jid) ?? [];
+  const isSelf = Boolean(
+    (targetGroup && targetGroup.folder === sourceGroup) ||
+    channelSubs.some((s) => s.agentFolder === sourceGroup),
+  );
+  return {
+    allowed: isMain || isSelf || !!targetGroup,
+    targetGroup,
+    isSelf,
+  };
+}
+
+function sourceCanReadJid(
+  jid: string,
+  sourceGroup: string,
+  isMain: boolean,
+  registeredGroups: Record<string, RegisteredGroup>,
+  deps: IpcDeps,
+): {
+  allowed: boolean;
+  targetGroup: RegisteredGroup | undefined;
+  isSelf: boolean;
+} {
+  const access = sourceCanAccessJid(
+    jid,
+    sourceGroup,
+    isMain,
+    registeredGroups,
+    deps,
+  );
+  return {
+    ...access,
+    allowed: isMain || access.isSelf,
+  };
+}
+
+function clampReadThreadLimit(limit: unknown): number {
+  if (typeof limit !== 'number' || !Number.isFinite(limit)) return 50;
+  return Math.max(1, Math.min(100, Math.floor(limit)));
+}
+
+function normalizeConfirmationEmoji(
+  value: unknown,
+  fallback: string,
+): string {
+  const raw = typeof value === 'string' ? value.trim() : '';
+  const stripped = raw.replace(/^:+|:+$/g, '');
+  if (!stripped || !/^[a-zA-Z0-9_+-]+$/.test(stripped)) return fallback;
+  return stripped.slice(0, 64);
+}
+
+function renderConfirmationRequest(data: IpcMessagePayload): {
+  text: string;
+  approveEmoji: string;
+  denyEmoji: string;
+} {
+  const action =
+    typeof data.action === 'string' && data.action.trim()
+      ? data.action.trim().slice(0, 240)
+      : 'Approve this action?';
+  const details =
+    typeof data.details === 'string' ? data.details.trim().slice(0, 4000) : '';
+  const approveName = normalizeConfirmationEmoji(
+    data.approveEmoji,
+    'white_check_mark',
+  );
+  const denyName = normalizeConfirmationEmoji(data.denyEmoji, 'x');
+  const approveEmoji = `:${approveName}:`;
+  const denyEmoji = `:${denyName}:`;
+  const lines = [`*Confirmation needed:* ${action}`, ''];
+
+  if (details) {
+    lines.push(details, '');
+  }
+
+  lines.push(
+    `React with ${approveEmoji} to approve or ${denyEmoji} to deny. You can also reply with changes or questions.`,
+  );
+
+  return {
+    text: lines.join('\n'),
+    approveEmoji,
+    denyEmoji,
+  };
 }
 
 type IpcSourceKind = 'messages' | 'tasks';
@@ -398,6 +520,286 @@ export async function processMessageIpc(
     return { action: 'handled' };
   }
 
+  // --- request_confirmation ---
+  if (data.type === 'request_confirmation' && data.chatJid) {
+    const chatJid = data.chatJid;
+    const access = sourceCanAccessJid(
+      chatJid,
+      sourceGroup,
+      isMain,
+      registeredGroups,
+      deps,
+    );
+    if (!access.allowed) {
+      const responseWrite = writeIpcMessageResponse(
+        ipcBaseDir,
+        sourceGroup,
+        data.requestId,
+        {
+          type: 'request_confirmation_response',
+          ok: false,
+          error: `Not authorized to request confirmation in ${chatJid}.`,
+        },
+      );
+      if (!responseWrite.ok) return responseWrite.result;
+      logger.warn(
+        { chatJid, sourceGroup },
+        'Unauthorized IPC request_confirmation attempt blocked',
+      );
+      return { action: 'blocked', reason: 'not authorized' };
+    }
+
+    const { text, approveEmoji, denyEmoji } = renderConfirmationRequest(data);
+    const msgText = stripInternalTags(text);
+    if (!msgText) {
+      const responseWrite = writeIpcMessageResponse(
+        ipcBaseDir,
+        sourceGroup,
+        data.requestId,
+        {
+          type: 'request_confirmation_response',
+          ok: false,
+          error: 'Confirmation request was empty after sanitization.',
+        },
+      );
+      if (!responseWrite.ok) return responseWrite.result;
+      return { action: 'blocked', reason: 'empty confirmation request' };
+    }
+
+    const sentMessageId = await deps.sendMessage(chatJid, msgText);
+    const messageId =
+      typeof sentMessageId === 'string' && sentMessageId.trim()
+        ? sentMessageId.trim()
+        : undefined;
+    const ch = deps.findChannel?.(chatJid);
+    const reactionsAdded: string[] = [];
+    const reactionErrors: string[] = [];
+
+    if (messageId && ch?.addReaction) {
+      for (const emoji of [approveEmoji, denyEmoji]) {
+        try {
+          await ch.addReaction(chatJid, messageId, emoji);
+          reactionsAdded.push(emoji);
+        } catch (err) {
+          reactionErrors.push(err instanceof Error ? err.message : String(err));
+        }
+      }
+    }
+
+    const responseWrite = writeIpcMessageResponse(
+      ipcBaseDir,
+      sourceGroup,
+      data.requestId,
+      {
+        type: 'request_confirmation_response',
+        ok: true,
+        result: {
+          chatJid,
+          messageId: messageId ?? null,
+          approveEmoji,
+          denyEmoji,
+          reactionsAdded,
+          reactionErrors,
+        },
+      },
+    );
+    if (!responseWrite.ok) return responseWrite.result;
+
+    logger.info(
+      {
+        chatJid,
+        sourceGroup,
+        messageId,
+        approveEmoji,
+        denyEmoji,
+        reactionErrorCount: reactionErrors.length,
+      },
+      'IPC request_confirmation processed',
+    );
+    return { action: 'handled' };
+  }
+
+  // --- read_thread ---
+  if (data.type === 'read_thread' && data.chatJid) {
+    const chatJid = data.chatJid;
+    const access = sourceCanReadJid(
+      chatJid,
+      sourceGroup,
+      isMain,
+      registeredGroups,
+      deps,
+    );
+    if (!access.allowed) {
+      const responseWrite = writeIpcMessageResponse(
+        ipcBaseDir,
+        sourceGroup,
+        data.requestId,
+        {
+          type: 'read_thread_response',
+          ok: false,
+          error: `Not authorized to read ${chatJid}.`,
+        },
+      );
+      if (!responseWrite.ok) return responseWrite.result;
+      logger.warn(
+        { chatJid, sourceGroup },
+        'Unauthorized IPC read_thread attempt blocked',
+      );
+      return { action: 'blocked', reason: 'not authorized' };
+    }
+
+    if (!deps.getMessages) {
+      const responseWrite = writeIpcMessageResponse(
+        ipcBaseDir,
+        sourceGroup,
+        data.requestId,
+        {
+          type: 'read_thread_response',
+          ok: false,
+          error: 'Host message reader is unavailable.',
+        },
+      );
+      if (!responseWrite.ok) return responseWrite.result;
+      return { action: 'blocked', reason: 'message reader unavailable' };
+    }
+
+    const limit = clampReadThreadLimit(data.limit);
+    const messages = deps.getMessages(chatJid, '', limit).map((m) => ({
+      id: m.id,
+      sender: m.sender_name || m.sender,
+      sender_id: m.sender,
+      timestamp: m.timestamp,
+      content: m.content,
+    }));
+    const threadSummary = deps.getThreadSummary?.(chatJid);
+    const responseWrite = writeIpcMessageResponse(
+      ipcBaseDir,
+      sourceGroup,
+      data.requestId,
+      {
+        type: 'read_thread_response',
+        ok: true,
+        result: {
+          chatJid,
+          count: messages.length,
+          summary: threadSummary ?? null,
+          messages,
+        },
+      },
+    );
+    if (!responseWrite.ok) return responseWrite.result;
+    logger.info(
+      { chatJid, sourceGroup, count: messages.length },
+      'IPC read_thread processed',
+    );
+    return { action: 'handled' };
+  }
+
+  // --- update_thread_summary ---
+  if (data.type === 'update_thread_summary' && data.chatJid) {
+    const chatJid = data.chatJid;
+    const access = sourceCanReadJid(
+      chatJid,
+      sourceGroup,
+      isMain,
+      registeredGroups,
+      deps,
+    );
+    if (!access.allowed) {
+      const responseWrite = writeIpcMessageResponse(
+        ipcBaseDir,
+        sourceGroup,
+        data.requestId,
+        {
+          type: 'update_thread_summary_response',
+          ok: false,
+          error: `Not authorized to update summary for ${chatJid}.`,
+        },
+      );
+      if (!responseWrite.ok) return responseWrite.result;
+      logger.warn(
+        { chatJid, sourceGroup },
+        'Unauthorized IPC update_thread_summary attempt blocked',
+      );
+      return { action: 'blocked', reason: 'not authorized' };
+    }
+
+    if (!deps.setThreadSummary) {
+      const responseWrite = writeIpcMessageResponse(
+        ipcBaseDir,
+        sourceGroup,
+        data.requestId,
+        {
+          type: 'update_thread_summary_response',
+          ok: false,
+          error: 'Host thread summary writer is unavailable.',
+        },
+      );
+      if (!responseWrite.ok) return responseWrite.result;
+      return { action: 'blocked', reason: 'thread summary writer unavailable' };
+    }
+
+    const summary = typeof data.summary === 'string' ? data.summary.trim() : '';
+    if (!summary) {
+      const responseWrite = writeIpcMessageResponse(
+        ipcBaseDir,
+        sourceGroup,
+        data.requestId,
+        {
+          type: 'update_thread_summary_response',
+          ok: false,
+          error: 'Summary must be non-empty.',
+        },
+      );
+      if (!responseWrite.ok) return responseWrite.result;
+      return { action: 'blocked', reason: 'empty summary' };
+    }
+
+    const status =
+      data.status === 'active' ||
+      data.status === 'resolved' ||
+      data.status === 'blocked'
+        ? data.status
+        : undefined;
+    const updated = deps.setThreadSummary({
+      chat_jid: chatJid,
+      summary,
+      status,
+      updated_by: sourceGroup,
+      through_message_id: data.throughMessageId,
+      through_timestamp: data.throughTimestamp,
+    });
+
+    const responseWrite = writeIpcMessageResponse(
+      ipcBaseDir,
+      sourceGroup,
+      data.requestId,
+      {
+        type: 'update_thread_summary_response',
+        ok: updated,
+        ...(updated
+          ? {
+              result: {
+                chatJid,
+                updated: true,
+              },
+            }
+          : {
+              error:
+                'Thread summary was not updated because it appears older than the saved summary.',
+            }),
+      },
+    );
+    if (!responseWrite.ok) return responseWrite.result;
+    logger.info(
+      { chatJid, sourceGroup, updated },
+      'IPC update_thread_summary processed',
+    );
+    return updated
+      ? { action: 'handled' }
+      : { action: 'blocked', reason: 'stale summary' };
+  }
+
   // --- ssh_pubkey ---
   if (data.type === 'ssh_pubkey' && data.pubkey) {
     logger.info(
@@ -425,17 +827,14 @@ export async function processMessageIpc(
       );
       return { action: 'suppressed', reason: 'internal-only' };
     }
-    // Authorization: any registered agent can message any other registered agent
-    const targetGroup = registeredGroups[msgChatJid];
-    // isSelf: sourceGroup is the primary agent OR any subscriber of this channel.
-    // Prevents secondary agents (e.g. OCPeyton) posting to a shared channel from
-    // triggering notifyGroup, which would wake up the primary agent (Clayton) to respond.
-    const channelSubs = deps.getSubscriptions?.(msgChatJid) ?? [];
-    const isSelf =
-      (targetGroup && targetGroup.folder === sourceGroup) ||
-      channelSubs.some((s) => s.agentFolder === sourceGroup);
-    const isRegisteredTarget = !!targetGroup;
-    if (isMain || isSelf || isRegisteredTarget) {
+    const { allowed, targetGroup, isSelf } = sourceCanAccessJid(
+      msgChatJid,
+      sourceGroup,
+      isMain,
+      registeredGroups,
+      deps,
+    );
+    if (allowed) {
       await deps.sendMessage(msgChatJid, msgText, data.discord_bot_id);
       // Cross-group message: also wake up the target agent.
       // Pass sourceGroup so the notify message is tagged — the source

--- a/src/migrations.ts
+++ b/src/migrations.ts
@@ -16,7 +16,7 @@ export interface Migration {
  * The version that represents the latest schema. Existing databases that
  * predate the migration framework are advanced through every migration to this.
  */
-export const BASELINE_VERSION = 8;
+export const BASELINE_VERSION = 9;
 
 // ---------------------------------------------------------------------------
 // Schema helpers (available for use in migrations)
@@ -279,6 +279,16 @@ const migration1: Migration = {
         fork_from TEXT,
         name TEXT,
         created_at TEXT NOT NULL DEFAULT (datetime('now'))
+      );
+
+      CREATE TABLE IF NOT EXISTS thread_summaries (
+        chat_jid TEXT PRIMARY KEY,
+        summary TEXT NOT NULL,
+        status TEXT,
+        updated_at TEXT NOT NULL,
+        updated_by TEXT,
+        through_message_id TEXT,
+        through_timestamp TEXT
       );
 
       CREATE TABLE IF NOT EXISTS registered_groups (
@@ -613,6 +623,24 @@ const migration8: Migration = {
   },
 };
 
+const migration9: Migration = {
+  version: 9,
+  description: 'Persist per-thread rolling conversation summaries',
+  up: (db) => {
+    db.exec(`
+      CREATE TABLE IF NOT EXISTS thread_summaries (
+        chat_jid TEXT PRIMARY KEY,
+        summary TEXT NOT NULL,
+        status TEXT,
+        updated_at TEXT NOT NULL,
+        updated_by TEXT,
+        through_message_id TEXT,
+        through_timestamp TEXT
+      );
+    `);
+  },
+};
+
 // ---------------------------------------------------------------------------
 // Migration registry
 // ---------------------------------------------------------------------------
@@ -632,4 +660,5 @@ export const allMigrations: Migration[] = [
   migration6,
   migration7,
   migration8,
+  migration9,
 ];

--- a/src/router.ts
+++ b/src/router.ts
@@ -1,5 +1,10 @@
 import { logger } from './logger.js';
-import type { Channel, NewMessage, RegisteredGroup } from './types.js';
+import type {
+  Channel,
+  NewMessage,
+  RegisteredGroup,
+  ThreadSummary,
+} from './types.js';
 
 export function escapeXml(s: string): string {
   if (!s) return '';
@@ -91,6 +96,27 @@ export function formatMessages(
     attrs.length > 0 ? `<messages ${attrs.join(' ')}>` : '<messages>';
 
   return `${header}\n${lines.join('\n')}\n</messages>`;
+}
+
+export function formatThreadSummary(summary: ThreadSummary): string {
+  const attrs = [
+    `chat_jid="${escapeXml(summary.chat_jid)}"`,
+    `updated_at="${escapeXml(summary.updated_at)}"`,
+  ];
+  if (summary.status) {
+    attrs.push(`status="${escapeXml(summary.status)}"`);
+  }
+  if (summary.updated_by) {
+    attrs.push(`updated_by="${escapeXml(summary.updated_by)}"`);
+  }
+  if (summary.through_message_id) {
+    attrs.push(`through_message_id="${escapeXml(summary.through_message_id)}"`);
+  }
+  if (summary.through_timestamp) {
+    attrs.push(`through_timestamp="${escapeXml(summary.through_timestamp)}"`);
+  }
+
+  return `<conversation_summary ${attrs.join(' ')}>\n${escapeXml(summary.summary)}\n</conversation_summary>`;
 }
 
 export function stripInternalTags(text: string): string {

--- a/src/seed-templates.ts
+++ b/src/seed-templates.ts
@@ -31,7 +31,7 @@ export interface SeedTemplate {
 
 const DISCORD_CHANNEL_TEMPLATE: SeedTemplate = {
   key: 'discord-channel',
-  version: 3,
+  version: 4,
   body: `## Channel: Discord (Secondary)
 This group communicates via Discord, a secondary channel.
 You can freely answer questions and have conversations here.
@@ -47,6 +47,13 @@ To end a turn silently, emit only \`<internal>…</internal>\` content. Anything
 those tags is stripped before send (see \`stripInternalTags\` in \`src/router.ts\`), and
 a turn that produces only internal-tagged text is suppressed entirely. Use this for
 private notes-to-self when the right action is no action.
+
+## Conversation Thread Context
+Use \`mcp__omniclaw__read_thread\` before summarizing, filing, extracting decisions or action items, updating durable thread state, or taking action that depends on prior messages in "this thread" or "above".
+
+When stable thread state changes, use \`mcp__omniclaw__update_thread_summary\` to save a compact neutral summary for the current conversation scope. Include the topic, decisions, open questions, owners, artifacts, and next steps. Do not include secrets, raw transcripts, or transient chatter.
+
+Before risky writes, external side effects, or irreversible actions that need human approval, use \`mcp__omniclaw__request_confirmation\`. After requesting confirmation, stop and wait for a later user reply or approval reaction before taking the action.
 
 ## Getting Context You Don't Have
 When you need project context, repo access, credentials, or information that hasn't been shared with you:

--- a/src/slack-jid.test.ts
+++ b/src/slack-jid.test.ts
@@ -1,6 +1,11 @@
 import { describe, expect, it } from 'bun:test';
 
-import { parseScopedSlackJid } from './slack-jid.js';
+import {
+  channelIdToSlackJid,
+  parseSlackJid,
+  parseScopedSlackJid,
+  slackThreadIdToJid,
+} from './slack-jid.js';
 
 describe('parseScopedSlackJid', () => {
   it('parses scoped Slack JIDs into bot and channel ids', () => {
@@ -19,9 +24,63 @@ describe('parseScopedSlackJid', () => {
     });
   });
 
+  it('does not parse explicit thread JIDs as scoped channel JIDs', () => {
+    expect(
+      parseScopedSlackJid('slack:OPS:C123456:thread:1700000000.000100'),
+    ).toBeNull();
+  });
+
   it('rejects unscoped or malformed JIDs', () => {
     expect(parseScopedSlackJid('slack:C123456')).toBeNull();
     expect(parseScopedSlackJid('discord:PRIMARY:C123456')).toBeNull();
     expect(parseScopedSlackJid('slack:PRIMARY:channel with spaces')).toBeNull();
+  });
+});
+
+describe('parseSlackJid', () => {
+  it('parses legacy channel JIDs', () => {
+    expect(parseSlackJid('slack:C123456')).toEqual({
+      channelId: 'C123456',
+      parentJid: 'slack:C123456',
+      legacyParentJid: 'slack:C123456',
+    });
+  });
+
+  it('parses scoped channel JIDs', () => {
+    expect(parseSlackJid('slack:PRIMARY:C123456')).toEqual({
+      botId: 'PRIMARY',
+      channelId: 'C123456',
+      parentJid: 'slack:PRIMARY:C123456',
+      legacyParentJid: 'slack:C123456',
+    });
+  });
+
+  it('parses scoped thread JIDs with parent fallbacks', () => {
+    expect(parseSlackJid('slack:OPS:C123456:thread:1700000000.000100')).toEqual(
+      {
+        botId: 'OPS',
+        channelId: 'C123456',
+        threadTs: '1700000000.000100',
+        parentJid: 'slack:OPS:C123456',
+        legacyParentJid: 'slack:C123456',
+      },
+    );
+  });
+
+  it('rejects malformed thread JIDs', () => {
+    expect(parseSlackJid('slack:OPS:C123456:thread:not-a-ts')).toBeNull();
+  });
+});
+
+describe('Slack JID formatters', () => {
+  it('formats scoped and legacy channel JIDs', () => {
+    expect(channelIdToSlackJid('C123')).toBe('slack:C123');
+    expect(channelIdToSlackJid('C123', 'OPS')).toBe('slack:OPS:C123');
+  });
+
+  it('formats scoped thread JIDs', () => {
+    expect(slackThreadIdToJid('C123', '1700000000.000100', 'OPS')).toBe(
+      'slack:OPS:C123:thread:1700000000.000100',
+    );
   });
 });

--- a/src/slack-jid.ts
+++ b/src/slack-jid.ts
@@ -1,7 +1,66 @@
+export interface ParsedSlackJid {
+  botId?: string;
+  channelId: string;
+  threadTs?: string;
+  parentJid: string;
+  legacyParentJid: string;
+}
+
+const SLACK_THREAD_RE = /^slack:([^:\s]+):([^:\s]+):thread:([0-9]+\.[0-9]+)$/;
+const SCOPED_SLACK_RE = /^slack:([^:]+):([^\s]+)$/;
+const LEGACY_SLACK_RE = /^slack:([^:\s]+)$/;
+
 export function parseScopedSlackJid(
   jid: string,
 ): { botId: string; channelId: string } | null {
-  const m = /^slack:([^:]+):([^\s]+)$/.exec(jid);
+  if (SLACK_THREAD_RE.test(jid)) return null;
+  const m = SCOPED_SLACK_RE.exec(jid);
   if (!m) return null;
+  if (m[2].includes(':thread:')) return null;
   return { botId: m[1], channelId: m[2] };
+}
+
+export function parseSlackJid(jid: string): ParsedSlackJid | null {
+  const thread = SLACK_THREAD_RE.exec(jid);
+  if (thread) {
+    const [, botId, channelId, threadTs] = thread;
+    return {
+      botId,
+      channelId,
+      threadTs,
+      parentJid: channelIdToSlackJid(channelId, botId),
+      legacyParentJid: channelIdToSlackJid(channelId),
+    };
+  }
+
+  const scoped = parseScopedSlackJid(jid);
+  if (scoped) {
+    return {
+      botId: scoped.botId,
+      channelId: scoped.channelId,
+      parentJid: jid,
+      legacyParentJid: channelIdToSlackJid(scoped.channelId),
+    };
+  }
+
+  const legacy = LEGACY_SLACK_RE.exec(jid);
+  if (!legacy) return null;
+  return {
+    channelId: legacy[1],
+    parentJid: jid,
+    legacyParentJid: jid,
+  };
+}
+
+export function channelIdToSlackJid(channelId: string, botId?: string): string {
+  if (botId) return `slack:${botId}:${channelId}`;
+  return `slack:${channelId}`;
+}
+
+export function slackThreadIdToJid(
+  channelId: string,
+  threadTs: string,
+  botId: string,
+): string {
+  return `slack:${botId}:${channelId}:thread:${threadTs}`;
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -162,6 +162,16 @@ export interface NewMessage {
   reply_to_bot_id?: string;
 }
 
+export interface ThreadSummary {
+  chat_jid: string;
+  summary: string;
+  status?: 'active' | 'resolved' | 'blocked';
+  updated_at: string;
+  updated_by?: string;
+  through_message_id?: string;
+  through_timestamp?: string;
+}
+
 /** Attachment type tag for the unified media pipeline. */
 export type MediaAttachmentType = 'image' | 'file' | 'video' | 'audio';
 
@@ -538,9 +548,18 @@ export interface IpcMessagePayload {
   currentChatJid?: string;
   targetWasExplicit?: boolean;
   text?: string;
+  action?: string;
+  details?: string;
+  approveEmoji?: string;
+  denyEmoji?: string;
+  summary?: string;
+  status?: string;
   messageId?: string;
+  throughMessageId?: string;
+  throughTimestamp?: string;
   emoji?: string;
   remove?: boolean;
+  limit?: number;
   userName?: string;
   platform?: string;
   requestId?: string;


### PR DESCRIPTION
## Summary
- Treat Slack threads as first-class conversation contexts with durable thread JIDs, isolated runtime folders, parent registration inheritance, and parent-session forks when useful.
- Add thread-scoped tools and summaries inspired by OpenTag: read_thread, update_thread_summary, and request_confirmation approval checkpoints.
- Hydrate explicitly summoned Slack threads with a bounded Slack transcript and document the Slack/OpenTag model for agents and setup docs.

## Verification
- bun run typecheck
- bun run build
- bun test src/db.test.ts src/db.migrations.test.ts src/formatting.test.ts src/context-layers.test.ts src/effect/user-registry.test.ts src/ipc-messages.test.ts src/ipc-processing.test.ts src/channels/slack.test.ts src/slack-jid.test.ts src/index.test.ts
- bun test ./container/agent-runner/src/__tests__/send-message-routing.test.ts
- git diff --check

## Known unrelated failures
- Full `bun test` still has the pre-existing task preprocessor expectation failure (`missing` vs `leaked`).
- Full `bun test` still has the pre-existing `src/simtest/admin-api.test.ts` timeout in `handles reset, arbitrary broadcasts, malformed JSON, and missing routes`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added persistent thread context for Slack and other supported runtimes, including saved thread summaries and retrieval during future conversations.
  * Introduced confirmation prompts for risky or irreversible actions, with clearer approval/deny handling.
  * Expanded mention formatting to support Slack users.

* **Bug Fixes**
  * Improved Slack thread routing so replies, streams, reactions, and polling stay attached to the correct conversation thread.
  * Better handling of thread history and fallback behavior when thread context can’t be fully loaded.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->