### PR TITLE
test(factory): cover workflow claim release

### DIFF
--- a/src/factory-workflows.test.ts
+++ b/src/factory-workflows.test.ts
@@ -219,6 +219,46 @@ describe('FactoryWorkflowStore claims', () => {
     db.close();
   });
 
+  it('releases only the matching owner claim when ownerRunId is provided', () => {
+    const { db, store } = makeStore();
+    store.acquireClaim({
+      workflowId: 'workflow-1',
+      repo: 'omniaura/omniclaw',
+      ownerAgentId: 'ocpeyton',
+      ownerRunId: 'run-1',
+      phase: 'impl',
+      ttlMs: 60_000,
+      now: new Date('2026-05-04T00:00:00.000Z'),
+    });
+
+    store.releaseClaim('workflow-1', 'wrong-run');
+    expect(store.getClaim('workflow-1')?.ownerRunId).toBe('run-1');
+
+    store.releaseClaim('workflow-1', 'run-1');
+    expect(store.getClaim('workflow-1')).toBeUndefined();
+
+    db.close();
+  });
+
+  it('releases a workflow claim without requiring owner identity', () => {
+    const { db, store } = makeStore();
+    store.acquireClaim({
+      workflowId: 'workflow-1',
+      repo: 'omniaura/omniclaw',
+      ownerAgentId: 'ocpeyton',
+      ownerRunId: 'run-1',
+      phase: 'impl',
+      ttlMs: 60_000,
+      now: new Date('2026-05-04T00:00:00.000Z'),
+    });
+
+    store.releaseClaim('workflow-1');
+
+    expect(store.getClaim('workflow-1')).toBeUndefined();
+
+    db.close();
+  });
+
   it('persists records and claims across database reopen', () => {
     const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'omniclaw-factory-'));
     tempDirs.push(dir);


### PR DESCRIPTION
## Summary

- Add deterministic coverage for `FactoryWorkflowStore.releaseClaim` owner-scoped release behavior.
- Cover unconditional workflow claim release without owner identity.
- Confirm `src/factory-workflows.ts` reaches 100% line/function coverage under the targeted coverage run.

## Test Counts

- Base `origin/main`: `2574 pass`, `0 fail`, `6825 expect() calls`, `106 files`.
- This branch: `2576 pass`, `0 fail`, `6828 expect() calls`, `106 files`.
- Targeted file: `8 pass` -> `10 pass`.

## Verification

- `bun test src/factory-workflows.test.ts`
- `bun test src/factory-workflows.test.ts --coverage`
- `bun test`

## Remaining Coverage Gaps

- Broad integration-heavy modules remain the largest gaps, especially channel adapters, `src/index.ts`, `src/backends/local-backend.ts`, `src/discovery/routes.ts`, and portions of `src/web/server.ts`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added validation tests for claim release operations under different ownership scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->