### PR TITLE
fix(security): require auth for discovery mutations

### DIFF
--- a/src/web/server.test.ts
+++ b/src/web/server.test.ts
@@ -539,7 +539,7 @@ describe('basic auth', () => {
     expect(apiRes.status).toBe(200);
   });
 
-  it('allows discovery admin routes from private network without credentials', async () => {
+  it('allows discovery read routes from private network without credentials', async () => {
     setTestDiscoveryContext();
     handle = startWebServer(testConfig({ auth: undefined }), makeState());
 
@@ -549,7 +549,7 @@ describe('basic auth', () => {
     await expect(res.json()).resolves.toEqual([]);
   });
 
-  it('allows discovery admin routes from loopback with trusted LAN mode enabled', async () => {
+  it('allows discovery read routes from loopback with trusted LAN mode enabled', async () => {
     setTestDiscoveryContext();
     handle = startWebServer(
       testConfig({ auth: undefined, trustLanDiscoveryAdmin: true }),
@@ -559,6 +559,23 @@ describe('basic auth', () => {
     const res = await fetch(url('/api/discovery/requests'));
     expect(res.status).toBe(200);
     await expect(res.json()).resolves.toEqual([]);
+  });
+
+  it('rejects discovery mutation routes without configured credentials', async () => {
+    setTestDiscoveryContext();
+    handle = startWebServer(testConfig({ auth: undefined }), makeState());
+
+    const res = await fetch(url('/api/discovery/state'), {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ enabled: false }),
+    });
+
+    expect(res.status).toBe(403);
+    await expect(res.json()).resolves.toEqual({
+      error:
+        'Discovery admin routes require authentication (set WEB_PASSWORD or WEB_UI_USER/WEB_UI_PASS)',
+    });
   });
 
   it('allows authenticated peer routes without Basic Auth', async () => {
@@ -659,6 +676,27 @@ describe('isTrustedLanDiscoveryAdminRequest', () => {
         true,
       ),
     ).toBe(true);
+  });
+
+  it('rejects trusted LAN peers for discovery mutation routes', () => {
+    const req = Object.assign(
+      new Request('http://evil.example/api/discovery/state', {
+        method: 'POST',
+        headers: { Host: 'evil.example' },
+      }),
+      {
+        socket: { remoteAddress: '192.168.1.25' },
+      },
+    ) as Request;
+
+    expect(
+      isTrustedLanDiscoveryAdminRequest(
+        req,
+        '/api/discovery/state',
+        undefined,
+        true,
+      ),
+    ).toBe(false);
   });
 
   it('rejects public peers even when the listener is bound to a private LAN IP', () => {

--- a/src/web/server.ts
+++ b/src/web/server.ts
@@ -437,7 +437,7 @@ export function startWebServer(
       return new Response(
         JSON.stringify({
           error:
-            'Discovery admin routes require authentication (set WEB_PASSWORD or WEB_UI_USER/WEB_UI_PASS or access from a private network)',
+            'Discovery admin routes require authentication (set WEB_PASSWORD or WEB_UI_USER/WEB_UI_PASS)',
         }),
         {
           status: 403,
@@ -1111,6 +1111,7 @@ export function isTrustedLanDiscoveryAdminRequest(
 ): boolean {
   if (!enabled || !pathname.startsWith('/api/discovery/')) return false;
   if (isUnauthDiscoveryRoute(pathname)) return false;
+  if (!isLanReadableDiscoveryRoute(req.method, pathname)) return false;
 
   const remoteAddress = (
     req as unknown as { socket?: { remoteAddress?: string } }
@@ -1125,6 +1126,26 @@ export function isTrustedLanDiscoveryAdminRequest(
   // Bun may not always expose a socket address in tests or some deployments.
   // Preserve the loopback-only fallback for local-only listeners.
   return isLoopbackAddress(listenerHostname);
+}
+
+function isLanReadableDiscoveryRoute(
+  method: string,
+  pathname: string,
+): boolean {
+  if (method.toUpperCase() !== 'GET') return false;
+  return (
+    pathname === '/api/discovery/peers' ||
+    pathname === '/api/discovery/requests' ||
+    pathname === '/api/discovery/state' ||
+    pathname === '/api/discovery/remote-agents' ||
+    /^\/api\/discovery\/peers\/[^/]+\/(agents|stats|logs|context\/(layers|compare))$/.test(
+      pathname,
+    ) ||
+    /^\/api\/discovery\/peers\/[^/]+\/agents\/[^/]+\/avatar\/image$/.test(
+      pathname,
+    ) ||
+    /^\/api\/discovery\/peers\/[^/]+\/chats\/[^/]+\/icon$/.test(pathname)
+  );
 }
 
 function isLoopbackAddress(address?: string): boolean {


### PR DESCRIPTION
## Summary

- Fixes #966.
- Limits the no-credentials trusted-LAN discovery bypass to safe read-only discovery routes.
- Requires configured Web UI authentication for discovery mutation routes, including discovery state changes, trusted-network changes, pair approval/rejection, peer revocation, request-access, and context write/push/pull paths.
- Updates the unauthenticated discovery rejection message and adds regression coverage.

## Security impact

Before this change, an OmniClaw instance without `WEB_PASSWORD` or `WEB_UI_USER`/`WEB_UI_PASS` configured treated private-network clients as authorized for every non-pairing `/api/discovery/*` route. That allowed LAN clients to perform operator mutations without credentials.

After this change, LAN clients can still read discovery status needed for local discovery UX, but mutation routes require normal Web UI authentication.

## Tests

- `bun test src/web/server.test.ts`
- `bun run typecheck`
- `git diff --check`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Tightened discovery access so read-only routes remain available on trusted local networks, while mutation routes now correctly require authentication.
  * Improved error messaging for unauthenticated discovery admin requests to clearly indicate that login is required.
  * Restricted LAN-based discovery access to approved methods and endpoints, preventing unintended access to admin actions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->