### PR TITLE
test(simtest): cover discovery environment state

### DIFF
--- a/src/simtest/discovery-sim.test.ts
+++ b/src/simtest/discovery-sim.test.ts
@@ -458,4 +458,77 @@ describe('createSimDiscoveryEnvironment', () => {
       'Remote peer not found: missing-peer',
     );
   });
+
+  it('builds a deterministic default network page state for the seeded peer', () => {
+    const env = createSimDiscoveryEnvironment(new FakeState());
+
+    const pageState = env.getNetworkPageState();
+
+    expect(pageState).toMatchObject({
+      instanceId: 'sim-local-instance',
+      instanceName: 'Sim Local OmniClaw',
+      discoveryAvailable: true,
+      discoveryEnabled: true,
+      runtime: {
+        enabled: true,
+        active: true,
+        currentNetwork: {
+          id: 'sim-lan',
+          label: 'Simulated LAN',
+        },
+        trustedNetworks: [],
+      },
+      pendingRequests: [],
+    });
+    expect(pageState.peers).toHaveLength(1);
+    expect(pageState.peers[0]).toMatchObject({
+      instanceId: 'peer-remote-1',
+      name: 'Remote OmniClaw',
+      host: 'remote-sim.local',
+      port: 3100,
+      addresses: ['192.168.1.80'],
+      status: 'trusted',
+      online: true,
+    });
+  });
+
+  it('adds an initially offline trusted peer without advertising addresses', () => {
+    const env = createSimDiscoveryEnvironment(new FakeState());
+
+    env.addRemotePeer({
+      instanceId: 'peer-offline',
+      name: 'Offline Builder',
+      host: 'offline-sim.local',
+      address: '192.168.1.99',
+      channelFolder: 'offline',
+      online: false,
+    });
+
+    expect(env.listRemotePeers()).toContainEqual(
+      expect.objectContaining({
+        instanceId: 'peer-offline',
+        name: 'Offline Builder',
+        online: false,
+        status: 'trusted',
+      }),
+    );
+    expect(env.getNetworkPageState().peers).toContainEqual(
+      expect.objectContaining({
+        instanceId: 'peer-offline',
+        host: 'offline-sim.local',
+        port: 3100,
+        addresses: [],
+        online: false,
+        status: 'trusted',
+      }),
+    );
+  });
+
+  it('returns null when direct peer-client lookup targets an unknown peer', () => {
+    const env = createSimDiscoveryEnvironment(new FakeState());
+
+    expect(env.context.createPeerClient({ instanceId: 'missing' } as any)).toBe(
+      null,
+    );
+  });
 });

--- a/src/simtest/discovery-sim.test.ts
+++ b/src/simtest/discovery-sim.test.ts
@@ -526,9 +526,19 @@ describe('createSimDiscoveryEnvironment', () => {
 
   it('returns null when direct peer-client lookup targets an unknown peer', () => {
     const env = createSimDiscoveryEnvironment(new FakeState());
+    const createPeerClient = env.context.createPeerClient;
 
-    expect(env.context.createPeerClient({ instanceId: 'missing' } as any)).toBe(
-      null,
-    );
+    expect(createPeerClient).toBeDefined();
+    expect(
+      createPeerClient!(
+        {
+          instanceId: 'missing',
+          host: 'missing.local',
+          port: 3100,
+          sharedSecret: 'sim-secret-missing',
+        },
+        env.context,
+      ),
+    ).toBe(null);
   });
 });

--- a/src/web/network.test.ts
+++ b/src/web/network.test.ts
@@ -256,8 +256,7 @@ describe('renderPeerRows', () => {
   });
 
   it('renders an offline peer with a last-seen relative chip and absolute title', () => {
-    const now = Date.parse('2026-06-07T12:00:00.000Z');
-    const lastSeen = new Date(now - 5 * 60_000).toISOString();
+    const lastSeen = new Date(Date.now() - 5 * 60_000).toISOString();
     const html = renderPeerRows([
       makePeer({
         instanceId: 'offline-1',


### PR DESCRIPTION
## Summary

- Adds deterministic assertions for the simtest discovery environment's default network page state.
- Covers initially-offline trusted peer insertion so offline peers remain visible without discovered addresses.
- Covers direct missing-peer client lookup returning null.
- Stabilizes the network last-seen test by deriving the fixture timestamp from current time instead of a stale fixed 2026 date.

## Test Count

- Baseline on origin/main before changes: `2573 pass, 1 fail` across 106 files. Failure was `src/web/network.test.ts` last-seen date drift.
- After changes: `2577 pass, 0 fail` across 106 files.

## Verification

- `bun test src/simtest/discovery-sim.test.ts` -> 14 pass, 0 fail
- `bun test src/web/network.test.ts` -> 32 pass, 0 fail
- `bun test` -> 2577 pass, 0 fail

## Remaining Coverage Gaps

- Simtest admin API still has many route branches that could use direct tests for invalid JSON/body validation and scenario mutation paths.
- Web UI route coverage is broad but still heavily HTML-string based; browser-level interaction coverage remains separate from this PR.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added coverage for peer discovery behavior, including default network state, trusted peer details, offline trusted peers, and missing peer lookups.
  * Updated an existing offline peer test to use the current runtime clock, keeping the timestamp check reliable across time drift.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->