### PR TITLE
feat(web): add markdown format to conversation export

### DIFF
--- a/src/web/routes.test.ts
+++ b/src/web/routes.test.ts
@@ -1431,6 +1431,35 @@ describe('conversation export', () => {
     expect(text).toContain('Hi! How can I help?');
   });
 
+  it('returns markdown export with proper formatting', async () => {
+    const state = makeState({
+      getMessages: () => sampleMessages,
+      getChats: () => sampleChats,
+    });
+    const res = await handle(
+      new Request(
+        'http://localhost/api/messages/dc%3A123/export?format=markdown',
+      ),
+      state,
+    );
+    expect(res.status).toBe(200);
+    expect(res.headers.get('content-type')).toContain('text/markdown');
+    expect(res.headers.get('content-disposition')).toContain(
+      'Test_Chat-export.md',
+    );
+
+    const md = await res.text();
+    expect(md).toContain('# Conversation: Test Chat');
+    expect(md).toContain('- **JID:** `dc:123`');
+    expect(md).toContain('- **Messages:** 2');
+    expect(md).toContain('### Alice · 2026-03-01T10:00:00.000Z');
+    expect(md).toContain('Hello there');
+    expect(md).toContain('### Agent · 2026-03-01T10:00:05.000Z');
+    expect(md).toContain('Hi! How can I help?');
+    // Messages are separated by horizontal rules.
+    expect(md).toContain('---');
+  });
+
   it('defaults to JSON format when no format specified', async () => {
     const state = makeState({
       getMessages: () => sampleMessages,

--- a/src/web/routes.ts
+++ b/src/web/routes.ts
@@ -838,8 +838,11 @@ function handleExportMessages(url: URL, state: WebStateProvider): Response {
   if (!chatJid) return json({ error: 'Missing chatJid' }, 400);
 
   const format = url.searchParams.get('format') || 'json';
-  if (format !== 'json' && format !== 'text')
-    return json({ error: 'Invalid format. Use "json" or "text".' }, 400);
+  if (format !== 'json' && format !== 'text' && format !== 'markdown')
+    return json(
+      { error: 'Invalid format. Use "json", "text", or "markdown".' },
+      400,
+    );
 
   const limit = Math.min(
     Math.max(1, parseInt(url.searchParams.get('limit') || '5000', 10) || 5000),
@@ -875,6 +878,36 @@ function handleExportMessages(url: URL, state: WebStateProvider): Response {
       headers: {
         'Content-Type': 'text/plain; charset=utf-8',
         'Content-Disposition': `attachment; filename="${safeName}-export.txt"`,
+      },
+    });
+  }
+
+  if (format === 'markdown') {
+    // Agent/user message content is already markdown, so it is embedded
+    // verbatim under per-message headings for a readable, portable transcript.
+    const lines: string[] = [];
+    lines.push(`# Conversation: ${chatName}`);
+    lines.push('');
+    lines.push(`- **JID:** \`${chatJid}\``);
+    lines.push(`- **Exported:** ${new Date().toISOString()}`);
+    lines.push(`- **Messages:** ${messages.length}`);
+    lines.push('');
+
+    for (const msg of messages) {
+      const time = new Date(msg.timestamp).toISOString();
+      const sender = msg.sender_name || 'Unknown';
+      lines.push('---');
+      lines.push('');
+      lines.push(`### ${sender} · ${time}`);
+      lines.push('');
+      lines.push(msg.content || '');
+      lines.push('');
+    }
+
+    return new Response(lines.join('\n'), {
+      headers: {
+        'Content-Type': 'text/markdown; charset=utf-8',
+        'Content-Disposition': `attachment; filename="${safeName}-export.md"`,
       },
     });
   }


### PR DESCRIPTION
## What

Adds a `markdown` format to the conversation export endpoint (`GET /api/messages/{jid}/export?format=markdown`), alongside the existing `json` and `text` formats.

## Why

Agent and user messages are already authored in markdown. Exporting a conversation as markdown yields a clean, portable transcript that renders directly in GitHub issues/PRs, docs, and note apps — more useful than the flat `text` dump for sharing or archiving agent sessions. This rounds out the Phase 3 "conversation export" line item (#505), which shipped JSON + plain text.

## Changes

- Accept `format=markdown` (invalid formats still return `400` with an updated message listing all three)
- Render:
  - `# Conversation: <name>` heading
  - Bulleted metadata: JID (code-formatted), export timestamp, message count
  - Per-message `### <sender> · <ISO timestamp>` sections with content embedded verbatim, separated by `---` horizontal rules
- Serve as `Content-Type: text/markdown; charset=utf-8` with a `.md` `Content-Disposition` filename
- Regression test asserting content-type, filename, metadata, and message rendering

## Scope note

Purely additive to an existing, well-tested handler — no changes to the `json`/`text` paths. The endpoint is backend/API-only (no frontend caller yet), so there's no UI surface to update.

## Testing

- `bun test src/web/` → **885 pass, 0 fail**
- `bun run typecheck` → clean


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Conversation exports now support **Markdown** format.
  * Markdown exports include a readable chat transcript with message sections, timestamps, and separators.
  * Exported files now download with a `.md` filename and the correct Markdown content type.

* **Bug Fixes**
  * Export requests now return a clearer error message when an unsupported format is selected.
  * Added test coverage for Markdown export behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->