### PR TITLE
feat(web): add /api/logs/recent structured log history endpoint

### DIFF
--- a/src/web/log-buffer.test.ts
+++ b/src/web/log-buffer.test.ts
@@ -1,0 +1,86 @@
+import { describe, it, expect } from 'bun:test';
+import { LogRingBuffer } from './log-buffer.js';
+
+describe('LogRingBuffer', () => {
+  it('stores records oldest-first', () => {
+    const buf = new LogRingBuffer(10);
+    buf.push({ level: 'info', msg: 'a' });
+    buf.push({ level: 'info', msg: 'b' });
+    expect(buf.recent().map((r) => r.msg)).toEqual(['a', 'b']);
+    expect(buf.size).toBe(2);
+  });
+
+  it('drops the oldest records past capacity', () => {
+    const buf = new LogRingBuffer(3);
+    for (const msg of ['a', 'b', 'c', 'd', 'e']) {
+      buf.push({ level: 'info', msg });
+    }
+    expect(buf.size).toBe(3);
+    expect(buf.recent().map((r) => r.msg)).toEqual(['c', 'd', 'e']);
+  });
+
+  it('filters by level', () => {
+    const buf = new LogRingBuffer(10);
+    buf.push({ level: 'info', msg: 'i1' });
+    buf.push({ level: 'error', msg: 'e1' });
+    buf.push({ level: 'info', msg: 'i2' });
+    expect(buf.recent({ level: 'error' }).map((r) => r.msg)).toEqual(['e1']);
+    expect(buf.recent({ level: 'info' }).map((r) => r.msg)).toEqual([
+      'i1',
+      'i2',
+    ]);
+  });
+
+  it('honors the limit (returns the most recent N)', () => {
+    const buf = new LogRingBuffer(10);
+    for (const msg of ['a', 'b', 'c', 'd']) {
+      buf.push({ level: 'info', msg });
+    }
+    expect(buf.recent({ limit: 2 }).map((r) => r.msg)).toEqual(['c', 'd']);
+  });
+
+  it('applies level filter before limit', () => {
+    const buf = new LogRingBuffer(10);
+    buf.push({ level: 'warn', msg: 'w1' });
+    buf.push({ level: 'info', msg: 'i1' });
+    buf.push({ level: 'warn', msg: 'w2' });
+    buf.push({ level: 'warn', msg: 'w3' });
+    expect(buf.recent({ level: 'warn', limit: 2 }).map((r) => r.msg)).toEqual([
+      'w2',
+      'w3',
+    ]);
+  });
+
+  it('ignores non-positive or non-finite limits', () => {
+    const buf = new LogRingBuffer(10);
+    buf.push({ level: 'info', msg: 'a' });
+    buf.push({ level: 'info', msg: 'b' });
+    expect(buf.recent({ limit: 0 }).length).toBe(2);
+    expect(buf.recent({ limit: -3 }).length).toBe(2);
+    expect(buf.recent({ limit: Number.NaN }).length).toBe(2);
+  });
+
+  it('returns a copy — mutating the result does not affect the buffer', () => {
+    const buf = new LogRingBuffer(10);
+    buf.push({ level: 'info', msg: 'a' });
+    const out = buf.recent();
+    out.push({ level: 'info', msg: 'injected' });
+    expect(buf.size).toBe(1);
+  });
+
+  it('clamps invalid capacities to at least one slot', () => {
+    const buf = new LogRingBuffer(0);
+    buf.push({ level: 'info', msg: 'a' });
+    buf.push({ level: 'info', msg: 'b' });
+    expect(buf.size).toBe(1);
+    expect(buf.recent()[0]?.msg).toBe('b');
+  });
+
+  it('clear() empties the buffer', () => {
+    const buf = new LogRingBuffer(10);
+    buf.push({ level: 'info', msg: 'a' });
+    buf.clear();
+    expect(buf.size).toBe(0);
+    expect(buf.recent()).toEqual([]);
+  });
+});

