### PR TITLE
test(backends): cover shared VM runtime listing

### DIFF
--- a/src/backends/shared-vm.test.ts
+++ b/src/backends/shared-vm.test.ts
@@ -39,6 +39,19 @@ describe('SharedVmManager', () => {
   const originalExtraDir = process.env.OMNICLAW_EXTRA_DIR;
   let extraDir = '';
 
+  function mockContainerList(containers: unknown) {
+    return spyOn(Bun, '$').mockImplementation(
+      (() => ({
+        quiet: mock(async () => ({
+          text: () =>
+            typeof containers === 'string'
+              ? containers
+              : JSON.stringify(containers),
+        })),
+      })) as unknown as typeof Bun.$,
+    );
+  }
+
   beforeEach(() => {
     extraDir = fs.mkdtempSync(path.join(os.tmpdir(), 'omniclaw-extra-'));
     process.env.OMNICLAW_EXTRA_DIR = extraDir;
@@ -146,5 +159,92 @@ describe('SharedVmManager', () => {
       'stop',
       'omniclaw-shared-claude-stop-me',
     ]);
+  });
+
+  it('reuses a live container discovered from runtime list output', async () => {
+    const manager = new SharedVmManager();
+    (manager as any).containerName = 'omniclaw-shared-claude-live';
+    const dollarSpy = mockContainerList([
+      {
+        status: 'running',
+        configuration: { id: 'omniclaw-shared-claude-live' },
+      },
+      {
+        status: 'stopped',
+        configuration: { id: 'omniclaw-shared-claude-live' },
+      },
+    ]);
+    const spawnSpy = spyOn(Bun, 'spawn');
+
+    await expect(manager.ensureRunning()).resolves.toBe(
+      'omniclaw-shared-claude-live',
+    );
+
+    expect(dollarSpy).toHaveBeenCalledTimes(1);
+    expect(spawnSpy).not.toHaveBeenCalled();
+  });
+
+  it('starts a replacement when runtime list parsing fails for a cached name', async () => {
+    const manager = new SharedVmManager();
+    (manager as any).containerName = 'omniclaw-shared-claude-stale';
+    const nowSpy = spyOn(Date, 'now').mockReturnValue(333);
+    mockContainerList('not json');
+    const spawnSpy = spyOn(Bun, 'spawn').mockImplementation((() =>
+      makeProcess(0)) as unknown as typeof Bun.spawn);
+
+    try {
+      await expect(manager.ensureRunning()).resolves.toBe(
+        'omniclaw-shared-claude-333',
+      );
+      expect(spawnSpy).toHaveBeenCalledTimes(1);
+    } finally {
+      nowSpy.mockRestore();
+    }
+  });
+
+  it('stops only running orphaned shared VMs during cleanup', async () => {
+    const manager = new SharedVmManager();
+    (manager as any).containerName = 'omniclaw-shared-claude-current';
+    mockContainerList([
+      {
+        status: 'running',
+        configuration: { id: 'omniclaw-shared-claude-current' },
+      },
+      {
+        status: 'running',
+        configuration: { id: 'omniclaw-shared-claude-orphan-a' },
+      },
+      {
+        status: 'stopped',
+        configuration: { id: 'omniclaw-shared-claude-stopped' },
+      },
+      {
+        status: 'running',
+        configuration: { id: 'unrelated-container' },
+      },
+      {
+        status: 'running',
+        configuration: { id: 'omniclaw-shared-claude-orphan-b' },
+      },
+    ]);
+    const spawnSpy = spyOn(Bun, 'spawn').mockImplementation((() =>
+      makeProcess(0)) as unknown as typeof Bun.spawn);
+
+    await expect(manager.cleanupOrphans()).resolves.toBeUndefined();
+
+    expect(spawnSpy.mock.calls.map((call) => call[0])).toEqual([
+      [LOCAL_RUNTIME, 'stop', 'omniclaw-shared-claude-orphan-a'],
+      [LOCAL_RUNTIME, 'stop', 'omniclaw-shared-claude-orphan-b'],
+    ]);
+  });
+
+  it('treats malformed runtime list output as non-fatal during cleanup', async () => {
+    const manager = new SharedVmManager();
+    mockContainerList('not json');
+    const spawnSpy = spyOn(Bun, 'spawn');
+
+    await expect(manager.cleanupOrphans()).resolves.toBeUndefined();
+
+    expect(spawnSpy).not.toHaveBeenCalled();
   });
 });

--- a/src/backends/shared-vm.test.ts
+++ b/src/backends/shared-vm.test.ts
@@ -40,16 +40,14 @@ describe('SharedVmManager', () => {
   let extraDir = '';
 
   function mockContainerList(containers: unknown) {
-    return spyOn(Bun, '$').mockImplementation(
-      (() => ({
-        quiet: mock(async () => ({
-          text: () =>
-            typeof containers === 'string'
-              ? containers
-              : JSON.stringify(containers),
-        })),
-      })) as unknown as typeof Bun.$,
-    );
+    return spyOn(Bun, '$').mockImplementation((() => ({
+      quiet: mock(async () => ({
+        text: () =>
+          typeof containers === 'string'
+            ? containers
+            : JSON.stringify(containers),
+      })),
+    })) as unknown as typeof Bun.$);
   }
 
   beforeEach(() => {


### PR DESCRIPTION
## Summary

- Add deterministic SharedVmManager tests for runtime list parsing and cached-container reuse.
- Cover orphan cleanup filtering so only running stale shared VMs are stopped.
- Cover malformed runtime list output as non-fatal for cleanup and as stale-cache fallback for ensureRunning.

## Test Counts

- Before: 2568 passing tests across 106 files.
- After: 2572 passing tests across 106 files.
- Focused coverage: `src/backends/shared-vm.ts` now reports 100% line coverage under `bun test src/backends/shared-vm.test.ts --coverage`.

## Verification

- `bun test src/backends/shared-vm.test.ts`
- `bun test src/backends/shared-vm.test.ts --coverage`
- `bun test`
- `bun run typecheck`

## Remaining Coverage Gaps

- `src/backends/local-backend.ts` still has substantial low coverage around container execution and mount/runtime paths.
- Channel adapters (`discord.ts`, `telegram.ts`, `whatsapp.ts`) remain lower coverage because much of their behavior is integration-heavy.
- `src/index.ts` remains low line coverage due to orchestrator startup/runtime branches.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Expanded shared VM test coverage for runtime list handling, including valid, malformed, and cached container scenarios.
  * Verified cleanup behavior only stops running orphaned containers and ignores unrelated or already-stopped ones.
  * Confirmed malformed runtime output does not break cleanup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->