### PR TITLE
test: cover agent model override normalization

### DIFF
--- a/src/model-override.test.ts
+++ b/src/model-override.test.ts
@@ -35,6 +35,16 @@ describe('normalizeAgentModelOverride', () => {
     ).toThrow(InvalidAgentModelOverrideError);
   });
 
+  test('reports a specific validation error for oversized overrides', () => {
+    expect(() =>
+      normalizeAgentModelOverride(
+        'a'.repeat(MAX_AGENT_MODEL_OVERRIDE_LENGTH + 1),
+      ),
+    ).toThrow(
+      `"model" must be ${MAX_AGENT_MODEL_OVERRIDE_LENGTH} characters or fewer`,
+    );
+  });
+
   test('rejects control characters after trimming', () => {
     const unsafeModels = [
       'claude\nopencode',
@@ -49,5 +59,11 @@ describe('normalizeAgentModelOverride', () => {
         InvalidAgentModelOverrideError,
       );
     }
+  });
+
+  test('reports a specific validation error for control characters', () => {
+    expect(() => normalizeAgentModelOverride('claude\nopencode')).toThrow(
+      '"model" must not contain control characters',
+    );
   });
 });

--- a/src/model-override.test.ts
+++ b/src/model-override.test.ts
@@ -1,0 +1,53 @@
+import { describe, expect, test } from 'bun:test';
+
+import {
+  InvalidAgentModelOverrideError,
+  MAX_AGENT_MODEL_OVERRIDE_LENGTH,
+  normalizeAgentModelOverride,
+} from './model-override.js';
+
+describe('normalizeAgentModelOverride', () => {
+  test('returns null for missing or blank model overrides', () => {
+    expect(normalizeAgentModelOverride(undefined)).toBeNull();
+    expect(normalizeAgentModelOverride(null)).toBeNull();
+    expect(normalizeAgentModelOverride('')).toBeNull();
+    expect(normalizeAgentModelOverride('   \t  ')).toBeNull();
+  });
+
+  test('trims surrounding whitespace from non-empty model overrides', () => {
+    expect(normalizeAgentModelOverride('  claude-opus-4-20250514  ')).toBe(
+      'claude-opus-4-20250514',
+    );
+  });
+
+  test('accepts overrides at the maximum normalized length', () => {
+    const model = 'a'.repeat(MAX_AGENT_MODEL_OVERRIDE_LENGTH);
+
+    expect(normalizeAgentModelOverride(model)).toBe(model);
+    expect(normalizeAgentModelOverride(` ${model} `)).toBe(model);
+  });
+
+  test('rejects overrides longer than the maximum normalized length', () => {
+    expect(() =>
+      normalizeAgentModelOverride(
+        'a'.repeat(MAX_AGENT_MODEL_OVERRIDE_LENGTH + 1),
+      ),
+    ).toThrow(InvalidAgentModelOverrideError);
+  });
+
+  test('rejects control characters after trimming', () => {
+    const unsafeModels = [
+      'claude\nopencode',
+      'claude\ropencode',
+      'claude\topencode',
+      'claude\0opencode',
+      `claude${String.fromCharCode(0x7f)}opencode`,
+    ];
+
+    for (const model of unsafeModels) {
+      expect(() => normalizeAgentModelOverride(model)).toThrow(
+        InvalidAgentModelOverrideError,
+      );
+    }
+  });
+});


### PR DESCRIPTION
## Summary

- Add direct unit coverage for `normalizeAgentModelOverride` in `src/model-override.ts`.
- Cover nullish and blank inputs, whitespace trimming, exact max-length acceptance, over-limit rejection, control-character rejection, and specific validation messages for env-file safety.

## Test Count

- Before this branch: `2573 pass`, `0 fail`, `6822 expect() calls`, across `106 files`.
- Before latest update: `2578 pass`, `0 fail`, `6835 expect() calls`, across `107 files`.
- After latest update: `2580 pass`, `0 fail`, `6837 expect() calls`, across `107 files`.

## Verification

- `bun test src/model-override.test.ts`
- `bun test`

## Files Covered

- `src/model-override.ts`

## Remaining Coverage Gaps

- Channel adapters and container backend integration paths still have low line coverage because much of their behavior depends on external SDKs, subprocesses, and long-running channel clients.
- Good next targets: pure helper boundaries inside channel adapters, backend path construction helpers, and validation logic around env/config state.