--- a/src/web/log-buffer.ts
+++ b/src/web/log-buffer.ts
@@ -1,0 +1,67 @@
+/**
+ * Bounded ring buffer of recent structured log records.
+ *
+ * The HTML dashboard SSE stream (`/api/events`) already backfills newly
+ * connected clients with recent *rendered* log lines. The raw structured
+ * stream (`/api/logs/stream`), however, only delivers records that arrive
+ * after a client connects — there is no way to fetch history as JSON.
+ *
+ * This buffer captures serialized (JSON-safe) records so the
+ * `/api/logs/recent` endpoint can return log history to JSON consumers
+ * (the raw log viewer, the SolidStart frontend, external tooling) without
+ * having to keep an SSE connection open the whole time.
+ *
+ * Records are stored oldest-first. When the buffer exceeds its capacity the
+ * oldest records are dropped.
+ */
+
+export type SerializedLogRecord = Record<string, unknown>;
+
+export class LogRingBuffer {
+  private readonly records: SerializedLogRecord[] = [];
+  private readonly maxSize: number;
+
+  constructor(maxSize: number) {
+    // Guard against non-positive/NaN sizes — always keep at least one slot.
+    this.maxSize = Number.isFinite(maxSize) && maxSize > 0 ? maxSize : 1;
+  }
+
+  /** Append a record, dropping the oldest entries past capacity. */
+  push(record: SerializedLogRecord): void {
+    this.records.push(record);
+    if (this.records.length > this.maxSize) {
+      this.records.splice(0, this.records.length - this.maxSize);
+    }
+  }
+
+  /**
+   * Return recent records (oldest-first).
+   *
+   * @param opts.level - if set, only records whose `level` matches are returned.
+   * @param opts.limit - if set (and > 0), return at most the last N matching records.
+   */
+  recent(opts: { level?: string; limit?: number } = {}): SerializedLogRecord[] {
+    const { level, limit } = opts;
+    let out =
+      level != null
+        ? this.records.filter((r) => r.level === level)
+        : this.records.slice();
+    if (level == null) {
+      // slice() above already copied; avoid a second copy for the common path.
+    }
+    if (typeof limit === 'number' && Number.isFinite(limit) && limit > 0) {
+      out = out.slice(Math.max(0, out.length - Math.floor(limit)));
+    }
+    return out;
+  }
+
+  /** Number of records currently buffered. */
+  get size(): number {
+    return this.records.length;
+  }
+
+  /** Drop all buffered records. */
+  clear(): void {
+    this.records.length = 0;
+  }
+}

--- a/src/web/server.test.ts
+++ b/src/web/server.test.ts
@@ -1533,6 +1533,96 @@ describe('SSE', () => {
   });
 });
 
