### PR TITLE
feat(web): annotate /agents total count with live working rollup

### DIFF
--- a/src/web/agents-page.test.ts
+++ b/src/web/agents-page.test.ts
@@ -5,6 +5,8 @@ import type { GroupQueueDetail } from '../group-queue.js';
 import { handleRequest } from './routes.js';
 import {
   buildAgentRowsHtml,
+  countWorkingAgents,
+  deriveAgentStatus,
   getAgentExecReason,
   getAgentExecStatus,
   getAgentQueueDepth,
@@ -18,6 +20,7 @@ import {
   shortenModelLabel,
 } from './agents-page.js';
 import type { WebStateProvider } from './types.js';
+import type { AgentChannelData } from './agent-channels.js';
 
 function makeAgent(overrides: Partial<Agent> = {}): Agent {
   return {
@@ -408,6 +411,31 @@ describe('renderAgentsContent', () => {
     expect(html).toContain('1 local (1 disabled)');
     expect(html).toContain('1 remote');
   });
+
+  it('annotates the total count with a working rollup when agents are live', () => {
+    const state = makeState();
+    state.getQueueDetails = () => [
+      makeQueueDetail({
+        messageLane: {
+          active: true,
+          idle: false,
+          pendingCount: 0,
+          containerName: 'ctr-1',
+        },
+      }),
+    ];
+
+    const html = renderAgentsContent(state);
+
+    expect(html).toContain('1 total (1 working)');
+  });
+
+  it('omits the working rollup when no agent is actively working', () => {
+    const html = renderAgentsContent(makeState());
+
+    expect(html).toContain('1 total</span>');
+    expect(html).not.toContain('working)');
+  });
 });
 
 describe('renderAgentsPage', () => {
@@ -636,6 +664,138 @@ describe('getAgentExecStatus', () => {
     ];
     expect(getAgentExecStatus('test-agent', details)).toBe('offline');
     expect(getAgentExecStatus('other-agent', details)).toBe('executing');
+  });
+});
+
+function makeChannelData(
+  overrides: Partial<AgentChannelData> = {},
+): AgentChannelData {
+  return {
+    id: 'agent-1',
+    name: 'Test Agent',
+    folder: 'test-agent',
+    backend: 'apple-container',
+    agentRuntime: 'claude-agent-sdk',
+    isAdmin: false,
+    channels: [],
+    ...overrides,
+  };
+}
+
+describe('deriveAgentStatus', () => {
+  it('reads remote agents as offline regardless of queue', () => {
+    const details = [
+      makeQueueDetail({
+        messageLane: {
+          active: true,
+          idle: false,
+          pendingCount: 0,
+          containerName: 'ctr-1',
+        },
+      }),
+    ];
+    const agent = makeChannelData({ remoteInstanceId: 'peer-1' });
+    expect(deriveAgentStatus(agent, {}, details)).toBe('offline');
+  });
+
+  it('reads operator-disabled local agents as disabled', () => {
+    const agent = makeChannelData();
+    const agents = { 'agent-1': makeAgent({ enabled: false }) };
+    expect(deriveAgentStatus(agent, agents, [])).toBe('disabled');
+  });
+
+  it('falls back to the live queue status for enabled local agents', () => {
+    const details = [
+      makeQueueDetail({
+        taskLane: {
+          active: true,
+          pendingCount: 0,
+          containerName: 'ctr-1',
+          activeTask: {
+            taskId: 'task-1',
+            promptPreview: 'Run check',
+            startedAt: 1_000,
+            runningMs: 1_000,
+          },
+        },
+      }),
+    ];
+    const agent = makeChannelData();
+    expect(deriveAgentStatus(agent, {}, details)).toBe('running-task');
+  });
+});
+
+describe('countWorkingAgents', () => {
+  it('returns zero when nothing is active', () => {
+    expect(countWorkingAgents([makeChannelData()], {}, [])).toBe(0);
+  });
+
+  it('counts both executing and running-task agents', () => {
+    const agents = [
+      makeChannelData({ id: 'a1', folder: 'a1' }),
+      makeChannelData({ id: 'a2', folder: 'a2' }),
+    ];
+    const details = [
+      makeQueueDetail({
+        folderKey: 'a1',
+        messageLane: {
+          active: true,
+          idle: false,
+          pendingCount: 0,
+          containerName: 'ctr-1',
+        },
+      }),
+      makeQueueDetail({
+        folderKey: 'a2',
+        taskLane: {
+          active: true,
+          pendingCount: 0,
+          containerName: 'ctr-2',
+          activeTask: {
+            taskId: 'task-1',
+            promptPreview: 'Run check',
+            startedAt: 1_000,
+            runningMs: 1_000,
+          },
+        },
+      }),
+    ];
+    expect(countWorkingAgents(agents, {}, details)).toBe(2);
+  });
+
+  it('excludes idle, queued, disabled, and remote agents', () => {
+    const agents = [
+      makeChannelData({ id: 'idle', folder: 'idle' }),
+      makeChannelData({ id: 'agent-1', folder: 'disabled-folder' }),
+      makeChannelData({
+        id: 'remote',
+        folder: 'remote',
+        remoteInstanceId: 'p1',
+      }),
+    ];
+    const details = [
+      makeQueueDetail({
+        folderKey: 'idle',
+        messageLane: {
+          active: true,
+          idle: true,
+          pendingCount: 0,
+          containerName: 'ctr-1',
+        },
+      }),
+      // Remote agent's folder has an active lane, but remote reads as offline.
+      makeQueueDetail({
+        folderKey: 'remote',
+        messageLane: {
+          active: true,
+          idle: false,
+          pendingCount: 0,
+          containerName: 'ctr-2',
+        },
+      }),
+    ];
+    const localAgents = { 'agent-1': makeAgent({ enabled: false }) };
+    expect(countWorkingAgents(agents, localAgents, details)).toBe(0);
   });
 });
 

