### PR TITLE
feat(web): add task run history export endpoint

### DIFF
--- a/src/web/routes.test.ts
+++ b/src/web/routes.test.ts
@@ -969,6 +969,128 @@ describe('handleRequest task run logs', () => {
   });
 });
 
+// ---- Task run history export ----
+
+describe('GET /api/tasks/{id}/runs/export', () => {
+  const sampleRuns: TaskRunLog[] = [
+    {
+      task_id: 'task-001',
+      run_at: '2026-03-10T12:00:00.000Z',
+      duration_ms: 5000,
+      status: 'success',
+      result: 'All good, said "hi"',
+      error: null,
+      outcome_state: 'done',
+      outcome_reason: 'finished cleanly',
+    },
+    {
+      task_id: 'task-001',
+      run_at: '2026-03-10T11:00:00.000Z',
+      duration_ms: 2000,
+      status: 'error',
+      result: null,
+      error: 'boom,\ncrash',
+    },
+  ];
+
+  function exportState(): WebStateProvider {
+    return {
+      ...makeState(makeAgent()),
+      getTaskById: (id) =>
+        id === 'task-001' ? makeTask({ id: 'task-001' }) : undefined,
+      getTaskRunLogs: (taskId, limit) =>
+        taskId === 'task-001' ? sampleRuns.slice(0, limit ?? 20) : [],
+    };
+  }
+
+  it('returns 404 for unknown task', async () => {
+    const res = await handleRequest(
+      new Request('http://localhost/api/tasks/nonexistent/runs/export'),
+      makeState(makeAgent()),
+    );
+    expect(res.status).toBe(404);
+  });
+
+  it('exports JSON by default with an envelope', async () => {
+    const res = await handleRequest(
+      new Request('http://localhost/api/tasks/task-001/runs/export'),
+      exportState(),
+    );
+    expect(res.status).toBe(200);
+    expect(res.headers.get('Content-Type')).toContain('application/json');
+    expect(res.headers.get('Content-Disposition')).toContain(
+      'task-task-001-runs.json',
+    );
+    const body = (await res.json()) as {
+      task_id: string;
+      run_count: number;
+      runs: TaskRunLog[];
+    };
+    expect(body.task_id).toBe('task-001');
+    expect(body.run_count).toBe(2);
+    expect(body.runs).toHaveLength(2);
+  });
+
+  it('exports CSV with a header and RFC-4180 escaping', async () => {
+    const res = await handleRequest(
+      new Request('http://localhost/api/tasks/task-001/runs/export?format=csv'),
+      exportState(),
+    );
+    expect(res.status).toBe(200);
+    expect(res.headers.get('Content-Type')).toContain('text/csv');
+    expect(res.headers.get('Content-Disposition')).toContain(
+      'task-task-001-runs.csv',
+    );
+    const text = await res.text();
+    const lines = text.split('\n');
+    expect(lines[0]).toBe(
+      'run_at,status,duration_ms,outcome_state,outcome_reason,result,error',
+    );
+    // First run: quoted result because it contains a comma and quotes.
+    expect(lines[1]).toContain('"All good, said ""hi"""');
+    // Second run: error field with comma + newline stays quoted (so it does
+    // not split into extra CSV rows).
+    expect(text).toContain('"boom,\ncrash"');
+  });
+
+  it('rejects an invalid format', async () => {
+    const res = await handleRequest(
+      new Request('http://localhost/api/tasks/task-001/runs/export?format=xml'),
+      exportState(),
+    );
+    expect(res.status).toBe(400);
+  });
+
+  it('rejects non-GET methods', async () => {
+    const res = await handleRequest(
+      new Request('http://localhost/api/tasks/task-001/runs/export', {
+        method: 'POST',
+      }),
+      exportState(),
+    );
+    expect(res.status).toBe(405);
+  });
+
+  it('caps the limit at MAX_EXPORT_LIMIT', async () => {
+    let receivedLimit = -1;
+    const state: WebStateProvider = {
+      ...exportState(),
+      getTaskRunLogs: (_taskId, limit) => {
+        receivedLimit = limit ?? -1;
+        return sampleRuns;
+      },
+    };
+    const res = await handleRequest(
+      new Request(
+        'http://localhost/api/tasks/task-001/runs/export?limit=999999',
+      ),
+      state,
+    );
+    expect(res.status).toBe(200);
+    expect(receivedLimit).toBe(5000);
+  });
+});
+
 // ---- Task run phase events ----
 
 describe('GET /api/tasks/{id}/runs/{runAt}/phases', () => {

--- a/src/web/routes.ts
+++ b/src/web/routes.ts
@@ -158,6 +158,19 @@ export function handleRequest(
       return json({ error: 'Method not allowed' }, 405);
     }
 
+    // Run history export: /api/tasks/{id}/runs/export
+    if (rest.endsWith('/runs/export')) {
+      let taskId: string;
+      try {
+        taskId = decodeURIComponent(rest.slice(0, -'/runs/export'.length));
+      } catch {
+        return json({ error: 'Invalid task ID encoding' }, 400);
+      }
+      if (!taskId) return json({ error: 'Missing task ID' }, 400);
+      if (method === 'GET') return handleExportTaskRuns(taskId, req, state);
+      return json({ error: 'Method not allowed' }, 405);
+    }
+
     // Run now: /api/tasks/{id}/run
     if (rest.endsWith('/run')) {
       let taskId: string;
@@ -470,6 +483,92 @@ function handleGetTaskRuns(
 
   const runs = state.getTaskRunLogs(taskId, limit);
   return json(runs);
+}
+
+/**
+ * Escape a value for a CSV cell: quote when it contains a comma, quote,
+ * or newline, doubling any embedded quotes (RFC 4180).
+ */
+function csvCell(value: string): string {
+  if (/[",\r\n]/.test(value)) {
+    return `"${value.replace(/"/g, '""')}"`;
+  }
+  return value;
+}
+
+/**
+ * Export a task's run history for offline audit/analysis.
+ * GET /api/tasks/{id}/runs/export?format=json|csv&limit=N
+ * JSON mirrors the conversation export envelope; CSV is spreadsheet-friendly
+ * (durations, statuses, outcomes) for success-rate / latency analysis.
+ */
+function handleExportTaskRuns(
+  taskId: string,
+  req: Request,
+  state: WebStateProvider,
+): Response {
+  const task = state.getTaskById(taskId);
+  if (!task) return json({ error: 'Task not found' }, 404);
+
+  const url = new URL(req.url);
+  const format = url.searchParams.get('format') || 'json';
+  if (format !== 'json' && format !== 'csv')
+    return json({ error: 'Invalid format. Use "json" or "csv".' }, 400);
+
+  const limit = Math.min(
+    Math.max(1, parseInt(url.searchParams.get('limit') || '1000', 10) || 1000),
+    MAX_EXPORT_LIMIT,
+  );
+
+  const runs = state.getTaskRunLogs(taskId, limit);
+  const safeId = taskId.replace(/[^a-zA-Z0-9_-]/g, '_');
+
+  if (format === 'csv') {
+    const header = [
+      'run_at',
+      'status',
+      'duration_ms',
+      'outcome_state',
+      'outcome_reason',
+      'result',
+      'error',
+    ];
+    const lines = [header.join(',')];
+    for (const run of runs) {
+      lines.push(
+        [
+          run.run_at,
+          run.status,
+          String(run.duration_ms),
+          run.outcome_state ?? '',
+          run.outcome_reason ?? '',
+          run.result ?? '',
+          run.error ?? '',
+        ]
+          .map(csvCell)
+          .join(','),
+      );
+    }
+    return new Response(lines.join('\n'), {
+      headers: {
+        'Content-Type': 'text/csv; charset=utf-8',
+        'Content-Disposition': `attachment; filename="task-${safeId}-runs.csv"`,
+      },
+    });
+  }
+
+  const payload = {
+    task_id: taskId,
+    exported_at: new Date().toISOString(),
+    run_count: runs.length,
+    runs,
+  };
+  return new Response(JSON.stringify(payload, null, 2), {
+    headers: {
+      'Content-Type': 'application/json; charset=utf-8',
+      'Content-Disposition': `attachment; filename="task-${safeId}-runs.json"`,
+    },
+  });
 }
 
 function handleGetTaskRunPhases(


### PR DESCRIPTION
## What

Adds a **task run history export** endpoint so operators can pull a scheduled task's execution history for offline audit and analysis:

```
GET /api/tasks/{id}/runs/export?format=json|csv&limit=N
```

Part of the Web UI (#157) task-manager surface — complements the existing `/api/tasks/{id}/runs` viewer with a downloadable, analysis-friendly export.

## Details

- **JSON** (default) mirrors the conversation-export envelope: `{ task_id, exported_at, run_count, runs[] }`, served as an attachment (`task-{id}-runs.json`).
- **CSV** is spreadsheet-friendly for success-rate / latency analysis — columns: `run_at, status, duration_ms, outcome_state, outcome_reason, result, error`. Uses RFC-4180 escaping (`csvCell`) so commas, quotes, and newlines in a run's `result`/`error` don't corrupt rows.
- `limit` defaults to 1000, capped at the existing `MAX_EXPORT_LIMIT` (5000).
- Error handling: `404` unknown task, `400` invalid format, `405` non-GET — consistent with sibling task routes.

## Testing

- 6 new tests in `src/web/routes.test.ts` (JSON envelope, CSV header + RFC-4180 escaping, invalid format, non-GET, limit cap, unknown task).
- `bun test src/web/routes.test.ts` → 72 pass, 0 fail.
- `bun run typecheck` → clean.
- Full `src/web/` suite: only pre-existing unrelated failure (`renderPeerRows` relative-time flake in `network.test.ts`, fails on `main` without this change).

## Scope

API-only, mirroring the pattern of #978 (`/api/logs/recent`). A download button in the tasks UI can follow as a small separate PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new export option for task run history, available in JSON or CSV format.
  * Export responses now include download-friendly headers and a clear file attachment name.

* **Bug Fixes**
  * Improved handling for invalid task IDs, unsupported export formats, and non-GET requests.
  * Added safer CSV escaping for quotes, commas, and multiline values.
  * Enforced a maximum limit on exported runs to prevent overly large responses.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->