### PR TITLE
fix(tasks): validate preprocess_script exists at creation (#973)

### DIFF
--- a/container/agent-runner/src/ipc-mcp-stdio.ts
+++ b/container/agent-runner/src/ipc-mcp-stdio.ts
@@ -24,7 +24,16 @@ const RESPONSES_DIR = path.join(IPC_DIR, 'responses');
 const USER_REGISTRY_PATH = path.join(IPC_DIR, 'user_registry.json');
 const taskWorkflowsDir =
   process.env.OMNICLAW_TASK_WORKFLOWS_DIR || 'task-workflows';
-const taskWorkflowsPath = `/workspace/group/${taskWorkflowsDir.replace(/^\/+/, '').replace(/\/+$/, '')}/`;
+// A scheduled task's preprocess script is resolved by the host under the
+// task's group folder, which for multi-channel / 4-layer-context agents is the
+// agent-identity folder mounted at /workspace/agent — NOT the channel folder
+// mounted at /workspace/group. Point the docs at the folder that actually maps
+// to the task's group folder so agents write the workflow where the scheduler
+// looks for it. See issue #973.
+const taskWorkspaceRoot = fs.existsSync('/workspace/agent')
+  ? '/workspace/agent'
+  : '/workspace/group';
+const taskWorkflowsPath = `${taskWorkspaceRoot}/${taskWorkflowsDir.replace(/^\/+/, '').replace(/\/+$/, '')}/`;
 
 // Context from environment variables (set by the agent runner)
 const initialChatJid = process.env.OMNICLAW_CHAT_JID!;

--- a/src/ipc-processing.test.ts
+++ b/src/ipc-processing.test.ts
@@ -3,6 +3,8 @@ import path from 'path';
 
 import { describe, it, expect, beforeEach } from 'bun:test';
 
+import { GROUPS_DIR, TASK_WORKFLOWS_DIR } from './config.js';
+
 import {
   _initTestDatabase,
   _backdateSessionForTest,
@@ -1043,26 +1045,43 @@ describe('processTaskIpc: task mutation behavior', () => {
   });
 
   it('stores deterministic preprocessor script when scheduling a task', async () => {
-    await processTaskIpc(
-      {
-        type: 'schedule_task',
-        prompt: 'Sync connectors if MCP package changed',
-        preprocess_script: 'sync-connectors-if-mcp-changed.ts',
-        schedule_type: 'interval',
-        schedule_value: '60000',
-        targetJid: 'other@g.us',
-      },
-      'other-group',
-      false,
-      deps,
+    // The workflow file must exist at the resolved path (issue #973), so
+    // create it under the target group's task-workflows directory first.
+    const scriptName = 'sync-connectors-if-mcp-changed.ts';
+    const groupWorkflowsDir = path.isAbsolute(TASK_WORKFLOWS_DIR)
+      ? TASK_WORKFLOWS_DIR
+      : path.join(GROUPS_DIR, 'other-group', TASK_WORKFLOWS_DIR);
+    const scriptPath = path.join(groupWorkflowsDir, scriptName);
+    fs.mkdirSync(groupWorkflowsDir, { recursive: true });
+    fs.writeFileSync(
+      scriptPath,
+      'console.log(JSON.stringify({ action: "skip" }));',
     );
 
-    const tasks = getAllTasks();
-    expect(tasks).toHaveLength(1);
-    expect(tasks[0]).toMatchObject({
-      prompt: 'Sync connectors if MCP package changed',
-      preprocess_script: 'sync-connectors-if-mcp-changed.ts',
-    });
+    try {
+      await processTaskIpc(
+        {
+          type: 'schedule_task',
+          prompt: 'Sync connectors if MCP package changed',
+          preprocess_script: scriptName,
+          schedule_type: 'interval',
+          schedule_value: '60000',
+          targetJid: 'other@g.us',
+        },
+        'other-group',
+        false,
+        deps,
+      );
+
+      const tasks = getAllTasks();
+      expect(tasks).toHaveLength(1);
+      expect(tasks[0]).toMatchObject({
+        prompt: 'Sync connectors if MCP package changed',
+        preprocess_script: scriptName,
+      });
+    } finally {
+      fs.rmSync(scriptPath, { force: true });
+    }
   });
 
   it('blocks a non-main group from scheduling tasks for another group', async () => {

--- a/src/ipc-task-handlers.test.ts
+++ b/src/ipc-task-handlers.test.ts
@@ -1,5 +1,8 @@
 import { describe, it, expect, beforeEach } from 'bun:test';
+import fs from 'fs';
+import path from 'path';
 
+import { GROUPS_DIR, TASK_WORKFLOWS_DIR } from './config.js';
 import {
   _initTestDatabase,
   createTask,
@@ -8,6 +11,7 @@ import {
   setRegisteredGroup,
 } from './db.js';
 import { processTaskIpc, IpcDeps } from './ipc.js';
+import { IpcEventKind } from './web/ipc-events.js';
 import { RegisteredGroup } from './types.js';
 
 // =============================================================================
@@ -941,5 +945,98 @@ describe('processTaskIpc: optional writeTasksSnapshot', () => {
     // Should create the task without error
     const tasks = getAllTasks();
     expect(tasks).toHaveLength(1);
+  });
+});
+
+// =============================================================================
+// processTaskIpc: schedule_task / edit_task preprocess existence check (#973)
+// =============================================================================
+
+describe('processTaskIpc: preprocess_script existence check (issue #973)', () => {
+  const groupWorkflowsDir = path.isAbsolute(TASK_WORKFLOWS_DIR)
+    ? TASK_WORKFLOWS_DIR
+    : path.join(GROUPS_DIR, 'main', TASK_WORKFLOWS_DIR);
+  const scriptName = 'exists-check-973.ts';
+  const scriptPath = path.join(groupWorkflowsDir, scriptName);
+
+  function cleanup() {
+    fs.rmSync(scriptPath, { force: true });
+  }
+
+  async function flushMicrotasks() {
+    await new Promise((resolve) => setTimeout(resolve, 0));
+  }
+
+  function withEvents(): {
+    deps: IpcDeps;
+    events: Array<{ kind: IpcEventKind; summary: string }>;
+  } {
+    const events: Array<{ kind: IpcEventKind; summary: string }> = [];
+    return {
+      deps: {
+        ...deps,
+        onIpcEvent: (kind, _sourceGroup, summary) => {
+          events.push({ kind, summary });
+        },
+      },
+      events,
+    };
+  }
+
+  beforeEach(cleanup);
+
+  it('rejects schedule_task when the workflow file is missing', async () => {
+    const { deps: evDeps, events } = withEvents();
+
+    await processTaskIpc(
+      {
+        type: 'schedule_task',
+        prompt: 'Watch something',
+        schedule_type: 'cron',
+        schedule_value: '0 7 * * *',
+        targetJid: 'main@g.us',
+        preprocess_script: scriptName,
+      } as any,
+      'main',
+      true,
+      evDeps,
+    );
+    await flushMicrotasks();
+
+    expect(getAllTasks()).toHaveLength(0);
+    const errorEvent = events.find((e) => e.kind === 'task_error');
+    expect(errorEvent).toBeDefined();
+    expect(errorEvent?.summary).toContain(scriptName);
+    expect(errorEvent?.summary).toContain('/workspace/agent/task-workflows/');
+  });
+
+  it('creates schedule_task when the workflow file exists', async () => {
+    fs.mkdirSync(groupWorkflowsDir, { recursive: true });
+    fs.writeFileSync(
+      scriptPath,
+      'console.log(JSON.stringify({ action: "skip" }));',
+    );
+
+    try {
+      await processTaskIpc(
+        {
+          type: 'schedule_task',
+          prompt: 'Watch something',
+          schedule_type: 'cron',
+          schedule_value: '0 7 * * *',
+          targetJid: 'main@g.us',
+          preprocess_script: scriptName,
+        } as any,
+        'main',
+        true,
+        deps,
+      );
+
+      const tasks = getAllTasks();
+      expect(tasks).toHaveLength(1);
+      expect(tasks[0].preprocess_script).toBe(scriptName);
+    } finally {
+      cleanup();
+    }
   });
 });

--- a/src/ipc.ts
+++ b/src/ipc.ts
@@ -36,7 +36,10 @@ import {
   RegisteredGroup,
   ThreadSummary,
 } from './types.js';
-import { normalizePreprocessScriptPath } from './task-preprocessor.js';
+import {
+  checkPreprocessScriptExists,
+  normalizePreprocessScriptPath,
+} from './task-preprocessor.js';
 import { parseSlackJid } from './slack-jid.js';
 import type { IpcEventKind } from './web/ipc-events.js';
 
@@ -1192,6 +1195,31 @@ export async function processTaskIpc(
             { sourceGroup, targetFolder, error: preprocessScript.error },
             'Invalid task preprocess_script rejected',
           );
+          safeEmitIpcEvent(
+            deps,
+            'task_error',
+            sourceGroup,
+            `Task not created: ${preprocessScript.error}`,
+            { targetFolder },
+          );
+          break;
+        }
+        const preprocessExists = checkPreprocessScriptExists(
+          targetFolder,
+          preprocessScript.path,
+        );
+        if (!preprocessExists.ok) {
+          logger.warn(
+            { sourceGroup, targetFolder, error: preprocessExists.error },
+            'Task preprocess_script missing at resolved path',
+          );
+          safeEmitIpcEvent(
+            deps,
+            'task_error',
+            sourceGroup,
+            `Task not created: ${preprocessExists.error}`,
+            { targetFolder },
+          );
           break;
         }
         createTask({
@@ -1272,6 +1300,35 @@ export async function processTaskIpc(
               error: preprocessScript.error,
             },
             'Invalid task preprocess_script rejected',
+          );
+          safeEmitIpcEvent(
+            deps,
+            'task_error',
+            sourceGroup,
+            `Task ${data.taskId} not edited: ${preprocessScript.error}`,
+            { taskId: data.taskId },
+          );
+          break;
+        }
+        const preprocessExists = checkPreprocessScriptExists(
+          task.group_folder,
+          preprocessScript.path,
+        );
+        if (!preprocessExists.ok) {
+          logger.warn(
+            {
+              taskId: data.taskId,
+              sourceGroup,
+              error: preprocessExists.error,
+            },
+            'Task preprocess_script missing at resolved path',
+          );
+          safeEmitIpcEvent(
+            deps,
+            'task_error',
+            sourceGroup,
+            `Task ${data.taskId} not edited: ${preprocessExists.error}`,
+            { taskId: data.taskId },
           );
           break;
         }

--- a/src/task-preprocessor.test.ts
+++ b/src/task-preprocessor.test.ts
@@ -5,7 +5,9 @@ import path from 'path';
 
 import { GROUPS_DIR, TASK_WORKFLOWS_DIR } from './config.js';
 import {
+  checkPreprocessScriptExists,
   normalizePreprocessScriptPath,
+  resolvePreprocessWorkflowPath,
   runTaskPreprocessor,
 } from './task-preprocessor.js';
 import type { ScheduledTask } from './types.js';
@@ -400,4 +402,52 @@ it('resolves the default group task-workflows directory when no override is prov
       },
     );
   }
+});
+
+describe('checkPreprocessScriptExists (issue #973)', () => {
+  it('passes when there is no preprocess script to check', () => {
+    expect(checkPreprocessScriptExists('main', null)).toEqual({ ok: true });
+    expect(checkPreprocessScriptExists('main', undefined)).toEqual({
+      ok: true,
+    });
+  });
+
+  it('passes when the script exists at the resolved workflow path', () => {
+    fs.writeFileSync(
+      path.join(workflowsDir, 'workflow.ts'),
+      'console.log(JSON.stringify({ action: "skip" }));',
+    );
+
+    expect(
+      checkPreprocessScriptExists('main', 'workflow.ts', { workflowsDir }),
+    ).toEqual({ ok: true });
+  });
+
+  it('fails with an actionable error naming the resolved dir when missing', () => {
+    const result = checkPreprocessScriptExists('main', 'missing.ts', {
+      workflowsDir,
+    });
+
+    expect(result.ok).toBe(false);
+    if (result.ok) throw new Error('expected failure');
+    expect(result.error).toContain('missing.ts');
+    expect(result.error).toContain(workflowsDir);
+    expect(result.error).toContain('/workspace/agent/task-workflows/');
+  });
+
+  it('rejects a traversal path without touching the filesystem', () => {
+    const result = checkPreprocessScriptExists('main', '../escape.ts', {
+      workflowsDir,
+    });
+
+    expect(result.ok).toBe(false);
+  });
+
+  it('resolves the workflow path under the group task-workflows dir', () => {
+    const { workflowsDir: resolvedDir, workflowPath } =
+      resolvePreprocessWorkflowPath('main', 'workflow.ts', { workflowsDir });
+
+    expect(resolvedDir).toBe(workflowsDir);
+    expect(workflowPath).toBe(path.join(workflowsDir, 'workflow.ts'));
+  });
 });