--- a/src/web/agents-page.ts
+++ b/src/web/agents-page.ts
@@ -19,6 +19,7 @@ import {
   type AgentChannelData,
 } from './agent-channels.js';
 import type { RemotePeerAgents } from '../discovery/types.js';
+import type { Agent } from '../types.js';
 
 export type AgentExecStatus =
   | 'executing'
@@ -128,6 +129,42 @@ export function getAgentExecReason(
   const detail = queueDetails.find((d) => d.folderKey === folder);
   if (!detail) return null;
   return deriveMessageLaneReasonFromDetail(detail);
+}
+
+/**
+ * Derive an agent's execution status the way the directory table does:
+ * remote agents read as `offline` (their live state lives on the owning host),
+ * operator-disabled local agents as `disabled`, and everything else from the
+ * live queue details. Shared by {@link buildAgentRowsHtml} and
+ * {@link countWorkingAgents} so the per-row badge and the header rollup can
+ * never drift out of sync.
+ */
+export function deriveAgentStatus(
+  agent: AgentChannelData,
+  localAgents: Record<string, Agent>,
+  queueDetails: GroupQueueDetail[],
+): AgentExecStatus {
+  if (agent.remoteInstanceId) return 'offline';
+  if (localAgents[agent.id]?.enabled === false) return 'disabled';
+  return getAgentExecStatus(agent.folder, queueDetails);
+}
+
+/**
+ * Count agents that are actively working — either processing a message
+ * (`executing`) or running a scheduled task (`running-task`). Used to annotate
+ * the agents-directory `total` count so an operator can see at a glance how
+ * much of the fleet is live without scanning the per-row status column.
+ * Disabled, idle, queued, offline, and remote agents are all excluded.
+ */
+export function countWorkingAgents(
+  agentData: AgentChannelData[],
+  localAgents: Record<string, Agent>,
+  queueDetails: GroupQueueDetail[],
+): number {
+  return agentData.reduce((sum, a) => {
+    const status = deriveAgentStatus(a, localAgents, queueDetails);
+    return sum + (status === 'executing' || status === 'running-task' ? 1 : 0);
+  }, 0);
 }
 
 const EXEC_STATUS_LABELS: Record<AgentExecStatus, string> = {
@@ -361,16 +398,11 @@ export function buildAgentRowsHtml(
   const localAgents = state.getAgents();
   return agentData
     .map((a) => {
-      let status: AgentExecStatus;
+      const status = deriveAgentStatus(a, localAgents, queueDetails);
       let reason: MessageLaneReason | null = null;
       let queueDepth: AgentQueueDepth = ZERO_QUEUE_DEPTH;
       let runningMs: number | null = null;
-      if (a.remoteInstanceId) {
-        status = 'offline';
-      } else if (localAgents[a.id]?.enabled === false) {
-        status = 'disabled';
-      } else {
-        status = getAgentExecStatus(a.folder, queueDetails);
+      if (!a.remoteInstanceId && localAgents[a.id]?.enabled !== false) {
         reason = getAgentExecReason(a.folder, queueDetails);
         queueDepth = getAgentQueueDepth(a.folder, queueDetails);
         runningMs = getAgentRunningMs(a.folder, queueDetails);
@@ -409,6 +441,7 @@ export function renderAgentsContent(
   // lives on the owning host. Matches the disabled-status derivation in
   // {@link buildAgentRowsHtml}.
   const localAgentsMap = state.getAgents();
+  const queueDetails = state.getQueueDetails();
   const disabledLocalCount = agentData.reduce(
     (sum, a) =>
       sum +
@@ -419,6 +452,20 @@ export function renderAgentsContent(
     disabledLocalCount > 0
       ? `${localCount} local (${disabledLocalCount} disabled)`
       : `${localCount} local`;
+
+  // How much of the fleet is live right now — executing a message or running a
+  // scheduled task. Surfacing this on the `total` count answers "is anything
+  // actually working?" without scanning the per-row status column. Suppressed
+  // when nothing is working to keep the header quiet at rest.
+  const workingCount = countWorkingAgents(
+    agentData,
+    localAgentsMap,
+    queueDetails,
+  );
+  const totalValue =
+    workingCount > 0
+      ? `${agentData.length} total (${workingCount} working)`
+      : `${agentData.length} total`;
 
   const backendOptions = backends
     .map((b) => `<option value="${escapeHtml(b)}">${escapeHtml(b)}</option>`)
@@ -438,7 +485,7 @@ export function renderAgentsContent(
     `<div class="ap-title-row">` +
     `<h2>Agents</h2>` +
     `<div class="ap-counts">` +
-    `<span class="ap-count">${agentData.length} total</span>` +
+    `<span class="ap-count">${totalValue}</span>` +
     `<span class="ap-count">${localValue}</span>` +
     (remoteCount > 0
       ? `<span class="ap-count">${remoteCount} remote</span>`


### PR DESCRIPTION
## What

Annotates the `/agents` directory header **total** count with a live "working" rollup — e.g. `5 total (2 working)` — so an operator can see at a glance how much of the fleet is actively running without scanning the per-row status column.

An agent counts as *working* when its lane is:
- `executing` — actively processing a message, or
- `running-task` — running a scheduled task.

`idle`, `queued`, `offline`, `disabled`, and remote agents are excluded. The rollup is suppressed when nothing is working, keeping the header quiet at rest — the same treatment the `local` count already gives its `(N disabled)` rollup.

## Why

The header already surfaces `total`, `local (N disabled)`, and `remote` counts, but there was no fleet-level signal for live activity. Answering "is anything actually running right now?" required scanning the status badge column row by row. This is the natural companion to the recent stat-card rollup work (#955, #915, #907, #901).

## How

- Extracted a shared `deriveAgentStatus(agent, localAgents, queueDetails)` helper that encodes the directory's status derivation once: remote → `offline`, operator-disabled local → `disabled`, else the live queue status. Both the per-row badge (`buildAgentRowsHtml`) and the new rollup (`countWorkingAgents`) now go through it, so they can't drift out of sync.
- Added `countWorkingAgents(...)` which sums agents in `executing`/`running-task`.
- Wired the rollup into `renderAgentsContent`'s `total` count as `totalValue`.

## Tests

- New unit coverage for `deriveAgentStatus` (remote/disabled/live-status branches) and `countWorkingAgents` (zero, both working states, exclusions for idle/queued/disabled/remote).
- New `renderAgentsContent` header assertions: rollup appears when live, omitted at rest.
- `agents-page.test.ts`: 117 → 125 tests.
- Full suite green: **2572 pass, 0 fail**. `bun run typecheck` clean. Prettier clean.

## Behavior

Header renders `1 total (1 working)` when an agent's message lane is active; `1 total` when idle.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Agent lists now show a clearer total count, including how many agents are currently working when applicable.
  * Agent statuses are displayed more consistently across the directory.

* **Bug Fixes**
  * Fixed status handling so remote agents appear offline, disabled local agents appear disabled, and active agents reflect their live queue state.
  * Improved the working-agent count so idle, queued, disabled, and remote agents are excluded.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->