+// ---- GET /api/logs/recent ----
+
+describe('GET /api/logs/recent', () => {
+  it('returns buffered structured log records as JSON', async () => {
+    const restoreLoggerBridge = ensureLoggerSubscriptionBridge();
+    try {
+      handle = startWebServer(testConfig(), makeState());
+      const marker = `recent-log-${Date.now()}`;
+      logger.info(marker);
+
+      const res = await authedFetch('/api/logs/recent');
+      expect(res.status).toBe(200);
+      expect(res.headers.get('Content-Type')).toContain('application/json');
+      const body = (await res.json()) as {
+        logs: Array<Record<string, unknown>>;
+        total: number;
+      };
+      expect(Array.isArray(body.logs)).toBe(true);
+      expect(body.total).toBeGreaterThan(0);
+      const found = body.logs.find((r) => r.msg === marker);
+      expect(found).toBeTruthy();
+      expect(found?.level).toBe('info');
+    } finally {
+      restoreLoggerBridge();
+    }
+  });
+
+  it('filters by level', async () => {
+    const restoreLoggerBridge = ensureLoggerSubscriptionBridge();
+    try {
+      handle = startWebServer(testConfig(), makeState());
+      const marker = `recent-warn-${Date.now()}`;
+      logger.info(`info-noise-${Date.now()}`);
+      logger.warn(marker);
+
+      const res = await authedFetch('/api/logs/recent?level=warn');
+      expect(res.status).toBe(200);
+      const body = (await res.json()) as {
+        logs: Array<Record<string, unknown>>;
+      };
+      expect(body.logs.length).toBeGreaterThan(0);
+      expect(body.logs.every((r) => r.level === 'warn')).toBe(true);
+      expect(body.logs.some((r) => r.msg === marker)).toBe(true);
+    } finally {
+      restoreLoggerBridge();
+    }
+  });
+
+  it('ignores an invalid level filter and returns all levels', async () => {
+    const restoreLoggerBridge = ensureLoggerSubscriptionBridge();
+    try {
+      handle = startWebServer(testConfig(), makeState());
+      logger.info(`recent-any-${Date.now()}`);
+
+      const res = await authedFetch('/api/logs/recent?level=bogus');
+      expect(res.status).toBe(200);
+      const body = (await res.json()) as {
+        logs: Array<Record<string, unknown>>;
+      };
+      expect(body.logs.length).toBeGreaterThan(0);
+    } finally {
+      restoreLoggerBridge();
+    }
+  });
+
+  it('honors the limit query parameter', async () => {
+    const restoreLoggerBridge = ensureLoggerSubscriptionBridge();
+    try {
+      handle = startWebServer(testConfig(), makeState());
+      for (let i = 0; i < 5; i++)
+        logger.info(`recent-limit-${i}-${Date.now()}`);
+
+      const res = await authedFetch('/api/logs/recent?limit=2');
+      expect(res.status).toBe(200);
+      const body = (await res.json()) as {
+        logs: Array<Record<string, unknown>>;
+      };
+      expect(body.logs.length).toBe(2);
+    } finally {
+      restoreLoggerBridge();
+    }
+  });
+
+  it('rejects non-GET methods', async () => {
+    handle = startWebServer(testConfig(), makeState());
+    const res = await authedFetch('/api/logs/recent', { method: 'POST' });
+    expect(res.status).toBe(405);
+  });
+});
+
 // ---- CORS ----
 
 describe('CORS', () => {

--- a/src/web/server.ts
+++ b/src/web/server.ts
@@ -41,6 +41,7 @@ import {
 import { checkPeerAuth } from '../discovery/routes.js';
 import type { TrustStore } from '../discovery/trust-store.js';
 import { serializeLogRecord } from './log-stream.js';
+import { LogRingBuffer } from './log-buffer.js';
 import { renderSystemContent } from './system.js';
 import { renderSettingsContent } from './settings.js';
 import { renderTasksContent } from './tasks.js';
@@ -59,6 +60,16 @@ import {
 
 const MAX_SSE_CLIENTS = 100;
 const MAX_LOG_LINES = 500;
+/**
+ * Capacity of the structured recent-log buffer served by `/api/logs/recent`.
+ * Larger than MAX_LOG_LINES (the rendered-HTML replay cap) since structured
+ * JSON records are cheap and JSON consumers benefit from deeper history.
+ */
+const MAX_RECENT_LOG_RECORDS = 1000;
+/** Hard cap on records returned in a single /api/logs/recent response. */
+const MAX_RECENT_LOG_LIMIT = MAX_RECENT_LOG_RECORDS;
+/** Valid log levels accepted by the ?level= filter on /api/logs/recent. */
+const LOG_LEVELS = new Set(['debug', 'info', 'warn', 'error', 'fatal']);
 const SNAPSHOT_INTERVAL_MS = 5000;
 const PORT_ZERO_RETRY_ATTEMPTS = 10;
 const PORT_ZERO_FALLBACK_START = 40000;
@@ -256,6 +267,16 @@ export function startWebServer(
     typeof logger.subscribe === 'function'
       ? logger.subscribe.bind(logger)
       : null;
+
+  // Structured recent-log buffer for /api/logs/recent. Populated by a single
+  // always-on subscription so JSON consumers can fetch history without an
+  // open SSE connection. Torn down in stop().
+  const logRingBuffer = new LogRingBuffer(MAX_RECENT_LOG_RECORDS);
+  const unsubscribeLogBuffer =
+    subscribeToRawLogs?.((record) => {
+      if (record.level === 'trace') return;
+      logRingBuffer.push(serializeLogRecord(record));
+    }) ?? null;
 
   // Initialize SolidStart handler if enabled.
   // Store the promise so the first proxied request can await it.
@@ -551,6 +572,35 @@ export function startWebServer(
         return response;
       }
       // Fall through to Datastar UI if SolidStart handler not ready
+    }
+
+    if (url.pathname === '/api/logs/recent') {
+      const jsonHeaders = {
+        'Content-Type': 'application/json',
+        'Cache-Control': 'no-cache, no-transform',
+        ...(corsOrigin ? makeCorsHeaders(corsOrigin) : {}),
+      };
+      if (req.method !== 'GET') {
+        return new Response(JSON.stringify({ error: 'Method not allowed' }), {
+          status: 405,
+          headers: jsonHeaders,
+        });
+      }
+      const levelParam = url.searchParams.get('level')?.trim();
+      const level =
+        levelParam && LOG_LEVELS.has(levelParam) ? levelParam : undefined;
+      const limitRaw = url.searchParams.get('limit');
+      let limit: number | undefined;
+      if (limitRaw != null) {
+        const parsed = Number.parseInt(limitRaw, 10);
+        if (Number.isFinite(parsed) && parsed > 0) {
+          limit = Math.min(parsed, MAX_RECENT_LOG_LIMIT);
+        }
+      }
+      const logs = logRingBuffer.recent({ level, limit });
+      return new Response(JSON.stringify({ logs, total: logRingBuffer.size }), {
+        headers: jsonHeaders,
+      });
     }
 
     if (url.pathname === '/api/logs/stream') {
@@ -988,6 +1038,7 @@ export function startWebServer(
     },
     async stop() {
       clearInterval(snapshotTicker);
+      unsubscribeLogBuffer?.();
       loginRateLimiter?.dispose();
       for (const client of sseClients) {
         client.close();
@@ -1087,6 +1138,7 @@ function isPeerRoute(pathname: string): boolean {
   return (
     pathname === '/api/agents' ||
     pathname === '/api/logs/stream' ||
+    pathname === '/api/logs/recent' ||
     pathname === '/api/stats' ||
     pathname === '/api/context/files' ||
     pathname === '/api/context/layers' ||


### PR DESCRIPTION
## What

Adds `GET /api/logs/recent` — returns recent **structured** log records as JSON, backed by a bounded in-memory ring buffer.

## Why

The raw structured log stream (`/api/logs/stream`) is SSE-only — a client only sees records that arrive *after* it connects. There was no way to fetch log **history** as JSON.

The HTML dashboard already backfills newly connected SSE clients with recent *rendered* log lines (`recentLogs`), but that's HTML, not structured data. JSON consumers — the SolidStart frontend, external tooling, or a fresh raw-log viewer — had no backfill at all. This closes that gap for the Web UI (#157) log tooling.

## How

- **`src/web/log-buffer.ts`** — new `LogRingBuffer` class: bounded FIFO of serialized (JSON-safe) records with `push()`, `recent({ level, limit })`, `size`, `clear()`. Oldest-first; drops oldest past capacity. Pure and fully unit-tested.
- **`src/web/server.ts`**:
  - A single always-on `logger.subscribe` populates the buffer (skips `trace`), reusing the existing `serializeLogRecord`. Capacity `MAX_RECENT_LOG_RECORDS = 1000` (deeper than the 500-line HTML replay cap — structured records are cheap).
  - New route `GET /api/logs/recent` -> `{ logs, total }`. Supports `?level=` (validated; invalid values ignored) and `?limit=` (parsed, positive, capped). Non-GET -> 405.
  - Subscription is unsubscribed in `stop()`.
  - Added to the peer-trusted route allowlist alongside `/api/logs/stream`.

## Tests

- `src/web/log-buffer.test.ts` — 9 unit tests (ordering, capacity eviction, level filter, limit, filter-before-limit, copy-on-read, capacity clamping, `clear`).
- `src/web/server.test.ts` — 5 endpoint tests (JSON records, level filter, invalid-level fallback, limit, 405).

`bun run typecheck` clean; full `bun test src/web/` passes. Prettier-formatted.

Co-Authored-By: Claude Opus 4.6

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new recent-logs API that returns structured log history in JSON, including total count and support for filtering by log level.
  * Added a limit option for recent log results so clients can request only the newest matching entries.
  * Improved log retention so more recent structured logs are available for retrieval without affecting the existing live log view.

* **Bug Fixes**
  * Invalid log-level and limit values are now handled safely, returning sensible results instead of failing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->