--- a/src/task-preprocessor.ts
+++ b/src/task-preprocessor.ts
@@ -1,4 +1,5 @@
 import { spawnSync } from 'child_process';
+import { existsSync } from 'fs';
 import path from 'path';
 
 import {
@@ -112,7 +113,9 @@ function resolveWorkflowPath(scriptPath: string, workflowsDir: string): string {
   return resolved;
 }
 
-function defaultWorkflowsDir(task: ScheduledTask): string {
+function defaultWorkflowsDir(
+  task: Pick<ScheduledTask, 'group_folder'>,
+): string {
   if (path.isAbsolute(TASK_WORKFLOWS_DIR)) {
     return TASK_WORKFLOWS_DIR;
   }
@@ -120,6 +123,69 @@ function defaultWorkflowsDir(task: ScheduledTask): string {
   const groupDir = path.resolve(GROUPS_DIR, task.group_folder);
   assertPathWithin(groupDir, GROUPS_DIR, 'task workflow group folder');
   return path.resolve(groupDir, TASK_WORKFLOWS_DIR);
+}
+
+/**
+ * Resolve the absolute workflow directory and file path a preprocess script
+ * will run from, using the same rules as {@link runTaskPreprocessor}. Exposed so
+ * task creation/edit can validate a script *before* it is persisted, instead of
+ * discovering a mismatch only at the next scheduled run. See issue #973.
+ */
+export function resolvePreprocessWorkflowPath(
+  groupFolder: string,
+  preprocessScript: string,
+  options: { workflowsDir?: string } = {},
+): { workflowsDir: string; workflowPath: string } {
+  const workflowsDir = path.resolve(
+    options.workflowsDir ?? defaultWorkflowsDir({ group_folder: groupFolder }),
+  );
+  const workflowPath = resolveWorkflowPath(preprocessScript, workflowsDir);
+  return { workflowsDir, workflowPath };
+}
+
+/**
+ * Validate that a task's preprocess script exists at the path the scheduler
+ * will resolve it from. Returns `ok: true` when there is no script (nothing to
+ * check) or the file is present; otherwise returns an actionable error that
+ * names the resolved directory so the caller can place the file correctly.
+ *
+ * This closes the silent-`blocked` failure mode where a multi-channel agent
+ * writes the workflow under `/workspace/group/task-workflows/` while the
+ * scheduler resolves it under the agent-identity folder
+ * (`/workspace/agent/task-workflows/`). See issue #973.
+ */
+export function checkPreprocessScriptExists(
+  groupFolder: string,
+  preprocessScript: string | null | undefined,
+  options: { workflowsDir?: string } = {},
+): { ok: true } | { ok: false; error: string } {
+  if (!preprocessScript) return { ok: true };
+  let resolved: { workflowsDir: string; workflowPath: string };
+  try {
+    resolved = resolvePreprocessWorkflowPath(
+      groupFolder,
+      preprocessScript,
+      options,
+    );
+  } catch (err) {
+    return {
+      ok: false,
+      error: err instanceof Error ? err.message : String(err),
+    };
+  }
+  if (!existsSync(resolved.workflowPath)) {
+    return {
+      ok: false,
+      error:
+        `preprocess_script "${preprocessScript}" was not found at ` +
+        `${resolved.workflowPath}. Create the workflow file in the task's ` +
+        `workflow directory (${resolved.workflowsDir}) before scheduling. ` +
+        `For multi-channel / 4-layer-context agents this directory is the ` +
+        `agent-identity folder mounted at /workspace/agent/task-workflows/, ` +
+        `not /workspace/group/task-workflows/.`,
+    };
+  }
+  return { ok: true };
 }
 
 function parseDecision(stdout: string): TaskPreprocessDecision {


### PR DESCRIPTION
## What

Closes #973. A scheduled task with a `preprocess_script` could be **permanently `blocked`** with a silent `Preprocessor failed: Module not found "…/groups/<group_folder>/task-workflows/<script>.ts"` — even though the agent created the workflow file exactly where the `schedule_task` tool docs said to.

Root cause: for **multi-channel / 4-layer-context agents**, the folder the agent writes to (`/workspace/group/task-workflows/`, the *channel* folder) is **not** the folder the scheduler resolves the workflow under (`groups/<task.group_folder>/task-workflows/` = the *agent-identity* folder mounted at `/workspace/agent/`). Nothing validated the file existed at creation time, so the misconfiguration only surfaced at the next scheduled run and then retried every tick with no notification.

Live repro: task `task-1779144774417-kxanmf` ("backend MCP watcher", `cron: 0 7 * * *`) has been failing daily; the workflow ran cleanly by hand but wasn't at the host path the scheduler resolves.

## Changes

- **Existence check** — new `checkPreprocessScriptExists` / `resolvePreprocessWorkflowPath` in `task-preprocessor.ts`, reusing the *exact* resolution `runTaskPreprocessor` uses (so the check and the runtime never disagree).
- **Reject early with an actionable error** — `schedule_task` / `edit_task` in `ipc.ts` now reject when the workflow file is missing and emit a `task_error` IPC event that **names the resolved directory**, turning a silent 2-month failure into an immediate "put the file in `…/task-workflows/`" message. The previously-silent invalid-path rejection is now surfaced the same way.
- **Doc correction** — the `schedule_task` MCP tool description (`container/agent-runner/src/ipc-mcp-stdio.ts`) now points at the folder that actually maps to the task's group folder: `/workspace/agent/task-workflows/` when that mount exists (4-layer agents), else `/workspace/group/task-workflows/`.

## Tests

- Unit: existence check (present / missing / no-script / traversal) + resolver path — `task-preprocessor.test.ts`.
- IPC handlers: reject-on-missing (asserts no task created + `task_error` naming the dir) and create-on-present — `ipc-task-handlers.test.ts`.
- Updated the existing deterministic-preprocessor test to create the workflow file first (reflects the new contract).
- `bun run typecheck` clean, agent-runner `tsc --noEmit` clean, full `bun test` green (2580 pass), prettier clean.

## Follow-up (not in this PR)

The issue also suggests option 3 — alert / auto-pause after N consecutive `blocked` `Module not found` outcomes so already-broken tasks surface rather than retrying silently. Happy to do that as a separate PR if wanted.

Note: this fixes the *class* of bug and makes the failure actionable going forward. The one live broken task still needs its workflow file placed at the resolved host path (`groups/clayton-discord/task-workflows/`) — the `/workspace/agent` copy in the container doesn't appear to propagate to that host path, which is worth confirming separately.
