### PR TITLE
fix(web): escape quotes in client HTML helper

### DIFF
--- a/src/web/shared.test.ts
+++ b/src/web/shared.test.ts
@@ -11,9 +11,19 @@ import {
 
 describe('escapeHtml', () => {
   it('escapes the HTML-sensitive characters used by the web UI', () => {
-    expect(escapeHtml('&<>"')).toBe('&amp;&lt;&gt;&quot;');
-    expect(escapeHtml("it's fine")).toBe("it's fine");
+    expect(escapeHtml('&<>"\'')).toBe('&amp;&lt;&gt;&quot;&#39;');
     expect(escapeHtml('')).toBe('');
+  });
+});
+
+describe('client escape helper', () => {
+  it('encodes quotes for generated HTML attribute contexts', () => {
+    const html = renderShell('/', 'Dashboard', '<div>content</div>', {});
+
+    expect(html).toContain('window.__esc=function(s){');
+    expect(html).toContain('c===\'"\'?"&quot;":"&#39;"');
+    expect(html).toContain('/[&<>"\']/g');
+    expect(html).not.toContain('document.createElement("div");d.textContent');
   });
 });
 

--- a/src/web/shared.ts
+++ b/src/web/shared.ts
@@ -23,7 +23,8 @@ export function escapeHtml(str: string): string {
     .replace(/&/g, '&amp;')
     .replace(/</g, '&lt;')
     .replace(/>/g, '&gt;')
-    .replace(/"/g, '&quot;');
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&#39;');
 }
 
 export function escapeJsonForHtml(json: string): string {
@@ -1691,7 +1692,7 @@ function shellScript(pageScripts: Record<string, string>): string {
 
   // ---- Escape helper (used by page inits) ----
   parts.push(
-    'window.__esc=function(s){if(!s)return"";var d=document.createElement("div");d.textContent=String(s);return d.innerHTML;};',
+    `window.__esc=function(s){if(!s)return"";return String(s).replace(/[&<>"']/g,function(c){return c==="&"?"&amp;":c==="<"?"&lt;":c===">"?"&gt;":c==='"'?"&quot;":"&#39;";});};`,
   );
   parts.push(
     'window.__sanitizeUrl=function(url){if(!url)return"";var v=String(url).trim();if(!v)return"";if(v[0]==="#"||v[0]==="/")return v;try{var p=new URL(v,window.location.origin).protocol.toLowerCase();if(p==="http:"||p==="https:"||p==="mailto:"||p==="tel:")return v;}catch{}return"";};',


### PR DESCRIPTION
## Summary

- Replace the browser-side `window.__esc` helper with deterministic escaping for `&`, `<`, `>`, double quotes, and single quotes.
- Align server-side `escapeHtml` with the same quote-safe attribute behavior.
- Add regression coverage that the emitted client helper encodes quotes and no longer relies on `textContent`/`innerHTML` quote behavior.

Closes #976.

## Security Notes

The previous helper used `textContent` plus `innerHTML`, which escapes text nodes but leaves quote characters unencoded. Several Web UI scripts reuse `window.__esc(...)` inside quoted attributes before assigning generated strings to `innerHTML`, so quote payloads could break out of attributes.

## Verification

- `bun test src/web/shared.test.ts src/web/page-scripts.test.ts`
- `bunx tsc --noEmit`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved HTML escaping to include both double and single quotes, helping prevent unsafe rendering in more cases.
  * Updated the client-side escaping helper to use a more reliable string-based approach for sanitizing special characters.

* **Tests**
  * Expanded coverage to verify the additional escaping behavior and the generated client-side helper output.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->