### PR TITLE
fix(web): validate context file realpaths

### DIFF
--- a/src/web/context-files.test.ts
+++ b/src/web/context-files.test.ts
@@ -8,12 +8,14 @@ import { listLocalContextFiles } from './context-files.js';
 
 const realExistsSync = fs.existsSync;
 const realReaddirSync = fs.readdirSync;
+const realRealpathSync = fs.realpathSync;
 const realStatSync = fs.statSync;
 const realReadFileSync = fs.readFileSync;
 
 const mockedFs = fs as unknown as {
   existsSync: typeof fs.existsSync;
   readdirSync: typeof fs.readdirSync;
+  realpathSync: typeof fs.realpathSync;
   statSync: typeof fs.statSync;
   readFileSync: typeof fs.readFileSync;
 };
@@ -31,6 +33,7 @@ function file(name: string): FakeDirent {
 afterEach(() => {
   mockedFs.existsSync = realExistsSync;
   mockedFs.readdirSync = realReaddirSync;
+  mockedFs.realpathSync = realRealpathSync;
   mockedFs.statSync = realStatSync;
   mockedFs.readFileSync = realReadFileSync;
 });
@@ -67,6 +70,8 @@ describe('listLocalContextFiles', () => {
       }
       throw new Error(`Unexpected readdir for ${dirPath}`);
     }) as unknown as typeof fs.readdirSync;
+    mockedFs.realpathSync = ((target: fs.PathLike) =>
+      String(target)) as typeof fs.realpathSync;
     mockedFs.statSync = ((target: fs.PathLike) => {
       const filePath = String(target);
       if (filePath === alphaClaude) {
@@ -137,6 +142,8 @@ describe('listLocalContextFiles', () => {
       }
       throw new Error(`Unexpected readdir for ${dirPath}`);
     }) as unknown as typeof fs.readdirSync;
+    mockedFs.realpathSync = ((target: fs.PathLike) =>
+      String(target)) as typeof fs.realpathSync;
     mockedFs.statSync = ((target: fs.PathLike) => {
       const filePath = String(target);
       if (filePath === okClaude) {
@@ -161,6 +168,54 @@ describe('listLocalContextFiles', () => {
         hash: crypto.createHash('sha256').update(okContent).digest('hex'),
         size: okContent.length,
         mtime: '2026-03-12T00:00:00.000Z',
+      },
+    ]);
+  });
+
+  it('skips CLAUDE.md symlinks that resolve outside groups directory', () => {
+    const root = GROUPS_DIR;
+    const safeClaude = path.join(root, 'safe', 'CLAUDE.md');
+    const symlinkClaude = path.join(root, 'escape', 'CLAUDE.md');
+    const secretPath = path.resolve(root, '..', '.env');
+    const safeContent = 'safe context';
+
+    mockedFs.existsSync = ((target: fs.PathLike) =>
+      target === root) as typeof fs.existsSync;
+    mockedFs.readdirSync = ((target: fs.PathLike) => {
+      const dirPath = String(target);
+      if (dirPath === root) return [dir('safe'), dir('escape')];
+      if (dirPath === path.join(root, 'safe')) return [file('CLAUDE.md')];
+      if (dirPath === path.join(root, 'escape')) return [file('CLAUDE.md')];
+      throw new Error(`Unexpected readdir for ${dirPath}`);
+    }) as unknown as typeof fs.readdirSync;
+    mockedFs.realpathSync = ((target: fs.PathLike) => {
+      const filePath = String(target);
+      if (filePath === safeClaude) return safeClaude;
+      if (filePath === symlinkClaude) return secretPath;
+      throw new Error(`Unexpected realpath for ${filePath}`);
+    }) as typeof fs.realpathSync;
+    mockedFs.statSync = ((target: fs.PathLike) => {
+      const filePath = String(target);
+      if (filePath === safeClaude) {
+        return {
+          size: safeContent.length,
+          mtime: new Date('2026-03-13T00:00:00.000Z'),
+        } as fs.Stats;
+      }
+      throw new Error(`Unexpected stat for ${filePath}`);
+    }) as typeof fs.statSync;
+    mockedFs.readFileSync = ((target: fs.PathLike) => {
+      const filePath = String(target);
+      if (filePath === safeClaude) return safeContent;
+      throw new Error(`Unexpected read for ${filePath}`);
+    }) as typeof fs.readFileSync;
+
+    expect(listLocalContextFiles()).toEqual([
+      {
+        path: 'safe',
+        hash: crypto.createHash('sha256').update(safeContent).digest('hex'),
+        size: safeContent.length,
+        mtime: '2026-03-13T00:00:00.000Z',
       },
     ]);
   });

--- a/src/web/context-files.ts
+++ b/src/web/context-files.ts
@@ -35,8 +35,10 @@ export function listLocalContextFiles(): ContextFileEntry[] {
       } else if (entry.name === 'CLAUDE.md') {
         try {
           assertPathWithin(fullPath, GROUPS_DIR, 'listContextFiles');
-          const stat = fs.statSync(fullPath);
-          const content = fs.readFileSync(fullPath, 'utf-8');
+          const realPath = fs.realpathSync(fullPath);
+          assertPathWithin(realPath, GROUPS_DIR, 'listContextFiles');
+          const stat = fs.statSync(realPath);
+          const content = fs.readFileSync(realPath, 'utf-8');
           const hash = crypto
             .createHash('sha256')
             .update(content)


### PR DESCRIPTION
## Summary

- resolve discovered local `CLAUDE.md` paths to their real filesystem targets before reading them
- reject context files whose realpath escapes `GROUPS_DIR`, preventing symlink metadata/hash leaks through the web/discovery context inventory
- add regression coverage for an outside-target symlink while preserving normal context-file listing

## Security Impact

`listLocalContextFiles()` previously validated the path string under `GROUPS_DIR` before calling `statSync` and `readFileSync`. A symlink named `CLAUDE.md` inside a group folder could point outside `GROUPS_DIR`; the scanner would then follow it and expose the target file's size, mtime, and SHA-256 hash through context-file inventory APIs.

This change validates both the discovered path and the resolved realpath before stat/read.

## Tests

- `bun test src/web/context-files.test.ts`
- `bun run typecheck`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved local context file discovery to follow symlinks safely before reading file details.
  * Context files that point outside the allowed directory are now ignored, preventing unexpected files from appearing.
  * Existing directory scanning behavior remains intact for valid `CLAUDE.md` files.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->