### PR TITLE
test(github): cover delta fetch failures

### DIFF
--- a/src/github-delta.fetch.test.ts
+++ b/src/github-delta.fetch.test.ts
@@ -326,4 +326,76 @@ describe('fetchGitHubDelta', () => {
     expect(secondDigest).toBeNull();
     expect(getDeltaCursor(channelJid)).toBe(until);
   });
+
+  it('returns null without reading config or fetching when no GitHub token is configured', async () => {
+    const channelJid = makeChannelJid('no-token');
+    const fetchMock = mock(() => {
+      throw new Error('fetch should not run without a token');
+    });
+
+    delete process.env.GITHUB_TOKEN;
+    globalThis.fetch = fetchMock as unknown as typeof globalThis.fetch;
+
+    const digest = await fetchGitHubDelta(
+      channelJid,
+      '2026-03-25T12:10:00.000Z',
+    );
+
+    expect(digest).toBeNull();
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it('advances the cursor and returns null when GitHub API responses are not ok', async () => {
+    const channelJid = makeChannelJid('api-not-ok');
+    const since = '2026-03-25T12:00:00.000Z';
+    const until = '2026-03-25T12:10:00.000Z';
+    const fetchMock = mock(() =>
+      Promise.resolve(new Response('rate limited', { status: 403 })),
+    );
+
+    writeGitHubWatchesConfig({
+      watches: [],
+      githubDeltaContextEnabled: true,
+      channelWatches: [
+        {
+          channelJid,
+          repos: [{ owner: 'omniaura', repo: 'omniclaw' }],
+        },
+      ],
+    });
+    setDeltaCursor(channelJid, since);
+    globalThis.fetch = fetchMock as unknown as typeof globalThis.fetch;
+
+    const digest = await fetchGitHubDelta(channelJid, until);
+
+    expect(digest).toBeNull();
+    expect(getDeltaCursor(channelJid)).toBe(until);
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+  });
+
+  it('advances the cursor and returns null when GitHub API requests reject', async () => {
+    const channelJid = makeChannelJid('api-reject');
+    const since = '2026-03-25T12:00:00.000Z';
+    const until = '2026-03-25T12:10:00.000Z';
+    const fetchMock = mock(() => Promise.reject(new Error('network down')));
+
+    writeGitHubWatchesConfig({
+      watches: [],
+      githubDeltaContextEnabled: true,
+      channelWatches: [
+        {
+          channelJid,
+          repos: [{ owner: 'omniaura', repo: 'omniclaw' }],
+        },
+      ],
+    });
+    setDeltaCursor(channelJid, since);
+    globalThis.fetch = fetchMock as unknown as typeof globalThis.fetch;
+
+    const digest = await fetchGitHubDelta(channelJid, until);
+
+    expect(digest).toBeNull();
+    expect(getDeltaCursor(channelJid)).toBe(until);
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+  });
 });


### PR DESCRIPTION
## Summary

- Add deterministic GitHub delta fetch tests for no-token short-circuit behavior.
- Cover non-OK GitHub API responses and rejected fetch requests without network access.
- Assert failed delta fetches return null while advancing the channel cursor after an attempted window.

## Test Counts

- Before: 2574 passing tests across 106 files.
- After: 2577 passing tests across 106 files.

## Coverage

- Overall line coverage: 92.62% -> 92.65%.
- `src/github-delta.ts` line coverage: 87.17% -> 89.35%.

## Verification

- `bun test src/github-delta.fetch.test.ts`
- `bun test --coverage`

## Remaining Gaps

- Large integration-heavy modules remain the biggest coverage gaps, especially `src/channels/discord.ts`, `src/channels/telegram.ts`, `src/channels/whatsapp.ts`, `src/backends/local-backend.ts`, and orchestrator paths in `src/index.ts`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added coverage for missing authentication and GitHub API/network failure scenarios.
  * Improved confidence that sync behavior continues safely even when GitHub requests fail or credentials aren’t available.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->